### PR TITLE
Add proto definition

### DIFF
--- a/proto/feature.proto
+++ b/proto/feature.proto
@@ -1,0 +1,84 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Feature Profile - A low level feature, typically a networking protocol,
+// supported by a vendor platform.
+//
+// Generally feature profiles are either baseline protocols (BGP base),
+// additional optional features supported with the protocol (BGP Add path), or
+// specific scale requirements (Full FIB support with BGP). A feature profile
+// can be dependent on one or more other feature profiles.
+//
+// Example feature profile:
+//
+// feature_profile {
+//   id {
+//     name: 'bgp_base'
+//     version: 1
+//   }
+//   openconfig_path:
+//   '/network-instance/<name>/protocols/INSTALL_PROTOCOL_TYPE_BGP/...'
+// }
+syntax = "proto2";
+
+package net.profiles;
+
+message FeatureProfileID {
+  // Unique name for the feature profile.
+  //
+  // Example: bgp_base
+  optional string name = 1;
+
+  // Version number for this instantiation of the profile.
+  optional int32 version = 2;
+}
+
+message TelemetryPath {
+  optional string path = 1;
+}
+
+message ConfigPath {
+  optional string path = 1;
+}
+
+message GNOIService {
+  // Service name for the GNOI endpoint
+  //
+  // Example: gnoi.bgp.BGP
+  optional string service_name = 1;
+
+  // Method name for GNOI endpoint
+  //
+  // Example: ClearBGPNeighbor
+  optional string method_name = 2;
+}
+
+message FeatureProfile {
+  // Unique identifier for the service profile.
+  optional FeatureProfileID id = 1;
+
+  // A list of configuration and state paths that compose the feature profile.
+  repeated ConfigPath config_path = 2;
+
+  // A list of configuration and state paths that compose the feature profile.
+  repeated TelemetryPath telemetry_path = 3;
+
+  // A list of GNOI operational commands that compose the feature profile.
+  repeated GNOIService gnoi_service = 5;
+
+  // A list of feature profiles this feature profile depends on.  For example,
+  // A iBGP feature profile might depend on the BGP base feature profile.
+  repeated FeatureProfileID feature_profile_dependency = 4;
+}


### PR DESCRIPTION
A feature profiles is a set of Open Config paths described in a
textproto file. This CL is adding the textproto definition.