### PR TITLE
Change feature.proto package

### DIFF
--- a/proto/feature.proto
+++ b/proto/feature.proto
@@ -33,7 +33,7 @@
 // }
 syntax = "proto2";
 
-package net.profiles;
+package openconfig.profiles;
 
 message FeatureProfileID {
   // Unique name for the feature profile.


### PR DESCRIPTION
Change `package` name to reflect the organization of the open source
project and avoid internal collisions.