### PR TITLE
Fix invalid Feature Profile paths

### DIFF
--- a/feature/experimental/policy/policy_base/feature.textproto
+++ b/feature/experimental/policy/policy_base/feature.textproto
@@ -50,25 +50,25 @@ telemetry_path {
 # Action base
 
 config_path {
-  path: "/network-instances/network-instance/policy-forwarding/policies/policy/actions/action/config/discard"
+  path: "/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/config/discard"
 }
 telemetry_path {
-  path: "/network-instances/network-instance/policy-forwarding/policies/policy/actions/action/state/discard"
+  path: "/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/state/discard"
 }
 
 # Interface base
 
 config_path {
-  path: "/network-instances/network-instance/policy-forwarding/policies/policy/interfaces/interface/config/interface-id"
+  path: "/network-instances/network-instance/policy-forwarding/interfaces/interface/config/interface-id"
 }
 telemetry_path {
-  path: "/network-instances/network-instance/policy-forwarding/policies/policy/interfaces/interface/state/interface-id"
+  path: "/network-instances/network-instance/policy-forwarding/interfaces/interface/state/interface-id"
 }
 
 # L2 rules
 
 config_path {
-  path: "/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/l2/config/ether-type"
+  path: "/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/l2/config/ethertype"
 }
 config_path {
   path: "/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/l2/config/source-mac"
@@ -83,7 +83,7 @@ config_path {
   path: "/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/l2/config/destination-mac-mask"
 }
 telemetry_path {
-  path: "/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/l2/state/ether-type"
+  path: "/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/l2/state/ethertype"
 }
 telemetry_path {
   path: "/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/l2/state/source-mac"

--- a/feature/experimental/policy/policy_vrf_selection/feature.textproto
+++ b/feature/experimental/policy/policy_vrf_selection/feature.textproto
@@ -20,19 +20,19 @@ id {
 # Interface
 
 config_path {
-  path: "/network-instances/network-instance/policy-forwarding/policies/policy/interfaces/interface/config/apply-vrf-selection-policy"
+  path: "/network-instances/network-instance/policy-forwarding/interfaces/interface/config/apply-vrf-selection-policy"
 }
 telemetry_path {
-  path: "/network-instances/network-instance/policy-forwarding/policies/policy/interfaces/interface/state/apply-vrf-selection-policy"
+  path: "/network-instances/network-instance/policy-forwarding/interfaces/interface/state/apply-vrf-selection-policy"
 }
 
 # VRF actions
 
 config_path {
-  path: "/network-instances/network-instance/policy-forwarding/policies/policy/actions/action/config/network-instance"
+  path: "/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/config/network-instance"
 }
 telemetry_path {
-  path: "/network-instances/network-instance/policy-forwarding/policies/policy/actions/action/state/network-instance"
+  path: "/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/state/network-instance"
 }
 
 

--- a/feature/experimental/route_redistribution/feature.textproto
+++ b/feature/experimental/route_redistribution/feature.textproto
@@ -20,49 +20,49 @@ id {
 # https://github.com/openconfig/public/blob/e9e3a82693d1f26c61d7fbf85b3b2d0418d4af9e/doc/network_instance_redistribution.md
 # Protocol tables
 config_path {
-  path: "/network-instances/tables/table/config/protocol"
+  path: "/network-instances/network-instance/tables/table/config/protocol"
 }
 config_path {
-  path: "/network-instances/tables/table/config/address-family"
+  path: "/network-instances/network-instance/tables/table/config/address-family"
 }
 telemetry_path {
-  path: "/network-instances/tables/table/state/protocol"
+  path: "/network-instances/network-instance/tables/table/state/protocol"
 }
 telemetry_path {
-  path: "/network-instances/tables/table/state/address-family"
+  path: "/network-instances/network-instance/tables/table/state/address-family"
 }
 
 
 # Table-connections
 config_path {
-  path: "/network-instances/table-connections/config/src-protocol"
+  path: "/network-instances/network-instance/table-connections/table-connection/config/src-protocol"
 }
 config_path {
-  path: "/network-instances/table-connections/config/dst-protocol"
+  path: "/network-instances/network-instance/table-connections/table-connection/config/dst-protocol"
 }
 config_path {
-  path: "/network-instances/table-connections/config/address-family"
+  path: "/network-instances/network-instance/table-connections/table-connection/config/address-family"
 }
 config_path {
-  path: "/network-instances/table-connections/config/import-policy"
+  path: "/network-instances/network-instance/table-connections/table-connection/config/import-policy"
 }
 config_path {
-  path: "/network-instances/table-connections/config/default-import-policy"
+  path: "/network-instances/network-instance/table-connections/table-connection/config/default-import-policy"
 }
 telemetry_path {
-  path: "/network-instances/table-connections/state/src-protocol"
+  path: "/network-instances/network-instance/table-connections/table-connection/state/src-protocol"
 }
 telemetry_path {
-  path: "/network-instances/table-connections/state/dst-protocol"
+  path: "/network-instances/network-instance/table-connections/table-connection/state/dst-protocol"
 }
 telemetry_path {
-  path: "/network-instances/table-connections/state/address-family"
+  path: "/network-instances/network-instance/table-connections/table-connection/state/address-family"
 }
 telemetry_path {
-  path: "/network-instances/table-connections/state/import-policy"
+  path: "/network-instances/network-instance/table-connections/table-connection/state/import-policy"
 }
 telemetry_path {
-  path: "/network-instances/table-connections/state/default-import-policy"
+  path: "/network-instances/network-instance/table-connections/table-connection/state/default-import-policy"
 }
 
 


### PR DESCRIPTION
Feature Profile paths must correspond to paths defined in OpenConfig.
Some of the paths snuck through out check. This commit fixes those
invalid paths.