### PR TITLE
Update missing OC paths from bgp_base test case.

### DIFF
--- a/feature/bgp/bgp_base/feature.textproto
+++ b/feature/bgp/bgp_base/feature.textproto
@@ -56,6 +56,7 @@ telemetry_path {
   path: "/network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/session-state"
 }
 
+
 # messages
 
 telemetry_path {


### PR DESCRIPTION
This PR is to update missing OC paths from bgp_base test case. 

These are some supported paths required for bgp_base test case based on POPGate HLD