### PR TITLE
Sync dut device naming

### DIFF
--- a/feature/system/system_base/tests/banner_test.go
+++ b/feature/system/system_base/tests/banner_test.go
@@ -40,7 +40,7 @@ func TestMotdBanner(t *testing.T) {
 		{"Long String", "WARNING : Unauthorized access to this system is forbidden and will be prosecuted by law. By accessing this system, you agree that your actions may be monitored if unauthorized usage is suspected."},
 	}
 
-	dut := ondatra.DUT(t, "dut1")
+	dut := ondatra.DUT(t, "dut")
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
@@ -91,7 +91,7 @@ func TestLoginBanner(t *testing.T) {
 		{"Long String", "WARNING : Unauthorized access to this system is forbidden and will be prosecuted by law. By accessing this system, you agree that your actions may be monitored if unauthorized usage is suspected."},
 	}
 
-	dut := ondatra.DUT(t, "dut1")
+	dut := ondatra.DUT(t, "dut")
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {

--- a/feature/system/system_base/tests/hostname_test.go
+++ b/feature/system/system_base/tests/hostname_test.go
@@ -41,7 +41,7 @@ func TestHostname(t *testing.T) {
 		{"63 Characters", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
 	}
 
-	dut := ondatra.DUT(t, "dut1")
+	dut := ondatra.DUT(t, "dut")
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
@@ -92,7 +92,7 @@ func TestDomainName(t *testing.T) {
 		{"63 Characters", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
 	}
 
-	dut := ondatra.DUT(t, "dut1")
+	dut := ondatra.DUT(t, "dut")
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {

--- a/feature/system/system_base/tests/time_test.go
+++ b/feature/system/system_base/tests/time_test.go
@@ -30,7 +30,7 @@ import (
 func TestCurrentDateTime(t *testing.T) {
 	t.Skip("Need working implementation to validate against")
 
-	dut := ondatra.DUT(t, "dut1")
+	dut := ondatra.DUT(t, "dut")
 	now := dut.Telemetry().System().CurrentDatetime().Get(t)
 	_, err := time.Parse(time.RFC3339, now)
 	if err != nil {
@@ -43,7 +43,7 @@ func TestCurrentDateTime(t *testing.T) {
 //
 // telemetry_path:/system/state/boot-time
 func TestBootTime(t *testing.T) {
-	dut := ondatra.DUT(t, "dut1")
+	dut := ondatra.DUT(t, "dut")
 	bt := dut.Telemetry().System().BootTime().Get(t)
 
 	// Boot time should be after Dec 22, 2021 00:00:00 GMT in nanoseconds
@@ -72,7 +72,7 @@ func TestTimeZone(t *testing.T) {
 		{"Europe/London", "Europe/London"},
 	}
 
-	dut := ondatra.DUT(t, "dut1")
+	dut := ondatra.DUT(t, "dut")
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {

--- a/feature/system/system_ntp/tests/server_test.go
+++ b/feature/system/system_ntp/tests/server_test.go
@@ -38,7 +38,7 @@ func TestNtpServerConfigurability(t *testing.T) {
 		{"IPv6 Basic Server", "2001:DB8::1"},
 	}
 
-	dut := ondatra.DUT(t, "dut1")
+	dut := ondatra.DUT(t, "dut")
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
 			config := dut.Config().System().Ntp()

--- a/feature/system/system_ntp/tests/system_ntp_test.go
+++ b/feature/system/system_ntp/tests/system_ntp_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 func TestNtpEnable(t *testing.T) {
 	t.Skip("Need working implementation to validate against")
 
-	dut := ondatra.DUT(t, "dut1")
+	dut := ondatra.DUT(t, "dut")
 	config := dut.Config().System().Ntp()
 	state := dut.Telemetry().System().Ntp()
 

--- a/topologies/kne/arista_ceos.textproto
+++ b/topologies/kne/arista_ceos.textproto
@@ -1,6 +1,6 @@
 name: "arista-ceos"
 nodes: {
-  name: "dut1"
+  name: "dut"
   type: ARISTA_CEOS
   config: {
     config_path: "/mnt/flash"

--- a/topologies/kne/nokia_srl.textproto
+++ b/topologies/kne/nokia_srl.textproto
@@ -1,6 +1,6 @@
 name: "nokia-srl"
 nodes: {
-    name: "dut1"
+    name: "dut"
     type: NOKIA_SRL
     config: {
         file: "nokia_srl.json"


### PR DESCRIPTION
#32 renamed the topology DUT from "dut1" to "dut".  The device naming needs to be consistent between topology files and tests.  This makes the naming consistent and allows tests to work again.