### PR TITLE
Add gNMI+gRIBI server configuration for KNE topologies.

### DIFF
--- a/topologies/kne/arista_ceos.config
+++ b/topologies/kne/arista_ceos.config
@@ -25,6 +25,10 @@ management api gnmi
       ssl profile octa-ssl-profile
    provider eos-native
 !
+management api gribi
+   transport grpc default
+      ssl profile octa-ssl-profile
+!
 management security
    ssl profile eapi
       tls versions 1.2

--- a/topologies/kne/arista_ceos.textproto
+++ b/topologies/kne/arista_ceos.textproto
@@ -30,4 +30,12 @@ nodes: {
       outside: 6030
     }
   }
+  services: {
+    key: 6040
+    value: {
+      name: "gribi"
+      inside: 6040
+      outside: 6040
+    }
+  }
 }

--- a/topologies/kne/nokia_srl.json
+++ b/topologies/kne/nokia_srl.json
@@ -1274,6 +1274,22 @@
         }
       ]
     },
+    "srl_nokia-gribi-server:gribi-server": {
+      "admin-state": "enable",
+      "network-instance": [
+        {
+          "name": "mgmt",
+          "admin-state": "enable",
+          "tls-profile": "kne-profile",
+          "port": 57401
+        }
+      ],
+      "trace-options": [
+         "request",
+         "response",
+         "common"
+      ]
+    },
     "srl_nokia-tls:tls": {
       "server-profile": [
         {
@@ -1456,6 +1472,11 @@
           "export-neighbors": true
         }
       }
+    },
+    {
+      "name": "DEFAULT",
+      "admin-state": "enable",
+      "type": "srl_nokia-network-instance:default"
     }
   ]
 }

--- a/topologies/kne/nokia_srl.textproto
+++ b/topologies/kne/nokia_srl.textproto
@@ -1,14 +1,15 @@
 name: "nokia-srl"
 nodes: {
     name: "dut"
-    type: NOKIA_SRL
+    vendor: NOKIA
     config: {
         file: "nokia_srl.json"
+        image: "srlinux:latest"
         cert: {
             self_signed: {
-                cert_name: "kne-profile",
-                key_name: "N/A",
-                key_size: 4096,
+                cert_name: "kne-profile"
+                key_name: "N/A"
+                key_size: 4096
             }
         }
     }
@@ -17,6 +18,7 @@ nodes: {
         value: {
             name: "ssh"
             inside: 22
+            outside: 22
         }
     }
     services:{
@@ -24,6 +26,15 @@ nodes: {
         value: {
             name: "gnmi"
             inside: 57400
+            outside: 57400
         }
+    }
+    services:{
+      key: 57401
+      value: {
+        name: "gribi"
+        inside: 57401
+        outside: 57401
+      }
     }
 }


### PR DESCRIPTION
```
﻿ * (M) topologies/kne/arista_ceos*
   - ensure that port 6040 is exposed in tests to allow gRIBI test
     to run directly.
 * (M) topologies/kne/nokia_srl*
   - ensure that default network instance, logging and gRIBI are running
     by default.
   - add configuration for kne to expose gRIBI.
```

After making these changes, we should be able to run tests against gNMI and gRIBI in KNE on SRL. One thing that is needed is to change the port to a default value across the two - unless we intend that this is parameterised in the binding. @liulk - any thoughts on this?