### PR TITLE
[DRAFT] Initial proposal for an abstraction of ATE/OTG

### DIFF
--- a/absate/absate.go
+++ b/absate/absate.go
@@ -1,0 +1,162 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package absate provides an abstracted interface to automated test infrastructure
+// which allows use of the ONDATRA ATE API, and the long-term target of Open
+// Traffic Generator specifically for feature profiles use.
+//
+// The APIs provided here seek to take some of the low-level flows and protocol
+// operations that ATEs within functional tests provide such that tests can
+// do not need to redefine them.
+package absate
+
+import (
+	"testing"
+
+	"github.com/open-traffic-generator/snappi/gosnappi"
+	"github.com/openconfig/ondatra"
+)
+
+// TODO(robjs): implementation :-) this file serves as a notes file for what
+// we need to do here.
+//
+// reference: wbbtest.go
+//		- we use ATETopology which is provided by ONDATRA. In an OTG world,
+//		  what is the plan for topology.
+//			- ATETopology isn't a first class citizen of the existing API in
+//			  IxNetwork, so we need to choose if this is something that ONDATRA
+//			  will continue to expose, or if it's something that we need to
+//			  re-implement itself.
+
+// Environment is a type that indicates which ATE environment the test is running
+// within.
+type Environment int64
+
+const (
+	_ Environment = iota
+	// ClassicATE indicates that the ATE should be interfaced with through the
+	// "classic" ONDATRA ATE API.
+	ClassicATE
+	// OTG indicates that the ATE should be interfaced with through the Open
+	// Traffic Generator API.
+	OTG
+)
+
+var (
+	// mode specifies which mode the abstract ATE should operate within to
+	// start with. By default we use the classic ATE API.
+	mode = ClassicATE
+)
+
+// SetMode allows the caller to determine which environment it should build
+// contents for.
+//
+// TODO(robjs): we could discuss here whether we want to - rather than only
+// building one set of contents, build both, and just have the actuation of
+// pushing the config choose which to push.
+func SetMode(m Environment) {
+	mode = m
+}
+
+// ATE is a wrapper struct that contains a 'classic' and 'OTG' ATE device.
+type ATE struct {
+	// From the OTG() implementation in ONDATRA, ATEDevice will be common across the
+	// different implementations, so we don't need to store anything specific
+	// for each type here.
+	dev *ondatra.ATEDevice
+
+	// otg is the OTG configuration for this ATE which is global for the device.
+	otg gosnappi.Config
+}
+
+// NewDevice returns a new abstract ATE device.
+func NewDevice(d *ondatra.ATEDevice) *ATE {
+	return &ATE{
+		dev: d,
+		otg: gosnappi.NewConfig(),
+	}
+}
+
+// AddFlow adds a flow to the ATE with the specified name.
+func (a *ATE) AddFlow(name string) *Flow {
+	f := newFlow(a, name)
+	return f
+}
+
+// StartTraffic starts traffic flowing for the flow specified.
+func (a *ATE) StartTraffic(t testing.TB) {
+	switch mode {
+	case ClassicATE:
+		a.dev.Traffic().Start(t)
+	case OTG:
+		if err := a.otg.Validate(); err != nil {
+			t.Fatalf("invalid OTG, got err: %v", err)
+		}
+		// TODO(robjs): understand how in the OTG API we start things, can we
+		// start a specific flow, or do we just start everything?
+	}
+}
+
+func (a *ATE) StopTraffic(t testing.TB) {
+	switch mode {
+	case ClassicATE:
+		a.dev.Traffic().Stop(t)
+	case OTG:
+		// TODO(robjs): same as above.
+	}
+}
+
+// Flow is the container ATE or OTG flow.
+type Flow struct {
+	parent *ATE
+	ate    *ondatra.Flow
+	otg    gosnappi.Flow
+}
+
+// newFlow adds a new flow to the ATE device specified with the specified
+// name, initialising the relevant structures required for the flow.
+func newFlow(a *ATE, name string) *Flow {
+	f := &Flow{parent: a}
+	switch mode {
+	case ClassicATE:
+		f.ate = f.parent.dev.Traffic().NewFlow(name)
+	case OTG:
+		f.otg = f.parent.otg.Flows().Add()
+		f.otg.SetName(name)
+	}
+	return f
+}
+
+// IPinIP tunnel defines an IP-in-IP tunnel with the specifid outer DSCP value
+// that represents a flow that can be matched within functional tests.
+func (f *Flow) IPinIPTunnel(dscp uint8) *Flow {
+	// TODO(robjs): figure out whether how this looks if we support explicit
+	// source and destination vs. between ATE ports that would be handled by the
+	// topology (see open question above).
+	switch mode {
+	case ClassicATE:
+		h := []ondatra.Header{
+			ondatra.NewEthernetHeader(),
+			ondatra.NewIPv4Header().WithDSCP(dscp), // TODO(robjs); set IP protocol
+			ondatra.NewIPv4Header(),
+		}
+		f.ate.WithHeaders(h...)
+	case OTG:
+		f.otg.Packet().Add().Ethernet()
+		f.otg.Packet().Add().Ipv4().SetProtocol(gosnappi.NewPatternFlowIpv4Protocol().SetValue(40))
+		f.otg.Packet().Add().Ipv4()
+	}
+	return f
+}

--- a/absate/absate.go
+++ b/absate/absate.go
@@ -91,8 +91,11 @@ func NewDevice(d *ondatra.ATEDevice) *ATE {
 
 // AddFlow adds a flow to the ATE with the specified name.
 func (a *ATE) AddFlow(name string) *Flow {
-	f := newFlow(a, name)
-	return f
+	return newFlow(a, name)
+}
+
+func (a *ATE) WithBGP() *BGP {
+	return newBGP(a)
 }
 
 // StartTraffic starts traffic flowing for the flow specified.
@@ -109,6 +112,7 @@ func (a *ATE) StartTraffic(t testing.TB) {
 	}
 }
 
+// StopTraffic stops traffic that is running on the abstract ATE.
 func (a *ATE) StopTraffic(t testing.TB) {
 	switch mode {
 	case ClassicATE:
@@ -160,3 +164,32 @@ func (f *Flow) IPinIPTunnel(dscp uint8) *Flow {
 	}
 	return f
 }
+
+/*type BGP struct {
+	parent *ATE
+
+	otg gosnappi.DeviceBgpRouter
+}
+
+func newBGP(a *ATE, devName string) *BGP {
+	b := &BGP{
+		parent: a,
+	}
+	switch mode {
+	case ClassicATE:
+	case OTG:
+		b.otg = a.otg.Devices().Add().SetName(devName).Bgp()
+	}
+	return b
+}
+
+func (b *BGP) ExternalIPv4Peer() *IPv4BGPPeer {
+
+}
+
+
+type IPv4BGPPeer struct {
+	parent *ATE
+
+	otg gosnappi.BgpV4Peer
+}*/

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
+	github.com/open-traffic-generator/snappi v0.7.13 // indirect
 	github.com/open-traffic-generator/snappi/gosnappi v0.7.6 // indirect
 	github.com/openconfig/gnmi v0.0.0-20220131173555-39aa74195f0d // indirect
 	github.com/openconfig/gnoi v0.0.0-20220131192435-7dd3a95a4f1e // indirect

--- a/go.sum
+++ b/go.sum
@@ -538,6 +538,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
+github.com/open-traffic-generator/snappi v0.7.13 h1:BFZLsH3dSvGeJrmk5sTHh2o2TSFv/SneCe6SsDsKDF0=
+github.com/open-traffic-generator/snappi v0.7.13/go.mod h1:0IMUmI+4r3MYEST2V9xmgEByPVule4ByILHmtgIp8OM=
 github.com/open-traffic-generator/snappi/gosnappi v0.7.6 h1:6o7CcRUF6MDCO7aGMfVYHH+KDvfzBTZV3bObOB73FXg=
 github.com/open-traffic-generator/snappi/gosnappi v0.7.6/go.mod h1:yy1mdBicujeM24qLEEz+DDqCazoeg4yXTJjOKeiSUr4=
 github.com/openconfig/gnmi v0.0.0-20200414194230-1597cc0f2600/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=


### PR DESCRIPTION
This draft PR providea a discussion point (WIP) for the way that we might implement an abstraction specifically for WBB tests that allows for use of both the ATE and OTG APIs whilst we wait for there to be common support for OTG.

At the moment, this is a FYI PR, but as we answer some of the questions (e.g., what the future of `ondatra.ATETopology` is, I'll firm something up into a proposal here.

One large open question is how we want to test this code, to some extent it's going to be tested by running the tests - and tests of this code will generally be assertions that ATE and gosnappi work as expected, so I'm erring towards not writing a lot of change detector tests, and only adding tests where there's real logic in this package.

```
 * (A) absate/absate.go
   - Initial wrapper for simple parts of the ATE API to demonstrate how
     we might run tests against ATE and OTG APIs.
 * (M) go.(mod|sum)
   - Add dependency on gosnappi.
```
