### PR TITLE
change ondatra version to the latest to enable cisco nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/go-cmp v0.5.7
 	github.com/openconfig/gnmi v0.0.0-20220131173555-39aa74195f0d
 	github.com/openconfig/goyang v0.4.0
-	github.com/openconfig/ondatra v0.0.0-20220202213352-565fe6df0714
+	github.com/openconfig/ondatra v0.0.0-20220215004306-0347c0155153
 	github.com/openconfig/ygot v0.14.0
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20220131092820-39736dd543b4
 	github.com/stretchr/testify v1.7.0
@@ -19,7 +19,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/kne v0.1.0 // indirect
+	github.com/google/kne v0.1.1-0.20220209214853-52a824020cd9 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -377,6 +377,8 @@ github.com/google/kne v0.0.0-20210909173245-efe949af4d64/go.mod h1:UXwGTvXQFvbjr
 github.com/google/kne v0.0.0-20211025172831-8c56d03dfbb6/go.mod h1:KWLSJWWQdKxjBr9fjCajpLpgeOM4o7T6qZW9G2izTq8=
 github.com/google/kne v0.1.0 h1:QuWIuwVFECJbL6XmMkQ7XU2hJFVSHQpIDMQRhFKPOQY=
 github.com/google/kne v0.1.0/go.mod h1:gesoiRVSXABO6WIXHK7S5ypBIZWJibOXW4itpy8/flk=
+github.com/google/kne v0.1.1-0.20220209214853-52a824020cd9 h1:YQai/7SCy+lmD3K5Wec3TZOVP/BRNEbPJ+ng01BerfI=
+github.com/google/kne v0.1.1-0.20220209214853-52a824020cd9/go.mod h1:ft4KFTJPSkXkThiTo/qZ3POazOIZv3aDuHzBuC5zVYw=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -572,6 +574,8 @@ github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d h1:zrs4U92QE
 github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d/go.mod h1:x9tAZ4EwqCQ0jI8D6S8Yhw9Z0ee7/BxWQX0k0Uib5Q8=
 github.com/openconfig/ondatra v0.0.0-20220202213352-565fe6df0714 h1:Byg5YuafgHH2Vd8ee8uWRaiNWr1STykDsjFpnwIMyOY=
 github.com/openconfig/ondatra v0.0.0-20220202213352-565fe6df0714/go.mod h1:iRNIRSC5S/8hrLff/vPisXkJUdTc7qtLijoX8L/YzTw=
+github.com/openconfig/ondatra v0.0.0-20220215004306-0347c0155153 h1:7nhLIgwIIlRJ/gv6/2vuZRQwRRxKgwpNgCOodF3SuNw=
+github.com/openconfig/ondatra v0.0.0-20220215004306-0347c0155153/go.mod h1:CRpcUdEnn6GFGGoRsBn7Ug2p2cjJeA9bEbtZztYZeSM=
 github.com/openconfig/ygot v0.6.0/go.mod h1:o30svNf7O0xK+R35tlx95odkDmZWS9JyWWQSmIhqwAs=
 github.com/openconfig/ygot v0.10.4/go.mod h1:oCQNdXnv7dWc8scTDgoFkauv1wwplJn5HspHcjlxSAQ=
 github.com/openconfig/ygot v0.14.0 h1:oSNgKAeDPZ45oRWY0ENIHV6Xm8amOnL6lftRBoxKi40=

--- a/topologies/binding/binding.go
+++ b/topologies/binding/binding.go
@@ -46,7 +46,7 @@ var _ = binding.Binding(&staticBind{})
 
 const resvID = "STATIC"
 
-func (b *staticBind) Reserve(ctx context.Context, tb *opb.Testbed, runTime, waitTime time.Duration) (*binding.Reservation, error) {
+func (b *staticBind) Reserve(ctx context.Context, tb *opb.Testbed, runTime, waitTime time.Duration, partial map[string]string) (*binding.Reservation, error) {
 	if b.resv != nil {
 		return nil, fmt.Errorf("only one reservation is allowed")
 	}
@@ -74,7 +74,7 @@ func (b *staticBind) FetchReservation(ctx context.Context, id string) (*binding.
 	return b.resv, nil
 }
 
-func (b *staticBind) PushConfig(ctx context.Context, dut *binding.DUT, config string, opts *binding.ConfigOptions) error {
+func (b *staticBind) PushConfig(ctx context.Context, dut *binding.DUT, config string, reset bool) error {
 	// If really needed, implement this using SSH cli.
 	return errors.New("featureprofiles tests should use gNMI, not PushConfig")
 }

--- a/topologies/binding/binding_test.go
+++ b/topologies/binding/binding_test.go
@@ -37,7 +37,7 @@ func TestReserveFetchRelease(t *testing.T) {
 		t.Error("Release should fail before reservation is made.")
 	}
 
-	resv, err := b.Reserve(ctx, tb, 0, 0)
+	resv, err := b.Reserve(ctx, tb, 0, 0, nil)
 	if err != nil {
 		t.Fatalf("Could not reserve testbed: %v", err)
 	}


### PR DESCRIPTION
This commit changes the ondatra version to the latest to enable cisco nodes.