### PR TITLE
Initial featureprofile for gNMI's `Get` RPC

### DIFF
--- a/cloudbuild/arista.sh
+++ b/cloudbuild/arista.sh
@@ -28,6 +28,6 @@ password: admin
 topology: ${PWD}/topologies/kne/arista_ceos.textproto
 cli: ${HOME}/go/bin/kne_cli
 EOF
-go test -v feature/system/tests/*.go -config "$PWD"/topologies/kne/testbed.kne.yml -testbed "$PWD"/topologies/dut.testbed
-go test -v feature/system/ntp/tests/*.go -config "$PWD"/topologies/kne/testbed.kne.yml -testbed "$PWD"/topologies/dut.testbed
+go test -v feature/system/tests/*.go -kne-config "$PWD"/topologies/kne/testbed.kne.yml -testbed "$PWD"/topologies/dut.testbed
+go test -v feature/system/ntp/tests/*.go -kne-config "$PWD"/topologies/kne/testbed.kne.yml -testbed "$PWD"/topologies/dut.testbed
 popd

--- a/feature/system/gnmi/feature.textproto
+++ b/feature/system/gnmi/feature.textproto
@@ -1,0 +1,32 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id {
+  name: "gnmi_base"
+  version: 1
+}
+
+config_path {
+  path: "/system/grpc-servers/grpc-server/config/name"
+}
+config_path {
+  # value GNMI only.
+  path: "/system/grpc-servers/grpc-server/config/services"
+}
+config_path {
+  path: "/system/grpc-servers/grpc-server/config/enable"
+}
+config_path {
+  path: "/system/grpc-servers/grpc-server/config/port"
+}

--- a/feature/system/gnmi/get/feature.textproto
+++ b/feature/system/gnmi/get/feature.textproto
@@ -1,0 +1,22 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id {
+  name: "gnmi_get"
+  version: 1
+}
+
+gnmi_service {
+  method_name: MD_GET
+}

--- a/feature/system/gnmi/get/tests/get_test.go
+++ b/feature/system/gnmi/get/tests/get_test.go
@@ -17,62 +17,121 @@
 package system_gnmi_get_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/ondatra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
 
-  gpb "github.com/openconfig/gnmi"
-
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
 )
+
+func TestMain(m *testing.M) {
+	fptest.RunTests(m)
+}
 
 func TestGNMIGet(t *testing.T) {
 	tests := []struct {
 		desc            string
 		inGetRequest    *gpb.GetRequest
 		wantGetResponse *gpb.GetResponse
-		wantErrCode     status.Status
-		cmpOpts         []cmp.Opt
-		chkFn           func(*testing.T, *spb.GetResponse)
+		wantErrCode     codes.Code
+		cmpOpts         []cmp.Option
+		chkFn           func(*testing.T, *gpb.GetResponse)
 	}{{
-		desc:            "single response for /",
-		inGetRequest:    &gpb.GetRequest{
-      Prefix: &gpb.Path{
-        Origin: "openconfig",
-      },
-      Path: []*gpb.Path{{
-        // empty path indicates the root.
-      }},
-      Encoding: gpb.JSON_IETF,
-    },
-		wantGetResponse: &gpb.GetResponse{},
+		desc: "single response for /",
+		inGetRequest: &gpb.GetRequest{
+			Prefix: &gpb.Path{
+				Origin: "openconfig",
+			},
+			Path: []*gpb.Path{{
+				// empty path indicates the root.
+			}},
+			Encoding: gpb.Encoding_JSON_IETF,
+		},
+		wantGetResponse: &gpb.GetResponse{
+			Notification: []*gpb.Notification{{
+				Update: []*gpb.Update{{
+					Path: &gpb.Path{},
+				}},
+			}},
+		},
+		cmpOpts: []cmp.Option{
+			protocmp.IgnoreFields(&gpb.GetResponse{}, "notification"),
+		},
 	}}
+
+	shortResponse := func(g *gpb.GetResponse) string {
+		p := proto.Clone(g).(*gpb.GetResponse)
+		for _, n := range p.Notification {
+			for _, u := range n.Update {
+				u.Val = nil
+			}
+		}
+		return prototext.Format(p)
+	}
 
 	for _, tt := range tests {
 		dut := ondatra.DUT(t, "dut")
 		gnmiC := dut.RawAPIs().GNMI().New(t)
 
 		t.Run(tt.desc, func(t *testing.T) {
-			got, err := gnmiC.Get(context.Background(), tt.inGetRequest)
+			gotRes, err := gnmiC.Get(context.Background(), tt.inGetRequest)
 			switch {
 			case err == nil && tt.wantErrCode != codes.OK:
 				t.Fatalf("did not get expected error, got: %v, want: %v", err, tt.wantErrCode)
-			case err != nil && tt.wantErrcode == codes.OK:
+			case err != nil && tt.wantErrCode == codes.OK:
 				t.Fatalf("got unexpected error, got: %v, want OK", err)
 			case err != nil:
-				s, sErr := status.FromError(err)
-				if sErr != nil {
-					t.Fatalf("error returned was not a status, got: %T, err: %v", err, sErr)
+				s, ok := status.FromError(err)
+				if !ok {
+					t.Fatalf("error returned was not a status, got: %T", err)
 				}
 				if got, want := s.Code(), tt.wantErrCode; got != want {
 					t.Fatalf("did not get expected error code, got: %v, want: %v", got, want)
 				}
 			}
 
-			if diff := cmp.Diff(got, tt.wantGetResponse, tt.cmpOpts...); diff != "" {
-				t.Fatalf("did not get expected error, diff(-got,+want):\n%s", diff)
+			if got, want := len(gotRes.Notification), len(tt.wantGetResponse.Notification); got != want {
+				t.Fatalf("did not get expected number of Notification fields, got: %d, want: %d", got, want)
 			}
 
-			chkFn(t, got)
+			found := map[*gpb.Path]bool{}
+			for _, n := range tt.wantGetResponse.Notification {
+				for _, u := range n.Update {
+					found[u.Path] = false
+				}
+			}
+
+			for _, n := range gotRes.Notification {
+				// TODO(robjs): today this is not specified in the spec, but means that there can be >1 update where the path does
+				// not match what the target responded.
+				if len(n.Update) != 1 {
+					t.Fatalf("did not get expected number of updates per Notification, got: %d (%v), want: 1", len(n.Update), shortResponse(gotRes))
+				}
+				msg := n.Update[0]
+
+				seen, ok := found[msg.Path]
+				if !ok {
+					t.Errorf("found unexpected path %v in Notifications, got: %v", msg.Path, shortResponse(gotRes))
+				}
+				if seen {
+					t.Errorf("saw repeated path %v in Notifications, got: %v", msg.Path, shortResponse(gotRes))
+				}
+				found[msg.Path] = true
+			}
+
+			for p, ok := range found {
+				if !ok {
+					t.Errorf("did not find path %v in Notifications, got: %v", p, shortResponse(gotRes))
+				}
+			}
 		})
 	}
 }

--- a/feature/system/gnmi/get/tests/get_test.go
+++ b/feature/system/gnmi/get/tests/get_test.go
@@ -1,0 +1,78 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package system_gnmi_get_test
+
+import (
+	"testing"
+
+	"github.com/openconfig/ondatra"
+
+  gpb "github.com/openconfig/gnmi"
+
+)
+
+func TestGNMIGet(t *testing.T) {
+	tests := []struct {
+		desc            string
+		inGetRequest    *gpb.GetRequest
+		wantGetResponse *gpb.GetResponse
+		wantErrCode     status.Status
+		cmpOpts         []cmp.Opt
+		chkFn           func(*testing.T, *spb.GetResponse)
+	}{{
+		desc:            "single response for /",
+		inGetRequest:    &gpb.GetRequest{
+      Prefix: &gpb.Path{
+        Origin: "openconfig",
+      },
+      Path: []*gpb.Path{{
+        // empty path indicates the root.
+      }},
+      Encoding: gpb.JSON_IETF,
+    },
+		wantGetResponse: &gpb.GetResponse{},
+	}}
+
+	for _, tt := range tests {
+		dut := ondatra.DUT(t, "dut")
+		gnmiC := dut.RawAPIs().GNMI().New(t)
+
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := gnmiC.Get(context.Background(), tt.inGetRequest)
+			switch {
+			case err == nil && tt.wantErrCode != codes.OK:
+				t.Fatalf("did not get expected error, got: %v, want: %v", err, tt.wantErrCode)
+			case err != nil && tt.wantErrcode == codes.OK:
+				t.Fatalf("got unexpected error, got: %v, want OK", err)
+			case err != nil:
+				s, sErr := status.FromError(err)
+				if sErr != nil {
+					t.Fatalf("error returned was not a status, got: %T, err: %v", err, sErr)
+				}
+				if got, want := s.Code(), tt.wantErrCode; got != want {
+					t.Fatalf("did not get expected error code, got: %v, want: %v", got, want)
+				}
+			}
+
+			if diff := cmp.Diff(got, tt.wantGetResponse, tt.cmpOpts...); diff != "" {
+				t.Fatalf("did not get expected error, diff(-got,+want):\n%s", diff)
+			}
+
+			chkFn(t, got)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,17 +6,20 @@ require (
 	github.com/golang/glog v1.0.0
 	github.com/google/go-cmp v0.5.7
 	github.com/openconfig/gnmi v0.0.0-20220131173555-39aa74195f0d
+	github.com/openconfig/gnoi v0.0.0-20220131192435-7dd3a95a4f1e
 	github.com/openconfig/goyang v0.4.0
+	github.com/openconfig/gribi v0.1.1-0.20210423184541-ce37eb4ba92f
 	github.com/openconfig/ondatra v0.0.0-20220202213352-565fe6df0714
 	github.com/openconfig/ygot v0.14.0
+	github.com/p4lang/p4runtime v1.3.0
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20220131092820-39736dd543b4
-	github.com/stretchr/testify v1.7.0
+	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838
+	google.golang.org/grpc v1.44.0
 	google.golang.org/protobuf v1.27.1
 )
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/kne v0.1.0 // indirect
@@ -26,21 +29,14 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/open-traffic-generator/snappi/gosnappi v0.7.12 // indirect
-	github.com/openconfig/gnoi v0.0.0-20220131192435-7dd3a95a4f1e // indirect
-	github.com/openconfig/gribi v0.1.1-0.20210423184541-ce37eb4ba92f // indirect
-	github.com/p4lang/p4runtime v1.3.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20220203182621-f4ae394cde3f // indirect
-	google.golang.org/grpc v1.44.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/proto/feature.proto
+++ b/proto/feature.proto
@@ -65,6 +65,25 @@ message GNOIService {
   optional string method_name = 2;
 }
 
+// GNMIService describes compliance with the gNMI service.
+message GNMIService {
+  // method_name specifies the name of the method that is
+  // being tested. The methods are from the gnmi service (e.g., Get).
+  enum Method {
+    MD_INVALID = 0;
+    MD_GET = 1;           // gNMI.Get
+    MD_CAPABILITIES = 2;  // gNMI.Capabilities
+    MD_SUBSCRIBE = 3;     // gNMI.Subscribe
+    MD_SET = 4;           // gNMI.Set
+  }
+
+  // The method that is covered within the gNMI protocol.
+  optional Method method_name = 2;
+  
+  // TODO(robjs): for some RPCs, like Subscribe, we may want
+  // further description of modes (e.g., POLL, STREAM, ONCE).
+}
+
 message FeatureProfile {
   // Unique identifier for the service profile.
   optional FeatureProfileID id = 1;


### PR DESCRIPTION
```
    Initial (basic) test for gNMI Get RPC.
    
     * (M) proto/feature.proto
        - Add support for specifying a method of the gNMI protocol that
          coverage is being implemented for.
     * (M) feature/system/gnmi/feature.textproto
        - Add feature profile for basic gNMI.
     * (M) feature/system/gnmi/get/...
        - Add feature profile for gNMI Get.
        - Add initial functional tests for gNMI Get against the root.
```