### PR TITLE
Update tests to use fptest vs. ondatra.RunTests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ EOF
 ```
 Testing
 ```
-go test -v feature/system/system_base/tests/*.go -config $PWD/topologies/kne/testbed.kne.yml -testbed $PWD/topologies/dut.testbed
+go test -v feature/system/tests/*.go -kne-config $PWD/topologies/kne/testbed.kne.yml -testbed $PWD/topologies/dut.testbed
 ```
 
 Cleanup
@@ -63,7 +63,7 @@ EOF
 
 Testing
 ```
-go test -v feature/system/system_base/tests/*.go -config $PWD/topologies/kne/testbed.kne.yml -testbed $PWD/topologies/dut.testbed
+go test -v feature/system/tests/*.go -kne-config $PWD/topologies/kne/testbed.kne.yml -testbed $PWD/topologies/dut.testbed
 ```
 
 Cleanup

--- a/cloudbuild/arista.sh
+++ b/cloudbuild/arista.sh
@@ -28,6 +28,6 @@ password: admin
 topology: ${PWD}/topologies/kne/arista_ceos.textproto
 cli: ${HOME}/go/bin/kne_cli
 EOF
-go test -v feature/system/tests/*.go -config "$PWD"/topologies/kne/testbed.kne.yml -testbed "$PWD"/topologies/dut.testbed
-go test -v feature/system/ntp/tests/*.go -config "$PWD"/topologies/kne/testbed.kne.yml -testbed "$PWD"/topologies/dut.testbed
+go test -v feature/system/tests/*.go -kne-config "$PWD"/topologies/kne/testbed.kne.yml -testbed "$PWD"/topologies/dut.testbed
+go test -v feature/system/ntp/tests/*.go -kne-config "$PWD"/topologies/kne/testbed.kne.yml -testbed "$PWD"/topologies/dut.testbed
 popd

--- a/feature/system/ntp/tests/system_ntp_test.go
+++ b/feature/system/ntp/tests/system_ntp_test.go
@@ -19,12 +19,12 @@ package system_ntp_test
 import (
 	"testing"
 
+	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/ondatra"
-	kinit "github.com/openconfig/ondatra/knebind/init"
 )
 
 func TestMain(m *testing.M) {
-	ondatra.RunTests(m, kinit.Init)
+	fptest.RunTests(m)
 }
 
 // TestNtpEnable validates the NTP enable path does not return an error.

--- a/feature/system/tests/system_base_test.go
+++ b/feature/system/tests/system_base_test.go
@@ -19,10 +19,9 @@ package system_base_test
 import (
 	"testing"
 
-	"github.com/openconfig/ondatra"
-	kinit "github.com/openconfig/ondatra/knebind/init"
+	"github.com/openconfig/featureprofiles/internal/fptest"
 )
 
 func TestMain(m *testing.M) {
-	ondatra.RunTests(m, kinit.Init)
+	fptest.RunTests(m)
 }


### PR DESCRIPTION
```
* (M) README.md
   - Update README contents to reflect changes required to CLI by
     fptest.
 * (M) feature/system.../*.go
   - Replace ondatra.RunTests with fptest.RunTests.
```
