### PR TITLE
Enable AFT and IP routing by default for EOS

### DIFF
--- a/topologies/kne/arista_ceos.config
+++ b/topologies/kne/arista_ceos.config
@@ -38,7 +38,14 @@ management security
    ssl profile octa-ssl-profile
       certificate gnmiCert.pem key gnmiCertKey.pem
 !
-no ip routing
+management api models
+   provider aft
+      ipv4-unicast
+      ipv6-unicast
+!
+ip routing
+!
+ipv6 unicast-routing
 !
 aaa authorization exec default local
 !


### PR DESCRIPTION
This is a prereq for GRIBI/AFT testing