### PR TITLE
Add DUT<->DUT BGP test

### DIFF
--- a/feature/bgp/tests/local_bgp_test/local_bgp_test.go
+++ b/feature/bgp/tests/local_bgp_test/local_bgp_test.go
@@ -1,0 +1,312 @@
+// Copyright 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localbgp_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openconfig/featureprofiles/internal/attrs"
+	"github.com/openconfig/featureprofiles/internal/confirm"
+	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/telemetry"
+	"github.com/openconfig/ygot/ygot"
+)
+
+func TestMain(m *testing.M) {
+	fptest.RunTests(m)
+}
+
+var (
+	dutAttrs = attrs.Attributes{
+		Desc:    "To ATE",
+		IPv4:    "192.0.2.1",
+		IPv4Len: 30,
+	}
+	ateAttrs = attrs.Attributes{
+		Desc:    "To DUT",
+		IPv4:    "192.0.2.2",
+		IPv4Len: 30,
+	}
+)
+
+const (
+	dutAS = 64500
+	ateAS = 64501
+)
+
+func bgpWithNbr(as uint32, routerID string, nbr *telemetry.NetworkInstance_Protocol_Bgp_Neighbor) *telemetry.NetworkInstance_Protocol_Bgp {
+	bgp := &telemetry.NetworkInstance_Protocol_Bgp{}
+	bgp.GetOrCreateGlobal().As = ygot.Uint32(as)
+	if routerID != "" {
+		bgp.Global.RouterId = ygot.String(routerID)
+	}
+	bgp.AppendNeighbor(nbr)
+	return bgp
+}
+
+func TestEstablish(t *testing.T) {
+	// Configure interfaces
+	dut := ondatra.DUT(t, "dut1")
+	dutPortName := dut.Port(t, "port1").Name()
+	intf1 := dutAttrs.NewInterface(dutPortName)
+	dut.Config().Interface(intf1.GetName()).Replace(t, intf1)
+	ate := ondatra.DUT(t, "dut2")
+	atePortName := ate.Port(t, "port1").Name()
+	intf2 := ateAttrs.NewInterface(atePortName)
+	ate.Config().Interface(intf2.GetName()).Replace(t, intf2)
+	// Get BGP paths
+	dutConfPath := dut.Config().NetworkInstance("default").Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	ateConfPath := ate.Config().NetworkInstance("default").Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	statePath := dut.Telemetry().NetworkInstance("default").Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	nbrPath := statePath.Neighbor(ateAttrs.IPv4)
+	// Remove any existing BGP config
+	dutConfPath.Replace(t, nil)
+	ateConfPath.Replace(t, nil)
+	startTime := uint64(time.Now().Unix())
+	// Start a new session
+	dutConf := bgpWithNbr(dutAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+		PeerAs:          ygot.Uint32(dutAS),
+		NeighborAddress: ygot.String(ateAttrs.IPv4),
+	})
+	ateConf := bgpWithNbr(dutAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+		PeerAs:          ygot.Uint32(dutAS),
+		NeighborAddress: ygot.String(dutAttrs.IPv4),
+	})
+	dutConfPath.Replace(t, dutConf)
+	ateConfPath.Replace(t, ateConf)
+	nbrPath.SessionState().Await(t, time.Second*15, telemetry.Bgp_Neighbor_SessionState_ESTABLISHED)
+
+	dutState := statePath.Get(t)
+	confirm.State(t, dutConf, dutState)
+	nbr := dutState.GetNeighbor(ateAttrs.IPv4)
+
+	if !nbr.GetEnabled() {
+		t.Errorf("Expected neighbor %v to be enabled", ateAttrs.IPv4)
+	}
+	if got, want := nbr.GetLastEstablished(), startTime*1000000000; got < want {
+		t.Errorf("Bad last-established timestamp: got %v, want >= %v", got, want)
+	}
+	if got := nbr.GetEstablishedTransitions(); got != 1 {
+		t.Errorf("Wrong established-transitions: got %v, want 1", got)
+	}
+
+	capabilities := map[telemetry.E_BgpTypes_BGP_CAPABILITY]bool{
+		telemetry.BgpTypes_BGP_CAPABILITY_ROUTE_REFRESH: false,
+		telemetry.BgpTypes_BGP_CAPABILITY_ASN32:         false,
+		telemetry.BgpTypes_BGP_CAPABILITY_MPBGP:         false,
+	}
+	for _, cap := range nbrPath.SupportedCapabilities().Get(t) {
+		capabilities[cap] = true
+	}
+	for cap, present := range capabilities {
+		if !present {
+			t.Errorf("Capability not reported: %v", cap)
+		}
+	}
+}
+
+func TestDisconnect(t *testing.T) {
+	dut := ondatra.DUT(t, "dut1")
+	ate := ondatra.DUT(t, "dut2")
+	dutConfPath := dut.Config().NetworkInstance("default").Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	ateConfPath := ate.Config().NetworkInstance("default").Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	statePath := dut.Telemetry().NetworkInstance("default").Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	ateIP := ateAttrs.IPv4
+	dutIP := dutAttrs.IPv4
+	nbrPath := statePath.Neighbor(ateIP)
+
+	// Clear any existing config
+	dutConfPath.Replace(t, nil)
+	ateConfPath.Replace(t, nil)
+
+	// Apply simple config
+	dutConf := bgpWithNbr(dutAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+		PeerAs:          ygot.Uint32(dutAS),
+		NeighborAddress: ygot.String(ateIP),
+	})
+	ateConf := bgpWithNbr(dutAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+		PeerAs:          ygot.Uint32(dutAS),
+		NeighborAddress: ygot.String(dutIP),
+	})
+	dutConfPath.Replace(t, dutConf)
+	ateConfPath.Replace(t, ateConf)
+	nbrPath.SessionState().Await(t, time.Second*15, telemetry.Bgp_Neighbor_SessionState_ESTABLISHED)
+	// ateConfPath.Replace(t, nil)
+	ateConfPath.Neighbor(dutIP).Enabled().Replace(t, false)
+	nbrPath.SessionState().Await(t, time.Second*15, telemetry.Bgp_Neighbor_SessionState_ACTIVE)
+	code := nbrPath.Messages().Received().LastNotificationErrorCode().Get(t)
+	if code != telemetry.BgpTypes_BGP_ERROR_CODE_CEASE {
+		t.Errorf("On disconnect: expected error code %v, got %v", telemetry.BgpTypes_BGP_ERROR_CODE_CEASE, code)
+	}
+}
+
+func TestParameters(t *testing.T) {
+	ateIP := ateAttrs.IPv4
+	dutIP := dutAttrs.IPv4
+	dut := ondatra.DUT(t, "dut1")
+	ate := ondatra.DUT(t, "dut2")
+	dutConfPath := dut.Config().NetworkInstance("default").Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	ateConfPath := ate.Config().NetworkInstance("default").Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	statePath := dut.Telemetry().NetworkInstance("default").Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	nbrPath := statePath.Neighbor(ateIP)
+
+	cases := []struct {
+		name      string
+		dutConf   *telemetry.NetworkInstance_Protocol_Bgp
+		ateConf   *telemetry.NetworkInstance_Protocol_Bgp
+		wantState *telemetry.NetworkInstance_Protocol_Bgp
+		skipMsg   string
+	}{
+		{
+			name: "basic internal",
+			dutConf: bgpWithNbr(dutAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(dutAS),
+				NeighborAddress: ygot.String(ateIP),
+			}),
+			ateConf: bgpWithNbr(dutAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(dutAS),
+				NeighborAddress: ygot.String(dutIP),
+			}),
+		},
+		{
+			name: "basic external",
+			dutConf: bgpWithNbr(dutAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(ateAS),
+				NeighborAddress: ygot.String(ateIP),
+			}),
+			ateConf: bgpWithNbr(ateAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(dutAS),
+				NeighborAddress: ygot.String(dutIP),
+			}),
+		},
+		{
+			name: "explicit AS",
+			dutConf: bgpWithNbr(dutAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				LocalAs:         ygot.Uint32(100),
+				PeerAs:          ygot.Uint32(ateAS),
+				NeighborAddress: ygot.String(ateIP),
+			}),
+			ateConf: bgpWithNbr(ateAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(100),
+				NeighborAddress: ygot.String(dutIP),
+			}),
+		},
+		{
+			name: "explicit router id",
+			dutConf: bgpWithNbr(dutAS, dutIP, &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(ateAS),
+				NeighborAddress: ygot.String(ateIP),
+			}),
+			ateConf: bgpWithNbr(ateAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(dutAS),
+				NeighborAddress: ygot.String(dutIP),
+			}),
+		},
+		{
+			name: "password",
+			dutConf: bgpWithNbr(dutAS, dutIP, &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(ateAS),
+				NeighborAddress: ygot.String(ateIP),
+				AuthPassword:    ygot.String("password"),
+			}),
+			ateConf: bgpWithNbr(ateAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(dutAS),
+				NeighborAddress: ygot.String(dutIP),
+				AuthPassword:    ygot.String("password"),
+			}),
+		},
+		{
+			name: "hold-time",
+			dutConf: bgpWithNbr(dutAS, dutIP, &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(ateAS),
+				NeighborAddress: ygot.String(ateIP),
+				Timers: &telemetry.NetworkInstance_Protocol_Bgp_Neighbor_Timers{
+					HoldTime:          ygot.Float64(100),
+					KeepaliveInterval: ygot.Float64(50),
+				},
+			}),
+			ateConf: bgpWithNbr(ateAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(dutAS),
+				NeighborAddress: ygot.String(dutIP),
+			}),
+		},
+		{
+			name: "connect-retry",
+			dutConf: bgpWithNbr(dutAS, dutIP, &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(ateAS),
+				NeighborAddress: ygot.String(ateIP),
+				Timers: &telemetry.NetworkInstance_Protocol_Bgp_Neighbor_Timers{
+					ConnectRetry: ygot.Float64(100),
+				},
+			}),
+			ateConf: bgpWithNbr(ateAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(dutAS),
+				NeighborAddress: ygot.String(dutIP),
+			}),
+			skipMsg: "Not currently supported by EOS (see b/186141921)",
+		},
+		{
+			name: "hold time negotiated",
+			dutConf: bgpWithNbr(dutAS, dutIP, &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(ateAS),
+				NeighborAddress: ygot.String(ateIP),
+				Timers: &telemetry.NetworkInstance_Protocol_Bgp_Neighbor_Timers{
+					HoldTime:          ygot.Float64(100),
+					KeepaliveInterval: ygot.Float64(50),
+				},
+			}),
+			ateConf: bgpWithNbr(ateAS, "", &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(dutAS),
+				NeighborAddress: ygot.String(dutIP),
+				Timers: &telemetry.NetworkInstance_Protocol_Bgp_Neighbor_Timers{
+					HoldTime:          ygot.Float64(135),
+					KeepaliveInterval: ygot.Float64(45),
+				},
+			}),
+			wantState: bgpWithNbr(dutAS, dutIP, &telemetry.NetworkInstance_Protocol_Bgp_Neighbor{
+				PeerAs:          ygot.Uint32(ateAS),
+				NeighborAddress: ygot.String(ateIP),
+				Timers: &telemetry.NetworkInstance_Protocol_Bgp_Neighbor_Timers{
+					HoldTime:           ygot.Float64(100),
+					NegotiatedHoldTime: ygot.Float64(100),
+					KeepaliveInterval:  ygot.Float64(50),
+				},
+			}),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.skipMsg) > 0 {
+				t.Skip(tc.skipMsg)
+			}
+			// Disable BGP
+			dutConfPath.Replace(t, nil)
+			ateConfPath.Replace(t, nil)
+			// Renable and wait to establish
+			dutConfPath.Replace(t, tc.dutConf)
+			ateConfPath.Replace(t, tc.ateConf)
+			nbrPath.SessionState().Await(t, time.Second*30, telemetry.Bgp_Neighbor_SessionState_ESTABLISHED)
+			stateDut := statePath.Get(t)
+			wantState := tc.wantState
+			if wantState == nil {
+				// if you don't specify a wantState, we just validate that the state corresponding to each config value is what it should be.
+				wantState = tc.dutConf
+			}
+			confirm.State(t, wantState, stateDut)
+		})
+	}
+}

--- a/feature/bgp/tests/local_bgp_test/local_bgp_test.md
+++ b/feature/bgp/tests/local_bgp_test/local_bgp_test.md
@@ -1,0 +1,22 @@
+# Local BGP Test
+
+## Summary
+
+The local_bgp_test brings up two OpenConfig controlled devices and tests that a
+BGP session can be established between them.
+
+This test is suitable for running in a KNE environment.
+
+## Parameter Coverage
+*  /network-instances/network-instance/protocols/protocol/bgp/global/config/as
+*  /network-instances/network-instance/protocols/protocol/bgp/global/config/router-id
+*  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/config/auth-password
+*  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/config/local-as
+*  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/config/neighbor-address
+*  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/config/peer-as
+*  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/neighbor-address
+*  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/messages/received/last-notification-error-code
+*  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/session-state
+*  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/supported-capabilities
+*  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/timers/config/hold-time
+*  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/timers/config/keepalive-interval

--- a/internal/confirm/confirm.go
+++ b/internal/confirm/confirm.go
@@ -1,0 +1,133 @@
+// Copyright 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package confirm provides experimental assertion helpers.
+package confirm
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ondatra/telemetry"
+	"github.com/openconfig/ygot/ygot"
+	"github.com/openconfig/ygot/ytypes"
+)
+
+// getSchema looks up a struct's schema by reflected name
+func getSchema(s ygot.GoStruct) (*yang.Entry, error) {
+	typ := reflect.TypeOf(s)
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	typeName := typ.Name()
+	schema, ok := telemetry.SchemaTree[typeName]
+	if !ok {
+		return nil, fmt.Errorf("no schema for type %v", typeName)
+	}
+	return schema, nil
+}
+
+// PathLabel converts a gnmi Path to a string, or to an error indicator if that
+// fails.
+func PathLabel(pth *gnmipb.Path) string {
+	pstr, err := ygot.PathToString(pth)
+	if err != nil {
+		return fmt.Sprintf("<unstringable path: %v>", err)
+	}
+	return pstr
+}
+
+// getSingleValue is ytypes.GetNode, except it returns the Data of the single
+// node found, or an error if the number of matching nodes is not exactly 1.
+func getSingleValue(schema *yang.Entry, root ygot.GoStruct, pth *gnmipb.Path) (interface{}, error) {
+	vals, err := ytypes.GetNode(schema, root, pth)
+	if err != nil {
+		return nil, err
+	}
+	if len(vals) != 1 {
+		return nil, fmt.Errorf("expected exactly one value, found %v", len(vals))
+	}
+	return vals[0].Data, nil
+}
+
+// Change represents a difference in value at the gNMI path.
+type Change struct {
+	Path    *gnmipb.Path
+	Want    interface{}
+	Missing bool
+	Got     interface{}
+}
+
+// Readable is the same as fmt.Sprintf("%v", v), except that pointers to basic types will be
+// formatted as e.g. "&42" instead of "0xc0000b6020", so that error messages are not useless.
+func Readable(v interface{}) string {
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Ptr {
+		return fmt.Sprintf("&%v", val.Elem().Interface())
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+// ExtractChanges turns a Notification into a collection of Change objects.
+func ExtractChanges(diff *gnmipb.Notification, want, got ygot.GoStruct) ([]*Change, error) {
+	schema, err := getSchema(want)
+	if err != nil {
+		return nil, fmt.Errorf("schema lookup failure: %v", err)
+	}
+	var changes []*Change
+	for _, pth := range diff.GetDelete() {
+		wantVal, err := getSingleValue(schema, want, pth)
+		if err != nil {
+			return nil, fmt.Errorf("faild to parse expected value at path %v: %v", pth, err)
+		}
+		changes = append(changes, &Change{pth, wantVal, true, nil})
+	}
+	for _, upd := range diff.GetUpdate() {
+		pth := upd.GetPath()
+		gotVal, err := getSingleValue(schema, got, pth)
+		if err != nil {
+			return nil, fmt.Errorf("faild to parse received value at path %v: %v", pth, err)
+		}
+		wantVal, err := getSingleValue(schema, want, pth)
+		if err != nil {
+			return nil, fmt.Errorf("faild to parse expected value at path %v: %v", pth, err)
+		}
+		changes = append(changes, &Change{pth, wantVal, false, gotVal})
+	}
+	return changes, nil
+}
+
+// State checks that every set value in want is present in got. Extra fields in got will be ignored
+// (typically the state contains many more keys than just the ones we're setting).
+//
+// DEPRECATED: experimental function
+func State(t testing.TB, want, got ygot.GoStruct) {
+	t.Helper()
+	diff, err := ygot.Diff(want, got, &ygot.IgnoreAdditions{})
+	if err != nil {
+		t.Errorf("ygot.Diff failure: %v", err)
+		return
+	}
+	changes, err := ExtractChanges(diff, want, got)
+	if err != nil {
+		t.Errorf("Failed to compare states: %v", err)
+		return
+	}
+	for _, change := range changes {
+		t.Errorf("%v: got %v, want %v", PathLabel(change.Path), Readable(change.Got), Readable(change.Want))
+	}
+}

--- a/topologies/kne/arista_ceos_dutdut.textproto
+++ b/topologies/kne/arista_ceos_dutdut.textproto
@@ -1,0 +1,105 @@
+name: "arista-ceos-dutdut"
+nodes: {
+  name: "dut1"
+  type: ARISTA_CEOS
+  config: {
+    config_path: "/mnt/flash"
+    config_file: "startup-config"
+    file: "arista_ceos.config"
+    cert: {
+      self_signed: {
+        cert_name: "gnmiCert.pem"
+        key_name: "gnmiCertKey.pem"
+        key_size: 4096
+      }
+    }
+  }
+  services: {
+    key: 22
+    value: {
+      name: "ssh"
+      inside: 22
+      outside: 22
+    }
+  }
+  services: {
+    key: 6030
+    value: {
+      name: "gnmi"
+      inside: 6030
+      outside: 6030
+    }
+  }
+  services: {
+    key: 6040
+    value: {
+      name: "gribi"
+      inside: 6040
+      outside: 6040
+    }
+  }
+}
+nodes: {
+  name: "dut2"
+  type: ARISTA_CEOS
+  config: {
+    config_path: "/mnt/flash"
+    config_file: "startup-config"
+    file: "arista_ceos.config"
+    cert: {
+      self_signed: {
+        cert_name: "gnmiCert.pem"
+        key_name: "gnmiCertKey.pem"
+        key_size: 4096
+      }
+    }
+  }
+  services: {
+    key: 22
+    value: {
+      name: "ssh"
+      inside: 22
+      outside: 22
+    }
+  }
+  services: {
+    key: 6030
+    value: {
+      name: "gnmi"
+      inside: 6030
+      outside: 6030
+    }
+  }
+  services: {
+    key: 6040
+    value: {
+      name: "gribi"
+      inside: 6040
+      outside: 6040
+    }
+  }
+}
+links: {
+  a_node: "dut1"
+  a_int: "eth1"
+  z_node: "dut2"
+  z_int: "eth1"
+}
+links: {
+  a_node: "dut1"
+  a_int: "eth2"
+  z_node: "dut2"
+  z_int: "eth2"
+}
+links: {
+  a_node: "dut1"
+  a_int: "eth3"
+  z_node: "dut2"
+  z_int: "eth3"
+}
+links: {
+  a_node: "dut1"
+  a_int: "eth4"
+  z_node: "dut2"
+  z_int: "eth4"
+}


### PR DESCRIPTION
BGP protocol tests which can be run on two DUTs. The test is suitable
for use with KNE, which doesn't provide ATE nodes.

PiperOrigin-RevId: 433759028