### PR TITLE
Update Get test to reflect updated decisions on spec.

### DIFF
--- a/feature/system/gnmi/get/tests/get_test.go
+++ b/feature/system/gnmi/get/tests/get_test.go
@@ -18,7 +18,6 @@ package system_gnmi_get_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"

--- a/feature/system/gnmi/get/tests/get_test.go
+++ b/feature/system/gnmi/get/tests/get_test.go
@@ -37,12 +37,10 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	fmt.Printf("running test...")
 	fptest.RunTests(m)
 }
 
 func TestGNMIGet(t *testing.T) {
-
 	shortResponse := func(g *gpb.GetResponse) string {
 		p := proto.Clone(g).(*gpb.GetResponse)
 		for _, n := range p.Notification {
@@ -101,7 +99,6 @@ func TestGNMIGet(t *testing.T) {
 			protocmp.IgnoreFields(&gpb.GetResponse{}, "notification"),
 		},
 		chkFn: func(t *testing.T, res *gpb.GetResponse) {
-
 			d := &fpoc.Device{}
 			for _, n := range res.Notification {
 				for _, u := range n.Update {

--- a/feature/system/gnmi/get/tests/get_test.go
+++ b/feature/system/gnmi/get/tests/get_test.go
@@ -98,27 +98,22 @@ func TestGNMIGet(t *testing.T) {
 			protocmp.IgnoreFields(&gpb.GetResponse{}, "notification"),
 		},
 		chkFn: func(t *testing.T, res *gpb.GetResponse) {
-			var val *gpb.TypedValue
-			for _, n := range res.Notification {
-				for _, u := range n.Update {
-					// we know notification[0].update[0] is the contents of our Get in JSON.
-					val = u.Val
-					break
-				}
-			}
 
-			if val == nil {
-				t.Fatalf("did not get a valid update, got: %v", shortResponse(res))
-			}
-
-			jv := val.GetJsonIetfVal()
-			if jv == nil {
-				t.Fatalf("did not get JSON IETF value as expected, got:  %v", val)
-			}
 
 			d := &fpoc.Device{}
-			if err := fpoc.Unmarshal(jv, d, &ytypes.IgnoreExtraFields{}); err != nil {
-				t.Fatalf("did not get valid JSON IETF value, got err: %v", err)
+			s, err := fpoc.Schema()
+			if err != nil {
+				t.Fatalf("cannot get schema for fpoc root, got err: %v", err)
+			}
+
+			for _, n := range res.Notification {
+				for _, u := range n.Update {
+					// The updates here are all TypedValue JSON_IETF fields that should be
+					// unmarshallable using SetNode to the root (since the get is for /.
+					if err := ytypes.SetNode(s, d, u.Path, u.Val, &ytypes.IgnoreExtraFields{}); err != nil {
+						t.Fatalf("cannot call SetNode for path %s, err: %v", u.Path, err)
+					}
+				}
 			}
 		},
 	}}
@@ -148,43 +143,39 @@ func TestGNMIGet(t *testing.T) {
 				t.Fatalf("did not get expected number of Notification fields, got: %d, want: %d", got, want)
 			}
 
-			found := map[string]bool{}
-			for _, n := range tt.wantGetResponse.Notification {
-				for _, u := range n.Update {
-					p, err := ygot.PathToString(u.Path)
-					if err != nil {
-						t.Fatalf("cannot convert path %v to string, err: %v", u.Path, err)
-					}
-					found[p] = false
-				}
-			}
-
+			// Check semantics of the response that we received from the DUT independently of its contents.
+			// Must be one Notification per Path, and each Notification must contain the same path.
+			foundPaths := map[string]bool{}
 			for _, n := range gotRes.Notification {
-				// TODO(robjs): today this is not specified in the spec, but means that there can be >1 update where the path does
-				// not match what the target responded.
-				if len(n.Update) != 1 {
-					t.Fatalf("did not get expected number of updates per Notification, got: %d (%v), want: 1", len(n.Update), shortResponse(gotRes))
-				}
-				msg := n.Update[0]
+				var p *gpb.Path
+				for _, u := range n.Update {
+					if p == nil {
+						p = u.Path
+					}
+					if !proto.Equal(p, u.Path) {
+						t.Fatalf("got mixed paths within a single Notification, want: %v, got: %v", prototext.Marshal(p), prototext.Marshal(u.Path), shortRes(gotRes))
+					}
 
-				p, err := ygot.PathToString(msg.Path)
-				if err != nil {
-					t.Fatalf("cannot convert path %v to string, err: %v", msg.Path, err)
+					ps, err := ygot.PathToString(u.Path)
+					if err != nil {
+						t.Fatalf("got invalid path within an Update, got: %v, err: %v", prototext.Marshal(u.Path), err)
+					}
+					foundPaths[ps] = true
 				}
-
-				seen, ok := found[p]
-				if !ok {
-					t.Errorf("found unexpected path %v in Notifications, got: %v", msg.Path, shortResponse(gotRes))
-				}
-				if seen {
-					t.Errorf("saw repeated path %v in Notifications, got: %v", msg.Path, shortResponse(gotRes))
-				}
-				found[p] = true
 			}
 
-			for p, ok := range found {
-				if !ok {
-					t.Errorf("did not find path %v in Notifications, got: %v", p, shortResponse(gotRes))
+			if len(foundPaths) != len(tt.inGetRequest.Path) {
+				t.Fatalf("did not get expected number of paths, got: %d (%v), want: %d (%v)", len(foundPaths), foundPaths, len(tt.inGetRequest.Path), tt.inGetRequest.Path)
+			}
+
+			for _, p := range tt.inGetRequest.Path {
+				ps, err := ygot.PathToString(p)
+				if err != nil {
+					t.Fatalf("invalid path in input GetRequest, got: %v, err: %v", p, err)
+				}
+				if !foundPaths[ps] {
+					// this path wasn't present
+					t.Fatalf("did not get a response for path %s, got: nil", ps)
 				}
 			}
 


### PR DESCRIPTION
Previously, we had decided that the gNMI `Get` RPC should return exactly one `update` per `Notification`, and this was validated by the functional test in `feature/system/gnmi/get/tests/get_test.go`. We concluded that it should likely be able to support N different updates per notification as long as they:

 * have the same path
 * can be unmarshalled together

This test is the updated `Get` test to reflect this.

Passes against KNE:

```
[17:53] robjs@robjs0:github.com/openconfig/featureprofiles   update-get ✔                                                                                                                  44m ⚑ ◒  ⍉
▶ go test -v feature/system/gnmi/get/tests/*.go -kne-config $PWD/topologies/kne/testbed.kne.yml -testbed $PWD/topologies/dut.testbed
running test...
*** Reserving the testbed...


********************************************************************************

  Testbed Reservation Complete
  ID: 145a398f-4a6c-4141-8a69-8001e91789a7

    dut:              dut

********************************************************************************

=== RUN   TestGNMIGet
    get_test.go:123: 
        *** Creating gNMI client for dut...
        
        
=== RUN   TestGNMIGet/single_response_for_/
=== CONT  TestGNMIGet
    get_test.go:123: 
        *** Creating gNMI client for dut...
        
        
=== RUN   TestGNMIGet/response_for_/_honours_encoding
--- PASS: TestGNMIGet (0.18s)
    --- PASS: TestGNMIGet/single_response_for_/ (0.06s)
    --- PASS: TestGNMIGet/response_for_/_honours_encoding (0.08s)
PASS

*** Releasing the testbed...

ok  	command-line-arguments	1.355s
```