### PR TITLE
Adjust staticcheck CI settings to lower memory use

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Install go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.17'
+        go-version: '1.18'
     - name: Install protobuf
       uses: arduino/setup-protoc@v1
       with:
@@ -46,7 +46,7 @@ jobs:
     - name: Install go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.17'
+        go-version: '1.18'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Cache
@@ -55,6 +55,7 @@ jobs:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
+          ~/.cache/staticcheck
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
     - name: Fetch Openconfig Models
       run: make openconfig_public
@@ -67,7 +68,7 @@ jobs:
     - name: Install go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.17'
+        go-version: '1.18'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Cache
@@ -76,6 +77,7 @@ jobs:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
+          ~/.cache/staticcheck
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
     - name: Go vet
       run: go vet ./...
@@ -88,9 +90,4 @@ jobs:
     - name: Get staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@latest
     - name: Run staticcheck
-      run: |
-        checkstr=""
-        for i in `go list ./... | grep -v github.com/openconfig/featureprofiles/yang`; do
-          checkstr="$checkstr $i"
-        done
-        staticcheck $checkstr
+      run: GOGC=30 staticcheck ./...


### PR DESCRIPTION
Github runners have [7GB](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) of RAM allocated to them.  Static check analysis appears to exceed this limit and crashes sometimes.  This is mostly due to the large generated code in Ondatra/ygot that this repo uses heavily.

Static checks on my dev machine report the following stats:
```
/usr/bin/time -v staticcheck ./...
...
Elapsed (wall clock) time (h:mm:ss or m:ss): 10:07.36
Maximum resident set size (kbytes): 5965512
...
```

Adjusting the GOGC setting, we can lower the memory usage at the cost of some additional CPU time:
```
GOGC=30 /usr/bin/time -v staticcheck ./...
...
Elapsed (wall clock) time (h:mm:ss or m:ss): 11:14.21
Maximum resident set size (kbytes): 4088248
...
```

We can also get a big improvement by adding ~/.cache/staticcheck to the cache.  A cached run example:
```
GOGC=30 /usr/bin/time -v staticcheck ./...
...
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:02.77
Maximum resident set size (kbytes): 73468
...
