### PR TITLE
Delete VM resources on preempt action

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
     - USERNAME=user
     - SSH_ARGS=--internal-ip
     - INSTANCE_NAME=fp-build-arista-$BUILD_ID
-    - INSTANCE_ARGS=--network cloudbuild-workers --image-project ubuntu-os-cloud --image-family ubuntu-minimal-2004-lts --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
+    - INSTANCE_ARGS=--network cloudbuild-workers --image-project ubuntu-os-cloud --image-family ubuntu-minimal-2004-lts --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible --instance-termination-action DELETE
     - ZONE=us-west1-a
     - REMOTE_WORKSPACE=/tmp/workspace
     - COMMAND=source /tmp/workspace/cloudbuild/setup.sh && source /tmp/workspace/cloudbuild/arista.sh


### PR DESCRIPTION
When Cloud Build cancels execution, the VM can remain running.  It gets terminated after 24 hours, but not deleted.  This change will delete the VM.