### PR TITLE
Remove 'show' command parsing via gNMI Get.

### DIFF
--- a/feature/system/gnmi/cliorigin/ate_tests/cli_origin_test/cli_origin_test.go
+++ b/feature/system/gnmi/cliorigin/ate_tests/cli_origin_test/cli_origin_test.go
@@ -16,7 +16,6 @@ package cli_origin_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -24,7 +23,6 @@ import (
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/telemetry"
-	"github.com/openconfig/ygot/util"
 
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 )


### PR DESCRIPTION
```
 * (M) feature/system/gnmi/cliorigin/ate_test/cli_origin_test.go
  - Remove use of gNMI.Get as means to have arbitrary CLI commands run. gNMI
    Get should not be used in this manner, but rather gNOI commands that have
    the equivalent functionality should be used.
```

This behaviour isn't specified anywhere in the gNMI specification, and I don't believe it is intended to be. If we think that this kind of functionality should be available, we need to primarily update the specifications before adding tests.
