### PR TITLE
Migrate uses of ate.Operations().SetInterfaceState to ate.Actions().SetPortState

### DIFF
--- a/feature/gribi/ate_tests/weighted_balancing_test/port_flap_rebalanced_test.go
+++ b/feature/gribi/ate_tests/weighted_balancing_test/port_flap_rebalanced_test.go
@@ -144,10 +144,11 @@ func TestPortFlap(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			if i < len(atePorts) {
 				t.Logf("Bringing down ate port: %v", atePorts[i])
-				ate.Operations().NewSetInterfaceState().
-					WithPhysicalInterface(atePorts[i]).
-					WithStateEnabled(false).
-					Operate(t)
+				ate.Actions().
+					NewSetPortState().
+					WithPort(atePorts[i]).
+					WithEnabled(false).
+					Send(t)
 
 				// ATE and DUT ports in the linked pair have the same ID(), but
 				// they are mapped to different Name().


### PR DESCRIPTION
This was missed in #243.