### PR TITLE
deviations' config

### DIFF
--- a/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
+++ b/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
@@ -245,7 +245,6 @@ func testIPv4LeaderActiveChange(ctx context.Context, t *testing.T, args *testArg
 
 func TestElectionIDChange(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
-	deviations.ConfigVendorDeviations(dut.Vendor())
 	ctx := context.Background()
 
 	// Configure the DUT

--- a/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
+++ b/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
@@ -113,7 +113,7 @@ func configInterfaceDUT(i *telemetry.Interface, a *attrs.Attributes) *telemetry.
 // configureDUT configures port1, port2 and port3 on the DUT.
 func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	d := dut.Config()
-	
+
 	p1 := dut.Port(t, "port1")
 	i1 := &telemetry.Interface{Name: ygot.String(p1.Name())}
 	d.Interface(p1.Name()).Replace(t, configInterfaceDUT(i1, &dutPort1))

--- a/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
+++ b/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
@@ -113,7 +113,6 @@ func configInterfaceDUT(i *telemetry.Interface, a *attrs.Attributes) *telemetry.
 // configureDUT configures port1, port2 and port3 on the DUT.
 func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	d := dut.Config()
-
 	p1 := dut.Port(t, "port1")
 	i1 := &telemetry.Interface{Name: ygot.String(p1.Name())}
 	d.Interface(p1.Name()).Replace(t, configInterfaceDUT(i1, &dutPort1))
@@ -245,6 +244,7 @@ func testIPv4LeaderActiveChange(ctx context.Context, t *testing.T, args *testArg
 
 func TestElectionIDChange(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
+	deviations.ConfigVendorDeviation(dut.Vendor())
 	ctx := context.Background()
 
 	// Configure the DUT

--- a/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
+++ b/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
@@ -113,6 +113,7 @@ func configInterfaceDUT(i *telemetry.Interface, a *attrs.Attributes) *telemetry.
 // configureDUT configures port1, port2 and port3 on the DUT.
 func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	d := dut.Config()
+	
 	p1 := dut.Port(t, "port1")
 	i1 := &telemetry.Interface{Name: ygot.String(p1.Name())}
 	d.Interface(p1.Name()).Replace(t, configInterfaceDUT(i1, &dutPort1))
@@ -244,7 +245,7 @@ func testIPv4LeaderActiveChange(ctx context.Context, t *testing.T, args *testArg
 
 func TestElectionIDChange(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
-	deviations.ConfigVendorDeviation(dut.Vendor())
+	deviations.ConfigVendorDeviations(dut.Vendor())
 	ctx := context.Background()
 
 	// Configure the DUT

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -19,7 +19,12 @@
 // future.
 package deviations
 
-import "flag"
+import (
+	"flag"
+
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ygot/ygot"
+)
 
 // Vendor deviation flags.
 var (
@@ -29,3 +34,12 @@ var (
 	AggregateAtomicUpdate = flag.Bool("deviation_aggregate_atomic_update", true,
 		"Device requires that aggregate Port-Channel and its members be defined in a single gNMI Update transaction at /interfaces; otherwise lag-type will be dropped, and no member can be added to the aggregate (b/201574574)")
 )
+
+// ConfigVendorDeviation sets the deviations for each vendor
+func ConfigVendorDeviation(vendor ondatra.Vendor) {
+	switch vendor {
+	case ondatra.CISCO:
+		InterfaceEnabled = ygot.Bool(false)
+		AggregateAtomicUpdate = ygot.Bool(false)
+	}
+}

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -19,27 +19,13 @@
 // future.
 package deviations
 
-import (
-	"flag"
-
-	"github.com/openconfig/ondatra"
-	"github.com/openconfig/ygot/ygot"
-)
+import "flag"
 
 // Vendor deviation flags.
 var (
-	InterfaceEnabled = flag.Bool("deviation_interface_enabled", true,
+	InterfaceEnabled = flag.Bool("deviation_interface_enabled", false,
 		"Device requires interface enabled leaf booleans to be explicitly set to true (b/197141773)")
 
 	AggregateAtomicUpdate = flag.Bool("deviation_aggregate_atomic_update", true,
 		"Device requires that aggregate Port-Channel and its members be defined in a single gNMI Update transaction at /interfaces; otherwise lag-type will be dropped, and no member can be added to the aggregate (b/201574574)")
 )
-
-// ConfigVendorDeviations sets the deviations for each vendor
-func ConfigVendorDeviations(vendor ondatra.Vendor) {
-	switch vendor {
-	case ondatra.CISCO:
-		InterfaceEnabled = ygot.Bool(false)
-		AggregateAtomicUpdate = ygot.Bool(false)
-	}
-}

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -35,8 +35,8 @@ var (
 		"Device requires that aggregate Port-Channel and its members be defined in a single gNMI Update transaction at /interfaces; otherwise lag-type will be dropped, and no member can be added to the aggregate (b/201574574)")
 )
 
-// ConfigVendorDeviation sets the deviations for each vendor
-func ConfigVendorDeviation(vendor ondatra.Vendor) {
+// ConfigVendorDeviations sets the deviations for each vendor
+func ConfigVendorDeviations(vendor ondatra.Vendor) {
 	switch vendor {
 	case ondatra.CISCO:
 		InterfaceEnabled = ygot.Bool(false)


### PR DESCRIPTION
Hello, Currently deviations are enabled by default that causes issue for vendors whose implementation does not deviate from the OC. Ideally, the deviations should be disabled by default. This pull adds a simple function `ConfigVendorDeviations` that can be called at the beginning of the each test to enable/disable the deviations based on the device vendor. 