### PR TITLE
Add config lib to ISIS base feature profile

### DIFF
--- a/feature/isis/feature.textproto
+++ b/feature/isis/feature.textproto
@@ -21,12 +21,33 @@ telemetry_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/global/state/level-capability"
 }
 
-# AFI-SAFI enabled
+# AFI-SAFI
+config_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/global/afi-safi/af/config/afi-name"
+}
+telemetry_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/global/afi-safi/af/state/afi-name"
+}
+config_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/global/afi-safi/af/config/safi-name"
+}
+telemetry_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/global/afi-safi/af/state/safi-name"
+}
 config_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/global/afi-safi/af/config/enabled"
 }
 telemetry_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/global/afi-safi/af/state/enabled"
+}
+
+# Transport
+config_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/global/transport/config/lsp-mtu-size"
+}
+
+telemetry_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/global/transport/state/lsp-mtu-size"
 }
 
 # Levels
@@ -37,6 +58,12 @@ config_path {
 }
 telemetry_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/levels/level/state/level-number"
+}
+config_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/levels/level/config/enabled"
+}
+telemetry_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/levels/level/state/enabled"
 }
 telemetry_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/levels/level/link-state-database/lsp/tlvs/tlv/extended-ipv4-reachability/prefixes/prefix/state/metric"
@@ -60,9 +87,6 @@ telemetry_path {
 }
 
 # Interfaces enabled
-config_path {
-  path: "/network-instances/network-instance/interfaces/interface/config/id"
-}
 config_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/config/enabled"
 }
@@ -94,12 +118,44 @@ telemetry_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/timers/state/lsp-pacing-interval"
 }
 
+# Interfaces afi name
+config_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/afi-safi/af/config/afi-name"
+}
+telemetry_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/afi-safi/af/state/afi-name"
+}
+
+# Interfaces safi name
+config_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/afi-safi/af/config/safi-name"
+}
+telemetry_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/afi-safi/af/state/safi-name"
+}
+
+# Interfaces afi-safi enabled
+config_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/afi-safi/af/config/enabled"
+}
+telemetry_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/afi-safi/af/state/enabled"
+}
+
 # Interfaces level number
 config_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/config/level-number"
 }
 telemetry_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/state/level-number"
+}
+
+# Interfaces level enabled
+config_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/config/enabled"
+}
+telemetry_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/state/enabled"
 }
 
 # Interfaces hello timers interval
@@ -120,37 +176,34 @@ telemetry_path {
 
 # Interfaces afi name
 config_path {
-  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/afi-safi/af/config/afi-name"
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/afi-safi/af/config/afi-name"
 }
 telemetry_path {
-  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/afi-safi/af/state/afi-name"
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/afi-safi/af/state/afi-name"
 }
 
 # Interfaces safi name
 config_path {
-  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/afi-safi/af/config/safi-name"
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/afi-safi/af/config/safi-name"
 }
 telemetry_path {
-  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/afi-safi/af/state/safi-name"
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/afi-safi/af/state/safi-name"
+}
+
+# Interfaces afi-safi enabled
+config_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/afi-safi/af/config/enabled"
+}
+telemetry_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/afi-safi/af/state/enabled"
 }
 
 # Interfaces afi-safi metric
 config_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/afi-safi/af/config/metric"
 }
-config_path {
-    path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/afi-safi/af/config/metric"
-}
 telemetry_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/afi-safi/af/state/metric"
-}
-
-# Interfaces afi-safi enabled
-config_path {
-  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/afi-safi/af/config/enabled"
-}
-telemetry_path {
-  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/afi-safi/af/state/enabled"
 }
 
 # IPv6 Reachability
@@ -173,11 +226,6 @@ telemetry_path {
 # System Level
 telemetry_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/levels/level/system-level-counters/state/part-changes"
-}
-
-# Transport
-config_path {
-  path: "/network-instances/network-instance/protocols/protocol/isis/global/transport/config/lsp-mtu-size"
 }
 
 # Interface counters
@@ -343,3 +391,12 @@ telemetry_path {
     path: "/network-instances/network-instance/protocols/protocol/isis/levels/level/system-level-counters/state/spf-runs"
 }
 
+feature_profile_dependency {
+  name: "networkinstance"
+  version: 1
+}
+
+feature_profile_dependency {
+  name: "interface_singleton"
+  version: 1
+}

--- a/feature/isis/interface.go
+++ b/feature/isis/interface.go
@@ -54,7 +54,7 @@ func (i *Interface) WithCSNPInterval(interval time.Duration) *Interface {
 // WithLSPPacingInterval sets the lsp-pacing-interval on the interface ISIS.
 func (i *Interface) WithLSPPacingInterval(interval time.Duration) *Interface {
 	toc := i.oc.GetOrCreateTimers()
-	toc.LspPacingInterval = ygot.Uint64(uint64(interval.Seconds()))
+	toc.LspPacingInterval = ygot.Uint64(uint64(interval.Milliseconds()))
 	return i
 }
 

--- a/feature/isis/interface.go
+++ b/feature/isis/interface.go
@@ -1,0 +1,91 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package isis
+
+import (
+	"time"
+
+	"github.com/openconfig/featureprofiles/yang/fpoc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+// Interface struct to hold ISIS interface OC attributes.
+type Interface struct {
+	oc fpoc.NetworkInstance_Protocol_Isis_Interface
+}
+
+// NewInterface returns a new Interface object.
+func NewInterface(interfaceID string) *Interface {
+	return &Interface{
+		oc: fpoc.NetworkInstance_Protocol_Isis_Interface{
+			Enabled:     ygot.Bool(true),
+			InterfaceId: ygot.String(interfaceID),
+		},
+	}
+}
+
+// WithCircuitType sets the circuit-type on the interface ISIS.
+func (i *Interface) WithCircuitType(ct fpoc.E_IsisTypes_CircuitType) *Interface {
+	i.oc.CircuitType = ct
+	return i
+}
+
+// WithCSNPInterval sets the csnp-interval on the interface ISIS.
+func (i *Interface) WithCSNPInterval(interval time.Duration) *Interface {
+	toc := i.oc.GetOrCreateTimers()
+	toc.CsnpInterval = ygot.Uint16(uint16(interval.Seconds()))
+	return i
+}
+
+// WithLSPPacingInterval sets the lsp-pacing-interval on the interface ISIS.
+func (i *Interface) WithLSPPacingInterval(interval time.Duration) *Interface {
+	toc := i.oc.GetOrCreateTimers()
+	toc.LspPacingInterval = ygot.Uint64(uint64(interval.Seconds()))
+	return i
+}
+
+// WithAFISAFI sets the AFI-SAFI for interface ISIS.
+func (i *Interface) WithAFISAFI(afi fpoc.E_IsisTypes_AFI_TYPE, safi fpoc.E_IsisTypes_SAFI_TYPE) *Interface {
+	i.oc.GetOrCreateAf(afi, safi).Enabled = ygot.Bool(true)
+	return i
+}
+
+// AugmentGlobal implements the isis.GlobalFeature interface.
+// This method augments the ISIS OC with level configuration.
+// Use isis.WithFeature(l) instead of calling this method directly.
+func (i *Interface) AugmentGlobal(isis *fpoc.NetworkInstance_Protocol_Isis) error {
+	if err := i.oc.Validate(); err != nil {
+		return err
+	}
+	ioc := isis.GetInterface(i.oc.GetInterfaceId())
+	if ioc == nil {
+		return isis.AppendInterface(&i.oc)
+	}
+	return ygot.MergeStructInto(ioc, &i.oc)
+}
+
+// InterfaceFeature provides interface to augment ISIS interface with
+// additional features.
+type InterfaceFeature interface {
+	// AugmentInterface augments ISIS interface with additional features.
+	AugmentInterface(oc *fpoc.NetworkInstance_Protocol_Isis_Interface) error
+}
+
+// WithFeature augments ISIS interface with provided feature.
+func (i *Interface) WithFeature(f InterfaceFeature) error {
+	return f.AugmentInterface(&i.oc)
+}

--- a/feature/isis/interface_test.go
+++ b/feature/isis/interface_test.go
@@ -1,0 +1,234 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package isis
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/featureprofiles/yang/fpoc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+// TestInterfaceAugmentGlobal tests the ISIS interface augment to ISIS global
+// OC.
+func TestInterfaceAugmentGlobal(t *testing.T) {
+	tests := []struct {
+		desc     string
+		intf     *Interface
+		inISIS   *fpoc.NetworkInstance_Protocol_Isis
+		wantISIS *fpoc.NetworkInstance_Protocol_Isis
+	}{{
+		desc:   "ISIS interface with no params",
+		intf:   NewInterface("Ethernet1"),
+		inISIS: &fpoc.NetworkInstance_Protocol_Isis{},
+		wantISIS: &fpoc.NetworkInstance_Protocol_Isis{
+			Interface: map[string]*fpoc.NetworkInstance_Protocol_Isis_Interface{
+				"Ethernet1": {
+					Enabled:     ygot.Bool(true),
+					InterfaceId: ygot.String("Ethernet1"),
+				},
+			},
+		},
+	}, {
+		desc:   "ISIS interface with circuit-type",
+		intf:   NewInterface("Ethernet1").WithCircuitType(fpoc.IsisTypes_CircuitType_POINT_TO_POINT),
+		inISIS: &fpoc.NetworkInstance_Protocol_Isis{},
+		wantISIS: &fpoc.NetworkInstance_Protocol_Isis{
+			Interface: map[string]*fpoc.NetworkInstance_Protocol_Isis_Interface{
+				"Ethernet1": {
+					Enabled:     ygot.Bool(true),
+					InterfaceId: ygot.String("Ethernet1"),
+					CircuitType: fpoc.IsisTypes_CircuitType_POINT_TO_POINT,
+				},
+			},
+		},
+	}, {
+		desc:   "ISIS interface with csnp-interval",
+		intf:   NewInterface("Ethernet1").WithCSNPInterval(10 * time.Second),
+		inISIS: &fpoc.NetworkInstance_Protocol_Isis{},
+		wantISIS: &fpoc.NetworkInstance_Protocol_Isis{
+			Interface: map[string]*fpoc.NetworkInstance_Protocol_Isis_Interface{
+				"Ethernet1": {
+					Enabled:     ygot.Bool(true),
+					InterfaceId: ygot.String("Ethernet1"),
+					Timers: &fpoc.NetworkInstance_Protocol_Isis_Interface_Timers{
+						CsnpInterval: ygot.Uint16(10),
+					},
+				},
+			},
+		},
+	}, {
+		desc:   "ISIS interface with lsp-pacing-interval",
+		intf:   NewInterface("Ethernet1").WithLSPPacingInterval(10 * time.Second),
+		inISIS: &fpoc.NetworkInstance_Protocol_Isis{},
+		wantISIS: &fpoc.NetworkInstance_Protocol_Isis{
+			Interface: map[string]*fpoc.NetworkInstance_Protocol_Isis_Interface{
+				"Ethernet1": {
+					Enabled:     ygot.Bool(true),
+					InterfaceId: ygot.String("Ethernet1"),
+					Timers: &fpoc.NetworkInstance_Protocol_Isis_Interface_Timers{
+						LspPacingInterval: ygot.Uint64(10),
+					},
+				},
+			},
+		},
+	}, {
+		desc:   "ISIS interface with AfiSafi",
+		intf:   NewInterface("Ethernet1").WithAFISAFI(fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST),
+		inISIS: &fpoc.NetworkInstance_Protocol_Isis{},
+		wantISIS: &fpoc.NetworkInstance_Protocol_Isis{
+			Interface: map[string]*fpoc.NetworkInstance_Protocol_Isis_Interface{
+				"Ethernet1": {
+					Enabled:     ygot.Bool(true),
+					InterfaceId: ygot.String("Ethernet1"),
+					Af: map[fpoc.NetworkInstance_Protocol_Isis_Interface_Af_Key]*fpoc.NetworkInstance_Protocol_Isis_Interface_Af{
+						{fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
+							AfiName:  fpoc.IsisTypes_AFI_TYPE_IPV4,
+							SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST,
+							Enabled:  ygot.Bool(true),
+						},
+					},
+				},
+			},
+		},
+	}, {
+		desc: "ISIS contains Interface OC with no conflicts",
+		intf: NewInterface("Ethernet1").WithLSPPacingInterval(10 * time.Second),
+		inISIS: &fpoc.NetworkInstance_Protocol_Isis{
+			Interface: map[string]*fpoc.NetworkInstance_Protocol_Isis_Interface{
+				"Ethernet1": {
+					Enabled:     ygot.Bool(true),
+					InterfaceId: ygot.String("Ethernet1"),
+					Timers: &fpoc.NetworkInstance_Protocol_Isis_Interface_Timers{
+						LspPacingInterval: ygot.Uint64(10),
+					},
+				},
+			},
+		},
+		wantISIS: &fpoc.NetworkInstance_Protocol_Isis{
+			Interface: map[string]*fpoc.NetworkInstance_Protocol_Isis_Interface{
+				"Ethernet1": {
+					Enabled:     ygot.Bool(true),
+					InterfaceId: ygot.String("Ethernet1"),
+					Timers: &fpoc.NetworkInstance_Protocol_Isis_Interface_Timers{
+						LspPacingInterval: ygot.Uint64(10),
+					},
+				},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			if err := test.intf.AugmentGlobal(test.inISIS); err != nil {
+				t.Fatalf("error not expected")
+			}
+			if diff := cmp.Diff(test.wantISIS, test.inISIS); diff != "" {
+				t.Errorf("did not get expected state, diff(-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestInterfaceAugmentGlobalErrors tests the ISIS interface augment to ISIS
+// OC validation.
+func TestInterfaceAugmentGlobalErrors(t *testing.T) {
+	tests := []struct {
+		desc          string
+		intf          *Interface
+		inISIS        *fpoc.NetworkInstance_Protocol_Isis
+		wantErrSubStr string
+	}{{
+		desc: "ISIS contains Interface OC with conflicts",
+		intf: NewInterface("Ethernet1").WithLSPPacingInterval(10 * time.Second),
+		inISIS: &fpoc.NetworkInstance_Protocol_Isis{
+			Interface: map[string]*fpoc.NetworkInstance_Protocol_Isis_Interface{
+				"Ethernet1": {
+					Enabled:     ygot.Bool(true),
+					InterfaceId: ygot.String("Ethernet1"),
+					Timers: &fpoc.NetworkInstance_Protocol_Isis_Interface_Timers{
+						LspPacingInterval: ygot.Uint64(11),
+					},
+				},
+			},
+		},
+		wantErrSubStr: "destination value was set, but was not equal to source value",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			err := test.intf.AugmentGlobal(test.inISIS)
+			if err == nil {
+				t.Fatalf("error expected")
+			}
+			if !strings.Contains(err.Error(), test.wantErrSubStr) {
+				t.Errorf("Error strings don't match: %v", err)
+			}
+		})
+	}
+}
+
+type InterfaceFakeFeature struct {
+	Err           error
+	augmentCalled bool
+	oc            *fpoc.NetworkInstance_Protocol_Isis_Interface
+}
+
+func (f *InterfaceFakeFeature) AugmentInterface(oc *fpoc.NetworkInstance_Protocol_Isis_Interface) error {
+	f.oc = oc
+	f.augmentCalled = true
+	return f.Err
+}
+
+// TestInterfaceWithFeature tests the WithFeature method.
+func TestInterfaceWithFeature(t *testing.T) {
+	tests := []struct {
+		desc    string
+		wantErr error
+	}{{
+		desc: "error not expected",
+	}, {
+		desc:    "error expected",
+		wantErr: errors.New("some error"),
+	}}
+
+	for _, test := range tests {
+		b := NewInterface("Ethernet1").WithLSPPacingInterval(10 * time.Second)
+		ff := &InterfaceFakeFeature{Err: test.wantErr}
+		gotErr := b.WithFeature(ff)
+		if !ff.augmentCalled {
+			t.Errorf("AugmentISIS was not called")
+		}
+		if ff.oc != &b.oc {
+			t.Errorf("Interface ptr is not equal")
+		}
+		if test.wantErr != nil {
+			if gotErr != nil {
+				if !strings.Contains(gotErr.Error(), test.wantErr.Error()) {
+					t.Errorf("Error strings are not equal: %v", gotErr)
+				}
+			}
+			if gotErr == nil {
+				t.Errorf("Expecting error but got none")
+			}
+		}
+	}
+}

--- a/feature/isis/interface_test.go
+++ b/feature/isis/interface_test.go
@@ -100,7 +100,7 @@ func TestInterfaceAugmentGlobal(t *testing.T) {
 					Enabled:     ygot.Bool(true),
 					InterfaceId: ygot.String("Ethernet1"),
 					Af: map[fpoc.NetworkInstance_Protocol_Isis_Interface_Af_Key]*fpoc.NetworkInstance_Protocol_Isis_Interface_Af{
-						{fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
+						{AfiName: fpoc.IsisTypes_AFI_TYPE_IPV4, SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
 							AfiName:  fpoc.IsisTypes_AFI_TYPE_IPV4,
 							SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST,
 							Enabled:  ygot.Bool(true),

--- a/feature/isis/interface_test.go
+++ b/feature/isis/interface_test.go
@@ -77,7 +77,7 @@ func TestInterfaceAugmentGlobal(t *testing.T) {
 		},
 	}, {
 		desc:   "ISIS interface with lsp-pacing-interval",
-		intf:   NewInterface("Ethernet1").WithLSPPacingInterval(10 * time.Second),
+		intf:   NewInterface("Ethernet1").WithLSPPacingInterval(10 * time.Millisecond),
 		inISIS: &fpoc.NetworkInstance_Protocol_Isis{},
 		wantISIS: &fpoc.NetworkInstance_Protocol_Isis{
 			Interface: map[string]*fpoc.NetworkInstance_Protocol_Isis_Interface{
@@ -111,7 +111,7 @@ func TestInterfaceAugmentGlobal(t *testing.T) {
 		},
 	}, {
 		desc: "ISIS contains Interface OC with no conflicts",
-		intf: NewInterface("Ethernet1").WithLSPPacingInterval(10 * time.Second),
+		intf: NewInterface("Ethernet1").WithLSPPacingInterval(10 * time.Millisecond),
 		inISIS: &fpoc.NetworkInstance_Protocol_Isis{
 			Interface: map[string]*fpoc.NetworkInstance_Protocol_Isis_Interface{
 				"Ethernet1": {
@@ -158,7 +158,7 @@ func TestInterfaceAugmentGlobalErrors(t *testing.T) {
 		wantErrSubStr string
 	}{{
 		desc: "ISIS contains Interface OC with conflicts",
-		intf: NewInterface("Ethernet1").WithLSPPacingInterval(10 * time.Second),
+		intf: NewInterface("Ethernet1").WithLSPPacingInterval(10 * time.Millisecond),
 		inISIS: &fpoc.NetworkInstance_Protocol_Isis{
 			Interface: map[string]*fpoc.NetworkInstance_Protocol_Isis_Interface{
 				"Ethernet1": {

--- a/feature/isis/interfacelevel.go
+++ b/feature/isis/interfacelevel.go
@@ -1,0 +1,75 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package isis
+
+import (
+	"time"
+
+	"github.com/openconfig/featureprofiles/yang/fpoc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+// InterfaceLevel struct to hold ISIS interface level OC attributes.
+type InterfaceLevel struct {
+	oc fpoc.NetworkInstance_Protocol_Isis_Interface_Level
+}
+
+// NewInterfaceLevel returns a new InterfaceLevel object.
+func NewInterfaceLevel(levelNum int) *InterfaceLevel {
+	return &InterfaceLevel{
+		oc: fpoc.NetworkInstance_Protocol_Isis_Interface_Level{
+			Enabled:     ygot.Bool(true),
+			LevelNumber: ygot.Uint8(uint8(levelNum)),
+		},
+	}
+}
+
+// WithHelloInterval sets the hello-interval on the interface ISIS level.
+func (il *InterfaceLevel) WithHelloInterval(interval time.Duration) *InterfaceLevel {
+	toc := il.oc.GetOrCreateTimers()
+	toc.HelloInterval = ygot.Uint32(uint32(interval.Seconds()))
+	return il
+}
+
+// WithHelloMultiplier sets the hello-interval on the interface ISIS level.
+func (il *InterfaceLevel) WithHelloMultiplier(m int) *InterfaceLevel {
+	toc := il.oc.GetOrCreateTimers()
+	toc.HelloMultiplier = ygot.Uint8(uint8(m))
+	return il
+}
+
+// WithAFISAFIMetric sets the AFI-SAFI metric for interface ISIS level.
+func (il *InterfaceLevel) WithAFISAFIMetric(afi fpoc.E_IsisTypes_AFI_TYPE, safi fpoc.E_IsisTypes_SAFI_TYPE, metric int) *InterfaceLevel {
+	aoc := il.oc.GetOrCreateAf(afi, safi)
+	aoc.Enabled = ygot.Bool(true)
+	aoc.Metric = ygot.Uint32(uint32(metric))
+	return il
+}
+
+// AugmentInterface implements the isis.InterfaceFeature interface.
+// This method augments the ISIS interface OC with level configuration.
+// Use isis.WithFeature(il) instead of calling this method directly.
+func (il *InterfaceLevel) AugmentInterface(isisIntf *fpoc.NetworkInstance_Protocol_Isis_Interface) error {
+	if err := il.oc.Validate(); err != nil {
+		return err
+	}
+	ioc := isisIntf.GetLevel(il.oc.GetLevelNumber())
+	if ioc == nil {
+		return isisIntf.AppendLevel(&il.oc)
+	}
+	return ygot.MergeStructInto(ioc, &il.oc)
+}

--- a/feature/isis/interfacelevel_test.go
+++ b/feature/isis/interfacelevel_test.go
@@ -1,0 +1,188 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package isis
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/featureprofiles/yang/fpoc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+// TestAugmentInterfaceLevel tests the level augment to ISIS interface OC.
+func TestAugmentInterfaceLevel(t *testing.T) {
+	tests := []struct {
+		desc     string
+		level    *InterfaceLevel
+		inIntf   *fpoc.NetworkInstance_Protocol_Isis_Interface
+		wantIntf *fpoc.NetworkInstance_Protocol_Isis_Interface
+	}{{
+		desc:   "ISIS interface level with no params",
+		level:  NewInterfaceLevel(2),
+		inIntf: &fpoc.NetworkInstance_Protocol_Isis_Interface{},
+		wantIntf: &fpoc.NetworkInstance_Protocol_Isis_Interface{
+			Level: map[uint8]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level{
+				2: {
+					LevelNumber: ygot.Uint8(2),
+					Enabled:     ygot.Bool(true),
+				},
+			},
+		},
+	}, {
+		desc:   "ISIS interface level with hello interval",
+		level:  NewInterfaceLevel(2).WithHelloInterval(10 * time.Second),
+		inIntf: &fpoc.NetworkInstance_Protocol_Isis_Interface{},
+		wantIntf: &fpoc.NetworkInstance_Protocol_Isis_Interface{
+			Level: map[uint8]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level{
+				2: {
+					LevelNumber: ygot.Uint8(2),
+					Enabled:     ygot.Bool(true),
+					Timers: &fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Timers{
+						HelloInterval: ygot.Uint32(10),
+					},
+				},
+			},
+		},
+	}, {
+		desc:   "ISIS interface level with hello multiplier",
+		level:  NewInterfaceLevel(2).WithHelloMultiplier(10),
+		inIntf: &fpoc.NetworkInstance_Protocol_Isis_Interface{},
+		wantIntf: &fpoc.NetworkInstance_Protocol_Isis_Interface{
+			Level: map[uint8]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level{
+				2: {
+					LevelNumber: ygot.Uint8(2),
+					Enabled:     ygot.Bool(true),
+					Timers: &fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Timers{
+						HelloMultiplier: ygot.Uint8(10),
+					},
+				},
+			},
+		},
+	}, {
+		desc:   "ISIS interface level with AFI-SAFI metric",
+		level:  NewInterfaceLevel(2).WithAFISAFIMetric(fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST, 10),
+		inIntf: &fpoc.NetworkInstance_Protocol_Isis_Interface{},
+		wantIntf: &fpoc.NetworkInstance_Protocol_Isis_Interface{
+			Level: map[uint8]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level{
+				2: {
+					LevelNumber: ygot.Uint8(2),
+					Enabled:     ygot.Bool(true),
+					Af: map[fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af_Key]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af{
+						{fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
+							AfiName:  fpoc.IsisTypes_AFI_TYPE_IPV4,
+							SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST,
+							Enabled:  ygot.Bool(true),
+							Metric:   ygot.Uint32(10),
+						},
+					},
+				},
+			},
+		},
+	}, {
+		desc:  "Augment with no conflicts",
+		level: NewInterfaceLevel(2).WithAFISAFIMetric(fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST, 10),
+		inIntf: &fpoc.NetworkInstance_Protocol_Isis_Interface{
+			Level: map[uint8]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level{
+				2: {
+					LevelNumber: ygot.Uint8(2),
+					Enabled:     ygot.Bool(true),
+					Af: map[fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af_Key]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af{
+						{fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
+							AfiName:  fpoc.IsisTypes_AFI_TYPE_IPV4,
+							SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST,
+							Enabled:  ygot.Bool(true),
+							Metric:   ygot.Uint32(10),
+						},
+					},
+				},
+			},
+		},
+		wantIntf: &fpoc.NetworkInstance_Protocol_Isis_Interface{
+			Level: map[uint8]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level{
+				2: {
+					LevelNumber: ygot.Uint8(2),
+					Enabled:     ygot.Bool(true),
+					Af: map[fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af_Key]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af{
+						{fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
+							AfiName:  fpoc.IsisTypes_AFI_TYPE_IPV4,
+							SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST,
+							Enabled:  ygot.Bool(true),
+							Metric:   ygot.Uint32(10),
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			if err := test.level.AugmentInterface(test.inIntf); err != nil {
+				t.Fatalf("error not expected")
+			}
+			if diff := cmp.Diff(test.wantIntf, test.inIntf); diff != "" {
+				t.Errorf("did not get expected state, diff(-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestAugmentInterfaceLevelErrors tests the level augment to ISIS Interface
+// OC validation.
+func TestAugmentInterfaceLevelErrors(t *testing.T) {
+	tests := []struct {
+		desc          string
+		level         *InterfaceLevel
+		inIntf        *fpoc.NetworkInstance_Protocol_Isis_Interface
+		wantErrSubStr string
+	}{{
+		desc:  "Augment with conflicts",
+		level: NewInterfaceLevel(2).WithAFISAFIMetric(fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST, 11),
+		inIntf: &fpoc.NetworkInstance_Protocol_Isis_Interface{
+			Level: map[uint8]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level{
+				2: {
+					LevelNumber: ygot.Uint8(2),
+					Enabled:     ygot.Bool(true),
+					Af: map[fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af_Key]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af{
+						{fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
+							AfiName:  fpoc.IsisTypes_AFI_TYPE_IPV4,
+							SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST,
+							Enabled:  ygot.Bool(true),
+							Metric:   ygot.Uint32(10),
+						},
+					},
+				},
+			},
+		},
+		wantErrSubStr: "destination value was set, but was not equal to source value",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			err := test.level.AugmentInterface(test.inIntf)
+			if err == nil {
+				t.Fatalf("error expected")
+			}
+			if !strings.Contains(err.Error(), test.wantErrSubStr) {
+				t.Errorf("Error strings don't match: %v", err)
+			}
+		})
+	}
+}

--- a/feature/isis/interfacelevel_test.go
+++ b/feature/isis/interfacelevel_test.go
@@ -85,7 +85,7 @@ func TestAugmentInterfaceLevel(t *testing.T) {
 					LevelNumber: ygot.Uint8(2),
 					Enabled:     ygot.Bool(true),
 					Af: map[fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af_Key]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af{
-						{fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
+						{AfiName: fpoc.IsisTypes_AFI_TYPE_IPV4, SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
 							AfiName:  fpoc.IsisTypes_AFI_TYPE_IPV4,
 							SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST,
 							Enabled:  ygot.Bool(true),
@@ -104,7 +104,7 @@ func TestAugmentInterfaceLevel(t *testing.T) {
 					LevelNumber: ygot.Uint8(2),
 					Enabled:     ygot.Bool(true),
 					Af: map[fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af_Key]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af{
-						{fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
+						{AfiName: fpoc.IsisTypes_AFI_TYPE_IPV4, SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
 							AfiName:  fpoc.IsisTypes_AFI_TYPE_IPV4,
 							SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST,
 							Enabled:  ygot.Bool(true),
@@ -120,7 +120,7 @@ func TestAugmentInterfaceLevel(t *testing.T) {
 					LevelNumber: ygot.Uint8(2),
 					Enabled:     ygot.Bool(true),
 					Af: map[fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af_Key]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af{
-						{fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
+						{AfiName: fpoc.IsisTypes_AFI_TYPE_IPV4, SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
 							AfiName:  fpoc.IsisTypes_AFI_TYPE_IPV4,
 							SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST,
 							Enabled:  ygot.Bool(true),
@@ -161,7 +161,7 @@ func TestAugmentInterfaceLevelErrors(t *testing.T) {
 					LevelNumber: ygot.Uint8(2),
 					Enabled:     ygot.Bool(true),
 					Af: map[fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af_Key]*fpoc.NetworkInstance_Protocol_Isis_Interface_Level_Af{
-						{fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
+						{AfiName: fpoc.IsisTypes_AFI_TYPE_IPV4, SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
 							AfiName:  fpoc.IsisTypes_AFI_TYPE_IPV4,
 							SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST,
 							Enabled:  ygot.Bool(true),

--- a/feature/isis/isis.go
+++ b/feature/isis/isis.go
@@ -80,13 +80,13 @@ func (i *ISIS) WithLSPRefreshInterval(interval time.Duration) *ISIS {
 
 // WithSPFFirstInterval sets the spf-first-interval for ISIS global.
 func (i *ISIS) WithSPFFirstInterval(interval time.Duration) *ISIS {
-	i.oc.GetOrCreateIsis().GetOrCreateGlobal().GetOrCreateTimers().GetOrCreateSpf().SpfFirstInterval = ygot.Uint64(uint64(interval.Seconds()))
+	i.oc.GetOrCreateIsis().GetOrCreateGlobal().GetOrCreateTimers().GetOrCreateSpf().SpfFirstInterval = ygot.Uint64(uint64(interval.Milliseconds()))
 	return i
 }
 
 // WithSPFHoldInterval sets the spf-hold-interval for ISIS global.
 func (i *ISIS) WithSPFHoldInterval(interval time.Duration) *ISIS {
-	i.oc.GetOrCreateIsis().GetOrCreateGlobal().GetOrCreateTimers().GetOrCreateSpf().SpfHoldInterval = ygot.Uint64(uint64(interval.Seconds()))
+	i.oc.GetOrCreateIsis().GetOrCreateGlobal().GetOrCreateTimers().GetOrCreateSpf().SpfHoldInterval = ygot.Uint64(uint64(interval.Milliseconds()))
 	return i
 }
 

--- a/feature/isis/isis.go
+++ b/feature/isis/isis.go
@@ -1,0 +1,116 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Package isis implements the Config Library for ISIS base feature profile.
+package isis
+
+import (
+	"time"
+
+	"github.com/openconfig/featureprofiles/yang/fpoc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+// Name of the ISIS protocol.
+const Name = "isis"
+
+// ISIS struct stores the OC attributes for ISIS base feature profile.
+type ISIS struct {
+	oc fpoc.NetworkInstance_Protocol
+}
+
+// New returns a new ISIS object.
+func New() *ISIS {
+	return &ISIS{
+		oc: fpoc.NetworkInstance_Protocol{
+			Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+			Name:       ygot.String(Name),
+		},
+	}
+}
+
+// WithNet sets the Net value for ISIS global.
+func (i *ISIS) WithNet(net string) *ISIS {
+	i.oc.GetOrCreateIsis().GetOrCreateGlobal().Net = []string{net}
+	return i
+}
+
+// WithAFISAFI sets the AFI-SAFI type for BGP global.
+func (i *ISIS) WithAFISAFI(afi fpoc.E_IsisTypes_AFI_TYPE, safi fpoc.E_IsisTypes_SAFI_TYPE) *ISIS {
+	i.oc.GetOrCreateIsis().GetOrCreateGlobal().GetOrCreateAf(afi, safi).Enabled = ygot.Bool(true)
+	return i
+}
+
+// WithLevelCapability sets the level-capability for ISIS global.
+func (i *ISIS) WithLevelCapability(level fpoc.E_IsisTypes_LevelType) *ISIS {
+	i.oc.GetOrCreateIsis().GetOrCreateGlobal().LevelCapability = level
+	return i
+}
+
+// WithLSPMTUSize sets the LSP MTU size for ISIS global.
+func (i *ISIS) WithLSPMTUSize(size int) *ISIS {
+	i.oc.GetOrCreateIsis().GetOrCreateGlobal().GetOrCreateTransport().LspMtuSize = ygot.Uint16(uint16(size))
+	return i
+}
+
+// WithLSPLifetimeInterval sets the lsp-lifetime-interval for ISIS global.
+func (i *ISIS) WithLSPLifetimeInterval(interval time.Duration) *ISIS {
+	i.oc.GetOrCreateIsis().GetOrCreateGlobal().GetOrCreateTimers().LspLifetimeInterval = ygot.Uint16(uint16(interval.Seconds()))
+	return i
+}
+
+// WithLSPRefreshInterval sets the lsp-refresh-interval for ISIS global.
+func (i *ISIS) WithLSPRefreshInterval(interval time.Duration) *ISIS {
+	i.oc.GetOrCreateIsis().GetOrCreateGlobal().GetOrCreateTimers().LspRefreshInterval = ygot.Uint16(uint16(interval.Seconds()))
+	return i
+}
+
+// WithSPFFirstInterval sets the spf-first-interval for ISIS global.
+func (i *ISIS) WithSPFFirstInterval(interval time.Duration) *ISIS {
+	i.oc.GetOrCreateIsis().GetOrCreateGlobal().GetOrCreateTimers().GetOrCreateSpf().SpfFirstInterval = ygot.Uint64(uint64(interval.Seconds()))
+	return i
+}
+
+// WithSPFHoldInterval sets the spf-hold-interval for ISIS global.
+func (i *ISIS) WithSPFHoldInterval(interval time.Duration) *ISIS {
+	i.oc.GetOrCreateIsis().GetOrCreateGlobal().GetOrCreateTimers().GetOrCreateSpf().SpfHoldInterval = ygot.Uint64(uint64(interval.Seconds()))
+	return i
+}
+
+// AugmentNetworkInstance implements networkinstance.Feature interface.
+// Augments the provided NI with ISIS OC.
+// Use ni.WithFeature(i) instead of calling this method directly.
+func (i *ISIS) AugmentNetworkInstance(ni *fpoc.NetworkInstance) error {
+	if err := i.oc.Validate(); err != nil {
+		return err
+	}
+	p := ni.GetProtocol(i.oc.GetIdentifier(), Name)
+	if p == nil {
+		return ni.AppendProtocol(&i.oc)
+	}
+	return ygot.MergeStructInto(p, &i.oc)
+}
+
+// GlobalFeature provides interface to augment ISIS with additional features.
+type GlobalFeature interface {
+	// AugmentISIS augments ISIS with additional features.
+	AugmentISIS(oc *fpoc.NetworkInstance_Protocol_Isis) error
+}
+
+// WithFeature augments ISIS with provided feature.
+func (i *ISIS) WithFeature(f GlobalFeature) error {
+	return f.AugmentISIS(i.oc.GetIsis())
+}

--- a/feature/isis/isis_test.go
+++ b/feature/isis/isis_test.go
@@ -167,7 +167,7 @@ func TestAugmentNetworkInstance(t *testing.T) {
 		},
 	}, {
 		desc: "ISIS with SPF First Interval",
-		isis: New().WithSPFFirstInterval(10 * time.Second),
+		isis: New().WithSPFFirstInterval(10 * time.Millisecond),
 		inNI: &fpoc.NetworkInstance{},
 		wantNI: &fpoc.NetworkInstance{
 			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{
@@ -188,7 +188,7 @@ func TestAugmentNetworkInstance(t *testing.T) {
 		},
 	}, {
 		desc: "ISIS with SPF Hold Interval",
-		isis: New().WithSPFHoldInterval(10 * time.Second),
+		isis: New().WithSPFHoldInterval(10 * time.Millisecond),
 		inNI: &fpoc.NetworkInstance{},
 		wantNI: &fpoc.NetworkInstance{
 			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{

--- a/feature/isis/isis_test.go
+++ b/feature/isis/isis_test.go
@@ -80,7 +80,7 @@ func TestAugmentNetworkInstance(t *testing.T) {
 					Isis: &fpoc.NetworkInstance_Protocol_Isis{
 						Global: &fpoc.NetworkInstance_Protocol_Isis_Global{
 							Af: map[fpoc.NetworkInstance_Protocol_Isis_Global_Af_Key]*fpoc.NetworkInstance_Protocol_Isis_Global_Af{
-								{fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
+								{AfiName: fpoc.IsisTypes_AFI_TYPE_IPV4, SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
 									AfiName:  fpoc.IsisTypes_AFI_TYPE_IPV4,
 									SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST,
 									Enabled:  ygot.Bool(true),

--- a/feature/isis/isis_test.go
+++ b/feature/isis/isis_test.go
@@ -1,0 +1,339 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package isis
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/featureprofiles/yang/fpoc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+var protocolKey = fpoc.NetworkInstance_Protocol_Key{
+	Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+	Name:       "isis",
+}
+
+// TestAugmentNetworkInstance tests the ISIS augment to NI OC.
+func TestAugmentNetworkInstance(t *testing.T) {
+	tests := []struct {
+		desc   string
+		isis   *ISIS
+		inNI   *fpoc.NetworkInstance
+		wantNI *fpoc.NetworkInstance
+	}{{
+		desc: "ISIS with no params",
+		isis: New(),
+		inNI: &fpoc.NetworkInstance{},
+		wantNI: &fpoc.NetworkInstance{
+			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{
+				protocolKey: {
+					Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+					Name:       ygot.String("isis"),
+				},
+			},
+		},
+	}, {
+		desc: "ISIS with Net",
+		isis: New().WithNet("50.3131.3131.3131.00"),
+		inNI: &fpoc.NetworkInstance{},
+		wantNI: &fpoc.NetworkInstance{
+			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{
+				protocolKey: {
+					Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+					Name:       ygot.String("isis"),
+					Isis: &fpoc.NetworkInstance_Protocol_Isis{
+						Global: &fpoc.NetworkInstance_Protocol_Isis_Global{
+							Net: []string{"50.3131.3131.3131.00"},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		desc: "ISIS with Global AfiSafi",
+		isis: New().WithAFISAFI(fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST),
+		inNI: &fpoc.NetworkInstance{},
+		wantNI: &fpoc.NetworkInstance{
+			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{
+				protocolKey: {
+					Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+					Name:       ygot.String("isis"),
+					Isis: &fpoc.NetworkInstance_Protocol_Isis{
+						Global: &fpoc.NetworkInstance_Protocol_Isis_Global{
+							Af: map[fpoc.NetworkInstance_Protocol_Isis_Global_Af_Key]*fpoc.NetworkInstance_Protocol_Isis_Global_Af{
+								{fpoc.IsisTypes_AFI_TYPE_IPV4, fpoc.IsisTypes_SAFI_TYPE_UNICAST}: {
+									AfiName:  fpoc.IsisTypes_AFI_TYPE_IPV4,
+									SafiName: fpoc.IsisTypes_SAFI_TYPE_UNICAST,
+									Enabled:  ygot.Bool(true),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		desc: "ISIS with Level Capability",
+		isis: New().WithLevelCapability(fpoc.IsisTypes_LevelType_LEVEL_1_2),
+		inNI: &fpoc.NetworkInstance{},
+		wantNI: &fpoc.NetworkInstance{
+			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{
+				protocolKey: {
+					Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+					Name:       ygot.String("isis"),
+					Isis: &fpoc.NetworkInstance_Protocol_Isis{
+						Global: &fpoc.NetworkInstance_Protocol_Isis_Global{
+							LevelCapability: fpoc.IsisTypes_LevelType_LEVEL_1_2,
+						},
+					},
+				},
+			},
+		},
+	}, {
+		desc: "ISIS with LSP MTU size",
+		isis: New().WithLSPMTUSize(9012),
+		inNI: &fpoc.NetworkInstance{},
+		wantNI: &fpoc.NetworkInstance{
+			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{
+				protocolKey: {
+					Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+					Name:       ygot.String("isis"),
+					Isis: &fpoc.NetworkInstance_Protocol_Isis{
+						Global: &fpoc.NetworkInstance_Protocol_Isis_Global{
+							Transport: &fpoc.NetworkInstance_Protocol_Isis_Global_Transport{
+								LspMtuSize: ygot.Uint16(9012),
+							},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		desc: "ISIS with LSP Lifetime Interval",
+		isis: New().WithLSPLifetimeInterval(10 * time.Second),
+		inNI: &fpoc.NetworkInstance{},
+		wantNI: &fpoc.NetworkInstance{
+			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{
+				protocolKey: {
+					Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+					Name:       ygot.String("isis"),
+					Isis: &fpoc.NetworkInstance_Protocol_Isis{
+						Global: &fpoc.NetworkInstance_Protocol_Isis_Global{
+							Timers: &fpoc.NetworkInstance_Protocol_Isis_Global_Timers{
+								LspLifetimeInterval: ygot.Uint16(10),
+							},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		desc: "ISIS with LSP Refresh Interval",
+		isis: New().WithLSPRefreshInterval(10 * time.Second),
+		inNI: &fpoc.NetworkInstance{},
+		wantNI: &fpoc.NetworkInstance{
+			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{
+				protocolKey: {
+					Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+					Name:       ygot.String("isis"),
+					Isis: &fpoc.NetworkInstance_Protocol_Isis{
+						Global: &fpoc.NetworkInstance_Protocol_Isis_Global{
+							Timers: &fpoc.NetworkInstance_Protocol_Isis_Global_Timers{
+								LspRefreshInterval: ygot.Uint16(10),
+							},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		desc: "ISIS with SPF First Interval",
+		isis: New().WithSPFFirstInterval(10 * time.Second),
+		inNI: &fpoc.NetworkInstance{},
+		wantNI: &fpoc.NetworkInstance{
+			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{
+				protocolKey: {
+					Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+					Name:       ygot.String("isis"),
+					Isis: &fpoc.NetworkInstance_Protocol_Isis{
+						Global: &fpoc.NetworkInstance_Protocol_Isis_Global{
+							Timers: &fpoc.NetworkInstance_Protocol_Isis_Global_Timers{
+								Spf: &fpoc.NetworkInstance_Protocol_Isis_Global_Timers_Spf{
+									SpfFirstInterval: ygot.Uint64(10),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		desc: "ISIS with SPF Hold Interval",
+		isis: New().WithSPFHoldInterval(10 * time.Second),
+		inNI: &fpoc.NetworkInstance{},
+		wantNI: &fpoc.NetworkInstance{
+			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{
+				protocolKey: {
+					Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+					Name:       ygot.String("isis"),
+					Isis: &fpoc.NetworkInstance_Protocol_Isis{
+						Global: &fpoc.NetworkInstance_Protocol_Isis_Global{
+							Timers: &fpoc.NetworkInstance_Protocol_Isis_Global_Timers{
+								Spf: &fpoc.NetworkInstance_Protocol_Isis_Global_Timers_Spf{
+									SpfHoldInterval: ygot.Uint64(10),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		desc: "NI contains ISIS OC with no conflicts",
+		isis: New().WithNet("50.3131.3131.3131.00"),
+		inNI: &fpoc.NetworkInstance{
+			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{
+				protocolKey: {
+					Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+					Name:       ygot.String("isis"),
+					Isis: &fpoc.NetworkInstance_Protocol_Isis{
+						Global: &fpoc.NetworkInstance_Protocol_Isis_Global{
+							Net: []string{"50.3131.3131.3131.00"},
+						},
+					},
+				},
+			},
+		},
+		wantNI: &fpoc.NetworkInstance{
+			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{
+				protocolKey: {
+					Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+					Name:       ygot.String("isis"),
+					Isis: &fpoc.NetworkInstance_Protocol_Isis{
+						Global: &fpoc.NetworkInstance_Protocol_Isis_Global{
+							Net: []string{"50.3131.3131.3131.00"},
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			if err := test.isis.AugmentNetworkInstance(test.inNI); err != nil {
+				t.Fatalf("error not expected")
+			}
+			if diff := cmp.Diff(test.wantNI, test.inNI); diff != "" {
+				t.Errorf("did not get expected state, diff(-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestAugmentNetworkInstanceErrors tests the ISIS augment to NI OC validation.
+func TestAugmentNetworkInstanceErrors(t *testing.T) {
+	tests := []struct {
+		desc          string
+		isis          *ISIS
+		inNI          *fpoc.NetworkInstance
+		wantErrSubStr string
+	}{{
+		desc: "NI contains ISIS OC with conflicts",
+		isis: New().WithLSPMTUSize(9011),
+		inNI: &fpoc.NetworkInstance{
+			Protocol: map[fpoc.NetworkInstance_Protocol_Key]*fpoc.NetworkInstance_Protocol{
+				protocolKey: {
+					Identifier: fpoc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+					Name:       ygot.String("isis"),
+					Isis: &fpoc.NetworkInstance_Protocol_Isis{
+						Global: &fpoc.NetworkInstance_Protocol_Isis_Global{
+							Transport: &fpoc.NetworkInstance_Protocol_Isis_Global_Transport{
+								LspMtuSize: ygot.Uint16(9012),
+							},
+						},
+					},
+				},
+			},
+		},
+		wantErrSubStr: "destination value was set, but was not equal to source value",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			err := test.isis.AugmentNetworkInstance(test.inNI)
+			if err == nil {
+				t.Fatalf("error expected")
+			}
+			if !strings.Contains(err.Error(), test.wantErrSubStr) {
+				t.Errorf("Error strings don't match: %v", err)
+			}
+		})
+	}
+}
+
+type FakeFeature struct {
+	Err           error
+	augmentCalled bool
+	oc            *fpoc.NetworkInstance_Protocol_Isis
+}
+
+func (f *FakeFeature) AugmentISIS(oc *fpoc.NetworkInstance_Protocol_Isis) error {
+	f.oc = oc
+	f.augmentCalled = true
+	return f.Err
+}
+
+// TestWithFeature tests the WithFeature method.
+func TestWithFeature(t *testing.T) {
+	tests := []struct {
+		desc    string
+		wantErr error
+	}{{
+		desc: "error not expected",
+	}, {
+		desc:    "error expected",
+		wantErr: errors.New("some error"),
+	}}
+
+	for _, test := range tests {
+		b := New().WithNet("50.3131.3131.3131.00")
+		ff := &FakeFeature{Err: test.wantErr}
+		gotErr := b.WithFeature(ff)
+		if !ff.augmentCalled {
+			t.Errorf("AugmentGlobal was not called")
+		}
+		if ff.oc != b.oc.GetIsis() {
+			t.Errorf("ISIS ptr is not equal")
+		}
+		if test.wantErr != nil {
+			if gotErr != nil {
+				if !strings.Contains(gotErr.Error(), test.wantErr.Error()) {
+					t.Errorf("Error strings are not equal: %v", gotErr)
+				}
+			}
+			if gotErr == nil {
+				t.Errorf("Expecting error but got none")
+			}
+		}
+	}
+}

--- a/feature/isis/level.go
+++ b/feature/isis/level.go
@@ -1,0 +1,51 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package isis
+
+import (
+	"github.com/openconfig/featureprofiles/yang/fpoc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+// Level struct to hold ISIS level OC attributes.
+type Level struct {
+	oc fpoc.NetworkInstance_Protocol_Isis_Level
+}
+
+// NewLevel returns a new Level object.
+func NewLevel(level int) *Level {
+	return &Level{
+		oc: fpoc.NetworkInstance_Protocol_Isis_Level{
+			Enabled:     ygot.Bool(true),
+			LevelNumber: ygot.Uint8(uint8(level)),
+		},
+	}
+}
+
+// AugmentGlobal implements the isis.GlobalFeature interface.
+// This method augments the ISIS OC with level configuration.
+// Use isis.WithFeature(l) instead of calling this method directly.
+func (l *Level) AugmentGlobal(isis *fpoc.NetworkInstance_Protocol_Isis) error {
+	if err := l.oc.Validate(); err != nil {
+		return err
+	}
+	loc := isis.GetLevel(l.oc.GetLevelNumber())
+	if loc == nil {
+		return isis.AppendLevel(&l.oc)
+	}
+	return ygot.MergeStructInto(loc, &l.oc)
+}

--- a/feature/isis/level_test.go
+++ b/feature/isis/level_test.go
@@ -1,0 +1,113 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package isis
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/featureprofiles/yang/fpoc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+// TestLevelAugmentGlobal tests the level augment to ISIS global OC.
+func TestLevelAugmentGlobal(t *testing.T) {
+	tests := []struct {
+		desc     string
+		level    *Level
+		inISIS   *fpoc.NetworkInstance_Protocol_Isis
+		wantISIS *fpoc.NetworkInstance_Protocol_Isis
+	}{{
+		desc:   "ISIS level with no params",
+		level:  NewLevel(2),
+		inISIS: &fpoc.NetworkInstance_Protocol_Isis{},
+		wantISIS: &fpoc.NetworkInstance_Protocol_Isis{
+			Level: map[uint8]*fpoc.NetworkInstance_Protocol_Isis_Level{
+				2: {
+					LevelNumber: ygot.Uint8(2),
+					Enabled:     ygot.Bool(true),
+				},
+			},
+		},
+	}, {
+		desc:  "Augment with no conflicts",
+		level: NewLevel(2),
+		inISIS: &fpoc.NetworkInstance_Protocol_Isis{
+			Level: map[uint8]*fpoc.NetworkInstance_Protocol_Isis_Level{
+				2: {
+					LevelNumber: ygot.Uint8(2),
+					Enabled:     ygot.Bool(true),
+				},
+			},
+		},
+		wantISIS: &fpoc.NetworkInstance_Protocol_Isis{
+			Level: map[uint8]*fpoc.NetworkInstance_Protocol_Isis_Level{
+				2: {
+					LevelNumber: ygot.Uint8(2),
+					Enabled:     ygot.Bool(true),
+				},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			if err := test.level.AugmentGlobal(test.inISIS); err != nil {
+				t.Fatalf("error not expected")
+			}
+			if diff := cmp.Diff(test.wantISIS, test.inISIS); diff != "" {
+				t.Errorf("did not get expected state, diff(-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestLevelAugmentGlobalErrors tests the level augment to ISIS global
+// OC validation.
+func TestLevelAugmentGlobalErrors(t *testing.T) {
+	tests := []struct {
+		desc          string
+		level         *Level
+		inISIS        *fpoc.NetworkInstance_Protocol_Isis
+		wantErrSubStr string
+	}{{
+		desc:  "Augment with conflicts",
+		level: NewLevel(2),
+		inISIS: &fpoc.NetworkInstance_Protocol_Isis{
+			Level: map[uint8]*fpoc.NetworkInstance_Protocol_Isis_Level{
+				2: {
+					LevelNumber: ygot.Uint8(2),
+					Enabled:     ygot.Bool(false),
+				},
+			},
+		},
+		wantErrSubStr: "destination value was set, but was not equal to source value",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			err := test.level.AugmentGlobal(test.inISIS)
+			if err == nil {
+				t.Fatalf("error expected")
+			}
+			if !strings.Contains(err.Error(), test.wantErrSubStr) {
+				t.Errorf("Error strings don't match: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Also fixed couple of errors and dependencies in the feature textproto. The config lib is for the entirety of ISIS base feature profile and is broken down into multiple files per sub tree. See BGP base feature profile for a similar pattern.