### PR TITLE
guard ipv4/enabled with deviations.InterfaceEnabled

### DIFF
--- a/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/telemetry"
@@ -321,7 +322,9 @@ func ConfigureDUTIntf(t *testing.T, dut *ondatra.DUTDevice) {
 		}
 		i.GetOrCreateEthernet()
 		s := i.GetOrCreateSubinterface(0).GetOrCreateIpv4()
-		s.Enabled = ygot.Bool(true)
+		if *deviations.InterfaceEnabled {
+			s.Enabled = ygot.Bool(true)
+		}
 		a := s.GetOrCreateAddress(intf.ipv4Addr)
 		a.PrefixLength = ygot.Uint8(intf.ipv4PrefixLen)
 		s6 := i.GetOrCreateSubinterface(0).GetOrCreateIpv6()
@@ -332,7 +335,7 @@ func ConfigureDUTIntf(t *testing.T, dut *ondatra.DUTDevice) {
 
 		t.Logf("Validate DUT IPv4 and IPv6 subinterface %s are enabled.", intf.intfName)
 		subint := dut.Telemetry().Interface(intf.intfName).Subinterface(0)
-		if !subint.Ipv4().Enabled().Get(t) {
+		if *deviations.InterfaceEnabled && !subint.Ipv4().Enabled().Get(t) {
 			t.Errorf("Ipv4().Enabled().Get(t) for interface %v: got false, want true", intf.intfName)
 		}
 		if !subint.Ipv6().Enabled().Get(t) {


### PR DESCRIPTION
This pull request guards the ipv4/enable for [telemetry_interface_packet_counters_test.go](https://github.com/openconfig/featureprofiles/compare/main...mojiiba:featureprofiles:moji_interface_deviation?expand=1#diff-df1d54880bfbdae0493ef1e2d51a80c91bb932962e512b437de73bbd75834ef4) with deviations.InterfaceEnabled simialr to other tests.
