### PR TITLE
Expire Cloud Build SSH keys after 1 day

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -1,9 +1,9 @@
 steps:
-- name: gcr.io/$PROJECT_ID/remote-builder-debug
+- name: gcr.io/$PROJECT_ID/remote-builder
   waitFor: ["-"]
   env:
     - USERNAME=user
-    - SSH_ARGS=--internal-ip --ssh-key-expire-after=2m
+    - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
     - INSTANCE_NAME=fp-build-arista-$BUILD_ID
     - INSTANCE_ARGS=--network cloudbuild-workers --image-project ubuntu-os-cloud --image-family ubuntu-minimal-2004-lts --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
     - ZONE=us-west1-a

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -13,3 +13,4 @@ options:
   pool:
     name: 'projects/disco-idea-817/locations/us-west1/workerPools/featureprofiles-workerpool'
 timeout: 1800s
+

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
   waitFor: ["-"]
   env:
     - USERNAME=user
-    - SSH_ARGS=--internal-ip --ssh-key-expire-after=30s
+    - SSH_ARGS=--internal-ip
     - INSTANCE_NAME=fp-build-arista-$BUILD_ID
     - INSTANCE_ARGS=--network cloudbuild-workers --image-project ubuntu-os-cloud --image-family ubuntu-minimal-2004-lts --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
     - ZONE=us-west1-a
@@ -13,4 +13,3 @@ options:
   pool:
     name: 'projects/disco-idea-817/locations/us-west1/workerPools/featureprofiles-workerpool'
 timeout: 1800s
-

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
   waitFor: ["-"]
   env:
     - USERNAME=user
-    - SSH_ARGS=--internal-ip
+    - SSH_ARGS=--internal-ip --ssh-key-expire-after 30s
     - INSTANCE_NAME=fp-build-arista-$BUILD_ID
     - INSTANCE_ARGS=--network cloudbuild-workers --image-project ubuntu-os-cloud --image-family ubuntu-minimal-2004-lts --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
     - ZONE=us-west1-a

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
   waitFor: ["-"]
   env:
     - USERNAME=user
-    - SSH_ARGS=--internal-ip --ssh-key-expire-after 30s --ssh-flag=-vvv
+    - SSH_ARGS=--internal-ip --ssh-key-expire-after=30s
     - INSTANCE_NAME=fp-build-arista-$BUILD_ID
     - INSTANCE_ARGS=--network cloudbuild-workers --image-project ubuntu-os-cloud --image-family ubuntu-minimal-2004-lts --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
     - ZONE=us-west1-a

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
   waitFor: ["-"]
   env:
     - USERNAME=user
-    - SSH_ARGS=--internal-ip
+    - SSH_ARGS=--internal-ip --ssh-key-expire-after=2m
     - INSTANCE_NAME=fp-build-arista-$BUILD_ID
     - INSTANCE_ARGS=--network cloudbuild-workers --image-project ubuntu-os-cloud --image-family ubuntu-minimal-2004-lts --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
     - ZONE=us-west1-a

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
   waitFor: ["-"]
   env:
     - USERNAME=user
-    - SSH_ARGS=--internal-ip --ssh-key-expire-after 30s --ssh-flag="-vvv"
+    - SSH_ARGS=--internal-ip --ssh-key-expire-after 30s --ssh-flag=-vvv
     - INSTANCE_NAME=fp-build-arista-$BUILD_ID
     - INSTANCE_ARGS=--network cloudbuild-workers --image-project ubuntu-os-cloud --image-family ubuntu-minimal-2004-lts --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
     - ZONE=us-west1-a

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
   waitFor: ["-"]
   env:
     - USERNAME=user
-    - SSH_ARGS=--internal-ip --ssh-key-expire-after 30s
+    - SSH_ARGS=--internal-ip --ssh-key-expire-after 30s --ssh-flag="-vvv"
     - INSTANCE_NAME=fp-build-arista-$BUILD_ID
     - INSTANCE_ARGS=--network cloudbuild-workers --image-project ubuntu-os-cloud --image-family ubuntu-minimal-2004-lts --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
     - ZONE=us-west1-a

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-- name: gcr.io/$PROJECT_ID/remote-builder
+- name: gcr.io/$PROJECT_ID/remote-builder-debug
   waitFor: ["-"]
   env:
     - USERNAME=user


### PR DESCRIPTION
Cloud Build tasks were failing with the following error:

`ERROR: (gcloud.compute.ssh) INVALID_ARGUMENT: Login profile size exceeds 32 KiB. Delete profile values to make additional space.`

This should prevent the profile from growing.