### PR TITLE
Validate only RFC5952 formatted IPv6 NTP server addresses

### DIFF
--- a/feature/system/ntp/tests/server_test.go
+++ b/feature/system/ntp/tests/server_test.go
@@ -60,6 +60,9 @@ func TestNtpServerConfigurability(t *testing.T) {
 
 			t.Run("Delete NTP Server", func(t *testing.T) {
 				config.Server(testCase.address).Delete(t)
+				if qs := config.Server(testCase.address).Lookup(t); qs.IsPresent() == true {
+					t.Errorf("Delete NTP Server fail: got %v", qs)
+				}
 			})
 		})
 	}

--- a/feature/system/ntp/tests/server_test.go
+++ b/feature/system/ntp/tests/server_test.go
@@ -17,6 +17,7 @@
 package system_ntp_test
 
 import (
+	"net"
 	"testing"
 
 	"github.com/openconfig/ondatra"
@@ -51,15 +52,15 @@ func TestNtpServerConfigurability(t *testing.T) {
 
 			t.Run("Get NTP Server Config", func(t *testing.T) {
 				configGot := config.Server(testCase.address).Get(t)
-				if address := configGot.GetAddress(); address != testCase.address {
-					t.Errorf("Config NTP Server: got %s, want %s", address, testCase.address)
+				if gotAddress, wantAddress := net.ParseIP(configGot.GetAddress()), net.ParseIP(testCase.address); !wantAddress.Equal(gotAddress) {
+					t.Errorf("Config NTP Server: got %v, want %v", gotAddress, wantAddress)
 				}
 			})
 
 			t.Run("Get NTP Server Telemetry", func(t *testing.T) {
 				stateGot := state.Server(testCase.address).Get(t)
-				if address := stateGot.GetAddress(); address != testCase.address {
-					t.Errorf("Telemetry NTP Server: got %s, want %s", address, testCase.address)
+				if gotAddress, wantAddress := net.ParseIP(stateGot.GetAddress()), net.ParseIP(testCase.address); !wantAddress.Equal(gotAddress) {
+					t.Errorf("Telemetry NTP Server: got %v, want %v", gotAddress, wantAddress)
 				}
 			})
 

--- a/feature/system/ntp/tests/server_test.go
+++ b/feature/system/ntp/tests/server_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/openconfig/ondatra"
-	oc "github.com/openconfig/ondatra/telemetry"
+	"github.com/openconfig/ondatra/telemetry"
 	"github.com/openconfig/testt"
 )
 
@@ -42,7 +42,7 @@ func TestNtpServerConfigurability(t *testing.T) {
 			config := dut.Config().System().Ntp()
 			state := dut.Telemetry().System().Ntp()
 
-			ntpServer := oc.System_Ntp_Server{
+			ntpServer := telemetry.System_Ntp_Server{
 				Address: &testCase.address,
 			}
 			config.Server(testCase.address).Replace(t, &ntpServer)

--- a/feature/system/ntp/tests/server_test.go
+++ b/feature/system/ntp/tests/server_test.go
@@ -1,18 +1,16 @@
-/*
- Copyright 2022 Google LLC
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-      https://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-*/
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package system_ntp_test
 
@@ -27,9 +25,6 @@ import (
 // TestNtpServerConfigurability tests basic configurability of NTP server paths.
 //
 // TODO(bstoll): port is a configurable path not tested here.
-//
-// config_path:/system/ntp/servers/server/config/address
-// telemetry_path:/system/ntp/servers/server/state/address
 func TestNtpServerConfigurability(t *testing.T) {
 	testCases := []struct {
 		description string

--- a/feature/system/ntp/tests/server_test.go
+++ b/feature/system/ntp/tests/server_test.go
@@ -33,7 +33,7 @@ func TestNtpServerConfigurability(t *testing.T) {
 	}{
 		{"IPv4 Basic Server", "192.0.2.1"},
 		{"IPv6 Basic Server", "2001:DB8::1"},
-		{"IPv6 RFC5952", "2001:db9::1"},
+		{"IPv6 RFC5952", "2001:db8::2"},
 	}
 
 	dut := ondatra.DUT(t, "dut")

--- a/feature/system/ntp/tests/system_ntp_test.go
+++ b/feature/system/ntp/tests/system_ntp_test.go
@@ -1,18 +1,16 @@
-/*
- Copyright 2022 Google LLC
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-      https://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-*/
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package system_ntp_test
 
@@ -28,9 +26,6 @@ func TestMain(m *testing.M) {
 }
 
 // TestNtpEnable validates the NTP enable path does not return an error.
-//
-// config_path:/system/ntp/config/enabled
-// telemetry_path:/system/ntp/config/enabled
 func TestNtpEnable(t *testing.T) {
 	t.Skip("Need working implementation to validate against")
 


### PR DESCRIPTION
String matching IP addresses may not be sufficient for comparison because there are many valid ways to express an IPv6 address.  This should address #284.