### PR TITLE
Fix Aggregate Load Balancing weight ratio test

### DIFF
--- a/feature/interface/aggregate/ate_tests/balancing_test/balancing_test.go
+++ b/feature/interface/aggregate/ate_tests/balancing_test/balancing_test.go
@@ -327,9 +327,10 @@ var approxOpt = cmpopts.EquateApprox(0 /* frac */, 0.01 /* absolute */)
 // portWants converts the nextHop wanted weights to per-port wanted
 // weights listed in the same order as atePorts.
 func (tc *testCase) portWants() []float64 {
-	weights := make([]float64, len(tc.dutPorts))
-	for i := range tc.dutPorts[1:] {
-		weights[i] = float64(1 / len(tc.dutPorts[1:]))
+	numPorts := len(tc.dutPorts[1:])
+	weights := []float64{}
+	for i := 0; i < numPorts; i++ {
+		weights = append(weights, 1/float64(numPorts))
 	}
 	return weights
 }
@@ -340,8 +341,8 @@ func (tc *testCase) verifyCounterDiff(t *testing.T, before, after map[string]*te
 
 	fmt.Fprint(w, "Interface Counter Deltas\n\n")
 	fmt.Fprint(w, "Name\tInPkts\tInOctets\tOutPkts\tOutOctets\n")
-	allInPkts := make([]uint64, len(tc.dutPorts[1:]))
-	allOutPkts := make([]uint64, len(tc.dutPorts[1:]))
+	allInPkts := []uint64{}
+	allOutPkts := []uint64{}
 
 	for port := range before {
 		inPkts := after[port].GetInUnicastPkts() - before[port].GetInUnicastPkts()


### PR DESCRIPTION

The "Ratio" subtest fails consistently in the aggregate link load balancing test.  The test would display the reason for the failure already in log messages:

```
outPkts normalized got: [0 0 0 0.33202573136537744 0.33593268058457215 0.3320415880500504]
want: [0 0 0 0]
...
Packet distribution ratios -want,+got:
          []float64{
          	0,
          	0,
          	0,
        - 	0,
        + 	0.33202573136537744,
        + 	0.33593268058457215,
        + 	0.3320415880500504,
          }
```

These lists get compared and are expected to be similar to eachother.  With this PR, the test returns the following output:

```
outPkts normalized got: [0.3359486895501926 0.3320247218493458 0.33202658860046164]
want: [0.3333333333333333 0.3333333333333333 0.3333333333333333]
```

Against a DUT, the test now passes.  This test was run in a testbed with a total of 4 ports (although it should support more).
