### PR TITLE
TE-4.1 use unique nhIndex/nhgIndex to avoid implicit replace

### DIFF
--- a/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
+++ b/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
@@ -218,18 +218,18 @@ func testIPv4LeaderActiveChange(ctx context.Context, t *testing.T, args *testArg
 	// Add an IPv4Entry for 198.51.100.0/24 pointing to ATE port-2 via gRIBI-A,
 	// ensure that the entry is ignored by the DUT.
 	t.Logf("Adding an IPv4Entry for %s pointing to ATE port-2 via gRIBI-A", ateDstNetCIDR)
-	args.clientA.AddNH(t, nhIndex, atePort2.IPv4, instance, fluent.ProgrammingFailed)
-	args.clientA.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, instance, fluent.ProgrammingFailed)
-	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex, instance, "", fluent.ProgrammingFailed)
+	args.clientA.AddNH(t, nhIndex+1, atePort2.IPv4, instance, fluent.ProgrammingFailed)
+	args.clientA.AddNHG(t, nhgIndex+1, map[uint64]uint64{nhIndex + 1: 1}, instance, fluent.ProgrammingFailed)
+	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex+1, instance, "", fluent.ProgrammingFailed)
 
 	// Send a ModifyRequest from gRIBI-A specifying election_id 12,
 	// followed by a ModifyRequest updating 198.51.100.0/24 pointing to ATE port-2,
 	// ensure that routing is updated to receive packets for 198.51.100.0/24 at ATE port-2.
 	args.clientA.UpdateElectionID(t, 12, 0)
 	t.Logf("Adding an IPv4Entry for %s pointing to ATE port-2 via client gRIBI-A", ateDstNetCIDR)
-	args.clientA.AddNH(t, nhIndex, atePort2.IPv4, instance, fluent.InstalledInRIB)
-	args.clientA.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, instance, fluent.InstalledInRIB)
-	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex, instance, "", fluent.InstalledInRIB)
+	args.clientA.AddNH(t, nhIndex+2, atePort2.IPv4, instance, fluent.InstalledInRIB)
+	args.clientA.AddNHG(t, nhgIndex+2, map[uint64]uint64{nhIndex + 2: 1}, instance, fluent.InstalledInRIB)
+	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex+2, instance, "", fluent.InstalledInRIB)
 
 	// Verify the entry for 198.51.100.0/24 is active through AFT Telemetry.
 	ipv4Path = args.dut.Telemetry().NetworkInstance(instance).Afts().Ipv4Entry(ateDstNetCIDR)

--- a/internal/gribi/gribi.go
+++ b/internal/gribi/gribi.go
@@ -138,6 +138,7 @@ func (c *Client) UpdateElectionID(t testing.TB, lowElecID, highElecID uint64) {
 
 // BecomeLeader learns the latest election id and the make the client leader by increasing the election id by one.
 func (c *Client) BecomeLeader(t testing.TB) {
+	t.Helper()
 	t.Logf("Trying to be a master with increasing the election id by one on dut: %s", c.DUT.Name())
 	low, high := c.learnElectionID(t)
 	newLow := low + 1
@@ -150,6 +151,7 @@ func (c *Client) BecomeLeader(t testing.TB) {
 // AddNHG adds a NextHopGroupEntry with a given index, and a map of next hop entry indices to the weights,
 // in a given network instance.
 func (c *Client) AddNHG(t testing.TB, nhgIndex uint64, nhWeights map[uint64]uint64, instance string, expectedResult fluent.ProgrammingResult) {
+	t.Helper()
 	nhg := fluent.NextHopGroupEntry().WithNetworkInstance(instance).WithID(nhgIndex)
 	for nhIndex, weight := range nhWeights {
 		nhg.AddNextHop(nhIndex, weight)
@@ -170,6 +172,7 @@ func (c *Client) AddNHG(t testing.TB, nhgIndex uint64, nhWeights map[uint64]uint
 
 // AddNH adds a NextHopEntry with a given index to an address within a given network instance.
 func (c *Client) AddNH(t testing.TB, nhIndex uint64, address, instance string, expectedResult fluent.ProgrammingResult) {
+	t.Helper()
 	c.fluentC.Modify().AddEntry(t,
 		fluent.NextHopEntry().
 			WithNetworkInstance(instance).
@@ -190,6 +193,7 @@ func (c *Client) AddNH(t testing.TB, nhIndex uint64, address, instance string, e
 
 // AddIPv4 adds an IPv4Entry mapping a prefix to a given next hop group index within a given network instance.
 func (c *Client) AddIPv4(t testing.TB, prefix string, nhgIndex uint64, instance, nhgInstance string, expectedResult fluent.ProgrammingResult) {
+	t.Helper()
 	ipv4Entry := fluent.IPv4Entry().WithPrefix(prefix).
 		WithNetworkInstance(instance).
 		WithNextHopGroup(nhgIndex)


### PR DESCRIPTION
Internal invocation ID: 77c4d72a-5a6e-4492-85cc-658e1fca8957