### PR TITLE
Pass current supervisor to watchStatus instead of supervisor capability

### DIFF
--- a/feature/gnoi/os/tests/osinstall/osinstall_test.go
+++ b/feature/gnoi/os/tests/osinstall/osinstall_test.go
@@ -222,7 +222,7 @@ func (tc *testCase) transferOS(ctx context.Context, t *testing.T, standby bool) 
 
 	awaitChan := make(chan error)
 	go func() {
-		err := watchStatus(t, ic, tc.dualSup)
+		err := watchStatus(t, ic, standby)
 		awaitChan <- err
 	}()
 


### PR DESCRIPTION
On dual supervisor DUT, `tc.dualSup` represents if the DUT has dual supervisors while `standby` represents the supervisor we are currently operating on.  watchStatus needs to know the current supervisor to determine what kind of messages are expected.

This always worked on single supervisor systems since both would be false.

The logs would show the following on dual supervisor systems:
```
osinstall_test.go:140: DUT is detected as dual supervisor.
osinstall_test.go:235: Transfer receive error: unexpected TransferProgress: got &{bytes_received:5046272}, want SyncProgress
```