### PR TITLE
Ensure transfer streams get closed on completion

### DIFF
--- a/feature/gnoi/os/tests/osinstall/osinstall_test.go
+++ b/feature/gnoi/os/tests/osinstall/osinstall_test.go
@@ -181,6 +181,9 @@ func (tc *testCase) rebootDUT(ctx context.Context, t *testing.T) {
 }
 
 func (tc *testCase) transferOS(ctx context.Context, t *testing.T, standby bool) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	ic, err := tc.osc.Install(ctx)
 	if err != nil {
 		t.Fatalf("OS.Install client request failed: %s", err)


### PR DESCRIPTION
A second transferOS may not be possible if the first transfer's streams do not get closed.