### PR TITLE
Forking RT-1.2, TE-1.1 and TE-4.1 ATE tests to OTG for baseline

### DIFF
--- a/feature/bgp/policybase/otg_tests/route_installation_test/README.md
+++ b/feature/bgp/policybase/otg_tests/route_installation_test/README.md
@@ -1,0 +1,48 @@
+# RT-1.2: BGP Policy & Route Installation
+
+## Summary
+
+Base BGP policy configuration and route installation.
+
+## Procedure
+
+*   Establish BGP sessions between:
+    *   ATE port-1 and DUT port-1
+*   For IPv4 and IPv6 routes:
+    *   Advertise prefixes from ATE port-1, observe received prefixes at ATE
+        port-2.
+    *   Specify table based policy configuration to cover:
+        *   Default accept for policies.
+        *   Default deny for policies.
+        *   Explicitly specifying local preference.
+        *   TODO: Explicitly specifying MED value.
+        *   Explicitly prepending AS for advertisement with a specified AS
+            number.
+    *   Validate that traffic can be forwarded to **all** installed routes
+        between ATE port-1 and ATE port-2, validate that flows between all
+        denied routes cannot be forwarded.
+    *   Validate that traffic is not forwarded to withdrawn routes between ATE
+        port-1 and ATE port-2.
+
+## Config Parameter Coverage
+
+*   /routing-policy/policy-definitions/policy-definition/config/name
+*   /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-local-pref
+*   /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-med
+*   /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-as-path-prepend/config/repeat-n
+
+## Telemetry Parameter Coverage
+
+For prefixes:
+
+*   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor
+*   /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group
+
+Paths:
+
+*   afi-safis/afi-safi/apply-policy/state/export-policy
+*   afi-safis/afi-safi/apply-policy/state/import-policy
+*   afi-safis/afi-safi/state/prefixes/installed
+*   afi-safis/afi-safi/state/prefixes/received
+*   afi-safis/afi-safi/state/prefixes/received-pre-policy
+*   afi-safis/afi-safi/state/prefixes/sent

--- a/feature/bgp/policybase/otg_tests/route_installation_test/route_installation_test.go
+++ b/feature/bgp/policybase/otg_tests/route_installation_test/route_installation_test.go
@@ -1,0 +1,583 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route_installation_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openconfig/featureprofiles/internal/attrs"
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/telemetry"
+	"github.com/openconfig/ygot/ygot"
+)
+
+func TestMain(m *testing.M) {
+	fptest.RunTests(m)
+}
+
+// The testbed consists of ate:port1 -> dut:port1 and
+// dut:port2 -> ate:port2.  The first pair is called the "source"
+// pair, and the second the "destination" pair.
+//
+// Source: ate:port1 -> dut:port1 subnet 192.0.2.0/30 2001:db8::0/126
+// Destination: dut:port2 -> ate:port2 subnet 192.0.2.4/30 2001:db8::4/126
+//
+// Note that the first (.0, .3) and last (.4, .7) IPv4 addresses are
+// reserved from the subnet for broadcast, so a /30 leaves exactly 2
+// usable addresses. This does not apply to IPv6 which allows /127
+// for point to point links, but we use /126 so the numbering is
+// consistent with IPv4.
+//
+// A traffic flow is configured from ate:port1 as the source interface
+// and ate:port2 as the destination interface. Then 255 BGP routes 203.0.113.[1-254]/32
+// are adverstised from port2 and traffic is sent originating from port1 to all
+// these advertised routes. The traffic will pass only if the DUT installs the
+// prefixes successfully in the routing table via BGP.Successful transmission of
+// traffic will ensure BGP routes are properly installed on the DUT and programmed.
+// Similarly, Traffic is sent for IPv6 destinations.
+
+const (
+	trafficDuration        = 1 * time.Minute
+	ipv4SrcTraffic         = "192.0.2.2"
+	ipv6SrcTraffic         = "2001:db8::192:0:2:2"
+	ipv4DstTrafficStart    = "203.0.113.1"
+	ipv4DstTrafficEnd      = "203.0.113.254"
+	ipv6DstTrafficStart    = "2001:db8::203:0:113:1"
+	ipv6DstTrafficEnd      = "2001:db8::203:0:113:fe"
+	advertisedRoutesv4CIDR = "203.0.113.1/32"
+	advertisedRoutesv6CIDR = "2001:db8::203:0:113:1/128"
+	peerGrpName            = "BGP-PEER-GROUP"
+	routeCount             = 254
+	dutAS                  = 64500
+	ateAS                  = 64501
+	badAS                  = 64502
+	plenIPv4               = 30
+	plenIPv6               = 126
+	tolerance              = 50
+	tolerancePct           = 2
+	ipPrefixSet            = "203.0.113.0/29"
+	prefixSubnetRange      = "29..32"
+	allowConnected         = "ALLOW-CONNECTED"
+	prefixSet              = "PREFIX-SET"
+	defaultPolicy          = ""
+	denyPolicy             = "DENY-ALL"
+	acceptPolicy           = "PERMIT-ALL"
+	setLocalPrefPolicy     = "SET-LOCAL-PREF"
+	localPrefValue         = 100
+	setAspathPrependPolicy = "SET-ASPATH-PREPEND"
+	asPathRepeatValue      = 3
+	aclStatement1          = "10"
+	aclStatement2          = "20"
+)
+
+var (
+	dutSrc = attrs.Attributes{
+		Desc:    "DUT to ATE source",
+		IPv4:    "192.0.2.1",
+		IPv6:    "2001:db8::192:0:2:1",
+		IPv4Len: plenIPv4,
+		IPv6Len: plenIPv6,
+	}
+	ateSrc = attrs.Attributes{
+		Name:    "ateSrc",
+		IPv4:    "192.0.2.2",
+		IPv6:    "2001:db8::192:0:2:2",
+		IPv4Len: plenIPv4,
+		IPv6Len: plenIPv6,
+	}
+
+	dutDst = attrs.Attributes{
+		Desc:    "DUT to ATE destination",
+		IPv4:    "192.0.2.5",
+		IPv6:    "2001:db8::192:0:2:5",
+		IPv4Len: plenIPv4,
+		IPv6Len: plenIPv6,
+	}
+
+	ateDst = attrs.Attributes{
+		Name:    "atedst",
+		IPv4:    "192.0.2.6",
+		IPv6:    "2001:db8::192:0:2:6",
+		IPv4Len: plenIPv4,
+		IPv6Len: plenIPv6,
+	}
+)
+
+// configureDUT configures all the interfaces on the DUT.
+func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
+	dc := dut.Config()
+	i1 := dutSrc.NewInterface(dut.Port(t, "port1").Name())
+	dc.Interface(i1.GetName()).Replace(t, i1)
+
+	i2 := dutDst.NewInterface(dut.Port(t, "port2").Name())
+	dc.Interface(i2.GetName()).Replace(t, i2)
+}
+
+// verifyPortsUp asserts that each port on the device is operating
+func verifyPortsUp(t *testing.T, dev *ondatra.Device) {
+	t.Helper()
+	for _, p := range dev.Ports() {
+		status := dev.Telemetry().Interface(p.Name()).OperStatus().Get(t)
+		if want := telemetry.Interface_OperStatus_UP; status != want {
+			t.Errorf("%s Status: got %v, want %v", p, status, want)
+		}
+	}
+}
+
+// bgpCreateNbr creates a BGP object with neighbors pointing to ateSrc and ateDst, optionally with
+// a peer group policy.
+func bgpCreateNbr(localAs, peerAs uint32, policy string) *telemetry.NetworkInstance_Protocol_Bgp {
+	nbr1v4 := &bgpNeighbor{as: peerAs, neighborip: ateSrc.IPv4, isV4: true}
+	nbr1v6 := &bgpNeighbor{as: peerAs, neighborip: ateSrc.IPv6, isV4: false}
+	nbr2v4 := &bgpNeighbor{as: peerAs, neighborip: ateDst.IPv4, isV4: true}
+	nbr2v6 := &bgpNeighbor{as: peerAs, neighborip: ateDst.IPv6, isV4: false}
+	nbrs := []*bgpNeighbor{nbr1v4, nbr2v4, nbr1v6, nbr2v6}
+
+	d := &telemetry.Device{}
+	ni1 := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
+	bgp := ni1.GetOrCreateProtocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
+	global := bgp.GetOrCreateGlobal()
+	global.As = ygot.Uint32(localAs)
+	// Note: we have to define the peer group even if we aren't setting any policy because it's
+	// invalid OC for the neighbor to be part of a peer group that doesn't exist.
+	pg := bgp.GetOrCreatePeerGroup(peerGrpName)
+	pg.PeerAs = ygot.Uint32(ateAS)
+	pg.PeerGroupName = ygot.String(peerGrpName)
+	if policy != "" {
+		pg.GetOrCreateApplyPolicy().ImportPolicy = []string{policy}
+	}
+	for _, nbr := range nbrs {
+		if nbr.isV4 {
+			nv4 := bgp.GetOrCreateNeighbor(nbr.neighborip)
+			nv4.PeerGroup = ygot.String(peerGrpName)
+			nv4.PeerAs = ygot.Uint32(nbr.as)
+			nv4.Enabled = ygot.Bool(true)
+			nv4.GetOrCreateAfiSafi(telemetry.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Enabled = ygot.Bool(true)
+		} else {
+			nv6 := bgp.GetOrCreateNeighbor(nbr.neighborip)
+			nv6.PeerGroup = ygot.String(peerGrpName)
+			nv6.PeerAs = ygot.Uint32(nbr.as)
+			nv6.Enabled = ygot.Bool(true)
+			nv6.GetOrCreateAfiSafi(telemetry.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).Enabled = ygot.Bool(true)
+		}
+
+	}
+	return bgp
+}
+
+// configureBGPPolicy configures a BGP routing policy to accept or reject routes based on prefix match conditions
+// Additonally, it configures LocalPreference and ASPathprepend as part of the BGP policy
+func configureBGPPolicy(d *telemetry.Device) *telemetry.RoutingPolicy {
+	rp := d.GetOrCreateRoutingPolicy()
+	pset := rp.GetOrCreateDefinedSets().GetOrCreatePrefixSet(prefixSet)
+	pset.GetOrCreatePrefix(ipPrefixSet, prefixSubnetRange)
+	pdef := rp.GetOrCreatePolicyDefinition(allowConnected)
+	stmt5 := pdef.GetOrCreateStatement(aclStatement1)
+	stmt5.GetOrCreateActions().PolicyResult = telemetry.RoutingPolicy_PolicyResultType_REJECT_ROUTE
+	stmt5.GetOrCreateConditions().GetOrCreateMatchPrefixSet().PrefixSet = ygot.String(prefixSet)
+	stmt10 := pdef.GetOrCreateStatement(aclStatement2)
+	stmt10.GetOrCreateActions().PolicyResult = telemetry.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+
+	pdef2 := rp.GetOrCreatePolicyDefinition(acceptPolicy)
+	pdef2.GetOrCreateStatement(aclStatement2).GetOrCreateActions().PolicyResult = telemetry.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+
+	pdef3 := rp.GetOrCreatePolicyDefinition(denyPolicy)
+	pdef3.GetOrCreateStatement(aclStatement2).GetOrCreateActions().PolicyResult = telemetry.RoutingPolicy_PolicyResultType_REJECT_ROUTE
+
+	pdef4 := rp.GetOrCreatePolicyDefinition(setLocalPrefPolicy)
+	actions := pdef4.GetOrCreateStatement(aclStatement2).GetOrCreateActions()
+	actions.GetOrCreateBgpActions().SetLocalPref = ygot.Uint32(localPrefValue)
+	actions.PolicyResult = telemetry.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+
+	pdef5 := rp.GetOrCreatePolicyDefinition(setAspathPrependPolicy)
+	actions5 := pdef5.GetOrCreateStatement(aclStatement2).GetOrCreateActions()
+	aspend := actions5.GetOrCreateBgpActions().GetOrCreateSetAsPathPrepend()
+	aspend.Asn = ygot.Uint32(ateAS)
+	aspend.RepeatN = ygot.Uint8(asPathRepeatValue)
+	actions5.PolicyResult = telemetry.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+
+	return rp
+}
+
+// verifyBgpTelemetry checks that the dut has an established BGP session with reasonable settings
+func verifyBgpTelemetry(t *testing.T, dut *ondatra.DUTDevice) {
+	ifName := dut.Port(t, "port1").Name()
+	lastFlapTime := dut.Telemetry().Interface(ifName).LastChange().Get(t)
+	t.Logf("Verifying BGP state")
+	statePath := dut.Telemetry().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	nbrPath := statePath.Neighbor(ateSrc.IPv4)
+	nbrPathv6 := statePath.Neighbor(ateSrc.IPv6)
+	nbr := statePath.Get(t).GetNeighbor(ateSrc.IPv4)
+
+	// Get BGP adjacency state
+	t.Logf("Waiting for BGP neighbor to establish...")
+	_, ok := nbrPath.SessionState().Watch(t, time.Minute, func(val *telemetry.QualifiedE_Bgp_Neighbor_SessionState) bool {
+		return val.IsPresent() && val.Val(t) == telemetry.Bgp_Neighbor_SessionState_ESTABLISHED
+	}).Await(t)
+	if !ok {
+		fptest.LogYgot(t, "BGP reported state", nbrPath, nbrPath.Get(t))
+		t.Fatal("No BGP neighbor formed")
+	}
+	status := nbrPath.SessionState().Get(t)
+	t.Logf("BGP adjacency for %s: %s", ateSrc.IPv4, status)
+	if want := telemetry.Bgp_Neighbor_SessionState_ESTABLISHED; status != want {
+		t.Errorf("BGP peer %s status got %d, want %d", ateSrc.IPv4, status, want)
+	}
+
+	// Check last established timestamp
+	lestTime := nbrPath.Get(t).GetLastEstablished()
+	lestTimev6 := nbrPathv6.Get(t).GetLastEstablished()
+	t.Logf("BGP last est time :%v, flapTime :%v", lestTime, lastFlapTime)
+	t.Logf("BGP v6 last est time :%d", lestTimev6)
+	if lestTime < lastFlapTime {
+		t.Errorf("Bad last-established timestamp: got %v, want >= %v", lestTime, lastFlapTime)
+	}
+
+	// Check BGP Transitions
+	estTrans := nbr.GetEstablishedTransitions()
+	t.Logf("Got established transitions: %d", estTrans)
+	if estTrans != 1 {
+		t.Errorf("Wrong established-transitions: got %v, want 1", estTrans)
+	}
+
+	// Check BGP neighbor address from telemetry
+	addrv4 := nbrPath.Get(t).GetNeighborAddress()
+	addrv6 := nbrPathv6.Get(t).GetNeighborAddress()
+	t.Logf("Got ipv4 neighbor address: %s", addrv4)
+	if addrv4 != ateSrc.IPv4 {
+		t.Errorf("BGP v4 neighbor address: got %v, want %v", addrv4, ateSrc.IPv4)
+	}
+
+	t.Logf("Got Ipv6 neighbor address: %s", addrv6)
+	if addrv6 != ateSrc.IPv6 {
+		t.Errorf("BGP v6 neighbor address: got %v, want %v", addrv6, ateSrc.IPv6)
+	}
+
+	// Check BGP neighbor address from telemetry
+	peerAS := nbrPath.Get(t).GetPeerAs()
+	if peerAS != ateAS {
+		t.Errorf("BGP peerAs: got %v, want %v", peerAS, ateAS)
+	}
+
+	// Check BGP neighbor is enabled
+	if !nbrPath.Get(t).GetEnabled() {
+		t.Errorf("Expected neighbor %v to be enabled", ateSrc.IPv4)
+	}
+}
+
+// verifyPrefixesTelemetry confirms that the dut shows the correct numbers of installed, sent and
+// received IPv4 prefixes
+// TODO: Need to refactor and compare using cmp.diff
+func verifyPrefixesTelemetry(t *testing.T, dut *ondatra.DUTDevice, wantInstalled, wantRx, wantSent uint32) {
+	statePath := dut.Telemetry().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	prefixesv4 := statePath.Neighbor(ateDst.IPv4).AfiSafi(telemetry.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Prefixes()
+	if gotInstalled := prefixesv4.Installed().Get(t); gotInstalled != wantInstalled {
+		t.Errorf("Installed prefixes mismatch: got %v, want %v", gotInstalled, wantInstalled)
+	}
+	if gotRx := prefixesv4.ReceivedPrePolicy().Get(t); gotRx != wantRx {
+		t.Errorf("Received prefixes mismatch: got %v, want %v", gotRx, wantRx)
+	}
+	if gotSent := prefixesv4.Sent().Get(t); gotSent != wantSent {
+		t.Errorf("Sent prefixes mismatch: got %v, want %v", gotSent, wantSent)
+	}
+}
+
+// verifyPrefixesTelemetryV6 confirms that the dut shows the correct numbers of installed, sent and
+// received IPv6 prefixes
+func verifyPrefixesTelemetryV6(t *testing.T, dut *ondatra.DUTDevice, wantInstalledv6, wantRxv6, wantSentv6 uint32) {
+	statePath := dut.Telemetry().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	prefixesv6 := statePath.Neighbor(ateDst.IPv6).AfiSafi(telemetry.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).Prefixes()
+
+	if gotInstalledv6 := prefixesv6.Installed().Get(t); gotInstalledv6 != wantInstalledv6 {
+		t.Errorf("IPV6 Installed prefixes mismatch: got %v, want %v", gotInstalledv6, wantInstalledv6)
+	}
+	if gotRxv6 := prefixesv6.ReceivedPrePolicy().Get(t); gotRxv6 != wantRxv6 {
+		t.Errorf("IPV6 Received prefixes mismatch: got %v, want %v", gotRxv6, wantRxv6)
+	}
+	if gotSentv6 := prefixesv6.Sent().Get(t); gotSentv6 != wantSentv6 {
+		t.Errorf("IPv6 Sent prefixes mismatch: got %v, want %v", gotSentv6, wantSentv6)
+	}
+}
+
+// verifyPolicyTelemetry confirms that the dut policy is set as expected.
+func verifyPolicyTelemetry(t *testing.T, dut *ondatra.DUTDevice, policy string) {
+	statePath := dut.Telemetry().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	policytel := statePath.PeerGroup(peerGrpName).ApplyPolicy().ImportPolicy().Get(t)
+	for _, val := range policytel {
+		if val != policy {
+			t.Errorf("Apply policy mismatch: got %v, want %v", policytel, policy)
+		}
+	}
+}
+
+// configureATE configures the interfaces and BGP protocols on an ATE, including advertising some
+// (faked) networks over BGP.
+func configureATE(t *testing.T, ate *ondatra.ATEDevice) []*ondatra.Flow {
+	port1 := ate.Port(t, "port1")
+	topo := ate.Topology().New()
+	iDut1 := topo.AddInterface(ateSrc.Name).WithPort(port1)
+	iDut1.IPv4().WithAddress(ateSrc.IPv4CIDR()).WithDefaultGateway(dutSrc.IPv4)
+	iDut1.IPv6().WithAddress(ateSrc.IPv6CIDR()).WithDefaultGateway(dutSrc.IPv6)
+
+	port2 := ate.Port(t, "port2")
+	iDut2 := topo.AddInterface(ateDst.Name).WithPort(port2)
+	iDut2.IPv4().WithAddress(ateDst.IPv4CIDR()).WithDefaultGateway(dutDst.IPv4)
+	iDut2.IPv6().WithAddress(ateDst.IPv6CIDR()).WithDefaultGateway(dutDst.IPv6)
+
+	// Setup ATE BGP route v4 advertisement
+	bgpDut1 := iDut1.BGP()
+	bgpDut1.AddPeer().WithPeerAddress(dutSrc.IPv4).WithLocalASN(ateAS).
+		WithTypeExternal()
+	bgpDut1.AddPeer().WithPeerAddress(dutSrc.IPv6).WithLocalASN(ateAS).
+		WithTypeExternal()
+
+	bgpDut2 := iDut2.BGP()
+	bgpDut2.AddPeer().WithPeerAddress(dutDst.IPv4).WithLocalASN(ateAS).
+		WithTypeExternal()
+	bgpDut2.AddPeer().WithPeerAddress(dutDst.IPv6).WithLocalASN(ateAS).
+		WithTypeExternal()
+
+	bgpNeti1 := iDut2.AddNetwork("bgpNeti1")
+	bgpNeti1.IPv4().WithAddress(advertisedRoutesv4CIDR).WithCount(routeCount)
+	bgpNeti1.BGP().WithNextHopAddress(ateDst.IPv4)
+
+	bgpNeti1v6 := iDut2.AddNetwork("bgpNeti1v6")
+	bgpNeti1v6.IPv6().WithAddress(advertisedRoutesv6CIDR).WithCount(routeCount)
+	bgpNeti1v6.BGP().WithActive(true).WithNextHopAddress(ateDst.IPv6)
+
+	t.Logf("Pushing config to ATE and starting protocols...")
+	topo.Push(t)
+	topo.StartProtocols(t)
+
+	// ATE Traffic Configuration
+	t.Logf("TestBGP:start ate Traffic config")
+	ethHeader := ondatra.NewEthernetHeader()
+	// BGP V4 Traffic
+	ipv4Header := ondatra.NewIPv4Header()
+	ipv4Header.WithSrcAddress(ipv4SrcTraffic).DstAddressRange().
+		WithMin(ipv4DstTrafficStart).WithMax(ipv4DstTrafficEnd).
+		WithCount(routeCount)
+	flowipv4 := ate.Traffic().NewFlow("Ipv4").
+		WithSrcEndpoints(iDut1).
+		WithDstEndpoints(iDut2).
+		WithHeaders(ethHeader, ipv4Header).
+		WithFrameSize(512)
+
+	// BGP IP V6 traffic
+	ipv6Header := ondatra.NewIPv6Header()
+	ipv6Header.WithECN(0).WithSrcAddress(ipv6SrcTraffic).
+		DstAddressRange().WithMin(ipv6DstTrafficStart).WithMax(ipv6DstTrafficEnd).
+		WithCount(routeCount)
+	flowipv6 := ate.Traffic().NewFlow("Ipv6").
+		WithSrcEndpoints(iDut1).
+		WithDstEndpoints(iDut2).
+		WithHeaders(ethHeader, ipv6Header).
+		WithFrameSize(512)
+
+	return []*ondatra.Flow{flowipv4, flowipv6}
+}
+
+// verifyTraffic confirms that every traffic flow has the expected amount of loss (0% or 100%
+// depending on wantLoss, +- 2%)
+func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, allFlows []*ondatra.Flow, wantLoss bool) {
+	captureTrafficStats(t, ate, wantLoss)
+	for _, flow := range allFlows {
+		lossPct := ate.Telemetry().Flow(flow.Name()).LossPct().Get(t)
+		if !wantLoss {
+			if lossPct > tolerancePct {
+				t.Errorf("Traffic Loss Pct for Flow: %s\n got %v, want 0", flow.Name(), lossPct)
+			} else {
+				t.Logf("Traffic Test Passed!")
+			}
+		} else {
+			if lossPct < 100-tolerancePct {
+				t.Errorf("Traffic is expected to fail %s\n got %v, want 100%% failure", flow.Name(), lossPct)
+			} else {
+				t.Logf("Traffic Loss Test Passed!")
+			}
+		}
+	}
+}
+
+func captureTrafficStats(t *testing.T, ate *ondatra.ATEDevice, wantLoss bool) {
+	ap := ate.Port(t, "port1")
+	aic1 := ate.Telemetry().Interface(ap.Name()).Counters()
+	outPkts := aic1.OutPkts().Get(t)
+	fptest.LogYgot(t, "ate:port1 counters", aic1, aic1.Get(t))
+
+	op := ate.Port(t, "port2")
+	aic2 := ate.Telemetry().Interface(op.Name()).Counters()
+	inPkts := aic2.InPkts().Get(t)
+	fptest.LogYgot(t, "ate:port2 counters", aic2, aic2.Get(t))
+
+	lostPkts := inPkts - outPkts
+	t.Logf("Sent Packets: %d, received Packets: %d", outPkts, inPkts)
+	if !wantLoss {
+		if lostPkts > tolerance {
+			t.Logf("Packets received not matching packets sent. Sent: %v, Received: %d", outPkts, inPkts)
+		} else {
+			t.Logf("Traffic Test Passed! Sent: %d, Received: %d", outPkts, inPkts)
+		}
+	}
+}
+
+func sendTraffic(t *testing.T, ate *ondatra.ATEDevice, allFlows []*ondatra.Flow) {
+	t.Logf("Starting traffic")
+	ate.Traffic().Start(t, allFlows...)
+	time.Sleep(trafficDuration)
+	ate.Traffic().Stop(t)
+	t.Logf("Stop traffic")
+}
+
+type bgpNeighbor struct {
+	as         uint32
+	neighborip string
+	isV4       bool
+}
+
+// TestEstablish sets up a basic BGP connection and confirms that traffic is forwarded according to
+// it.
+func TestEstablish(t *testing.T) {
+	// DUT configurations.
+	t.Logf("Start DUT config load:")
+	dut := ondatra.DUT(t, "dut")
+
+	// Configure interface on the DUT
+	t.Logf("Start DUT interface Config")
+	configureDUT(t, dut)
+
+	t.Log("Configure Network Instance")
+
+	dutConfNIPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath.RouterId().Replace(t, dutDst.IPv4)
+
+	// Configure BGP+Neighbors on the DUT
+	t.Logf("Start DUT BGP Config")
+	dutConfPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	dutConfPath.Replace(t, nil)
+	dutConf := bgpCreateNbr(dutAS, ateAS, defaultPolicy)
+	dutConfPath.Replace(t, dutConf)
+	fptest.LogYgot(t, "DUT BGP Config", dutConfPath, dutConfPath.Get(t))
+
+	// ATE Configuration.
+	t.Logf("Start ATE Config")
+	ate := ondatra.ATE(t, "ate")
+	allFlows := configureATE(t, ate)
+
+	// Verify Port Status
+	t.Logf("Verifying port status")
+	verifyPortsUp(t, dut.Device)
+
+	t.Logf("Check BGP parameters")
+	verifyBgpTelemetry(t, dut)
+
+	// Starting ATE Traffic
+	sendTraffic(t, ate, allFlows)
+
+	// Verify Traffic Flows and packet loss
+	verifyTraffic(t, ate, allFlows, false)
+	verifyPrefixesTelemetry(t, dut, routeCount, routeCount, 0)
+	verifyPrefixesTelemetryV6(t, dut, routeCount, routeCount, 0)
+
+	t.Run("RoutesWithdrawn", func(t *testing.T) {
+		t.Log("Breaking BGP config and confirming that forwarding stops working.")
+		// Break config with a mismatching AS number
+		dutConfPath.Replace(t, bgpCreateNbr(dutAS, badAS, defaultPolicy))
+
+		// Resend traffic
+		sendTraffic(t, ate, allFlows)
+
+		// Verify traffic fails as routes are withdrawn and 100% packet loss is seen.
+		verifyTraffic(t, ate, allFlows, true)
+	})
+}
+
+func TestBGPPolicy(t *testing.T) {
+	// DUT configurations.
+	t.Logf("Start DUT config load:")
+	dut := ondatra.DUT(t, "dut")
+
+	// Configure interface on the DUT
+	t.Logf("Start DUT interface Config")
+	configureDUT(t, dut)
+
+	t.Log("Configure Network Instance")
+
+	dutConfNIPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath.RouterId().Replace(t, dutDst.IPv4)
+
+	cases := []struct {
+		desc                      string
+		policy                    string
+		installed, received, sent uint32
+		wantLoss                  bool
+	}{{
+		desc:      "Configure Accept All Policy",
+		policy:    acceptPolicy,
+		installed: routeCount,
+		received:  routeCount,
+		sent:      0,
+		wantLoss:  false,
+	}, {
+		desc:      "Configure Deny All Policy",
+		policy:    denyPolicy,
+		installed: 0,
+		received:  routeCount,
+		sent:      0,
+		wantLoss:  true,
+	}, {
+		desc:      "Configure Set Local Preference Policy",
+		policy:    setLocalPrefPolicy,
+		installed: routeCount,
+		received:  routeCount,
+		sent:      0,
+		wantLoss:  false,
+	}, {
+		desc:      "Configure Set AS Path prepend Policy",
+		policy:    setAspathPrependPolicy,
+		installed: routeCount,
+		received:  routeCount,
+		sent:      0,
+		wantLoss:  false,
+	}}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			dut := ondatra.DUT(t, "dut")
+			ate := ondatra.ATE(t, "ate")
+
+			// Configure Routing Policy on the DUT
+			dutConfPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+			fptest.LogYgot(t, "DUT BGP Config before", dutConfPath, dutConfPath.Get(t))
+			d := &telemetry.Device{}
+			t.Log("Configure BGP Policy with BGP actions on the neighbor")
+			rpl := configureBGPPolicy(d)
+			dut.Config().RoutingPolicy().Replace(t, rpl)
+			bgp := bgpCreateNbr(dutAS, ateAS, tc.policy)
+			// Configure ATE to setup traffic.
+			allFlows := configureATE(t, ate)
+			dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().Replace(t, bgp)
+			// Send and verify traffic.
+			sendTraffic(t, ate, allFlows)
+			verifyTraffic(t, ate, allFlows, tc.wantLoss)
+			// Verify traffic and telemetry.
+			verifyPrefixesTelemetry(t, dut, tc.installed, tc.received, tc.sent)
+			verifyPrefixesTelemetryV6(t, dut, tc.installed, tc.received, tc.sent)
+			verifyPolicyTelemetry(t, dut, tc.policy)
+		})
+	}
+}

--- a/feature/gribi/otg_tests/base_leader_election_test/README.md
+++ b/feature/gribi/otg_tests/base_leader_election_test/README.md
@@ -1,0 +1,39 @@
+# TE-4.1: Base Leader Election
+
+## Summary
+
+Validate Election ID is accepted from a gRIBI client.
+
+## Procedure
+
+*   Connect DUT port-1 to ATE port-1, DUT port-2 to ATE port-2, DUT port-3 to
+    ATE port-3. Assign IPv4 addresses to all ports.
+
+*   Establish two gRIBI clients to the DUT (referred to as `gRIBI-A` and
+    `gRIBI-B`).
+
+*   Connect `gRIBI-A` to DUT specifying `SINGLE_PRIMARY` client redundancy in
+    the SessionParameters request, and `election_id` 10. Ensure that no error is
+    reported from the gRIBI server.
+
+*   Connect `gRIBI-B` to DUT specifying `SINGLE_PRIMARY` client redundancy with
+    `election_id` 11.
+
+*   Add an `IPv4Entry` for `198.51.100.0/24` pointing to ATE port-3 via
+    `gRIBI-B`, ensure that the entry is active through AFT telemetry and
+    traffic.
+
+*   Add an `IPv4Entry` for `198.51.100.0/24` pointing to ATE port-2 via
+    `gRIBI-A`, ensure that the entry is ignored by the DUT.
+
+*   Send a `ModifyRequest` from `gRIBI-A` specifying `election_id` 12, followed
+    by a `ModifyRequest` updating `198.51.100.0/24` pointing to ATE port-2,
+    ensure that routing is updated to receive packets for `198.51.100.0/24` at
+    ATE port-2.
+
+## Protocol/RPC Parameter Coverage
+
+*   gRIBI
+    *   ModifyRequest
+        *   SessionParameters:
+            *   redundancy

--- a/feature/gribi/otg_tests/base_leader_election_test/base_leader_election_test.go
+++ b/feature/gribi/otg_tests/base_leader_election_test/base_leader_election_test.go
@@ -1,0 +1,292 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base_leader_election_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openconfig/featureprofiles/internal/attrs"
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/featureprofiles/internal/gribi"
+	"github.com/openconfig/gribigo/fluent"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/telemetry"
+	"github.com/openconfig/ygot/ygot"
+)
+
+func TestMain(m *testing.M) {
+	fptest.RunTests(m)
+}
+
+// Settings for configuring the baseline testbed with the test
+// topology.
+//
+// The testbed consists of ate:port1 -> dut:port1,
+// dut:port2 -> ate:port2 and dut:port3 -> ate:port3.
+//
+//   * ate:port1 -> dut:port1 subnet 192.0.2.0/30
+//   * ate:port2 -> dut:port2 subnet 192.0.2.4/30
+//   * ate:port3 -> dut:port3 subnet 192.0.2.8/30
+//
+//   * Destination network: 198.51.100.0/24
+
+const (
+	ipv4PrefixLen = 30
+	instance      = "default"
+	ateDstNetCIDR = "198.51.100.0/24"
+	nhIndex       = 1
+	nhgIndex      = 42
+)
+
+var (
+	dutPort1 = attrs.Attributes{
+		Desc:    "dutPort1",
+		IPv4:    "192.0.2.1",
+		IPv4Len: ipv4PrefixLen,
+	}
+
+	atePort1 = attrs.Attributes{
+		Name:    "atePort1",
+		IPv4:    "192.0.2.2",
+		IPv4Len: ipv4PrefixLen,
+	}
+
+	dutPort2 = attrs.Attributes{
+		Desc:    "dutPort2",
+		IPv4:    "192.0.2.5",
+		IPv4Len: ipv4PrefixLen,
+	}
+
+	atePort2 = attrs.Attributes{
+		Name:    "atePort2",
+		IPv4:    "192.0.2.6",
+		IPv4Len: ipv4PrefixLen,
+	}
+
+	dutPort3 = attrs.Attributes{
+		Desc:    "dutPort3",
+		IPv4:    "192.0.2.9",
+		IPv4Len: ipv4PrefixLen,
+	}
+
+	atePort3 = attrs.Attributes{
+		Name:    "atePort3",
+		IPv4:    "192.0.2.10",
+		IPv4Len: ipv4PrefixLen,
+	}
+)
+
+// configInterfaceDUT configures the interface with the Addrs.
+func configInterfaceDUT(i *telemetry.Interface, a *attrs.Attributes) *telemetry.Interface {
+	i.Description = ygot.String(a.Desc)
+	i.Type = telemetry.IETFInterfaces_InterfaceType_ethernetCsmacd
+	if *deviations.InterfaceEnabled {
+		i.Enabled = ygot.Bool(true)
+	}
+
+	s := i.GetOrCreateSubinterface(0)
+	s4 := s.GetOrCreateIpv4()
+	if *deviations.InterfaceEnabled {
+		s4.Enabled = ygot.Bool(true)
+	}
+	s4a := s4.GetOrCreateAddress(a.IPv4)
+	s4a.PrefixLength = ygot.Uint8(ipv4PrefixLen)
+
+	return i
+}
+
+// configureDUT configures port1, port2 and port3 on the DUT.
+func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
+	d := dut.Config()
+
+	p1 := dut.Port(t, "port1")
+	i1 := &telemetry.Interface{Name: ygot.String(p1.Name())}
+	d.Interface(p1.Name()).Replace(t, configInterfaceDUT(i1, &dutPort1))
+
+	p2 := dut.Port(t, "port2")
+	i2 := &telemetry.Interface{Name: ygot.String(p2.Name())}
+	d.Interface(p2.Name()).Replace(t, configInterfaceDUT(i2, &dutPort2))
+
+	p3 := dut.Port(t, "port3")
+	i3 := &telemetry.Interface{Name: ygot.String(p3.Name())}
+	d.Interface(p3.Name()).Replace(t, configInterfaceDUT(i3, &dutPort3))
+}
+
+// configureATE configures port1, port2 and port3 on the ATE.
+func configureATE(t *testing.T, ate *ondatra.ATEDevice) *ondatra.ATETopology {
+	top := ate.Topology().New()
+
+	p1 := ate.Port(t, "port1")
+	i1 := top.AddInterface(atePort1.Name).WithPort(p1)
+	i1.IPv4().
+		WithAddress(atePort1.IPv4CIDR()).
+		WithDefaultGateway(dutPort1.IPv4)
+
+	p2 := ate.Port(t, "port2")
+	i2 := top.AddInterface(atePort2.Name).WithPort(p2)
+	i2.IPv4().
+		WithAddress(atePort2.IPv4CIDR()).
+		WithDefaultGateway(dutPort2.IPv4)
+
+	p3 := ate.Port(t, "port3")
+	i3 := top.AddInterface(atePort3.Name).WithPort(p3)
+	i3.IPv4().
+		WithAddress(atePort3.IPv4CIDR()).
+		WithDefaultGateway(dutPort3.IPv4)
+
+	return top
+}
+
+// testTraffic generates traffic flow from source network to
+// destination network via srcEndPoint to dstEndPoint and checks for
+// packet loss.
+func testTraffic(t *testing.T, ate *ondatra.ATEDevice, top *ondatra.ATETopology, srcEndPoint, dstEndPoint *ondatra.Interface) {
+	ethHeader := ondatra.NewEthernetHeader()
+	ipv4Header := ondatra.NewIPv4Header()
+	ipv4Header.DstAddressRange().
+		WithMin("198.51.100.0").
+		WithMax("198.51.100.254").
+		WithCount(250)
+
+	flow := ate.Traffic().NewFlow("Flow").
+		WithSrcEndpoints(srcEndPoint).
+		WithDstEndpoints(dstEndPoint).
+		WithHeaders(ethHeader, ipv4Header)
+
+	ate.Traffic().Start(t, flow)
+	time.Sleep(15 * time.Second)
+	ate.Traffic().Stop(t)
+
+	time.Sleep(time.Minute)
+
+	flowPath := ate.Telemetry().Flow(flow.Name())
+	if got := flowPath.LossPct().Get(t); got > 0 {
+		t.Errorf("LossPct for flow %s got %g, want 0", flow.Name(), got)
+	}
+}
+
+// testArgs holds the objects needed by a test case.
+type testArgs struct {
+	ctx     context.Context
+	clientA *gribi.Client
+	clientB *gribi.Client
+	dut     *ondatra.DUTDevice
+	ate     *ondatra.ATEDevice
+	top     *ondatra.ATETopology
+}
+
+// testIPv4LeaderActiveChange first configures an IPV4 Entry through clientB
+// and ensures that the entry is active by checking AFT Telemetry and traffic.
+// It then configures an IPv4 entry through clientA without updating the election
+// and ensures that the installation fails. Finally, it updated the ClientA election
+// id to 12, configures an IPV4 through clinetA and ensures that the entry is active
+// by checking AFT Telemetry and traffic.
+func testIPv4LeaderActiveChange(ctx context.Context, t *testing.T, args *testArgs) {
+	// Add an IPv4Entry for 198.51.100.0/24 pointing to ATE port-3 via gRIBI-B,
+	// ensure that the entry is active through AFT telemetry and traffic.
+	t.Logf("an IPv4Entry for %s pointing to ATE port-3 via gRIBI-B", ateDstNetCIDR)
+	args.clientB.AddNH(t, nhIndex, atePort3.IPv4, instance, fluent.InstalledInRIB)
+	args.clientB.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, instance, fluent.InstalledInRIB)
+	args.clientB.AddIPv4(t, ateDstNetCIDR, nhgIndex, instance, "", fluent.InstalledInRIB)
+
+	// Verify the entry for 198.51.100.0/24 is active through AFT Telemetry.
+	ipv4Path := args.dut.Telemetry().NetworkInstance(instance).Afts().Ipv4Entry(ateDstNetCIDR)
+	if got, want := ipv4Path.Prefix().Get(t), ateDstNetCIDR; got != want {
+		t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
+	}
+
+	// Verify the entry for 198.51.100.0/24 is active through Traffic.
+	srcEndPoint := args.top.Interfaces()[atePort1.Name]
+	dstEndPoint := args.top.Interfaces()[atePort3.Name]
+	testTraffic(t, args.ate, args.top, srcEndPoint, dstEndPoint)
+
+	// Add an IPv4Entry for 198.51.100.0/24 pointing to ATE port-2 via gRIBI-A,
+	// ensure that the entry is ignored by the DUT.
+	t.Logf("Adding an IPv4Entry for %s pointing to ATE port-2 via gRIBI-A", ateDstNetCIDR)
+	args.clientA.AddNH(t, nhIndex+1, atePort2.IPv4, instance, fluent.ProgrammingFailed)
+	args.clientA.AddNHG(t, nhgIndex+1, map[uint64]uint64{nhIndex + 1: 1}, instance, fluent.ProgrammingFailed)
+	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex+1, instance, "", fluent.ProgrammingFailed)
+
+	// Send a ModifyRequest from gRIBI-A specifying election_id 12,
+	// followed by a ModifyRequest updating 198.51.100.0/24 pointing to ATE port-2,
+	// ensure that routing is updated to receive packets for 198.51.100.0/24 at ATE port-2.
+	args.clientA.UpdateElectionID(t, 12, 0)
+	t.Logf("Adding an IPv4Entry for %s pointing to ATE port-2 via client gRIBI-A", ateDstNetCIDR)
+	args.clientA.AddNH(t, nhIndex+2, atePort2.IPv4, instance, fluent.InstalledInRIB)
+	args.clientA.AddNHG(t, nhgIndex+2, map[uint64]uint64{nhIndex + 2: 1}, instance, fluent.InstalledInRIB)
+	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex+2, instance, "", fluent.InstalledInRIB)
+
+	// Verify the entry for 198.51.100.0/24 is active through AFT Telemetry.
+	ipv4Path = args.dut.Telemetry().NetworkInstance(instance).Afts().Ipv4Entry(ateDstNetCIDR)
+	if got, want := ipv4Path.Prefix().Get(t), ateDstNetCIDR; got != want {
+		t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
+	}
+
+	// Verify with traffic that the entry for 198.51.100.0/24 is installed through the ATE port-2.
+	srcEndPoint = args.top.Interfaces()[atePort1.Name]
+	dstEndPoint = args.top.Interfaces()[atePort2.Name]
+	testTraffic(t, args.ate, args.top, srcEndPoint, dstEndPoint)
+}
+
+func TestElectionIDChange(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	ctx := context.Background()
+
+	// Configure the DUT
+	configureDUT(t, dut)
+
+	// Configure the ATE
+	ate := ondatra.ATE(t, "ate")
+	top := configureATE(t, ate)
+	top.Push(t).StartProtocols(t)
+
+	// Configure the gRIBI client clientA
+	clientA := gribi.Client{
+		DUT:                  dut,
+		FibACK:               false,
+		Persistence:          true,
+		InitialElectionIDLow: 10,
+	}
+	defer clientA.Close(t)
+	if err := clientA.Start(t); err != nil {
+		t.Fatalf("gRIBI Connection can not be established")
+	}
+
+	// Configure the gRIBI client clientB
+	clientB := gribi.Client{
+		DUT:                  dut,
+		FibACK:               false,
+		Persistence:          true,
+		InitialElectionIDLow: 11,
+	}
+	defer clientB.Close(t)
+	if err := clientB.Start(t); err != nil {
+		t.Fatalf("gRIBI Connection can not be established")
+	}
+
+	args := &testArgs{
+		ctx:     ctx,
+		clientA: &clientA,
+		clientB: &clientB,
+		dut:     dut,
+		ate:     ate,
+		top:     top,
+	}
+
+	testIPv4LeaderActiveChange(ctx, t, args)
+}

--- a/feature/interface/staticarp/otg_tests/static_arp_test/README.md
+++ b/feature/interface/staticarp/otg_tests/static_arp_test/README.md
@@ -1,0 +1,39 @@
+# TE-1.1: Static ARP
+
+## Summary
+
+Ensure static ARP entries installed on the DUT are honoured.
+
+## Procedure
+
+*   Configure ATE port-1 connected to DUT port-1, and ATE port-2 connected to
+    DUT port-2, with the relevant IPv4 and IPv6 addresses.
+*   Without static ARP entry:
+    *   Configure ATE traffic flow to enable custom egress filter on the last
+        15-bits of the destination MAC (starting at bit offset 33 of the
+        ethernet packet).
+    *   Ensure that traffic can be forwarded between ATE port-1 and ATE port-2
+        normally.
+    *   Check that the egress filter picks up the last 15-bit of ATE default MAC
+        address.
+*   Add static entry to DUT interfaces to override the ATE MAC address.
+*   With static ARP entry:
+    *   Configure ATE traffic flow with custom egress filter as before, and
+        ensure that traffic can be forwarded between ATE port-1 and ATE port-2.
+    *   Check that the egress filter picks up the last 15-bit of the MAC address
+        set by static ARP.
+
+Note that ATE ports are promiscuous, i.e. they will receive all packets
+regardless of the destination MAC. The custom egress filter is used to tell what
+are the destination MAC addresses of the packets seen by the ATE.
+
+## Config Parameter Coverage
+
+*   /interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/config/ip
+*   /interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/config/prefix-length
+*   /interfaces/interface/subinterfaces/subinterface/ipv4/neighbors/neighbor/config/ip
+*   /interfaces/interface/subinterfaces/subinterface/ipv4/neighbors/neighbor/config/link-layer-address
+*   /interfaces/interface/subinterfaces/subinterface/ipv6/addresses/address/config/ip
+*   /interfaces/interface/subinterfaces/subinterface/ipv6/addresses/address/config/prefix-length
+*   /interfaces/interface/subinterfaces/subinterface/ipv6/neighbors/neighbor/config/ip
+*   /interfaces/interface/subinterfaces/subinterface/ipv6/neighbors/neighbor/config/link-layer-address

--- a/feature/interface/staticarp/otg_tests/static_arp_test/static_arp_test.go
+++ b/feature/interface/staticarp/otg_tests/static_arp_test/static_arp_test.go
@@ -1,0 +1,280 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package te_1_1_static_arp_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/openconfig/featureprofiles/internal/attrs"
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/ondatra/telemetry"
+	"github.com/openconfig/ygot/ygot"
+
+	"github.com/openconfig/ondatra"
+)
+
+func TestMain(m *testing.M) {
+	fptest.RunTests(m)
+}
+
+// Settings for configuring the baseline testbed with the test
+// topology.  IxNetwork flow requires both source and destination
+// networks be configured on the ATE.  It is not possible to send
+// packets to the ether.
+//
+// The testbed consists of ate:port1 -> dut:port1 and
+// dut:port2 -> ate:port2.  The first pair is called the "source"
+// pair, and the second the "destination" pair.
+//
+//   * Source: ate:port1 -> dut:port1 subnet 192.0.2.0/30 2001:db8::0/126
+//   * Destination: dut:port2 -> ate:port2 subnet 192.0.2.4/30 2001:db8::4/126
+//
+// Note that the first (.0, .4) and last (.3, .7) IPv4 addresses are
+// reserved from the subnet for broadcast, so a /30 leaves exactly 2
+// usable addresses.  This does not apply to IPv6 which allows /127
+// for point to point links, but we use /126 so the numbering is
+// consistent with IPv4.
+//
+// A traffic flow is configured from ate:port1 as the source interface
+// and ate:port2 as the destination interface.  The traffic should
+// flow as expected both when using dynamic or static ARP since the
+// Ixia interfaces are promiscuous.  However, using custom egress
+// filter, we can tell if the static ARP is honored or not.
+//
+// Synthesized static MAC addresses have the form 02:1a:WW:XX:YY:ZZ
+// where WW:XX:YY:ZZ are the four octets of the IPv4 in hex.  The 0x02
+// means the MAC address is locally administered.
+const (
+	plen4 = 30
+	plen6 = 126
+
+	poisonedMAC = "12:34:56:78:7a:69" // 0x7a69 = 31337
+	noStaticMAC = ""
+)
+
+var (
+	ateSrc = attrs.Attributes{
+		Name:    "ateSrc",
+		IPv4:    "192.0.2.1",
+		IPv6:    "2001:db8::1",
+		IPv4Len: plen4,
+		IPv6Len: plen6,
+	}
+
+	dutSrc = attrs.Attributes{
+		Desc:    "DUT to ATE source",
+		IPv4:    "192.0.2.2",
+		IPv6:    "2001:db8::2",
+		MAC:     "02:1a:c0:00:02:02", // 02:1a+192.0.2.2
+		IPv4Len: plen4,
+		IPv6Len: plen6,
+	}
+
+	dutDst = attrs.Attributes{
+		Desc:    "DUT to ATE destination",
+		IPv4:    "192.0.2.5",
+		IPv6:    "2001:db8::5",
+		MAC:     "02:1a:c0:00:02:05", // 02:1a+192.0.2.5
+		IPv4Len: plen4,
+		IPv6Len: plen6,
+	}
+
+	ateDst = attrs.Attributes{
+		Name:    "dst",
+		IPv4:    "192.0.2.6",
+		IPv6:    "2001:db8::6",
+		IPv4Len: plen4,
+		IPv6Len: plen6,
+	}
+)
+
+// configInterfaceDUT configures the interface on "me" with static ARP
+// of peer.  Note that peermac is used for static ARP, and not
+// peer.MAC.
+func configInterfaceDUT(i *telemetry.Interface, me, peer *attrs.Attributes, peermac string) *telemetry.Interface {
+	i.Description = ygot.String(me.Desc)
+	i.Type = telemetry.IETFInterfaces_InterfaceType_ethernetCsmacd
+	if *deviations.InterfaceEnabled {
+		i.Enabled = ygot.Bool(true)
+	}
+
+	if me.MAC != "" {
+		e := i.GetOrCreateEthernet()
+		e.MacAddress = ygot.String(me.MAC)
+	}
+
+	s := i.GetOrCreateSubinterface(0)
+	s4 := s.GetOrCreateIpv4()
+	if *deviations.InterfaceEnabled {
+		s4.Enabled = ygot.Bool(true)
+	}
+	a := s4.GetOrCreateAddress(me.IPv4)
+	a.PrefixLength = ygot.Uint8(plen4)
+
+	if peermac != noStaticMAC {
+		n4 := s4.GetOrCreateNeighbor(peer.IPv4)
+		n4.LinkLayerAddress = ygot.String(peermac)
+	}
+
+	s6 := s.GetOrCreateIpv6()
+	if *deviations.InterfaceEnabled {
+		s6.Enabled = ygot.Bool(true)
+	}
+	s6.GetOrCreateAddress(me.IPv6).PrefixLength = ygot.Uint8(plen6)
+
+	if peermac != noStaticMAC {
+		n6 := s6.GetOrCreateNeighbor(peer.IPv6)
+		n6.LinkLayerAddress = ygot.String(peermac)
+	}
+
+	return i
+}
+
+func configureDUT(t *testing.T, peermac string) {
+	dut := ondatra.DUT(t, "dut")
+	d := dut.Config()
+
+	p1 := dut.Port(t, "port1")
+	i1 := &telemetry.Interface{Name: ygot.String(p1.Name())}
+	d.Interface(p1.Name()).Replace(t,
+		configInterfaceDUT(i1, &dutSrc, &ateSrc, peermac))
+
+	p2 := dut.Port(t, "port2")
+	i2 := &telemetry.Interface{Name: ygot.String(p2.Name())}
+	d.Interface(p2.Name()).Replace(t,
+		configInterfaceDUT(i2, &dutDst, &ateDst, peermac))
+}
+
+func configureATE(t *testing.T) (*ondatra.ATEDevice, *ondatra.ATETopology) {
+	ate := ondatra.ATE(t, "ate")
+	top := ate.Topology().New()
+
+	p1 := ate.Port(t, "port1")
+	i1 := top.AddInterface(ateSrc.Name).WithPort(p1)
+	i1.IPv4().
+		WithAddress(ateSrc.IPv4CIDR()).
+		WithDefaultGateway(dutSrc.IPv4)
+	i1.IPv6().
+		WithAddress(ateSrc.IPv6CIDR()).
+		WithDefaultGateway(dutSrc.IPv6)
+
+	p2 := ate.Port(t, "port2")
+	i2 := top.AddInterface(ateDst.Name).WithPort(p2)
+	i2.IPv4().
+		WithAddress(ateDst.IPv4CIDR()).
+		WithDefaultGateway(dutDst.IPv4)
+	i2.IPv6().
+		WithAddress(ateDst.IPv6CIDR()).
+		WithDefaultGateway(dutDst.IPv6)
+
+	return ate, top
+}
+
+func testFlow(
+	t *testing.T,
+	want string,
+	ate *ondatra.ATEDevice,
+	top *ondatra.ATETopology,
+	headers ...ondatra.Header,
+) {
+	i1 := top.Interfaces()[ateSrc.Name]
+	i2 := top.Interfaces()[ateDst.Name]
+
+	// Egress tracking inspects packets from DUT and key the flow
+	// counters by custom bit offset and width.  Width is limited to
+	// 15-bits.
+	//
+	// Ethernet header:
+	//   - Destination MAC (6 octets)
+	//   - Source MAC (6 octets)
+	//   - Optional 802.1q VLAN tag (4 octets)
+	//   - Frame size (2 octets)
+	flow := ate.Traffic().NewFlow("Flow").
+		WithSrcEndpoints(i1).
+		WithDstEndpoints(i2).
+		WithHeaders(headers...).
+		WithEgressTrackingEnabled(33 /* bit offset */, 15 /* width */)
+
+	ate.Traffic().Start(t, flow)
+	time.Sleep(15 * time.Second)
+	ate.Traffic().Stop(t)
+
+	flowPath := ate.Telemetry().Flow(flow.Name())
+
+	if got := flowPath.LossPct().Get(t); got > 0 {
+		t.Errorf("LossPct for flow %s got %g, want 0", flow.Name(), got)
+	}
+
+	etPath := flowPath.EgressTrackingAny()
+	ets := etPath.Get(t)
+	for i, et := range ets {
+		fptest.LogYgot(t, fmt.Sprintf("ATE flow EgressTracking[%d]", i), etPath, et)
+	}
+
+	if got := len(ets); got != 1 {
+		t.Errorf("EgressTracking got %d items, want 1", got)
+		return
+	}
+
+	if got := ets[0].GetFilter(); got != want {
+		t.Errorf("EgressTracking filter got %q, want %q", got, want)
+	}
+
+	if got := ets[0].GetCounters().GetInPkts(); got < 1000 {
+		t.Errorf("EgressTracking counter in-pkts got %d, want >= 1000", got)
+	}
+}
+
+func TestStaticARP(t *testing.T) {
+	// First configure the DUT with dynamic ARP.
+	configureDUT(t, noStaticMAC)
+	ate, top := configureATE(t)
+	top.Push(t).StartProtocols(t)
+
+	ethHeader := ondatra.NewEthernetHeader()
+	ipv4Header := ondatra.NewIPv4Header()
+	ipv6Header := ondatra.NewIPv6Header()
+
+	// Default MAC addresses on Ixia are assigned incrementally as:
+	//   - 00:11:01:00:00:01
+	//   - 00:12:01:00:00:01
+	// etc.
+	//
+	// The last 15-bits therefore resolve to "1".
+	t.Run("NotPoisoned", func(t *testing.T) {
+		t.Run("IPv4", func(t *testing.T) {
+			testFlow(t, "1" /* want */, ate, top, ethHeader, ipv4Header)
+		})
+		t.Run("IPv6", func(t *testing.T) {
+			testFlow(t, "1" /* want */, ate, top, ethHeader, ipv6Header)
+		})
+	})
+
+	// Reconfigure the DUT with static MAC.
+	configureDUT(t, poisonedMAC)
+
+	// Poisoned MAC address ends with 7a:69, so 0x7a69 = 31337.
+	t.Run("Poisoned", func(t *testing.T) {
+		t.Run("IPv4", func(t *testing.T) {
+			testFlow(t, "31337" /* want */, ate, top, ethHeader, ipv4Header)
+		})
+		t.Run("IPv6", func(t *testing.T) {
+			testFlow(t, "31337" /* want */, ate, top, ethHeader, ipv6Header)
+		})
+	})
+}


### PR DESCRIPTION
This is a file copy to serve as a baseline.  No change.