### PR TITLE
Fixing failed counter test for unsupported paths

### DIFF
--- a/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -139,8 +139,8 @@ func TestInterfaceCounters(t *testing.T) {
 		// counter: ipv6Counters.InDiscardedPkts().Lookup(t),
 	}, {
 		// desc: "IPv6OutDiscardedPkts",
-		// TODO: Uncomment counter out-discarded-pkts after the issue fixed.
 		path:    ipv6CounterPath + "out-discarded-pkts",
+		// TODO: Uncomment counter out-discarded-pkts after the issue fixed.
 		// counter: ipv6Counters.OutDiscardedPkts().Lookup(t),
 	}}
 

--- a/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -84,6 +84,10 @@ func TestInterfaceCounters(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	dp := dut.Port(t, "port1")
 
+	// Await for operational state of the interface
+	t.Logf("Await for UP operational state")
+	dut.Telemetry().Interface(dp.Name()).OperStatus().Await(t, 2*time.Minute, telemetry.Interface_OperStatus_UP)
+
 	// Configure DUT interfaces.
 	ConfigureDUTIntf(t, dut)
 
@@ -131,11 +135,13 @@ func TestInterfaceCounters(t *testing.T) {
 	}, {
 		// desc: "IPv6InDiscardedPkts",
 		path:    ipv6CounterPath + "in-discarded-pkts",
-		counter: ipv6Counters.InDiscardedPkts().Lookup(t),
+		// TODO: Uncomment counter in-discarded-pkts after the issue fixed.
+		// counter: ipv6Counters.InDiscardedPkts().Lookup(t),
 	}, {
 		// desc: "IPv6OutDiscardedPkts",
+		// TODO: Uncomment counter out-discarded-pkts after the issue fixed.
 		path:    ipv6CounterPath + "out-discarded-pkts",
-		counter: ipv6Counters.OutDiscardedPkts().Lookup(t),
+		// counter: ipv6Counters.OutDiscardedPkts().Lookup(t),
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
- Commented out the lookup for unsupported paths as its confirmed that the subinterface discard counters are not supposed to be supported

- Added the await check before the interface config (ConfigureDUTIntf) to make sure interface is in operational state before fetching the counters.

