### PR TITLE
Interface packet counter deviation 

### DIFF
--- a/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -139,8 +139,8 @@ func TestInterfaceCounters(t *testing.T) {
 		// counter: ipv6Counters.InDiscardedPkts().Lookup(t),
 	}, {
 		// desc: "IPv6OutDiscardedPkts",
-		// TODO: Uncomment counter out-discarded-pkts after the issue fixed.
 		path:    ipv6CounterPath + "out-discarded-pkts",
+		// TODO: Uncomment counter out-discarded-pkts after the issue fixed.
 		// counter: ipv6Counters.OutDiscardedPkts().Lookup(t),
 	}}
 

--- a/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -84,6 +84,10 @@ func TestInterfaceCounters(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	dp := dut.Port(t, "port1")
 
+	// Await for operational state of the interface
+	t.Logf("Await for UP operational state")
+	dut.Telemetry().Interface(dp.Name()).OperStatus().Await(t, 2*time.Minute, telemetry.Interface_OperStatus_UP)
+
 	// Configure DUT interfaces.
 	ConfigureDUTIntf(t, dut)
 
@@ -131,11 +135,13 @@ func TestInterfaceCounters(t *testing.T) {
 	}, {
 		// desc: "IPv6InDiscardedPkts",
 		path:    ipv6CounterPath + "in-discarded-pkts",
-		counter: ipv6Counters.InDiscardedPkts().Lookup(t),
+		// TODO: Uncomment counter in-discarded-pkts after the issue fixed.
+		// counter: ipv6Counters.InDiscardedPkts().Lookup(t),
 	}, {
 		// desc: "IPv6OutDiscardedPkts",
+		// TODO: Uncomment counter out-discarded-pkts after the issue fixed.
 		path:    ipv6CounterPath + "out-discarded-pkts",
-		counter: ipv6Counters.OutDiscardedPkts().Lookup(t),
+		// counter: ipv6Counters.OutDiscardedPkts().Lookup(t),
 	}}
 
 	for _, tc := range cases {

--- a/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/telemetry"
@@ -100,49 +101,58 @@ func TestInterfaceCounters(t *testing.T) {
 	ipv4CounterPath := "/interfaces/interface/subinterfaces/subinterface/ipv4/state/counters/"
 	ipv6CounterPath := "/interfaces/interface/subinterfaces/subinterface/ipv6/state/counters/"
 
-	cases := []struct {
+	type counterCase struct {
 		desc    string
 		path    string
-		counter *telemetry.QualifiedUint64
-	}{{
+		counter func(testing.TB) *telemetry.QualifiedUint64
+	}
+	type counterCases []counterCase
+	cases := make(counterCases, 0)
+	cases = append(cases, counterCase{
 		desc:    "InUnicastPkts",
 		path:    intfCounterPath + "in-unicast-pkts",
-		counter: intfCounters.InUnicastPkts().Lookup(t),
-	}, {
+		counter: intfCounters.InUnicastPkts().Lookup,
+	}, counterCase{
+		desc:    "InUnicastPkts",
+		path:    intfCounterPath + "in-unicast-pkts",
+		counter: intfCounters.InUnicastPkts().Lookup,
+	}, counterCase{
 		desc:    "InPkts",
 		path:    intfCounterPath + "in-pkts",
-		counter: intfCounters.InPkts().Lookup(t),
-	}, {
+		counter: intfCounters.InPkts().Lookup,
+	}, counterCase{
 		desc:    "OutPkts",
 		path:    intfCounterPath + "out-pkts",
-		counter: intfCounters.OutPkts().Lookup(t),
-	}, {
+		counter: intfCounters.OutPkts().Lookup,
+	}, counterCase{
 		// desc: "IPv4InPkts",
 		path:    ipv4CounterPath + "in-pkts",
-		counter: ipv4Counters.InPkts().Lookup(t),
-	}, {
+		counter: ipv4Counters.InPkts().Lookup,
+	}, counterCase{
 		// desc: "IPv4OutPkts",
 		path:    ipv4CounterPath + "out-pkts",
-		counter: ipv4Counters.OutPkts().Lookup(t),
-	}, {
+		counter: ipv4Counters.OutPkts().Lookup,
+	}, counterCase{
 		// desc: "IPv6InPkts",
 		path:    ipv6CounterPath + "in-pkts",
-		counter: ipv6Counters.InPkts().Lookup(t),
-	}, {
+		counter: ipv6Counters.InPkts().Lookup,
+	}, counterCase{
 		// desc: "IPv6OutPkts",
 		path:    ipv6CounterPath + "out-pkts",
-		counter: ipv6Counters.OutPkts().Lookup(t),
-	}, {
-		// desc: "IPv6InDiscardedPkts",
-		path:    ipv6CounterPath + "in-discarded-pkts",
-		// TODO: Uncomment counter in-discarded-pkts after the issue fixed.
-		// counter: ipv6Counters.InDiscardedPkts().Lookup(t),
-	}, {
-		// desc: "IPv6OutDiscardedPkts",
-		path:    ipv6CounterPath + "out-discarded-pkts",
-		// TODO: Uncomment counter out-discarded-pkts after the issue fixed.
-		// counter: ipv6Counters.OutDiscardedPkts().Lookup(t),
-	}}
+		counter: ipv6Counters.OutPkts().Lookup,
+	})
+	// Lookup for the input/output discard counter values only if the deviation flag is SET
+	if *deviations.SubInterfacePacketCountersSupported {
+		cases = append(cases, counterCase{
+			desc:    "IPv6InDiscardedPkts",
+			path:    ipv6CounterPath + "in-discarded-pkts",
+			counter: ipv6Counters.InDiscardedPkts().Lookup,
+		}, counterCase{
+			desc:    "IPv6OutDiscardedPkts",
+			path:    ipv6CounterPath + "out-discarded-pkts",
+			counter: ipv6Counters.OutDiscardedPkts().Lookup,
+		})
+	}
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -151,10 +161,10 @@ func TestInterfaceCounters(t *testing.T) {
 				t.Skipf("Counter %v is not supported.", tc.desc)
 			}
 
-			if !tc.counter.IsPresent() {
+			if !tc.counter(t).IsPresent() {
 				t.Errorf("Get IsPresent status for path %q: got false, want true", tc.path)
 			}
-			t.Logf("Got path/value: %s:%d", tc.path, tc.counter.Val(t))
+			t.Logf("Got path/value: %s:%d", tc.path, tc.counter(t).Val(t))
 		})
 	}
 }

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -30,4 +30,7 @@ var (
 		"Device requires that aggregate Port-Channel and its members be defined in a single gNMI Update transaction at /interfaces; otherwise lag-type will be dropped, and no member can be added to the aggregate.")
 
 	DefaultNetworkInstance = flag.String("deviation_default_network_instance", "DEFAULT", "The name used for the default network instance for VRF.")
+
+	SubInterfacePacketCountersSupported = flag.Bool("deviation_subinterface_counter_supported", true,
+		"Subinterface discard packet counters for ipv4/ipv6 are not supported by default. Manually set it to False to skip lookup of discard counters in the test")
 )


### PR DESCRIPTION
This change add deviation functionality for ipv4/ipv6 discard packet counters. By default it checks for discard counters and the test will fail if paths are not supported.

To pass the test, add deviation (deviation_subinterface_counter_supported) - that will skip the discard counter lookup