### PR TITLE
Get component list by type instead of matching the component name

### DIFF
--- a/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
+++ b/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
@@ -32,10 +32,10 @@ import (
 )
 
 const (
-	controlcardType = telemetry.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_CONTROLLER_CARD
-	linecardType    = telemetry.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_LINECARD
-	activeController    = telemetry.PlatformTypes_ComponentRedundantRole_PRIMARY
-	standbyController    = telemetry.PlatformTypes_ComponentRedundantRole_SECONDARY
+	controlcardType   = telemetry.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_CONTROLLER_CARD
+	linecardType      = telemetry.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_LINECARD
+	activeController  = telemetry.PlatformTypes_ComponentRedundantRole_PRIMARY
+	standbyController = telemetry.PlatformTypes_ComponentRedundantRole_SECONDARY
 )
 
 func TestMain(m *testing.M) {

--- a/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
+++ b/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
@@ -215,7 +215,7 @@ func findComponentsByType(t *testing.T, dut *ondatra.DUTDevice, cType telemetry.
 
 			switch v := componentType.(type) {
 			case telemetry.E_PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT:
-				if v ==cType {
+				if v == cType {
 					s = append(s, c)
 				}
 			default:

--- a/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
+++ b/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
@@ -75,7 +75,7 @@ func TestMain(m *testing.M) {
 //    https://github.com/fullstorydev/grpcurl
 //
 
-func TestStandbySupervisorReboot(t *testing.T) {
+func TestStandbyControllerCardReboot(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
 	supervisors := findComponentsByType(t, dut, controlcardType)
@@ -215,14 +215,11 @@ func findComponentsByType(t *testing.T, dut *ondatra.DUTDevice, cType telemetry.
 
 			switch v := componentType.(type) {
 			case telemetry.E_PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT:
-				switch v {
-				case cType:
+				if v ==cType {
 					s = append(s, c)
-				default:
-					continue
 				}
 			default:
-				t.Fatalf("Error extracting component state, could not type assert union. union: %v", componentType)
+				t.Fatalf("Expected component type to be a hardware component, got (%T, %v)", componentType, componentType)
 			}
 		}
 	}


### PR DESCRIPTION
  - Added func findComponentsByType()

Test passed:
  - http://sponge2/1e6c1475-0172-4885-81f4-79c1af9f4a72