### PR TITLE
Update annotation_test.go

### DIFF
--- a/feature/system/gnmi/metadata/tests/annotation_test/annotation_test.go
+++ b/feature/system/gnmi/metadata/tests/annotation_test/annotation_test.go
@@ -110,7 +110,8 @@ func TestGNMIMetadataAnnotation(t *testing.T) {
 			Path: []*gpb.Path{{
 				Elem: []*gpb.PathElem{},
 			}},
-			Type: gpb.GetRequest_CONFIG,
+			Type:     gpb.GetRequest_CONFIG,
+			Encoding: gpb.Encoding_JSON_IETF,
 		})
 		if err != nil {
 			t.Fatalf("Cannot fetch metadata annotation from the DUT: %v", err)


### PR DESCRIPTION
Use Encoding_JSON_IETF (Encoding = 4) instead of the default 0 - Encoding_JSON

Test passed:
  - http://sponge2/7ff4c0a0-1f3a-456c-9b03-e589f996a980