### PR TITLE
Update README.md

### DIFF
--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
@@ -16,7 +16,7 @@ Validate IPv4 AFT support in gRIBI with recursion.
 *   Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
 *   Validate that both routes are shown as installed via AFT telemetry.
-*   Ensure that removing the NextHopGroup containing 203.0.113.1/32 with a
+*   Ensure that removing the IPv4Entry 203.0.113.1/32 with a
     DELETE operation results in traffic loss, and removal from AFT.
 *   Repeat above test with the following (table) cases:
     *   TODO: Explicitly specified egress interface of DUT port-2.

--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
@@ -16,8 +16,8 @@ Validate IPv4 AFT support in gRIBI with recursion.
 *   Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
 *   Validate that both routes are shown as installed via AFT telemetry.
-*   Ensure that removing the IPv4Entry 203.0.113.1/32 with a
-    DELETE operation results in traffic loss, and removal from AFT.
+*   Ensure that removing the IPv4Entry 203.0.113.1/32 with a DELETE operation
+    results in traffic loss, and removal from AFT.
 *   Repeat above test with the following (table) cases:
     *   TODO: Explicitly specified egress interface of DUT port-2.
     *   TODO: Explicitly specified MAC address for ATE port-2.

--- a/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
@@ -16,8 +16,8 @@ Validate IPv4 AFT support in gRIBI with recursion.
 *   Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
 *   Validate that both routes are shown as installed via AFT telemetry.
-*   Ensure that removing the NextHopGroup containing 203.0.113.1/32 with a
-    DELETE operation results in traffic loss, and removal from AFT.
+*   Ensure that removing the IPv4Entry 203.0.113.1/32 with a DELETE operation
+    results in traffic loss, and removal from AFT.
 *   Repeat above test with the following (table) cases:
     *   TODO: Explicitly specified egress interface of DUT port-2.
     *   TODO: Explicitly specified MAC address for ATE port-2.


### PR DESCRIPTION
The code, `deleteRecursiveIPv4Entry()`, has the right implementation that is removing the IPv4Entry, instead of NHG.