### PR TITLE
Update TE-3.1

### DIFF
--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
@@ -17,10 +17,10 @@ Validate IPv4 AFT support in gRIBI with recursion.
         the address of ATE port-2.
     *   TODO: ensure installing the above 2 sets in the following ordering, and
         receive [FIB_PROGRAMMED] for all the AFTOperations.
-        1.  203.0.113.1/32 to NextHopGroup containing one NextHop specified to
+        1.  In default VRF, add 203.0.113.1/32 to NextHopGroup containing one NextHop specified to
             be the address of ATE port-2.
-        2.  198.51.100.0/24 to NextHopGroup containing one NextHop, specified to
-            be 203.0.113.1/32
+        2.  in VRF-1, add 198.51.100.0/24 to NextHopGroup containing one NextHop, specified to
+            be 203.0.113.1/32 in the default VRF.
 4.  Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
 5.  Validate that both routes are shown as installed via AFT telemetry.

--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
@@ -27,20 +27,27 @@ Validate IPv4 AFT support in gRIBI with recursion.
 6.  Ensure that removing the IPEntry 203.0.113.1/32 with a DELETE operation
     results in traffic loss, and removal from AFT.
 
-TODO: Validate error reporting. * Repeat step 1-3 as above but with the
-following (table) scenarios: * Replace 203.0.113.1/32 with a syntax invalid IP
-address. * Missing NextHopGroup for the IPv4Entry 203.0.113.1/32. * Empty
-NextHopGroup for the IPv4Entry 203.0.113.1/32. * Empty NextHop for the IPv4Entry
-203.0.113.1/32. * Invalid IPv4 address in NextHop for the IPv4Entry
-203.0.113.1/32. * Ensure [FAILED] returned for the related IPv4Entry, NHG and NH
-in the above scenarios. * Ensure [RIB_PROGRAMMED] but not [FIB_PROGRAMMED] is
-returned for the IPv4Entry 198.51.100.0/24 in all the scenarios.
+TODO: Validate error reporting.
 
-TODO: Validate in-place update: * Repeat step 1-5 above. * Use the Modify RPC to
-[ADD] a new NH with next-hop pointing to ATE port-3, and [ADD] the same NHG (for
-198.51.100.0/24) but pointing to the new added NH. * Validate that routes are
-pointing to ATE port-3 via AFT, and ensure traffic are now being forwarded to
-ATE port-3.
+*   Repeat step 1-3 as above but with the following (table) scenarios:
+    *   Replace 203.0.113.1/32 with a syntax invalid IP address.
+    *   Missing NextHopGroup for the IPv4Entry 203.0.113.1/32.
+    *   Empty NextHopGroup for the IPv4Entry 203.0.113.1/32.
+    *   Empty NextHop for the IPv4Entry 203.0.113.1/32.
+    *   Invalid IPv4 address in NextHop for the IPv4Entry 203.0.113.1/32.
+*   Ensure [FAILED] returned for the related IPv4Entry, NHG and NH in the above
+    scenarios.
+*   Ensure [RIB_PROGRAMMED] but not [FIB_PROGRAMMED] is returned for the
+    IPv4Entry 198.51.100.0/24 in all the scenarios.
+
+TODO: Validate in-place update:
+
+*   Repeat step 1-5 above.
+*   Use the Modify RPC to [ADD] a new NH with next-hop pointing to ATE port-3,
+    and [ADD] the same NHG (for 198.51.100.0/24) but pointing to the new added
+    NH.
+*   Validate that routes are pointing to ATE port-3 via AFT, and ensure traffic
+    are now being forwarded to ATE port-3.
 
 [ADD]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L171
 [FAILED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L265

--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
@@ -8,37 +8,48 @@ Validate IPv4 AFT support in gRIBI with recursion.
 
 **Topology**
 
-*  Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
+*   Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
     *   TODO: create a non-default VRF (VRF-1) that includes DUT port-1.
 
 **Validate hierarchical resolution**
 
 1.  Establish gRIBI client connection with DUT.
-1.  TODO: Use gRIBI Modify RPC to install entries per the following order, and ensure FIB ACK is received for each of the AFTOperation:
+1.  TODO: Use gRIBI Modify RPC to install entries per the following order, and
+    ensure FIB ACK is received for each of the AFTOperation:
 
-    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
-            be the address of ATE port-2.
-    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
-            be 203.0.113.1/32 in the default VRF.
+    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
+        containing one NextHop (default VRF) specified to be the address of ATE
+        port-2.
+    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
+        NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
+
 1.  Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
+
 1.  Validate that both routes are shown as installed via AFT telemetry.
+
 1.  Ensure that removing the IPv4Entry 203.0.113.1/32 with a DELETE operation
     results in traffic loss, and removal from AFT.
-1. TODO: Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF) containing one NextHop (default VRF) that specifies DUT port-2 as the egress interface and `00:1A:11:00:00:01` as the destination MAC address. 
-1. TODO: Ensure that ATE port-2 receives packet with `00:1A:11:00:00:01` as the destination MAC address.
+
+1.  TODO: Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
+    containing one NextHop (default VRF) that specifies DUT port-2 as the egress
+    interface and `00:1A:11:00:00:01` as the destination MAC address.
+
+1.  TODO: Ensure that ATE port-2 receives packet with `00:1A:11:00:00:01` as the
+    destination MAC address.
 
 **TODO: Validate error reporting**
 
 1.  Establish gRIBI client connection with DUT.
 1.  Use gRIBI Modify RPC to install the following entries:
 
-    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
-            be the address of ATE port-2.
-    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
-            be 203.0.113.1/32 in the default VRF.
-    
-    but with the following (table) scenarios: 
+    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
+        containing one NextHop (default VRF) specified to be the address of ATE
+        port-2.
+    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
+        NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
+
+    but with the following (table) scenarios:
 
     *   Replace 203.0.113.1/32 with a syntax invalid IP address.
     *   Missing NextHopGroup for the IPv4Entry 203.0.113.1/32.
@@ -46,8 +57,11 @@ Validate IPv4 AFT support in gRIBI with recursion.
     *   Empty NextHop for the IPv4Entry 203.0.113.1/32.
     *   Invalid IPv4 address in NextHop for the IPv4Entry 203.0.113.1/32.
 
-1.   Ensure FAILED returned for the related IPv4Entry, NHG and NH in all the above scenarios.
-1.   Ensure RIB ACK but not FIB ACK is, returned for the IPv4Entry 198.51.100.0/24 in all the above scenarios.
+1.  Ensure FAILED returned for the related IPv4Entry, NHG and NH in all the
+    above scenarios.
+
+1.  Ensure RIB ACK but not FIB ACK is, returned for the IPv4Entry
+    198.51.100.0/24 in all the above scenarios.
 
 ## Config Parameter coverage
 

--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
@@ -21,8 +21,9 @@ Validate hierarchical resolution across VRFs:
     1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
         containing one NextHop (default VRF) specified to be the address of ATE
         port-2.
-    2.  Add 198.51.100.0/24 (TODO: VRF-1) to NextHopGroup (default VRF) containing one
-        NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
+    2.  Add 198.51.100.0/24 (TODO: VRF-1) to NextHopGroup (default VRF)
+        containing one NextHop (default VRF) specified to be 203.0.113.1/32 in
+        the default VRF.
 
 2.  Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
@@ -37,11 +38,11 @@ TODO: Validate hierarchical resolution using egress interface and MAC:
 1.  Using gRIBI Modify RPC install the following IPv4Entry set per the following
     order, and ensure FIB ACK is received for each of the AFTOperation:
 
-     1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
-         containing one NextHop (default VRF) that specifies DUT port-2 as the egress
-         interface and `00:1A:11:00:00:01` as the destination MAC address.
-     2.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
-         NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
+    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
+        containing one NextHop (default VRF) that specifies DUT port-2 as the
+        egress interface and `00:1A:11:00:00:01` as the destination MAC address.
+    2.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
+        NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
 
 2.  Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and ensure that ATE port-2 receives packet with

--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
@@ -6,47 +6,49 @@ Validate IPv4 AFT support in gRIBI with recursion.
 
 ## Procedure
 
-**Topology**
+Topology:
 
 *   Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
-    *   TODO: create a non-default VRF (VRF-1) that includes DUT port-1.
+*   TODO: create a non-default VRF (VRF-1) that includes DUT port-1.
+*   Establish gRIBI client connection with DUT using default parameters and
+    persistence mode `PRESERVE` and flush all entries after each case.
 
-**Validate hierarchical resolution**
+Validate hierarchical resolution across VRFs:
 
-1.  Establish gRIBI client connection with DUT.
-1.  TODO: Use gRIBI Modify RPC to install entries per the following order, and
-    ensure FIB ACK is received for each of the AFTOperation:
+1.  Using gRIBI Modify RPC install the following IPv4Entry set per the following
+    order, and ensure FIB ACK is received for each of the AFTOperation:
 
     1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
         containing one NextHop (default VRF) specified to be the address of ATE
         port-2.
-    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
+    2.  Add 198.51.100.0/24 (TODO: VRF-1) to NextHopGroup (default VRF) containing one
         NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
 
-1.  Forward packets between ATE port-1 and ATE port-2 (destined to
+2.  Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
 
-1.  Validate that both routes are shown as installed via AFT telemetry.
+3.  Validate that both routes are shown as installed via AFT telemetry.
 
-1.  Ensure that removing the IPv4Entry 203.0.113.1/32 with a DELETE operation
+4.  Ensure that removing the IPv4Entry 203.0.113.1/32 with a DELETE operation
     results in traffic loss, and removal from AFT.
 
-1.  TODO: Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
+TODO: Validate hierarchical resolution using egress interface and MAC:
+
+1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
     containing one NextHop (default VRF) that specifies DUT port-2 as the egress
     interface and `00:1A:11:00:00:01` as the destination MAC address.
 
-1.  TODO: Ensure that ATE port-2 receives packet with `00:1A:11:00:00:01` as the
+2.  Ensure that ATE port-2 receives packet with `00:1A:11:00:00:01` as the
     destination MAC address.
 
-**TODO: Validate error reporting**
+TODO: Validate error reporting:
 
-1.  Establish gRIBI client connection with DUT.
 1.  Use gRIBI Modify RPC to install the following entries:
 
     1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
         containing one NextHop (default VRF) specified to be the address of ATE
         port-2.
-    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
+    2.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
         NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
 
     but with the following (table) scenarios:
@@ -57,11 +59,14 @@ Validate IPv4 AFT support in gRIBI with recursion.
     *   Empty NextHop for the IPv4Entry 203.0.113.1/32.
     *   Invalid IPv4 address in NextHop for the IPv4Entry 203.0.113.1/32.
 
-1.  Ensure FAILED returned for the related IPv4Entry, NHG and NH in all the
+2.  Ensure FAILED returned for the related IPv4Entry, NHG and NH in all the
     above scenarios.
 
-1.  Ensure RIB ACK but not FIB ACK is, returned for the IPv4Entry
+3.  Ensure RIB ACK, but not FIB ACK, is returned for the IPv4Entry
     198.51.100.0/24 in all the above scenarios.
+
+If the device supports it, repeat the cases in this test with gRIBI client
+persistence mode `DELETE` without flushing entries between cases.
 
 ## Config Parameter coverage
 

--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
@@ -34,12 +34,18 @@ Validate hierarchical resolution across VRFs:
 
 TODO: Validate hierarchical resolution using egress interface and MAC:
 
-1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
-    containing one NextHop (default VRF) that specifies DUT port-2 as the egress
-    interface and `00:1A:11:00:00:01` as the destination MAC address.
+1.  Using gRIBI Modify RPC install the following IPv4Entry set per the following
+    order, and ensure FIB ACK is received for each of the AFTOperation:
 
-2.  Ensure that ATE port-2 receives packet with `00:1A:11:00:00:01` as the
-    destination MAC address.
+     1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
+         containing one NextHop (default VRF) that specifies DUT port-2 as the egress
+         interface and `00:1A:11:00:00:01` as the destination MAC address.
+     2.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
+         NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
+
+2.  Forward packets between ATE port-1 and ATE port-2 (destined to
+    198.51.100.0/24) and ensure that ATE port-2 receives packet with
+    `00:1A:11:00:00:01` as the destination MAC address.
 
 TODO: Validate error reporting:
 
@@ -51,7 +57,7 @@ TODO: Validate error reporting:
     2.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
         NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
 
-    but with the following (table) scenarios:
+    But with the following (table) scenarios:
 
     *   Replace 203.0.113.1/32 with a syntax invalid IP address.
     *   Missing NextHopGroup for the IPv4Entry 203.0.113.1/32.

--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
@@ -6,53 +6,48 @@ Validate IPv4 AFT support in gRIBI with recursion.
 
 ## Procedure
 
-1.  Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
+**Topology**
+
+*  Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
     *   TODO: create a non-default VRF (VRF-1) that includes DUT port-1.
-    *   TODO: connect ATE port-3 to DUT port-3.
-2.  Establish gRIBI client connection with DUT using default parameters.
-3.  Using gRIBI Modify RPC install the following IPv4Entry set:
-    *   198.51.100.0/24 to NextHopGroup containing one NextHop, specified to be
-        203.0.113.1/32
-    *   203.0.113.1/32 to NextHopGroup containing one NextHop specified to be
-        the address of ATE port-2.
-    *   TODO: ensure installing the above 2 sets in the following ordering, and
-        receive [FIB_PROGRAMMED] for all the AFTOperations.
-        1.  In default VRF, add 203.0.113.1/32 to NextHopGroup containing one NextHop specified to
+
+**Validate hierarchical resolution**
+
+1.  Establish gRIBI client connection with DUT.
+1.  TODO: Use gRIBI Modify RPC to install entries per the following order, and ensure FIB ACK is received for each of the AFTOperation:
+
+    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
             be the address of ATE port-2.
-        2.  in VRF-1, add 198.51.100.0/24 to NextHopGroup containing one NextHop, specified to
+    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
             be 203.0.113.1/32 in the default VRF.
-4.  Forward packets between ATE port-1 and ATE port-2 (destined to
+1.  Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
-5.  Validate that both routes are shown as installed via AFT telemetry.
-6.  Ensure that removing the IPEntry 203.0.113.1/32 with a DELETE operation
+1.  Validate that both routes are shown as installed via AFT telemetry.
+1.  Ensure that removing the IPv4Entry 203.0.113.1/32 with a DELETE operation
     results in traffic loss, and removal from AFT.
+1. TODO: Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF) containing one NextHop (default VRF) that specifies DUT port-2 as the egress interface and `00:1A:11:00:00:01` as the destination MAC address. 
+1. TODO: Ensure that ATE port-2 receives packet with `00:1A:11:00:00:01` as the destination MAC address.
 
-TODO: Validate error reporting.
+**TODO: Validate error reporting**
 
-*   Repeat step 1-3 as above but with the following (table) scenarios:
+1.  Establish gRIBI client connection with DUT.
+1.  Use gRIBI Modify RPC to install the following entries:
+
+    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
+            be the address of ATE port-2.
+    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
+            be 203.0.113.1/32 in the default VRF.
+    
+    but with the following (table) scenarios: 
+
     *   Replace 203.0.113.1/32 with a syntax invalid IP address.
     *   Missing NextHopGroup for the IPv4Entry 203.0.113.1/32.
     *   Empty NextHopGroup for the IPv4Entry 203.0.113.1/32.
     *   Empty NextHop for the IPv4Entry 203.0.113.1/32.
     *   Invalid IPv4 address in NextHop for the IPv4Entry 203.0.113.1/32.
-*   Ensure [FAILED] returned for the related IPv4Entry, NHG and NH in the above
-    scenarios.
-*   Ensure [RIB_PROGRAMMED] but not [FIB_PROGRAMMED] is returned for the
-    IPv4Entry 198.51.100.0/24 in all the scenarios.
 
-TODO: Validate in-place update:
-
-*   Repeat step 1-5 above.
-*   Use the Modify RPC to [ADD] a new NH with next-hop pointing to ATE port-3,
-    and [ADD] the same NHG (for 198.51.100.0/24) but pointing to the new added
-    NH.
-*   Validate that routes are pointing to ATE port-3 via AFT, and ensure traffic
-    are now being forwarded to ATE port-3.
-
-[ADD]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L171
-[FAILED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L265
-[RIB_PROGRAMMED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L269
-[FIB_PROGRAMMED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L285
+1.   Ensure FAILED returned for the related IPv4Entry, NHG and NH in all the above scenarios.
+1.   Ensure RIB ACK but not FIB ACK is, returned for the IPv4Entry 198.51.100.0/24 in all the above scenarios.
 
 ## Config Parameter coverage
 

--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/README.md
@@ -6,35 +6,46 @@ Validate IPv4 AFT support in gRIBI with recursion.
 
 ## Procedure
 
-*   Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
-*   Establish gRIBI client connection with DUT using default parameters.
-*   Using gRIBI Modify RPC install the following IPv4Entry set:
+1.  Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
+    *   TODO: create a non-default VRF (VRF-1) that includes DUT port-1.
+    *   TODO: connect ATE port-3 to DUT port-3.
+2.  Establish gRIBI client connection with DUT using default parameters.
+3.  Using gRIBI Modify RPC install the following IPv4Entry set:
     *   198.51.100.0/24 to NextHopGroup containing one NextHop, specified to be
         203.0.113.1/32
     *   203.0.113.1/32 to NextHopGroup containing one NextHop specified to be
         the address of ATE port-2.
-*   Forward packets between ATE port-1 and ATE port-2 (destined to
+    *   TODO: ensure installing the above 2 sets in the following ordering, and
+        receive [FIB_PROGRAMMED] for all the AFTOperations.
+        1.  203.0.113.1/32 to NextHopGroup containing one NextHop specified to
+            be the address of ATE port-2.
+        2.  198.51.100.0/24 to NextHopGroup containing one NextHop, specified to
+            be 203.0.113.1/32
+4.  Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
-*   Validate that both routes are shown as installed via AFT telemetry.
-*   Ensure that removing the NextHopGroup containing 203.0.113.1/32 with a
-    DELETE operation results in traffic loss, and removal from AFT.
-*   Repeat above test with the following (table) cases:
-    *   TODO: Explicitly specified egress interface of DUT port-2.
-    *   TODO: Explicitly specified MAC address for ATE port-2.
-    *   TODO: Entry installed in a non-default network instance (with ATE port-1
-        and port-2 assigned to a non-default NI)
-*   Ensure that the following cases result in an error being returned:
-    *   TODO: Invalid IPv4 prefix in the IPv4Entry
-    *   TODO: Missing NextHopGroup within an IPv4Entry
-    *   TODO: Empty NextHopGroup
-    *   TODO: Empty NextHop
-    *   TODO: Invalid IPv4 address in NextHop.
-*   Validate that REPLACE operations:
-    *   TODO: Fail when using 2.0.0.0/8 within the Ipv4EntryKey (does not
-        exist).
-    *   TODO: After installing a second next-hop-group with a different ID,
-        validate that a REPLACE for 1.0.0.0/8 can update (in-place) the NHG to
-        the new value. Validate via traffic and telemetry.
+5.  Validate that both routes are shown as installed via AFT telemetry.
+6.  Ensure that removing the IPEntry 203.0.113.1/32 with a DELETE operation
+    results in traffic loss, and removal from AFT.
+
+TODO: Validate error reporting. * Repeat step 1-3 as above but with the
+following (table) scenarios: * Replace 203.0.113.1/32 with a syntax invalid IP
+address. * Missing NextHopGroup for the IPv4Entry 203.0.113.1/32. * Empty
+NextHopGroup for the IPv4Entry 203.0.113.1/32. * Empty NextHop for the IPv4Entry
+203.0.113.1/32. * Invalid IPv4 address in NextHop for the IPv4Entry
+203.0.113.1/32. * Ensure [FAILED] returned for the related IPv4Entry, NHG and NH
+in the above scenarios. * Ensure [RIB_PROGRAMMED] but not [FIB_PROGRAMMED] is
+returned for the IPv4Entry 198.51.100.0/24 in all the scenarios.
+
+TODO: Validate in-place update: * Repeat step 1-5 above. * Use the Modify RPC to
+[ADD] a new NH with next-hop pointing to ATE port-3, and [ADD] the same NHG (for
+198.51.100.0/24) but pointing to the new added NH. * Validate that routes are
+pointing to ATE port-3 via AFT, and ensure traffic are now being forwarded to
+ATE port-3.
+
+[ADD]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L171
+[FAILED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L265
+[RIB_PROGRAMMED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L269
+[FIB_PROGRAMMED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L285
 
 ## Config Parameter coverage
 

--- a/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
@@ -17,10 +17,10 @@ Validate IPv4 AFT support in gRIBI with recursion.
         the address of ATE port-2.
     *   TODO: ensure installing the above 2 sets in the following ordering, and
         receive [FIB_PROGRAMMED] for all the AFTOperations.
-        1.  203.0.113.1/32 to NextHopGroup containing one NextHop specified to
+        1.  In default VRF, add 203.0.113.1/32 to NextHopGroup containing one NextHop specified to
             be the address of ATE port-2.
-        2.  198.51.100.0/24 to NextHopGroup containing one NextHop, specified to
-            be 203.0.113.1/32
+        2.  in VRF-1, add 198.51.100.0/24 to NextHopGroup containing one NextHop, specified to
+            be 203.0.113.1/32 in the default VRF.
 4.  Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
 5.  Validate that both routes are shown as installed via AFT telemetry.

--- a/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
@@ -27,20 +27,27 @@ Validate IPv4 AFT support in gRIBI with recursion.
 6.  Ensure that removing the IPEntry 203.0.113.1/32 with a DELETE operation
     results in traffic loss, and removal from AFT.
 
-TODO: Validate error reporting. * Repeat step 1-3 as above but with the
-following (table) scenarios: * Replace 203.0.113.1/32 with a syntax invalid IP
-address. * Missing NextHopGroup for the IPv4Entry 203.0.113.1/32. * Empty
-NextHopGroup for the IPv4Entry 203.0.113.1/32. * Empty NextHop for the IPv4Entry
-203.0.113.1/32. * Invalid IPv4 address in NextHop for the IPv4Entry
-203.0.113.1/32. * Ensure [FAILED] returned for the related IPv4Entry, NHG and NH
-in the above scenarios. * Ensure [RIB_PROGRAMMED] but not [FIB_PROGRAMMED] is
-returned for the IPv4Entry 198.51.100.0/24 in all the scenarios.
+TODO: Validate error reporting.
 
-TODO: Validate in-place update: * Repeat step 1-5 above. * Use the Modify RPC to
-[ADD] a new NH with next-hop pointing to ATE port-3, and [ADD] the same NHG (for
-198.51.100.0/24) but pointing to the new added NH. * Validate that routes are
-pointing to ATE port-3 via AFT, and ensure traffic are now being forwarded to
-ATE port-3.
+*   Repeat step 1-3 as above but with the following (table) scenarios:
+    *   Replace 203.0.113.1/32 with a syntax invalid IP address.
+    *   Missing NextHopGroup for the IPv4Entry 203.0.113.1/32.
+    *   Empty NextHopGroup for the IPv4Entry 203.0.113.1/32.
+    *   Empty NextHop for the IPv4Entry 203.0.113.1/32.
+    *   Invalid IPv4 address in NextHop for the IPv4Entry 203.0.113.1/32.
+*   Ensure [FAILED] returned for the related IPv4Entry, NHG and NH in the above
+    scenarios.
+*   Ensure [RIB_PROGRAMMED] but not [FIB_PROGRAMMED] is returned for the
+    IPv4Entry 198.51.100.0/24 in all the scenarios.
+
+TODO: Validate in-place update:
+
+*   Repeat step 1-5 above.
+*   Use the Modify RPC to [ADD] a new NH with next-hop pointing to ATE port-3,
+    and [ADD] the same NHG (for 198.51.100.0/24) but pointing to the new added
+    NH.
+*   Validate that routes are pointing to ATE port-3 via AFT, and ensure traffic
+    are now being forwarded to ATE port-3.
 
 [ADD]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L171
 [FAILED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L265

--- a/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
@@ -6,50 +6,59 @@ Validate IPv4 AFT support in gRIBI with recursion.
 
 ## Procedure
 
-**Topology**
+Topology:
 
 *   Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
-    *   TODO: create a non-default VRF (VRF-1) that includes DUT port-1.
+*   TODO: create a non-default VRF (VRF-1) that includes DUT port-1.
+*   Establish gRIBI client connection with DUT using default parameters and
+    persistence mode `PRESERVE` and flush all entries after each case.
 
-**Validate hierarchical resolution**
+Validate hierarchical resolution across VRFs:
 
-1.  Establish gRIBI client connection with DUT.
-1.  TODO: Use gRIBI Modify RPC to install entries per the following order, and
-    ensure FIB ACK is received for each of the AFTOperation:
+1.  Using gRIBI Modify RPC install the following IPv4Entry set per the following
+    order, and ensure FIB ACK is received for each of the AFTOperation:
 
     1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
         containing one NextHop (default VRF) specified to be the address of ATE
         port-2.
-    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
-        NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
+    2.  Add 198.51.100.0/24 (TODO: VRF-1) to NextHopGroup (default VRF)
+        containing one NextHop (default VRF) specified to be 203.0.113.1/32 in
+        the default VRF.
 
-1.  Forward packets between ATE port-1 and ATE port-2 (destined to
+2.  Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
 
-1.  Validate that both routes are shown as installed via AFT telemetry.
+3.  Validate that both routes are shown as installed via AFT telemetry.
 
-1.  Ensure that removing the IPv4Entry 203.0.113.1/32 with a DELETE operation
+4.  Ensure that removing the IPv4Entry 203.0.113.1/32 with a DELETE operation
     results in traffic loss, and removal from AFT.
 
-1.  TODO: Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
-    containing one NextHop (default VRF) that specifies DUT port-2 as the egress
-    interface and `00:1A:11:00:00:01` as the destination MAC address.
+TODO: Validate hierarchical resolution using egress interface and MAC:
 
-1.  TODO: Ensure that ATE port-2 receives packet with `00:1A:11:00:00:01` as the
-    destination MAC address.
+1.  Using gRIBI Modify RPC install the following IPv4Entry set per the following
+    order, and ensure FIB ACK is received for each of the AFTOperation:
 
-**TODO: Validate error reporting**
+    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
+        containing one NextHop (default VRF) that specifies DUT port-2 as the
+        egress interface and `00:1A:11:00:00:01` as the destination MAC address.
+    2.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
+        NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
 
-1.  Establish gRIBI client connection with DUT.
+2.  Forward packets between ATE port-1 and ATE port-2 (destined to
+    198.51.100.0/24) and ensure that ATE port-2 receives packet with
+    `00:1A:11:00:00:01` as the destination MAC address.
+
+TODO: Validate error reporting:
+
 1.  Use gRIBI Modify RPC to install the following entries:
 
     1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
         containing one NextHop (default VRF) specified to be the address of ATE
         port-2.
-    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
+    2.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
         NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
 
-    but with the following (table) scenarios:
+    But with the following (table) scenarios:
 
     *   Replace 203.0.113.1/32 with a syntax invalid IP address.
     *   Missing NextHopGroup for the IPv4Entry 203.0.113.1/32.
@@ -57,11 +66,14 @@ Validate IPv4 AFT support in gRIBI with recursion.
     *   Empty NextHop for the IPv4Entry 203.0.113.1/32.
     *   Invalid IPv4 address in NextHop for the IPv4Entry 203.0.113.1/32.
 
-1.  Ensure FAILED returned for the related IPv4Entry, NHG and NH in all the
+2.  Ensure FAILED returned for the related IPv4Entry, NHG and NH in all the
     above scenarios.
 
-1.  Ensure RIB ACK but not FIB ACK is, returned for the IPv4Entry
+3.  Ensure RIB ACK, but not FIB ACK, is returned for the IPv4Entry
     198.51.100.0/24 in all the above scenarios.
+
+If the device supports it, repeat the cases in this test with gRIBI client
+persistence mode `DELETE` without flushing entries between cases.
 
 ## Config Parameter coverage
 

--- a/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
@@ -8,37 +8,48 @@ Validate IPv4 AFT support in gRIBI with recursion.
 
 **Topology**
 
-*  Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
+*   Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
     *   TODO: create a non-default VRF (VRF-1) that includes DUT port-1.
 
 **Validate hierarchical resolution**
 
 1.  Establish gRIBI client connection with DUT.
-1.  TODO: Use gRIBI Modify RPC to install entries per the following order, and ensure FIB ACK is received for each of the AFTOperation:
+1.  TODO: Use gRIBI Modify RPC to install entries per the following order, and
+    ensure FIB ACK is received for each of the AFTOperation:
 
-    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
-            be the address of ATE port-2.
-    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
-            be 203.0.113.1/32 in the default VRF.
+    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
+        containing one NextHop (default VRF) specified to be the address of ATE
+        port-2.
+    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
+        NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
+
 1.  Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
+
 1.  Validate that both routes are shown as installed via AFT telemetry.
+
 1.  Ensure that removing the IPv4Entry 203.0.113.1/32 with a DELETE operation
     results in traffic loss, and removal from AFT.
-1. TODO: Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF) containing one NextHop (default VRF) that specifies DUT port-2 as the egress interface and `00:1A:11:00:00:01` as the destination MAC address. 
-1. TODO: Ensure that ATE port-2 receives packet with `00:1A:11:00:00:01` as the destination MAC address.
+
+1.  TODO: Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
+    containing one NextHop (default VRF) that specifies DUT port-2 as the egress
+    interface and `00:1A:11:00:00:01` as the destination MAC address.
+
+1.  TODO: Ensure that ATE port-2 receives packet with `00:1A:11:00:00:01` as the
+    destination MAC address.
 
 **TODO: Validate error reporting**
 
 1.  Establish gRIBI client connection with DUT.
 1.  Use gRIBI Modify RPC to install the following entries:
 
-    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
-            be the address of ATE port-2.
-    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
-            be 203.0.113.1/32 in the default VRF.
-    
-    but with the following (table) scenarios: 
+    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF)
+        containing one NextHop (default VRF) specified to be the address of ATE
+        port-2.
+    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one
+        NextHop (default VRF) specified to be 203.0.113.1/32 in the default VRF.
+
+    but with the following (table) scenarios:
 
     *   Replace 203.0.113.1/32 with a syntax invalid IP address.
     *   Missing NextHopGroup for the IPv4Entry 203.0.113.1/32.
@@ -46,8 +57,11 @@ Validate IPv4 AFT support in gRIBI with recursion.
     *   Empty NextHop for the IPv4Entry 203.0.113.1/32.
     *   Invalid IPv4 address in NextHop for the IPv4Entry 203.0.113.1/32.
 
-1.   Ensure FAILED returned for the related IPv4Entry, NHG and NH in all the above scenarios.
-1.   Ensure RIB ACK but not FIB ACK is, returned for the IPv4Entry 198.51.100.0/24 in all the above scenarios.
+1.  Ensure FAILED returned for the related IPv4Entry, NHG and NH in all the
+    above scenarios.
+
+1.  Ensure RIB ACK but not FIB ACK is, returned for the IPv4Entry
+    198.51.100.0/24 in all the above scenarios.
 
 ## Config Parameter coverage
 

--- a/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
@@ -6,53 +6,48 @@ Validate IPv4 AFT support in gRIBI with recursion.
 
 ## Procedure
 
-1.  Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
+**Topology**
+
+*  Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
     *   TODO: create a non-default VRF (VRF-1) that includes DUT port-1.
-    *   TODO: connect ATE port-3 to DUT port-3.
-2.  Establish gRIBI client connection with DUT using default parameters.
-3.  Using gRIBI Modify RPC install the following IPv4Entry set:
-    *   198.51.100.0/24 to NextHopGroup containing one NextHop, specified to be
-        203.0.113.1/32
-    *   203.0.113.1/32 to NextHopGroup containing one NextHop specified to be
-        the address of ATE port-2.
-    *   TODO: ensure installing the above 2 sets in the following ordering, and
-        receive [FIB_PROGRAMMED] for all the AFTOperations.
-        1.  In default VRF, add 203.0.113.1/32 to NextHopGroup containing one NextHop specified to
+
+**Validate hierarchical resolution**
+
+1.  Establish gRIBI client connection with DUT.
+1.  TODO: Use gRIBI Modify RPC to install entries per the following order, and ensure FIB ACK is received for each of the AFTOperation:
+
+    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
             be the address of ATE port-2.
-        2.  in VRF-1, add 198.51.100.0/24 to NextHopGroup containing one NextHop, specified to
+    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
             be 203.0.113.1/32 in the default VRF.
-4.  Forward packets between ATE port-1 and ATE port-2 (destined to
+1.  Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
-5.  Validate that both routes are shown as installed via AFT telemetry.
-6.  Ensure that removing the IPEntry 203.0.113.1/32 with a DELETE operation
+1.  Validate that both routes are shown as installed via AFT telemetry.
+1.  Ensure that removing the IPv4Entry 203.0.113.1/32 with a DELETE operation
     results in traffic loss, and removal from AFT.
+1. TODO: Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF) containing one NextHop (default VRF) that specifies DUT port-2 as the egress interface and `00:1A:11:00:00:01` as the destination MAC address. 
+1. TODO: Ensure that ATE port-2 receives packet with `00:1A:11:00:00:01` as the destination MAC address.
 
-TODO: Validate error reporting.
+**TODO: Validate error reporting**
 
-*   Repeat step 1-3 as above but with the following (table) scenarios:
+1.  Establish gRIBI client connection with DUT.
+1.  Use gRIBI Modify RPC to install the following entries:
+
+    1.  Add 203.0.113.1/32 (default VRF) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
+            be the address of ATE port-2.
+    1.  Add 198.51.100.0/24 (VRF-1) to NextHopGroup (default VRF) containing one NextHop (default VRF) specified to
+            be 203.0.113.1/32 in the default VRF.
+    
+    but with the following (table) scenarios: 
+
     *   Replace 203.0.113.1/32 with a syntax invalid IP address.
     *   Missing NextHopGroup for the IPv4Entry 203.0.113.1/32.
     *   Empty NextHopGroup for the IPv4Entry 203.0.113.1/32.
     *   Empty NextHop for the IPv4Entry 203.0.113.1/32.
     *   Invalid IPv4 address in NextHop for the IPv4Entry 203.0.113.1/32.
-*   Ensure [FAILED] returned for the related IPv4Entry, NHG and NH in the above
-    scenarios.
-*   Ensure [RIB_PROGRAMMED] but not [FIB_PROGRAMMED] is returned for the
-    IPv4Entry 198.51.100.0/24 in all the scenarios.
 
-TODO: Validate in-place update:
-
-*   Repeat step 1-5 above.
-*   Use the Modify RPC to [ADD] a new NH with next-hop pointing to ATE port-3,
-    and [ADD] the same NHG (for 198.51.100.0/24) but pointing to the new added
-    NH.
-*   Validate that routes are pointing to ATE port-3 via AFT, and ensure traffic
-    are now being forwarded to ATE port-3.
-
-[ADD]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L171
-[FAILED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L265
-[RIB_PROGRAMMED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L269
-[FIB_PROGRAMMED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L285
+1.   Ensure FAILED returned for the related IPv4Entry, NHG and NH in all the above scenarios.
+1.   Ensure RIB ACK but not FIB ACK is, returned for the IPv4Entry 198.51.100.0/24 in all the above scenarios.
 
 ## Config Parameter coverage
 

--- a/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
+++ b/feature/gribi/otg_tests/base_hierarchical_route_installation_test/README.md
@@ -6,35 +6,46 @@ Validate IPv4 AFT support in gRIBI with recursion.
 
 ## Procedure
 
-*   Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
-*   Establish gRIBI client connection with DUT using default parameters.
-*   Using gRIBI Modify RPC install the following IPv4Entry set:
+1.  Connect ATE port-1 to DUT port-1 and ATE port-2 to DUT port-2.
+    *   TODO: create a non-default VRF (VRF-1) that includes DUT port-1.
+    *   TODO: connect ATE port-3 to DUT port-3.
+2.  Establish gRIBI client connection with DUT using default parameters.
+3.  Using gRIBI Modify RPC install the following IPv4Entry set:
     *   198.51.100.0/24 to NextHopGroup containing one NextHop, specified to be
         203.0.113.1/32
     *   203.0.113.1/32 to NextHopGroup containing one NextHop specified to be
         the address of ATE port-2.
-*   Forward packets between ATE port-1 and ATE port-2 (destined to
+    *   TODO: ensure installing the above 2 sets in the following ordering, and
+        receive [FIB_PROGRAMMED] for all the AFTOperations.
+        1.  203.0.113.1/32 to NextHopGroup containing one NextHop specified to
+            be the address of ATE port-2.
+        2.  198.51.100.0/24 to NextHopGroup containing one NextHop, specified to
+            be 203.0.113.1/32
+4.  Forward packets between ATE port-1 and ATE port-2 (destined to
     198.51.100.0/24) and determine that packets are forwarded successfully.
-*   Validate that both routes are shown as installed via AFT telemetry.
-*   Ensure that removing the NextHopGroup containing 203.0.113.1/32 with a
-    DELETE operation results in traffic loss, and removal from AFT.
-*   Repeat above test with the following (table) cases:
-    *   TODO: Explicitly specified egress interface of DUT port-2.
-    *   TODO: Explicitly specified MAC address for ATE port-2.
-    *   TODO: Entry installed in a non-default network instance (with ATE port-1
-        and port-2 assigned to a non-default NI)
-*   Ensure that the following cases result in an error being returned:
-    *   TODO: Invalid IPv4 prefix in the IPv4Entry
-    *   TODO: Missing NextHopGroup within an IPv4Entry
-    *   TODO: Empty NextHopGroup
-    *   TODO: Empty NextHop
-    *   TODO: Invalid IPv4 address in NextHop.
-*   Validate that REPLACE operations:
-    *   TODO: Fail when using 2.0.0.0/8 within the Ipv4EntryKey (does not
-        exist).
-    *   TODO: After installing a second next-hop-group with a different ID,
-        validate that a REPLACE for 1.0.0.0/8 can update (in-place) the NHG to
-        the new value. Validate via traffic and telemetry.
+5.  Validate that both routes are shown as installed via AFT telemetry.
+6.  Ensure that removing the IPEntry 203.0.113.1/32 with a DELETE operation
+    results in traffic loss, and removal from AFT.
+
+TODO: Validate error reporting. * Repeat step 1-3 as above but with the
+following (table) scenarios: * Replace 203.0.113.1/32 with a syntax invalid IP
+address. * Missing NextHopGroup for the IPv4Entry 203.0.113.1/32. * Empty
+NextHopGroup for the IPv4Entry 203.0.113.1/32. * Empty NextHop for the IPv4Entry
+203.0.113.1/32. * Invalid IPv4 address in NextHop for the IPv4Entry
+203.0.113.1/32. * Ensure [FAILED] returned for the related IPv4Entry, NHG and NH
+in the above scenarios. * Ensure [RIB_PROGRAMMED] but not [FIB_PROGRAMMED] is
+returned for the IPv4Entry 198.51.100.0/24 in all the scenarios.
+
+TODO: Validate in-place update: * Repeat step 1-5 above. * Use the Modify RPC to
+[ADD] a new NH with next-hop pointing to ATE port-3, and [ADD] the same NHG (for
+198.51.100.0/24) but pointing to the new added NH. * Validate that routes are
+pointing to ATE port-3 via AFT, and ensure traffic are now being forwarded to
+ATE port-3.
+
+[ADD]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L171
+[FAILED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L265
+[RIB_PROGRAMMED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L269
+[FIB_PROGRAMMED]: https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L285
 
 ## Config Parameter coverage
 


### PR DESCRIPTION
* Integrate non-default VRF test as part of the base testing procedure (which is our interest and also reduce test complexity).
* Ensure that we are programming them in the correct hierarchical order and receive  FIB ACK (current code implementation only checks for RIB ACK).
* Clarify the scenarios for testing error reporting.
* In-place NHG update will be covered by TE-3.7. 