### PR TITLE
Update TE-3.5 README

### DIFF
--- a/feature/gribi/ate_tests/ordering_ack_test/README.md
+++ b/feature/gribi/ate_tests/ordering_ack_test/README.md
@@ -11,11 +11,8 @@ Ensure that acknowledgements are sent as is expected by gRIBI controller.
     the requested `ack_type`.
 *   Install the following entries and determine whether the expected result is
     observed:
-    *   A `NextHopGroup` referencing a `NextHop` is responded to with RIB+FIB
+    *   A `NextHopGroup` referencing a `NextHop` is responded to with FIB
         ACK, and is reported through the AFT telemetry.
-    *   A `NextHopGroup` referencing a `NextHop` with a referencing `IPv4Entry`
-        within a single `ModifyRequest` is ACKed, verified through AFT telemetry
-        and traffic.
     *   A single `ModifyRequest` with the following ordered operations is
         responded to with an error:
         *   An `AFTOperation` containing an `IPv4Entry` referencing


### PR DESCRIPTION
* In the case of FIB ACK, RIB ACK is optional. gRIBI does allow a device to only return FIB ACK (skip RIB_ACK) after a success FIB programming. This is also aligned with current implementation that checks either FIB ACK or RIB ACK (with flag), but not both.  
* Remove case#2:
	* If case#2 means IPv4Entry -> NHG -> NH, then it's already covered by case#4.
	* If case#2 means hierarchical resolution, then it's covered by TE-3.1
	* case#2 is not implemented anyway.