### PR TITLE
OS Install don't send standby supervisor data

### DIFF
--- a/feature/gnoi/os/tests/osinstall/osinstall_test.go
+++ b/feature/gnoi/os/tests/osinstall/osinstall_test.go
@@ -229,9 +229,11 @@ func (tc *testCase) transferOS(ctx context.Context, t *testing.T, standby bool) 
 		awaitChan <- err
 	}()
 
-	err = transferContent(ic, tc.reader)
-	if err != nil {
-		t.Fatalf("Error transferring content: %s", err)
+	if !standby {
+		err = transferContent(ic, tc.reader)
+		if err != nil {
+			t.Fatalf("Error transferring content: %s", err)
+		}
 	}
 
 	if err = <-awaitChan; err != nil {


### PR DESCRIPTION
Don't attempt to send data during standby transfer. The data should be synced from primary to standby.

This bug would only be seen if DUT has dual supervisors and does not have the image cached.

PiperOrigin-RevId: 468572156