### PR TITLE
Add tool to generate wiki docs

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -3,8 +3,6 @@ name: Update Wiki
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   update-wiki:

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -40,7 +40,7 @@ jobs:
         popd
 
         pushd featureprofiles
-        go run tools/wikidoc/wikidoc.go -feature_root feature/ -output_root ../featureprofiles.wiki/testplans
+        go run tools/wikidoc/wikidoc.go -feature_root feature/ -output_root ../featureprofiles.wiki
         popd
 
         pushd featureprofiles.wiki

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build-wiki:
+  update-wiki:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -36,7 +36,7 @@ jobs:
         pushd featureprofiles.wiki
         git config --local user.email "action@github.com"
         git config --local user.name "Github Action"
-        git rm -r testplans
+        git rm -r testplans || true
         popd
 
         pushd featureprofiles

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,49 @@
+name: Update Wiki
+
+on:
+  push:
+    branches: [ wikidoc ]
+  pull_request:
+    branches: [ wikidoc ]
+
+jobs:
+  build-wiki:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        path: featureprofiles
+    - name: Checkout wiki
+      uses: actions/checkout@v2
+      with:
+        repository: "bstoll/featureprofiles.wiki"
+        path: featureprofiles.wiki
+    - name: Set up Go
+      uses: actions/setup-go@v2.1.3
+      with:
+        go-version: 1.19.x
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
+    - name: Build Wiki
+      run: |
+        pushd featureprofiles.wiki
+        git config --local user.email "action@github.com"
+        git config --local user.name "Github Action"
+        git rm -r testplans
+        popd
+
+        pushd featureprofiles
+        go run tools/wikidoc/wikidoc.go -feature_root feature/ -output_root ../featureprofiles.wiki/testplans
+        popd
+
+        pushd featureprofiles.wiki
+        git add .
+        git diff --quiet HEAD || git commit -m "Update wiki from featureprofiles" && git push
+        popd

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -2,9 +2,9 @@ name: Update Wiki
 
 on:
   push:
-    branches: [ wikidoc ]
+    branches: [ main ]
   pull_request:
-    branches: [ wikidoc ]
+    branches: [ main ]
 
 jobs:
   build-wiki:
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout wiki
       uses: actions/checkout@v2
       with:
-        repository: "bstoll/featureprofiles.wiki"
+        repository: "openconfig/featureprofiles.wiki"
         path: featureprofiles.wiki
     - name: Set up Go
       uses: actions/setup-go@v2.1.3

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/openconfig/ygot v0.24.2
 	github.com/p4lang/p4runtime v1.3.0
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20220608084003-fc78c767cd6a
+	github.com/yuin/goldmark v1.3.5
 	golang.org/x/crypto v0.0.0-20220518034528-6f7dac969898
 	google.golang.org/grpc v1.49.0
 	google.golang.org/protobuf v1.28.1

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,7 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5 h1:dPmz1Snjq0kmkz159iL7S6WzdahUTHnHB5M56WFVifs=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/tools/wikidoc/sidebar.tmpl
+++ b/tools/wikidoc/sidebar.tmpl
@@ -1,0 +1,6 @@
+* [Home](Home)
+    * Test Plans
+{{- range . }}
+        * [{{.Title}}]({{.Name}})
+{{- end }}
+

--- a/tools/wikidoc/wikidoc.go
+++ b/tools/wikidoc/wikidoc.go
@@ -1,3 +1,19 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// wikidoc inspects all feature profiles for test plans and compiles into a
+// single location
 package main
 
 import (

--- a/tools/wikidoc/wikidoc.go
+++ b/tools/wikidoc/wikidoc.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	log "github.com/golang/glog"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/text"
+)
+
+// testDoc describes a test plan document
+type testDoc struct {
+	Name  string
+	Title string
+	Path  string
+}
+
+// path relative from outputRoot containing all test plans
+const wikiPath = "/testplans/"
+
+var (
+	featureRoot = flag.String("feature_root", "", "root directory of the feature profiles")
+	outputRoot  = flag.String("output_root", "", "root directory to output test docs")
+	sidebarTmpl = flag.String("sidebar_tmpl", "tools/wikidoc/sidebar.tmpl", "path to sidebar template")
+)
+
+func main() {
+	flag.Parse()
+	if *featureRoot == "" {
+		log.Fatal("feature_root must be set.")
+	}
+	if *outputRoot == "" {
+		log.Fatal("output_root must be set.")
+	}
+
+	docs, err := fetchTestDocs()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = writeTestDocs(docs)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = writeSidebar(docs)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// writeSidebar creates a sidebar document formatted from sidebarTmpl in outputRoot
+func writeSidebar(docs []testDoc) error {
+	f, err := os.Create(*outputRoot + "/_Sidebar.md")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	sidebar, err := os.ReadFile(*sidebarTmpl)
+	if err != nil {
+		return err
+	}
+	t, err := template.New("sidebar").Parse(string(sidebar))
+	if err != nil {
+		return err
+	}
+	t.Execute(f, docs)
+
+	return nil
+}
+
+// writeTestDocs outputs test docs into outputRoot
+func writeTestDocs(docs []testDoc) error {
+	err := os.MkdirAll(*outputRoot+wikiPath, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	for _, doc := range docs {
+		f, err := os.ReadFile(doc.Path)
+		if err != nil {
+			return err
+		}
+		err = os.WriteFile(*outputRoot+wikiPath+doc.Name+".md", f, 0644)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// fetchTestDocs finds all valid test documents in featureRoot
+func fetchTestDocs() ([]testDoc, error) {
+	docs := []testDoc{}
+
+	err := filepath.WalkDir(*featureRoot,
+		func(path string, e fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if !validPath(path) {
+				return nil
+			}
+
+			testTitle, err := docTitle(path)
+			if err != nil {
+				return err
+			}
+
+			doc := testDoc{
+				Name:  filepath.Base(filepath.Dir(path)),
+				Title: testTitle,
+				Path:  path,
+			}
+			docs = append(docs, doc)
+
+			return nil
+		})
+
+	return docs, err
+}
+
+// validPath checks if a given file path is eligible to contain a test doc.
+func validPath(path string) bool {
+	if filepath.Base(path) != "README.md" {
+		return false
+	}
+
+	validPaths := []string{"/ate_tests/", "/tests/"}
+	for _, validPath := range validPaths {
+		if strings.Contains(path, validPath) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// docTitle fetches the first header string from a markdown file
+func docTitle(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	markdown := goldmark.New()
+	doc := markdown.Parser().Parse(text.NewReader(b))
+	if doc.ChildCount() == 0 {
+		return "", errors.New("no children")
+	}
+
+	return string(doc.FirstChild().Text(b)), nil
+}

--- a/tools/wikidoc/wikidoc.go
+++ b/tools/wikidoc/wikidoc.go
@@ -83,6 +83,7 @@ func writeSidebar(docs []testDoc, tmplFile string, rootPath string) error {
 	if err != nil {
 		return err
 	}
+
 	t, err := template.New("sidebar").Parse(string(sidebar))
 	if err != nil {
 		return err
@@ -98,11 +99,13 @@ func writeTestDocs(docs []testDoc, rootPath string) error {
 	if err != nil {
 		return err
 	}
+
 	for _, doc := range docs {
 		f, err := os.ReadFile(doc.Path)
 		if err != nil {
 			return err
 		}
+
 		err = os.WriteFile(rootPath+wikiPath+doc.Name+".md", f, 0644)
 		if err != nil {
 			return err


### PR DESCRIPTION
It is currently difficult to see all test plans in a single location.  This PR creates a Github action triggered on every commit that will update the Github Wiki with all the test plans.

An example of the output can be seen on my fork at https://github.com/bstoll/featureprofiles/wiki
