### PR TITLE
changed call from replace to update to avoid overwriting LAG config

### DIFF
--- a/feature/interface/aggregate/ate_tests/aggregate_test/aggregate_test.go
+++ b/feature/interface/aggregate/ate_tests/aggregate_test/aggregate_test.go
@@ -214,7 +214,7 @@ func (tc *testCase) configureDUT(t *testing.T) {
 	tc.configDstAggregateDUT(agg, &dutDst)
 	aggPath := d.Interface(tc.aggID)
 	fptest.LogYgot(t, tc.aggID, aggPath, agg)
-	aggPath.Replace(t, agg)
+	aggPath.Update(t, agg)
 
 	srcp := tc.dutPorts[0]
 	srci := &telemetry.Interface{Name: ygot.String(srcp.Name())}

--- a/feature/interface/aggregate/ate_tests/balancing_test/balancing_test.go
+++ b/feature/interface/aggregate/ate_tests/balancing_test/balancing_test.go
@@ -227,7 +227,7 @@ func (tc *testCase) configureDUT(t *testing.T) {
 	tc.configDstAggregateDUT(agg, &dutDst)
 	aggPath := d.Interface(tc.aggID)
 	fptest.LogYgot(t, tc.aggID, aggPath, agg)
-	aggPath.Replace(t, agg)
+	aggPath.Update(t, agg)
 
 	for n, port := range tc.dutPorts {
 		if n < 1 {


### PR DESCRIPTION
The automation configures lag mode and then overwrites it with ip address configuration with existing "Replace" call, changing it to "Update" call appends to the configuration.
