### PR TITLE
feature.textproto for qos add dscp

### DIFF
--- a/feature/qos/feature.textproto
+++ b/feature/qos/feature.textproto
@@ -153,29 +153,3 @@ config_path {
 telemetry_path {
   path: "/qos/scheduler-policies/scheduler-policy/schedulers/scheduler/two-rate-three-color/state/pir"
 }
-
-# Queue management profiles
-config_path {
-  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/config/min-threshold"
-}
-telemetry_path {
-  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/state/min-threshold"
-}
-config_path {
-  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/config/max-threshold"
-}
-telemetry_path {
-  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/state/max-threshold"
-}
-config_path {
-  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/config/max-drop-probability-percent"
-}
-telemetry_path {
-  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/state/max-drop-probability-percent"
-}
-config_path {
-  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/config/weight"
-}
-telemetry_path {
-  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/state/weight"
-}

--- a/feature/qos/feature.textproto
+++ b/feature/qos/feature.textproto
@@ -168,12 +168,6 @@ telemetry_path {
   path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/state/max-threshold"
 }
 config_path {
-  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/config/enable-ecn"
-}
-telemetry_path {
-  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/state/enable-ecn"
-}
-config_path {
   path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/config/max-drop-probability-percent"
 }
 telemetry_path {

--- a/feature/qos/feature.textproto
+++ b/feature/qos/feature.textproto
@@ -29,10 +29,22 @@ telemetry_path {
   path: "/qos/classifiers/classifier/terms/term/conditions/ipv4/state/dscp"
 }
 config_path {
+  path: "/qos/classifiers/classifier/terms/term/conditions/ipv4/config/dscp-set"
+}
+telemetry_path {
+  path: "/qos/classifiers/classifier/terms/term/conditions/ipv4/state/dscp-set"
+}
+config_path {
   path: "/qos/classifiers/classifier/terms/term/conditions/ipv6/config/dscp"
 }
 telemetry_path {
   path: "/qos/classifiers/classifier/terms/term/conditions/ipv6/state/dscp"
+}
+config_path {
+  path: "/qos/classifiers/classifier/terms/term/conditions/ipv6/config/dscp-set"
+}
+telemetry_path {
+  path: "/qos/classifiers/classifier/terms/term/conditions/ipv6/state/dscp-set"
 }
 config_path {
   path: "/qos/classifiers/classifier/terms/term/config/id"
@@ -140,4 +152,36 @@ config_path {
 }
 telemetry_path {
   path: "/qos/scheduler-policies/scheduler-policy/schedulers/scheduler/two-rate-three-color/state/pir"
+}
+
+# Queue management profiles
+config_path {
+  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/config/min-threshold"
+}
+telemetry_path {
+  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/state/min-threshold"
+}
+config_path {
+  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/config/max-threshold"
+}
+telemetry_path {
+  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/state/max-threshold"
+}
+config_path {
+  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/config/enable-ecn"
+}
+telemetry_path {
+  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/state/enable-ecn"
+}
+config_path {
+  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/config/max-drop-probability-percent"
+}
+telemetry_path {
+  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/state/max-drop-probability-percent"
+}
+config_path {
+  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/config/weight"
+}
+telemetry_path {
+  path: "/qos/queue-management-profiles/queue-management-profile/wred/uniform/state/weight"
 }


### PR DESCRIPTION
Added missing qos config and telemetry paths
  - Reference:  https://ops.openconfig.net/branches/models/master/openconfig-qos.html#