### PR TITLE
Helper function to get telemetry components list

### DIFF
--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -11,7 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package wbbtest
+
+// Package components provides functions to enumerate components from the device.
+package components
 
 import (
 	"regexp"

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -1,0 +1,57 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package wbbtest
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/telemetry"
+)
+
+// FindComponentsByType finds the list of components based on hardware type.
+func FindComponentsByType(t *testing.T, dut *ondatra.DUTDevice, cType telemetry.E_PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT) []string {
+	components := dut.Telemetry().ComponentAny().Name().Get(t)
+	var s []string
+	for _, c := range components {
+		lookupType := dut.Telemetry().Component(c).Type().Lookup(t)
+		if !lookupType.IsPresent() {
+			t.Logf("Component %s type is missing from telemetry", c)
+			continue
+		}
+		componentType := lookupType.Val(t)
+		t.Logf("Component %s has type: %v", c, componentType)
+		switch v := componentType.(type) {
+		case telemetry.E_PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT:
+			if v == cType {
+				s = append(s, c)
+			}
+		default:
+			t.Logf("Detected non-hardware component: (%T, %v)", componentType, componentType)
+		}
+	}
+	return s
+}
+
+// FindMatchingStrings filters out the components list based on regex pattern.
+func FindMatchingStrings(components []string, r *regexp.Regexp) []string {
+	var s []string
+	for _, c := range components {
+		if r.MatchString(c) == true {
+			s = append(s, c)
+		}
+	}
+	return s
+}

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -49,7 +49,7 @@ func FindComponentsByType(t *testing.T, dut *ondatra.DUTDevice, cType telemetry.
 func FindMatchingStrings(components []string, r *regexp.Regexp) []string {
 	var s []string
 	for _, c := range components {
-		if r.MatchString(c) == true {
+		if r.MatchString(c) {
 			s = append(s, c)
 		}
 	}

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 Google Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package wbbtest
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFindMatchingStrings(t *testing.T) {
+	args := []string{
+		"LineCard1",
+		"Supervisor1",
+		"LineCard2",
+		"Supervisor2",
+		"Supervisor3",
+		"LineCard2",
+	}
+	r := regexp.MustCompile(`^Supervisor[0-9]$`)
+	want := []string{
+		"Supervisor1",
+		"Supervisor2",
+		"Supervisor3",
+	}
+	got := FindMatchingStrings(args, r)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("FindMatchingStrings(%s) returned unexpected diff (-want +got):\n%s", args, diff)
+	}
+}

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -1,18 +1,18 @@
-/*
-Copyright 2022 Google Inc.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-package wbbtest
+package components
 
 import (
 	"regexp"


### PR DESCRIPTION
Create package to remove dependency on static mapping to get hardware component type.

This PR fetches all the hardware components based on hardware type defined in enum.go 
After fetching hardware list - validate the properties associated with each component

Run- 13cd3a36-09a9-43b0-a618-786a5ec95b8f