### PR TITLE
Change string_val used in oc gnmi set to json_ietf_val

### DIFF
--- a/feature/system/gnmi/cliorigin/mixed_oc_cli_origin_support_test/mixed_oc_cli_origin_support_test.go
+++ b/feature/system/gnmi/cliorigin/mixed_oc_cli_origin_support_test/mixed_oc_cli_origin_support_test.go
@@ -46,10 +46,10 @@ func buildOCUpdate(path *gpb.Path, value string) *gpb.Update {
 	if len(path.GetElem()) == 0 || path.GetElem()[0].GetName() != "meta" {
 		path.Origin = "openconfig"
 	}
-	json_value := fmt.Sprintf("\"%s\"", value)
+	jsonVal, _ := ygot.Marshal7951(ygot.String(value))
 	update := &gpb.Update{
 		Path: path,
-		Val:  &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{JsonIetfVal: []byte(json_value)}},
+		Val:  &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{JsonIetfVal: []byte(jsonVal)}},
 	}
 	return update
 }

--- a/feature/system/gnmi/cliorigin/mixed_oc_cli_origin_support_test/mixed_oc_cli_origin_support_test.go
+++ b/feature/system/gnmi/cliorigin/mixed_oc_cli_origin_support_test/mixed_oc_cli_origin_support_test.go
@@ -46,9 +46,10 @@ func buildOCUpdate(path *gpb.Path, value string) *gpb.Update {
 	if len(path.GetElem()) == 0 || path.GetElem()[0].GetName() != "meta" {
 		path.Origin = "openconfig"
 	}
+	json_value := fmt.Sprintf("\"%s\"", value)
 	update := &gpb.Update{
 		Path: path,
-		Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: value}},
+		Val:  &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{JsonIetfVal: []byte(json_value)}},
 	}
 	return update
 }


### PR DESCRIPTION
Change string_val used in oc gnmi set to json_ietf_val
Encodings other than json_ietf_val are not supported