### PR TITLE
Add Apache license header

### DIFF
--- a/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package base_hierarchical_nhg_update_test
 
 import (


### PR DESCRIPTION
I missed the comment in #506 - add a license header to the Base Hierarchical NHG Update test.