### PR TITLE
CloudBuild - pin KNE version to a specific tag

### DIFF
--- a/cloudbuild/setup.sh
+++ b/cloudbuild/setup.sh
@@ -16,6 +16,7 @@
 set -xe
 
 GOLANG_URL="https://dl.google.com/go/go1.19.linux-amd64.tar.gz"
+KNE_TAG="v0.1.6"
 
 # Install Go
 curl -o go.tar.gz ${GOLANG_URL}
@@ -41,7 +42,7 @@ curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stabl
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 # Install KNE
-git clone https://github.com/openconfig/kne.git
+git clone -b "${KNE_TAG}" https://github.com/openconfig/kne.git
 pushd kne/kne_cli
 go install -v
 popd


### PR DESCRIPTION
KNE has been having issues running at HEAD.  Pin Cloud Build to use a tagged version of KNE.