### PR TITLE
Update supervisor_switchover_test.go

### DIFF
--- a/feature/gnoi/system/tests/supervisor_switchover_test/supervisor_switchover_test.go
+++ b/feature/gnoi/system/tests/supervisor_switchover_test/supervisor_switchover_test.go
@@ -87,7 +87,7 @@ func TestSupervisorSwitchover(t *testing.T) {
 		t.Errorf("Get the number of intfsOperStatusUP interfaces for %q: got 0, want > 0", dut.Name())
 	}
 
-	gnoiClient := dut.RawAPIs().GNOI().Default(t)
+	gnoiClient := dut.RawAPIs().GNOI().New(t)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
 		ControlProcessor: &tpb.Path{
 			Elem: []*tpb.PathElem{{Name: rpStandbyBeforeSwitch}},


### PR DESCRIPTION
Fixed the similar connection issue like #501 using dut.RawAPIs().GNOI().New(t) instead of dut.RawAPIs().GNOI().Default()