### PR TITLE
Use BGP router-id instead of global router-id

### DIFF
--- a/feature/bgp/gracefulrestart/ate_tests/bgp_graceful_restart_test/bgp_graceful_restart_test.go
+++ b/feature/bgp/gracefulrestart/ate_tests/bgp_graceful_restart_test/bgp_graceful_restart_test.go
@@ -117,7 +117,6 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	t.Log("Configure/update Network Instance")
 	dutConfNIPath := dc.NetworkInstance(*deviations.DefaultNetworkInstance)
 	dutConfNIPath.Type().Replace(t, telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
-	dutConfNIPath.RouterId().Replace(t, dutDst.IPv4)
 }
 
 func verifyPortsUp(t *testing.T, dev *ondatra.Device) {
@@ -148,6 +147,7 @@ func bgpWithNbr(as uint32, nbrs []*bgpNeighbor) *telemetry.NetworkInstance_Proto
 	bgp := &telemetry.NetworkInstance_Protocol_Bgp{}
 	g := bgp.GetOrCreateGlobal()
 	g.As = ygot.Uint32(as)
+	g.RouterId = ygot.String(dutDst.IPv4)
 	bgpgr := g.GetOrCreateGracefulRestart()
 	bgpgr.Enabled = ygot.Bool(true)
 	bgpgr.RestartTime = ygot.Uint16(grRestartTime)

--- a/feature/bgp/policybase/ate_tests/route_installation_test/route_installation_test.go
+++ b/feature/bgp/policybase/ate_tests/route_installation_test/route_installation_test.go
@@ -152,6 +152,7 @@ func bgpCreateNbr(localAs, peerAs uint32, policy string) *telemetry.NetworkInsta
 	ni1 := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
 	bgp := ni1.GetOrCreateProtocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
 	global := bgp.GetOrCreateGlobal()
+	global.RouterId = ygot.String(dutDst.IPv4)
 	global.As = ygot.Uint32(localAs)
 	// Note: we have to define the peer group even if we aren't setting any policy because it's
 	// invalid OC for the neighbor to be part of a peer group that doesn't exist.
@@ -461,11 +462,6 @@ func TestEstablish(t *testing.T) {
 	t.Logf("Start DUT interface Config")
 	configureDUT(t, dut)
 
-	t.Log("Configure Network Instance")
-
-	dutConfNIPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance)
-	dutConfNIPath.RouterId().Replace(t, dutDst.IPv4)
-
 	// Configure BGP+Neighbors on the DUT
 	t.Logf("Start DUT BGP Config")
 	dutConfPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
@@ -515,11 +511,6 @@ func TestBGPPolicy(t *testing.T) {
 	// Configure interface on the DUT
 	t.Logf("Start DUT interface Config")
 	configureDUT(t, dut)
-
-	t.Log("Configure Network Instance")
-
-	dutConfNIPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance)
-	dutConfNIPath.RouterId().Replace(t, dutDst.IPv4)
 
 	cases := []struct {
 		desc                      string

--- a/feature/bgp/policybase/otg_tests/route_installation_test/route_installation_test.go
+++ b/feature/bgp/policybase/otg_tests/route_installation_test/route_installation_test.go
@@ -160,6 +160,7 @@ func bgpCreateNbr(localAs, peerAs uint32, policy string) *telemetry.NetworkInsta
 	ni1 := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
 	bgp := ni1.GetOrCreateProtocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
 	global := bgp.GetOrCreateGlobal()
+	global.RouterId = ygot.String(dutDst.IPv4)
 	global.As = ygot.Uint32(localAs)
 	// Note: we have to define the peer group even if we aren't setting any policy because it's
 	// invalid OC for the neighbor to be part of a peer group that doesn't exist.
@@ -511,11 +512,6 @@ func TestEstablish(t *testing.T) {
 	t.Logf("Start DUT interface Config")
 	configureDUT(t, dut)
 
-	t.Log("Configure Network Instance")
-
-	dutConfNIPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance)
-	dutConfNIPath.RouterId().Replace(t, dutDst.IPv4)
-
 	// Configure BGP+Neighbors on the DUT
 	t.Logf("Start DUT BGP Config")
 	dutConfPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
@@ -570,11 +566,6 @@ func TestBGPPolicy(t *testing.T) {
 	// Configure interface on the DUT
 	t.Logf("Start DUT interface Config")
 	configureDUT(t, dut)
-
-	t.Log("Configure Network Instance")
-
-	dutConfNIPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance)
-	dutConfNIPath.RouterId().Replace(t, dutDst.IPv4)
 
 	cases := []struct {
 		desc                      string

--- a/feature/experimental/bgp/ate_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
+++ b/feature/experimental/bgp/ate_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
@@ -235,11 +235,10 @@ func TestEstablishAndDisconnect(t *testing.T) {
 	t.Log("Start DUT interface Config")
 	configureDUT(t, dut)
 
-	// Configure Network instance type and router id on DUT
+	// Configure Network instance type on DUT
 	t.Log("Configure Network Instance")
 	dutConfNIPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance)
 	dutConfNIPath.Type().Replace(t, telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
-	dutConfNIPath.RouterId().Replace(t, dutAttrs.IPv4)
 
 	t.Log("Configure BGP")
 	dutConfPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
@@ -306,11 +305,10 @@ func TestParameters(t *testing.T) {
 	dutIP := dutAttrs.IPv4
 	dut := ondatra.DUT(t, "dut")
 
-	// Configure Network instance type and router id on DUT
+	// Configure Network instance type on DUT
 	t.Log("Configure Network Instance")
 	dutConfNIPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance)
 	dutConfNIPath.Type().Replace(t, telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
-	dutConfNIPath.RouterId().Replace(t, dutAttrs.IPv4)
 
 	dutConfPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	statePath := dut.Telemetry().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()


### PR DESCRIPTION
The BGP feature profile router-id path is defined here:

https://github.com/openconfig/featureprofiles/blob/a46e6b1acf1623739d73f4befaf1e26fb20f02a1/feature/bgp/feature.textproto#L56

We should use `/network-instances/network-instance/protocols/protocol/bgp/global/router-id` rather than `/network-instances/network-instance/config/router-id` in tests.  This PR updates tests to utilize the protocol path for BGP router-id rather than the global knob.

Resolves #393.