### PR TITLE
TE-2.1, TE-4.2:   Add GRIBIPreserveOnly flag and fix refrencing issue

### DIFF
--- a/feature/gribi/ate_tests/ipv4_entry_test/ipv4_entry_test.go
+++ b/feature/gribi/ate_tests/ipv4_entry_test/ipv4_entry_test.go
@@ -256,7 +256,6 @@ func TestIPv4Entry(t *testing.T) {
 			if err := awaitTimeout(ctx, c, t, time.Minute); err != nil {
 				t.Fatalf("Await got error during session negotiation: %v", err)
 			}
-			// flush the entries,
 			if tc.downPort != nil {
 				ate.Actions().NewSetPortState().WithPort(tc.downPort).WithEnabled(false).Send(t)
 				defer ate.Actions().NewSetPortState().WithPort(tc.downPort).WithEnabled(true).Send(t)

--- a/feature/gribi/ate_tests/leader_failover_test/leader_failover_test.go
+++ b/feature/gribi/ate_tests/leader_failover_test/leader_failover_test.go
@@ -250,7 +250,9 @@ func TestLeaderFailover(t *testing.T) {
 	}
 
 	t.Run("SINGLE_PRIMARY/PERSISTENCE=DELETE", func(t *testing.T) {
-
+		if *deviations.GRIBIPreserveOnly {
+			t.Skip()
+		}
 		// Set parameters for gRIBI client clientA.
 		// Set Persistence to false.
 		clientA := &gribi.Client{
@@ -289,6 +291,9 @@ func TestLeaderFailover(t *testing.T) {
 	})
 
 	t.Run("ShouldDelete", func(t *testing.T) {
+		if *deviations.GRIBIPreserveOnly {
+			t.Skip()
+		}
 
 		t.Logf("Verify through Telemetry and Traffic that the route to %s has been deleted after gRIBI client disconnected", ateDstNetCIDR)
 

--- a/feature/gribi/ate_tests/leader_failover_test/leader_failover_test.go
+++ b/feature/gribi/ate_tests/leader_failover_test/leader_failover_test.go
@@ -251,7 +251,7 @@ func TestLeaderFailover(t *testing.T) {
 
 	t.Run("SINGLE_PRIMARY/PERSISTENCE=DELETE", func(t *testing.T) {
 		if *deviations.GRIBIPreserveOnly {
-			t.Skip()
+			t.Skip("Skipping due to --deviations_gribi_preserve_only")
 		}
 		// Set parameters for gRIBI client clientA.
 		// Set Persistence to false.
@@ -292,7 +292,7 @@ func TestLeaderFailover(t *testing.T) {
 
 	t.Run("ShouldDelete", func(t *testing.T) {
 		if *deviations.GRIBIPreserveOnly {
-			t.Skip()
+			t.Skip("Skipping due to --deviations_gribi_preserve_only")
 		}
 
 		t.Logf("Verify through Telemetry and Traffic that the route to %s has been deleted after gRIBI client disconnected", ateDstNetCIDR)


### PR DESCRIPTION
Hi This pull adds GRIBIPreserveOnly guard to TE-2.1 and TE-4.2. It also  fixes referencing issue for deleting entries in TE-2.1. We can not delete a NHG before deleting all dependent ipv4 entries and the same holds for NH. The reason that current tests does not catch this issue is because it uses delete mode and does not verify RIB ack.  