### PR TITLE
Remove featureprofiles-go reviewers as required

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,8 +10,3 @@
 
 # Order is important; the last matching pattern takes the most
 # precedence.
-
-# When someone opens a pull request that only modifies Go files, only
-# @openconfig/featureprofiles-go-reviewers and not the global
-# owner(s) will be requested for a review.
-*.go    @openconfig/featureprofiles-go-reviewers


### PR DESCRIPTION
featureprofiles-maintainers members will choose if a go-reviewer is required.