### PR TITLE
Add switchover_ready status before switchover.

### DIFF
--- a/feature/experimental/gribi/ate_tests/supervisor_failure/supervisor_failure_test.go
+++ b/feature/experimental/gribi/ate_tests/supervisor_failure/supervisor_failure_test.go
@@ -317,6 +317,13 @@ func TestSupFailure(t *testing.T) {
 	secondaryBeforeSwitch, primaryBeforeSwitch := findSecondaryController(t, dut, controllers)
 	t.Logf("Detected Secondary: %v, Primary: %v", secondaryBeforeSwitch, primaryBeforeSwitch)
 
+	switchoverReady := dut.Telemetry().Component(primaryBeforeSwitch).SwitchoverReady()
+	switchoverReady.Await(t, 30*time.Minute, true)
+	t.Logf("SwitchoverReady().Get(t): %v", switchoverReady.Get(t))
+	if !switchoverReady.Get(t) {
+		t.Errorf("switchoverReady.Get(t): got %v, want %v", switchoverReady.Get(t), true)
+	}
+
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
 		ControlProcessor: &tpb.Path{


### PR DESCRIPTION
* Add switchover_ready status for the test.

* Rename file to reflect the standard used in other files (all small caps).