### PR TITLE
added network instance type to default

### DIFF
--- a/feature/bgp/policybase/ate_tests/route_installation_test/route_installation_test.go
+++ b/feature/bgp/policybase/ate_tests/route_installation_test/route_installation_test.go
@@ -467,7 +467,6 @@ func TestEstablish(t *testing.T) {
 	dutConfNIPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance)
 	dutConfNIPath.Type().Replace(t, telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 
-
 	// Configure BGP+Neighbors on the DUT
 	t.Logf("Start DUT BGP Config")
 	dutConfPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
@@ -522,7 +521,6 @@ func TestBGPPolicy(t *testing.T) {
 	t.Log("Configure Network Instance type ")
 	dutConfNIPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance)
 	dutConfNIPath.Type().Replace(t, telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
-
 
 	cases := []struct {
 		desc                      string

--- a/feature/bgp/policybase/ate_tests/route_installation_test/route_installation_test.go
+++ b/feature/bgp/policybase/ate_tests/route_installation_test/route_installation_test.go
@@ -462,6 +462,12 @@ func TestEstablish(t *testing.T) {
 	t.Logf("Start DUT interface Config")
 	configureDUT(t, dut)
 
+	// Configure Network instance type on DUT
+	t.Log("Configure Network Instance type")
+	dutConfNIPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath.Type().Replace(t, telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
+
+
 	// Configure BGP+Neighbors on the DUT
 	t.Logf("Start DUT BGP Config")
 	dutConfPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
@@ -511,6 +517,12 @@ func TestBGPPolicy(t *testing.T) {
 	// Configure interface on the DUT
 	t.Logf("Start DUT interface Config")
 	configureDUT(t, dut)
+
+	// Configure Network instance type on DUT
+	t.Log("Configure Network Instance type ")
+	dutConfNIPath := dut.Config().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath.Type().Replace(t, telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
+
 
 	cases := []struct {
 		desc                      string


### PR DESCRIPTION
Hi,

Instance type config is required when DUT is assumed to have no network instance configured prior to running the test.
If instance type is not configured prior to script run, config failure will be seen as instance type is mandatory.

If DUT already have instance type configured, it also will be of type DEFAULT_INSTANCE.
Script also does replace with same type, hence replacing instance type is not a problem such DUT devices.

Ref PR #: https://github.com/openconfig/featureprofiles/pull/592

Thanks,
Prabha