### PR TITLE
add a deviation for vrf/enabled

### DIFF
--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -288,7 +288,7 @@ func createVrf(t *testing.T, dut *ondatra.DUTDevice, d *telemetry.Device, vrfs [
 		// entire VRF tree so the instance is created.
 		i := d.GetOrCreateNetworkInstance(vrf)
 		i.Type = telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
-		if !*deviations.VRFEnabled {
+		if !*deviations.VRFMissingEnabled {
 			i.Enabled = ygot.Bool(true)
 		}
 		i.EnabledAddressFamilies = []telemetry.E_Types_ADDRESS_FAMILY{

--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -288,7 +288,9 @@ func createVrf(t *testing.T, dut *ondatra.DUTDevice, d *telemetry.Device, vrfs [
 		// entire VRF tree so the instance is created.
 		i := d.GetOrCreateNetworkInstance(vrf)
 		i.Type = telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
-		i.Enabled = ygot.Bool(true)
+		if !*deviations.VRFEnabled {
+			i.Enabled = ygot.Bool(true)
+		}
 		i.EnabledAddressFamilies = []telemetry.E_Types_ADDRESS_FAMILY{
 			telemetry.Types_ADDRESS_FAMILY_IPV4,
 			telemetry.Types_ADDRESS_FAMILY_IPV6,

--- a/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -346,7 +346,7 @@ func networkInstance(t *testing.T, name string) *telemetry.NetworkInstance {
 	ni := d.GetOrCreateNetworkInstance(name)
 	ni.Description = ygot.String("Non Default routing instance created for testing")
 	ni.Type = telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
-	if !*deviations.VRFEnabled {
+	if !*deviations.VRFMissingEnabled {
 		ni.Enabled = ygot.Bool(true)
 	}
 	ni.EnabledAddressFamilies = []telemetry.E_Types_ADDRESS_FAMILY{telemetry.Types_ADDRESS_FAMILY_IPV4, telemetry.Types_ADDRESS_FAMILY_IPV6}

--- a/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -104,7 +104,6 @@ func TestRouteRemovalNonDefaultVRFFlush(t *testing.T) {
 
 	ateTop.Push(t).StartProtocols(t)
 	configureNetworkInstance(t, dut)
-	configureDUT(t, dut)
 
 	// Configure the gRIBI client clientA with election ID of 10.
 	clientA := &gribi.Client{
@@ -347,7 +346,9 @@ func networkInstance(t *testing.T, name string) *telemetry.NetworkInstance {
 	ni := d.GetOrCreateNetworkInstance(name)
 	ni.Description = ygot.String("Non Default routing instance created for testing")
 	ni.Type = telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
-	ni.Enabled = ygot.Bool(true)
+	if !*deviations.VRFEnabled {
+		ni.Enabled = ygot.Bool(true)
+	}
 	ni.EnabledAddressFamilies = []telemetry.E_Types_ADDRESS_FAMILY{telemetry.Types_ADDRESS_FAMILY_IPV4, telemetry.Types_ADDRESS_FAMILY_IPV6}
 	return ni
 }

--- a/feature/gribi/otg_tests/ack_in_presence_other_routes/route_ack_test.go
+++ b/feature/gribi/otg_tests/ack_in_presence_other_routes/route_ack_test.go
@@ -230,7 +230,7 @@ func configureNetworkInstance(t *testing.T) {
 func configStaticRoute(t *testing.T, dut *ondatra.DUTDevice, prefix string, nexthop string) *telemetry.NetworkInstance_Protocol_Static {
 	d := &telemetry.Device{}
 	ni1 := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
-	if !*deviations.VRFEnabled {
+	if !*deviations.VRFMissingEnabled {
 		ni1.Enabled = ygot.Bool(true)
 	}
 	ni1.Name = ygot.String(*deviations.DefaultNetworkInstance)

--- a/feature/gribi/otg_tests/ack_in_presence_other_routes/route_ack_test.go
+++ b/feature/gribi/otg_tests/ack_in_presence_other_routes/route_ack_test.go
@@ -230,7 +230,9 @@ func configureNetworkInstance(t *testing.T) {
 func configStaticRoute(t *testing.T, dut *ondatra.DUTDevice, prefix string, nexthop string) *telemetry.NetworkInstance_Protocol_Static {
 	d := &telemetry.Device{}
 	ni1 := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
-	ni1.Enabled = ygot.Bool(true)
+	if !*deviations.VRFEnabled {
+		ni1.Enabled = ygot.Bool(true)
+	}
 	ni1.Name = ygot.String(*deviations.DefaultNetworkInstance)
 	ni1.Description = ygot.String("Static route added by gNMI-OC")
 	static := ni1.GetOrCreateProtocol(telemetry.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, "STATIC")

--- a/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
@@ -288,7 +288,7 @@ func createVrf(t *testing.T, dut *ondatra.DUTDevice, d *telemetry.Device, vrfs [
 		// entire VRF tree so the instance is created.
 		i := d.GetOrCreateNetworkInstance(vrf)
 		i.Type = telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
-		if !*deviations.VRFEnabled {
+		if !*deviations.VRFMissingEnabled {
 			i.Enabled = ygot.Bool(true)
 		}
 		i.EnabledAddressFamilies = []telemetry.E_Types_ADDRESS_FAMILY{

--- a/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
@@ -288,7 +288,9 @@ func createVrf(t *testing.T, dut *ondatra.DUTDevice, d *telemetry.Device, vrfs [
 		// entire VRF tree so the instance is created.
 		i := d.GetOrCreateNetworkInstance(vrf)
 		i.Type = telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
-		i.Enabled = ygot.Bool(true)
+		if !*deviations.VRFEnabled {
+			i.Enabled = ygot.Bool(true)
+		}
 		i.EnabledAddressFamilies = []telemetry.E_Types_ADDRESS_FAMILY{
 			telemetry.Types_ADDRESS_FAMILY_IPV4,
 			telemetry.Types_ADDRESS_FAMILY_IPV6,

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -70,6 +70,9 @@ var (
 	InterfaceEnabled = flag.Bool("deviation_interface_enabled", false,
 		"Device requires interface enabled leaf booleans to be explicitly set to true.  Full OpenConfig compliant devices should pass both with and without this deviation.")
 
+	VRFEnabled = flag.Bool("deviation_vrf_enabled", false,
+		"Device does not support network-instance/enabled leaf. The network-instance is always enabled when it is configured.")
+
 	AggregateAtomicUpdate = flag.Bool("deviation_aggregate_atomic_update", false,
 		"Device requires that aggregate Port-Channel and its members be defined in a single gNMI Update transaction at /interfaces; otherwise lag-type will be dropped, and no member can be added to the aggregate.  Full OpenConfig compliant devices should pass both with and without this deviation.")
 

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -70,8 +70,7 @@ var (
 	InterfaceEnabled = flag.Bool("deviation_interface_enabled", false,
 		"Device requires interface enabled leaf booleans to be explicitly set to true.  Full OpenConfig compliant devices should pass both with and without this deviation.")
 
-	VRFEnabled = flag.Bool("deviation_vrf_enabled", false,
-		"Device does not support network-instance/enabled leaf. The network-instance is always enabled when it is configured.")
+	VRFMissingEnabled = flag.Bool("deviation_vrf_enabled", false, "Device does not support network-instance/enabled leaf, so suppress configuring this leaf.")
 
 	AggregateAtomicUpdate = flag.Bool("deviation_aggregate_atomic_update", false,
 		"Device requires that aggregate Port-Channel and its members be defined in a single gNMI Update transaction at /interfaces; otherwise lag-type will be dropped, and no member can be added to the aggregate.  Full OpenConfig compliant devices should pass both with and without this deviation.")


### PR DESCRIPTION
This pull adds a deviation for vrf/enabled. This deviation does not have a functional impact since a vrf is enabled as soon it is defined. 