### PR TITLE
Add ipv4/enabled deviation

### DIFF
--- a/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -341,7 +341,7 @@ func ConfigureDUTIntf(t *testing.T, dut *ondatra.DUTDevice) {
 		// per: https://github.com/openconfig/featureprofiles/issues/253
 		i.Enabled = ygot.Bool(true)
 		s.Enabled = ygot.Bool(true)
-		if !*deviations.IPV4Enabled {
+		if !*deviations.IPv4MissingEnabled {
 			v4.Enabled = ygot.Bool(true)
 		}
 		v6.Enabled = ygot.Bool(true)
@@ -351,8 +351,10 @@ func ConfigureDUTIntf(t *testing.T, dut *ondatra.DUTDevice) {
 		t.Logf("Validate that IPv4 and IPv6 addresses are enabled: %s", intf.intfName)
 		subint := dut.Telemetry().Interface(intf.intfName).Subinterface(0)
 
-		if !*deviations.IPV4Enabled && !subint.Ipv4().Enabled().Get(t) {
-			t.Errorf("Ipv4().Enabled().Get(t) for interface %v: got false, want true", intf.intfName)
+		if !*deviations.IPv4MissingEnabled {
+			if !subint.Ipv4().Enabled().Get(t) {
+				t.Errorf("Ipv4().Enabled().Get(t) for interface %v: got false, want true", intf.intfName)
+			}
 		}
 		if !subint.Ipv6().Enabled().Get(t) {
 			t.Errorf("Ipv6().Enabled().Get(t) for interface %v: got false, want true", intf.intfName)

--- a/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -341,14 +341,17 @@ func ConfigureDUTIntf(t *testing.T, dut *ondatra.DUTDevice) {
 		// per: https://github.com/openconfig/featureprofiles/issues/253
 		i.Enabled = ygot.Bool(true)
 		s.Enabled = ygot.Bool(true)
-		v4.Enabled = ygot.Bool(true)
+		if !*deviations.IPV4Enabled {
+			v4.Enabled = ygot.Bool(true)
+		}
 		v6.Enabled = ygot.Bool(true)
 
 		dut.Config().Interface(intf.intfName).Replace(t, i)
 
 		t.Logf("Validate that IPv4 and IPv6 addresses are enabled: %s", intf.intfName)
 		subint := dut.Telemetry().Interface(intf.intfName).Subinterface(0)
-		if !subint.Ipv4().Enabled().Get(t) {
+
+		if !*deviations.IPV4Enabled && !subint.Ipv4().Enabled().Get(t) {
 			t.Errorf("Ipv4().Enabled().Get(t) for interface %v: got false, want true", intf.intfName)
 		}
 		if !subint.Ipv6().Enabled().Get(t) {

--- a/internal/attrs/attrs.go
+++ b/internal/attrs/attrs.go
@@ -76,7 +76,7 @@ func (a *Attributes) ConfigInterface(intf *oc.Interface) *oc.Interface {
 	s := intf.GetOrCreateSubinterface(0)
 	if a.IPv4 != "" {
 		s4 := s.GetOrCreateIpv4()
-		if *deviations.InterfaceEnabled {
+		if *deviations.InterfaceEnabled && !*deviations.IPV4Enabled {
 			s4.Enabled = ygot.Bool(true)
 		}
 		if a.MTU > 0 {

--- a/internal/attrs/attrs.go
+++ b/internal/attrs/attrs.go
@@ -76,7 +76,7 @@ func (a *Attributes) ConfigInterface(intf *oc.Interface) *oc.Interface {
 	s := intf.GetOrCreateSubinterface(0)
 	if a.IPv4 != "" {
 		s4 := s.GetOrCreateIpv4()
-		if *deviations.InterfaceEnabled && !*deviations.IPV4Enabled {
+		if *deviations.InterfaceEnabled && !*deviations.IPv4MissingEnabled {
 			s4.Enabled = ygot.Bool(true)
 		}
 		if a.MTU > 0 {

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -70,7 +70,7 @@ var (
 	InterfaceEnabled = flag.Bool("deviation_interface_enabled", false,
 		"Device requires interface enabled leaf booleans to be explicitly set to true.  Full OpenConfig compliant devices should pass both with and without this deviation.")
 
-	IPV4Enabled = flag.Bool("deviation_ipv4_enabled", false, "Device does not support interface/ipv4/enabled leaf. The ipv4 is enabled when it is configured.")
+	IPv4MissingEnabled = flag.Bool("deviation_ipv4_missing_enabled", false, "Device does not support interface/ipv4/enabled, so suppress configuring this leaf.")
 
 	AggregateAtomicUpdate = flag.Bool("deviation_aggregate_atomic_update", false,
 		"Device requires that aggregate Port-Channel and its members be defined in a single gNMI Update transaction at /interfaces; otherwise lag-type will be dropped, and no member can be added to the aggregate.  Full OpenConfig compliant devices should pass both with and without this deviation.")

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -70,6 +70,8 @@ var (
 	InterfaceEnabled = flag.Bool("deviation_interface_enabled", false,
 		"Device requires interface enabled leaf booleans to be explicitly set to true.  Full OpenConfig compliant devices should pass both with and without this deviation.")
 
+	IPV4Enabled = flag.Bool("deviation_ipv4_enabled", false, "Device does not support interface/ipv4/enabled leaf. The ipv4 is enabled when it is configured.")
+
 	AggregateAtomicUpdate = flag.Bool("deviation_aggregate_atomic_update", false,
 		"Device requires that aggregate Port-Channel and its members be defined in a single gNMI Update transaction at /interfaces; otherwise lag-type will be dropped, and no member can be added to the aggregate.  Full OpenConfig compliant devices should pass both with and without this deviation.")
 


### PR DESCRIPTION
This pull adds a deviation for ipv4/enabled leaf. It is expected that ipv4 to be enabled by default for the devices with this deviation. 