### PR TITLE
Fix IS-IS tests

### DIFF
--- a/feature/experimental/isis/ate_tests/base_adjacencies_test/README.md
+++ b/feature/experimental/isis/ate_tests/base_adjacencies_test/README.md
@@ -6,22 +6,39 @@ Base IS-IS functionality and adjacency establishment.
 
 ## Procedure
 
-*   Configure IS-IS for ATE port-1 and DUT port-1.
-    *   Configure DUT with global hello padding set to `DISABLED` accepted.
-        Interface-specific ISIS hello padding configuration not accepted.
-*   Ensure that adjacencies are established with:
-    *   Hello authentication enabled.
-    *   Global hello padding disabled.
-*   With ISIS level authentication enabled and hello authentication enabled:
-    *   Ensure that IPv4 and IPv6 prefixes that are advertised as attached
-        prefixes within each LSP are correctly installed into the DUT routing
-        table, by ensuring that packets are received to the attached prefix when
-        forwarded from ATE port-1.
-    *   Ensure that IPv4 and IPv6 prefixes that are advertised as part of an
-        (emulated) neighboring system are installed into the DUT routing table,
-        and validate that packets are sent and received to them.
-*   With a known LSP content, ensure that the telemetry received from the device
-    for the LSP matches the expected content.
+*   Basic fields test
+    *   Configure DUT:port1 for an IS-IS session with ATE:port1.
+    *   Read back the configuration to ensure that all fields are readable and
+        have been set properly (or correctly have their default value).
+    *   Check that all relevant counters are readable and are 0 since the
+        adjacency has not yet been established.
+    *   Push ATE configuration for the other end of the adjacency, and wait for
+        the adjacency to form.
+    *   Check that the various state fields of the adjacency are reported
+        correctly.
+    *   Check that error counters are still 0 and that packet counters have all
+        increased.
+*   Hello padding test
+    *   Configure IS-IS between DUT:port1 and ATE:port1 for each possible value
+        of hello padding (DISABLED, STRICT, etc.)
+    *   Confirm in each case that that adjacency forms and the correct values
+        are reported back by the device.
+*   Authentication test
+    *   Configure IS-IS between DUT:port1 and ATE:port1 With authentication
+        disabled, then enabled in TEXT mode, then enabled in MD5 mode.
+    *   Confirm in each case that that adjacency forms and the correct values
+        are reported back by the device.
+*   Routing test
+    *   With ISIS level authentication enabled and hello authentication enabled:
+        *   Ensure that IPv4 and IPv6 prefixes that are advertised as attached
+            prefixes within each LSP are correctly installed into the DUT
+            routing table, by ensuring that packets are received to the attached
+            prefix when forwarded from ATE port-1.
+        *   Ensure that IPv4 and IPv6 prefixes that are advertised as part of an
+            (emulated) neighboring system are installed into the DUT routing
+            table, and validate that packets are sent and received to them.
+    *   With a known LSP content, ensure that the telemetry received from the
+        device for the LSP matches the expected content.
 
 ## Config Parameter coverage
 
@@ -34,7 +51,7 @@ Base IS-IS functionality and adjacency establishment.
     *   TODO: global/config/authentication-check
     *   global/config/net
     *   global/config/level-capability
-    *   TODO: global/config/hello-padding
+    *   global/config/hello-padding
     *   global/afi-safi/af/config/enabled
     *   levels/level/config/level-number
     *   levels/level/config/enabled
@@ -99,7 +116,6 @@ Base IS-IS functionality and adjacency establishment.
     *   interfaces/interfaces/circuit-counters/state/auth-fails
     *   interfaces/interfaces/circuit-counters/state/auth-type-fails
     *   interfaces/interfaces/circuit-counters/state/id-field-len-mismatches
-    *   interfaces/interfaces/circuit-counters/state/init-fails
     *   interfaces/interfaces/circuit-counters/state/lan-dis-changes
     *   interfaces/interfaces/circuit-counters/state/max-area-address-mismatch
     *   interfaces/interfaces/circuit-counters/state/rejected-adj
@@ -126,10 +142,8 @@ Base IS-IS functionality and adjacency establishment.
     *   levels/level/system-level-counters/state/exceeded-max-seq-nums
     *   levels/level/system-level-counters/state/id-len-mismatch
     *   levels/level/system-level-counters/state/lsp-errors
-    *   levels/level/system-level-counters/state/manual-address-drop-from-area
     *   levels/level/system-level-counters/state/max-area-address-mismatches
     *   levels/level/system-level-counters/state/own-lsp-purges
-    *   levels/level/system-level-counters/state/part-changes
     *   levels/level/system-level-counters/state/seq-num-skips
     *   levels/level/system-level-counters/state/spf-runs
 

--- a/feature/experimental/isis/ate_tests/base_adjacencies_test/base_adjacencies_test.go
+++ b/feature/experimental/isis/ate_tests/base_adjacencies_test/base_adjacencies_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 // to return a nil value. This should only be used when `val` is the default
 // for this particular query.
 func EqualToDefault[T any](query ygnmi.SingletonQuery[T], val T) check.Validator {
-	if *deviations.AllowNilForDefaults {
+	if *deviations.MissingValueForDefaults {
 		return check.EqualOrNil(query, val)
 	}
 	return check.Equal(query, val)

--- a/feature/experimental/isis/ate_tests/lsp_updates_test/lsp_updates_test.go
+++ b/feature/experimental/isis/ate_tests/lsp_updates_test/lsp_updates_test.go
@@ -41,7 +41,7 @@ func TestOverloadBit(t *testing.T) {
 	setBit := isisPath.Global().LspBit().OverloadBit().SetBit()
 	deadline := time.Now().Add(time.Second)
 	checkSetBit := check.Equal(setBit.State(), false)
-	if *deviations.AllowNilForDefaults {
+	if *deviations.MissingValueForDefaults {
 		checkSetBit = check.EqualOrNil(setBit.State(), false)
 	}
 

--- a/feature/experimental/isis/ate_tests/lsp_updates_test/lsp_updates_test.go
+++ b/feature/experimental/isis/ate_tests/lsp_updates_test/lsp_updates_test.go
@@ -40,8 +40,13 @@ func TestOverloadBit(t *testing.T) {
 	overloads := isisPath.Level(2).SystemLevelCounters().DatabaseOverloads()
 	setBit := isisPath.Global().LspBit().OverloadBit().SetBit()
 	deadline := time.Now().Add(time.Second)
+	checkSetBit := check.Equal(setBit.State(), false)
+	if *deviations.AllowNilForDefaults {
+		checkSetBit = check.EqualOrNil(setBit.State(), false)
+	}
+
 	for _, vd := range []check.Validator{
-		check.Equal(setBit.State(), false),
+		checkSetBit,
 		check.Equal(overloads.State(), uint32(0)),
 	} {
 		if err := vd.AwaitUntil(deadline, ts.DUTClient); err != nil {

--- a/feature/isis/feature.textproto
+++ b/feature/isis/feature.textproto
@@ -223,11 +223,6 @@ telemetry_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/levels/level/link-state-database/lsp/tlvs/tlv/ipv6-reachability/prefixes/prefix/subtlvs/subtlv/flags/state/flags"
 }
 
-# System Level
-telemetry_path {
-  path: "/network-instances/network-instance/protocols/protocol/isis/levels/level/system-level-counters/state/part-changes"
-}
-
 # Interface counters
 telemetry_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/packet-counters/iih/state/retransmit"

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -67,8 +67,6 @@ import "flag"
 
 // Vendor deviation flags.
 var (
-	MixedOcCliPrefersCli = flag.Bool("deviation_mixed_occli_prefers_cli", false,
-		"Device requires that irrespective of the order of Updates, CLI takes precedence. Compliant devices should pass both with and without this deviation.")
 	InterfaceEnabled = flag.Bool("deviation_interface_enabled", false,
 		"Device requires interface enabled leaf booleans to be explicitly set to true.  Full OpenConfig compliant devices should pass both with and without this deviation.")
 
@@ -97,8 +95,8 @@ var (
 
 	NextHopAFTNotSupported = flag.Bool("deviation_nexthop_aft_not_supported", false, "Device currently doesnot support AFT Next Hop Telemetry. A fully compliant device should support all types of AFT telemetry without this deviation.")
 
-	AllowNilForDefaults = flag.Bool("deviation_allow_nil_for_defaults", false,
-		"Device returns no value for some OpenConfig paths if the operational value equals the default. Full OpenConfig compliant devices should pass without this deviation.")
+	MissingValueForDefaults = flag.Bool("deviation_missing_value_for_defaults", false,
+		"Device returns no value for some OpenConfig paths if the operational value equals the default. A fully compliant device should pass regardless of this deviation.")
 
 	StaticProtocolName = flag.String("deviation_static_protocol_name", "DEFAULT", "The name used for the static routing protocol.  The default name in OpenConfig is \"DEFAULT\" but some devices use other names.")
 )


### PR DESCRIPTION
The `init-fails`, `part-changes`, and `manual-address-drop-from-area` are not generally used and shouldn't be tested or required by the IS-IS feature spec (init-fails and manual-...-area were already removed from the spec, but not from the corresponding tests or test plans). This removes them entirely.

This also adds a nil deviation check in the LSP update check, since some vendors return nil instead of false when the value isn't set.