### PR TITLE
Add GOGC to go vet

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -134,7 +134,7 @@ jobs:
         key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
         restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
     - name: Go vet
-      run: go vet ./...
+      run: GOGC=30 go vet ./...
     - name: Gofmt
       run: |
         # gofmt always returns true, so we use grep '^' which returns


### PR DESCRIPTION
The `go vet` step has been failing on some CI builds lately:

https://github.com/openconfig/featureprofiles/actions/runs/3299940756/jobs/5443879777
https://github.com/openconfig/featureprofiles/actions/runs/3299299059/jobs/5442504748
https://github.com/openconfig/featureprofiles/actions/runs/3298815086/jobs/5441414755

I suspect this is a memory utilization problem.  From running on my local machine, I get these memory usages from `/usr/bin/time -v go vet ./...` after clearing the build cache.

```
go vet ./...:
Maximum resident set size (kbytes): 5930296
Maximum resident set size (kbytes): 6366100
```

```
go vet w/ GOGC=30:
Maximum resident set size (kbytes): 4576932
Maximum resident set size (kbytes): 4557508
```

We've already made this change to staticcheck, this is applying the same change to the `go vet`.  I think there is a long term improvement that will come from ygnmi/generics that @dan-lepage is looking into.