### PR TITLE
change GetOrCreateNextHop from 'AUTO_0' to '0'

### DIFF
--- a/feature/gribi/ate_tests/get_rpc_test/get_rpc_test.go
+++ b/feature/gribi/ate_tests/get_rpc_test/get_rpc_test.go
@@ -322,7 +322,7 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	static := &telemetry.NetworkInstance_Protocol_Static{
 		Prefix: ygot.String(staticCIDR),
 	}
-	static.GetOrCreateNextHop("AUTO_0").NextHop = telemetry.UnionString(atePort2.IPv4)
+	static.GetOrCreateNextHop("0").NextHop = telemetry.UnionString(atePort2.IPv4)
 	ni.Static(staticCIDR).Replace(t, static)
 	validateGetRPC(ctx, t, args.clientA)
 	for ip := range ateDstNetCIDR {


### PR DESCRIPTION
Changes for below error hit during get_rpc_test.go script execution -

[InvalidArgument] failed to set .network-instance{.name=="DEFAULT"}.next-hop-groups.group{.name=="oc-static-198.51.100.192/26"}.nexthop{.index==0}.index - Invalid value "AUTO_0": Must be an integer in range 0..65535