### PR TITLE
Remove AFT not supported deviation

### DIFF
--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -108,6 +108,13 @@ var (
 		ip:         atePort2IPv4,
 		gateway:    dutPort2IPv4,
 	}
+
+	// nhgIPv4EntryMap maps NextHopGroups to the ipv4 entries pointing to that NextHopGroup.
+	nhgIPv4EntryMap = map[uint64]string{
+		1: ipv4EntryPrefix,
+		2: cidr(nhEntryIP1, 32),
+		3: cidr(nhEntryIP2, 32),
+	}
 )
 
 func TestMain(m *testing.M) {
@@ -391,16 +398,27 @@ func flushGRIBI(t *testing.T, gRIBI *fluent.GRIBIClient) {
 	}
 }
 
-// aftNextHopWeight queries AFT telemetry using Lookup() and returns
-// the value and a boolean suggesting whether the value was found. If not-found,
-// the value is 0.
-func aftNextHopWeight(t *testing.T, dut *ondatra.DUTDevice, nhg uint64, nh uint64,
-	weight uint64, networkInstance string) (uint64, bool) {
-	w := dut.Telemetry().NetworkInstance(networkInstance).Afts().NextHopGroup(nhg).NextHop(nh).Weight().Lookup(t)
-	if w == nil {
-		return 0, false
+// aftNextHopWeights queries AFT telemetry using Get() and returns
+// the weights. If not-found, an empty list is returned.
+func aftNextHopWeights(t *testing.T, dut *ondatra.DUTDevice, nhg uint64, networkInstance string) []uint64 {
+	aft := dut.Telemetry().NetworkInstance(networkInstance).Afts().Get(t)
+	var nhgD *telemetry.NetworkInstance_Afts_NextHopGroup
+	for _, nhgData := range aft.NextHopGroup {
+		if nhgData.GetProgrammedId() == nhg {
+			nhgD = nhgData
+			break
+		}
 	}
-	return w.Val(t), true
+	if nhgD == nil {
+		return []uint64{}
+	}
+
+	got := []uint64{}
+	for _, nhD := range nhgD.NextHop {
+		got = append(got, nhD.GetWeight())
+	}
+
+	return got
 }
 
 // testBasicHierarchicalWeight tests and validates traffic through 4 Vlans.
@@ -412,7 +430,7 @@ func testBasicHierarchicalWeight(ctx context.Context, t *testing.T, dut *ondatra
 	nh10 := nextHopEntry(10, defaultVRF, atePort2.ip(1))
 	nh11 := nextHopEntry(11, defaultVRF, atePort2.ip(2))
 	nhg2 := nextHopGroupEntry(2, defaultVRF, []nhInfo{{index: 10, weight: 1}, {index: 11, weight: 3}})
-	ipEntry2 := ipv4Entry(cidr(nhEntryIP1, 32), defaultVRF, 2, defaultVRF)
+	ipEntry2 := ipv4Entry(nhgIPv4EntryMap[2], defaultVRF, 2, defaultVRF)
 
 	gRIBI.Modify().AddEntry(t, nh10, nh11, nhg2, ipEntry2)
 
@@ -420,7 +438,7 @@ func testBasicHierarchicalWeight(ctx context.Context, t *testing.T, dut *ondatra
 	nh100 := nextHopEntry(100, defaultVRF, atePort2.ip(3))
 	nh101 := nextHopEntry(101, defaultVRF, atePort2.ip(4))
 	nhg3 := nextHopGroupEntry(3, defaultVRF, []nhInfo{{index: 100, weight: 2}, {index: 101, weight: 3}})
-	ipEntry3 := ipv4Entry(cidr(nhEntryIP2, 32), defaultVRF, 3, defaultVRF)
+	ipEntry3 := ipv4Entry(nhgIPv4EntryMap[3], defaultVRF, 3, defaultVRF)
 
 	gRIBI.Modify().AddEntry(t, nh100, nh101, nhg3, ipEntry3)
 
@@ -428,7 +446,7 @@ func testBasicHierarchicalWeight(ctx context.Context, t *testing.T, dut *ondatra
 	nh1 := nextHopEntry(1, defaultVRF, nhEntryIP1)
 	nh2 := nextHopEntry(2, defaultVRF, nhEntryIP2)
 	nhg1 := nextHopGroupEntry(1, defaultVRF, []nhInfo{{index: 1, weight: 1}, {index: 2, weight: 3}})
-	ipEntry1 := ipv4Entry(ipv4EntryPrefix, nonDefaultVRF, 1, defaultVRF)
+	ipEntry1 := ipv4Entry(nhgIPv4EntryMap[1], nonDefaultVRF, 1, defaultVRF)
 
 	gRIBI.Modify().AddEntry(t, nh1, nh2, nhg1, ipEntry1)
 
@@ -437,7 +455,7 @@ func testBasicHierarchicalWeight(ctx context.Context, t *testing.T, dut *ondatra
 	}
 
 	// Validate entries were installed in FIB.
-	for _, route := range []string{cidr(nhEntryIP1, 32), cidr(nhEntryIP2, 32), ipv4EntryPrefix} {
+	for _, route := range nhgIPv4EntryMap {
 		chk.HasResult(t, gRIBI.Results(t),
 			fluent.OperationResult().
 				WithIPv4Operation(route).
@@ -463,24 +481,14 @@ func testBasicHierarchicalWeight(ctx context.Context, t *testing.T, dut *ondatra
 	})
 
 	t.Run("validateAFTWeights", func(t *testing.T) {
-		if *deviations.NextHopAFTNotSupported {
-			t.Skip("TODO: AFT Telemetry not supported.")
-		}
-
-		for _, tc := range []nhInfo{
-			{nhg: 1, index: 1, weight: 1},
-			{nhg: 1, index: 2, weight: 3},
-			{nhg: 2, index: 10, weight: 1},
-			{nhg: 2, index: 11, weight: 3},
-			{nhg: 3, index: 100, weight: 2},
-			{nhg: 3, index: 101, weight: 3},
+		for nhg, weights := range map[uint64][]uint64{
+			2: {1, 3},
+			3: {2, 3},
 		} {
-			got, ok := aftNextHopWeight(t, dut, tc.nhg, tc.index, tc.weight, defaultVRF)
+			got := aftNextHopWeights(t, dut, nhg, defaultVRF)
+			ok := cmp.Equal(weights, got, cmpopts.SortSlices(func(a, b uint64) bool { return a < b }))
 			if !ok {
-				t.Errorf("Weight not present for NI: %s, NHG: %d, NH: %d.", defaultVRF, tc.nhg, tc.index)
-			}
-			if got != tc.weight {
-				t.Errorf("Unexpected weight found for NI: %s, NHG: %d, NH: %d, got: %d, want: %d.", defaultVRF, tc.nhg, tc.index, got, tc.weight)
+				t.Errorf("Valid weights not present for NI: %s, NHG: %d, got: %v, want: %v", defaultVRF, nhg, got, weights)
 			}
 		}
 	})
@@ -498,7 +506,7 @@ func testHierarchicalWeightBoundaryScenario(ctx context.Context, t *testing.T, d
 	nh10 := nextHopEntry(10, defaultVRF, atePort2.ip(1))
 	nh11 := nextHopEntry(11, defaultVRF, atePort2.ip(2))
 	nhg2 := nextHopGroupEntry(2, defaultVRF, []nhInfo{{index: 10, weight: 2}, {index: 11, weight: 3}})
-	ipEntry2 := ipv4Entry(cidr(nhEntryIP1, 32), defaultVRF, 2, defaultVRF)
+	ipEntry2 := ipv4Entry(nhgIPv4EntryMap[2], defaultVRF, 2, defaultVRF)
 
 	gRIBI.Modify().AddEntry(t, nh10, nh11, nhg2, ipEntry2)
 
@@ -513,7 +521,7 @@ func testHierarchicalWeightBoundaryScenario(ctx context.Context, t *testing.T, d
 		nhIdx++
 	}
 	nhg3 := nextHopGroupEntry(3, defaultVRF, nextHopWeights)
-	ipEntry3 := ipv4Entry(cidr(nhEntryIP2, 32), defaultVRF, 3, defaultVRF)
+	ipEntry3 := ipv4Entry(nhgIPv4EntryMap[3], defaultVRF, 3, defaultVRF)
 	gribiEntries = append(gribiEntries, nhg3, ipEntry3)
 
 	gRIBI.Modify().AddEntry(t, gribiEntries...)
@@ -522,7 +530,7 @@ func testHierarchicalWeightBoundaryScenario(ctx context.Context, t *testing.T, d
 	nh1 := nextHopEntry(1, defaultVRF, nhEntryIP1)
 	nh2 := nextHopEntry(2, defaultVRF, nhEntryIP2)
 	nhg1 := nextHopGroupEntry(1, defaultVRF, []nhInfo{{index: 1, weight: 1}, {index: 2, weight: 31}})
-	ipEntry1 := ipv4Entry(ipv4EntryPrefix, nonDefaultVRF, 1, defaultVRF)
+	ipEntry1 := ipv4Entry(nhgIPv4EntryMap[1], nonDefaultVRF, 1, defaultVRF)
 
 	gRIBI.Modify().AddEntry(t, nh1, nh2, nhg1, ipEntry1)
 
@@ -531,7 +539,7 @@ func testHierarchicalWeightBoundaryScenario(ctx context.Context, t *testing.T, d
 	}
 
 	// Validate entries were installed in FIB.
-	for _, route := range []string{cidr(nhEntryIP1, 32), cidr(nhEntryIP2, 32), ipv4EntryPrefix} {
+	for _, route := range nhgIPv4EntryMap {
 		chk.HasResult(t, gRIBI.Results(t),
 			fluent.OperationResult().
 				WithIPv4Operation(route).
@@ -558,25 +566,15 @@ func testHierarchicalWeightBoundaryScenario(ctx context.Context, t *testing.T, d
 	})
 
 	t.Run("validateAFTWeights", func(t *testing.T) {
-		if *deviations.NextHopAFTNotSupported {
-			t.Skip("TODO: AFT Telemetry not supported.")
+		testCases := map[uint64][]uint64{
+			2: {2, 3},
+			3: {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
 		}
-		testCases := []nhInfo{
-			{nhg: 1, index: 1, weight: 1},
-			{nhg: 1, index: 2, weight: 31},
-			{nhg: 2, index: 10, weight: 2},
-			{nhg: 2, index: 11, weight: 3},
-		}
-		for i := uint64(100); i < 116; i++ {
-			testCases = append(testCases, nhInfo{nhg: 3, index: i, weight: 1})
-		}
-		for _, tc := range testCases {
-			got, ok := aftNextHopWeight(t, dut, tc.nhg, tc.index, tc.weight, defaultVRF)
+		for nhg, weights := range testCases {
+			got := aftNextHopWeights(t, dut, nhg, defaultVRF)
+			ok := cmp.Equal(weights, got, cmpopts.SortSlices(func(a, b uint64) bool { return a < b }))
 			if !ok {
-				t.Errorf("Weight not present for NI: %s, NHG: %d, NH: %d.", defaultVRF, tc.nhg, tc.index)
-			}
-			if got != tc.weight {
-				t.Errorf("Unexpected weight found for NI: %s, NHG: %d, NH: %d, got: %d, want: %d.", defaultVRF, tc.nhg, tc.index, got, tc.weight)
+				t.Errorf("Valid weights not present for NI: %s, NHG: %d, got: %v, want: %v", defaultVRF, nhg, got, weights)
 			}
 		}
 	})

--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -566,11 +566,10 @@ func testHierarchicalWeightBoundaryScenario(ctx context.Context, t *testing.T, d
 	})
 
 	t.Run("validateAFTWeights", func(t *testing.T) {
-		testCases := map[uint64][]uint64{
+		for nhg, weights := range map[uint64][]uint64{
 			2: {2, 3},
 			3: {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
-		}
-		for nhg, weights := range testCases {
+		} {
 			got := aftNextHopWeights(t, dut, nhg, defaultVRF)
 			ok := cmp.Equal(weights, got, cmpopts.SortSlices(func(a, b uint64) bool { return a < b }))
 			if !ok {

--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -45,7 +45,6 @@ type attributes struct {
 }
 
 type nhInfo struct {
-	nhg    uint64
 	index  uint64
 	weight uint64
 }

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -93,8 +93,6 @@ var (
 
 	GRIBIRIBAckOnly = flag.Bool("deviation_gribi_riback_only", false, "Device only supports RIB ack, so tests that normally expect FIB_ACK will allow just RIB_ACK.  Full gRIBI compliant devices should pass both with and without this deviation.")
 
-	NextHopAFTNotSupported = flag.Bool("deviation_nexthop_aft_not_supported", false, "Device currently doesnot support AFT Next Hop Telemetry. A fully compliant device should support all types of AFT telemetry without this deviation.")
-
 	MissingValueForDefaults = flag.Bool("deviation_missing_value_for_defaults", false,
 		"Device returns no value for some OpenConfig paths if the operational value equals the default. A fully compliant device should pass regardless of this deviation.")
 


### PR DESCRIPTION
* Filter NextHopGroup using the ProgrammedID.
* Only validate the weights of the NextHops contained in the NextHopGroup.

eb64add8-4a54-4bcb-9022-1ec75a7c9431