### PR TITLE
OTG Test Update - RT-5.2

### DIFF
--- a/feature/interface/aggregate/otg_tests/aggregate_test/aggregate_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_test/aggregate_test.go
@@ -218,7 +218,7 @@ func (tc *testCase) configureDUT(t *testing.T) {
 	fptest.LogYgot(t, "LACP", lacpPath, lacp)
 	lacpPath.Replace(t, lacp)
 
-	tc.dut.Telemetry().Interface(tc.aggID).OperStatus().Await(t, 20*time.Second, opUp)
+	time.Sleep(5 * time.Second)
 
 	agg := &telemetry.Interface{Name: ygot.String(tc.aggID)}
 	tc.configDstAggregateDUT(agg, &dutDst)
@@ -263,10 +263,7 @@ func (tc *testCase) configureATE(t *testing.T) {
 	srcEth.Ipv6Addresses().Add().SetName(ateSrc.Name + ".IPv6").SetAddress(ateSrc.IPv6).SetGateway(dutSrc.IPv6).SetPrefix(int32(ateSrc.IPv6Len))
 
 	// Adding the rest of the ports to the configuration and to the LAG
-	totalPorts := len(tc.dutPorts)
-	numLagPorts := totalPorts - 1
-	minLinks := uint16(numLagPorts - 1)
-	agg := tc.top.Lags().Add().SetName(ateDst.Name).SetMinLinks(int32(minLinks))
+	agg := tc.top.Lags().Add().SetName(ateDst.Name)
 	if tc.lagType == lagTypeSTATIC {
 		lagId, _ := strconv.Atoi(tc.aggID)
 		agg.Protocol().SetChoice("static").Static().SetLagId(int32(lagId))
@@ -378,7 +375,7 @@ func (tc *testCase) verifyATE(t *testing.T) {
 // setDutInterfaceWithState sets the admin state to a member of the lag
 func (tc *testCase) setDutInterfaceWithState(t testing.TB, p *ondatra.Port, state bool) {
 	dc := tc.dut.Config()
-	i := &telemetry.Interface{Name: ygot.String(p.Name())}
+	i := &telemetry.Interface{}
 	i.Enabled = ygot.Bool(state)
 	dc.Interface(p.Name()).Update(t, i)
 }

--- a/feature/interface/aggregate/otg_tests/aggregate_test/aggregate_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_test/aggregate_test.go
@@ -218,6 +218,7 @@ func (tc *testCase) configureDUT(t *testing.T) {
 	fptest.LogYgot(t, "LACP", lacpPath, lacp)
 	lacpPath.Replace(t, lacp)
 
+	// TODO - to remove this sleep later
 	time.Sleep(5 * time.Second)
 
 	agg := &telemetry.Interface{Name: ygot.String(tc.aggID)}

--- a/topologies/kne/arista_ceos.config
+++ b/topologies/kne/arista_ceos.config
@@ -19,6 +19,8 @@ agent LicenseManager shutdown
 !
 ip routing
 !
+port-channel min-links review interval 10
+!
 platform tfa personality arfa
 !
 ipv6 unicast-routing


### PR DESCRIPTION
Removed otg minlinks unnecessary configuration 
Removed operStatus check on the aggr
Simplified setDutInterfaceWithState to include only the new state
Added line to dut vendor startup config
Fixes #558 