### PR TITLE
Change string_val used in oc gnmi set to json_ietf_val

### DIFF
--- a/feature/system/gnmi/cliorigin/ate_tests/mixed_oc_cli_origin_support_test/mixed_oc_cli_origin_support_test.go
+++ b/feature/system/gnmi/cliorigin/ate_tests/mixed_oc_cli_origin_support_test/mixed_oc_cli_origin_support_test.go
@@ -49,7 +49,7 @@ func buildOCUpdate(path *gpb.Path, value string) *gpb.Update {
 	jsonVal, _ := ygot.Marshal7951(ygot.String(value))
 	update := &gpb.Update{
 		Path: path,
-		Val:  &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{JsonIetfVal: []byte(jsonVal)}},
+		Val:  &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{JsonIetfVal: jsonVal}},
 	}
 	return update
 }

--- a/feature/system/gnmi/cliorigin/ate_tests/mixed_oc_cli_origin_support_test/mixed_oc_cli_origin_support_test.go
+++ b/feature/system/gnmi/cliorigin/ate_tests/mixed_oc_cli_origin_support_test/mixed_oc_cli_origin_support_test.go
@@ -46,9 +46,10 @@ func buildOCUpdate(path *gpb.Path, value string) *gpb.Update {
 	if len(path.GetElem()) == 0 || path.GetElem()[0].GetName() != "meta" {
 		path.Origin = "openconfig"
 	}
+	jsonVal, _ := ygot.Marshal7951(ygot.String(value))
 	update := &gpb.Update{
 		Path: path,
-		Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: value}},
+		Val:  &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{JsonIetfVal: []byte(jsonVal)}},
 	}
 	return update
 }


### PR DESCRIPTION
Change string_val used in oc gnmi set to json_ietf_val
Closing #523 and Raising new since test moved to a new location in https://github.com/openconfig/featureprofiles/pull/520
