### PR TITLE
Use delete instead of nil replace

### DIFF
--- a/feature/experimental/bgp/ate_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
+++ b/feature/experimental/bgp/ate_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
@@ -248,7 +248,7 @@ func TestEstablishAndDisconnect(t *testing.T) {
 	nbrPath := statePath.Neighbor(ateAttrs.IPv4)
 
 	fptest.LogYgot(t, "DUT BGP Config before", dutConfPath, dutConfPath.Get(t))
-	dutConfPath.Replace(t, nil)
+	dutConfPath.Delete(t)
 	dutConf := bgpCreateNbr(&bgpTestParams{localAS: dutAS, peerAS: ateAS})
 	dutConfPath.Replace(t, dutConf)
 	fptest.LogYgot(t, "DUT BGP Config", dutConfPath, dutConfPath.Get(t))
@@ -297,7 +297,7 @@ func TestEstablishAndDisconnect(t *testing.T) {
 
 	// Clear config on DUT and ATE
 	topo.StopProtocols(t)
-	dutConfPath.Replace(t, nil)
+	dutConfPath.Delete(t)
 }
 
 // TestParameters is to verify normal session establishment and termination
@@ -348,7 +348,7 @@ func TestParameters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fptest.LogYgot(t, "DUT BGP Config before", dutConfPath, dutConfPath.Get(t))
 			t.Log("Clear BGP Configs on DUT")
-			dutConfPath.Replace(t, nil)
+			dutConfPath.Delete(t)
 			t.Log("Configure BGP Configs on DUT")
 			dutConfPath.Replace(t, tc.dutConf)
 			fptest.LogYgot(t, "DUT BGP Config ", dutConfPath, dutConfPath.Get(t))


### PR DESCRIPTION
Replace should not be used to remove configuration values - instead, delete should be used.  See https://github.com/openconfig/reference/blob/c243b35b36e366852f9476c87fb2efe6e9050dfe/rpc/gnmi/gnmi-specification.md?plain=1#L1070-L1073.

Resolves #515.