### PR TITLE
Add deviation to support deprecated vlan-id config

### DIFF
--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -214,10 +214,12 @@ func getSubInterface(dutPort *attrs.Attributes, index uint32, vlanID uint16) *oc
 	s6 := s.GetOrCreateIpv6()
 	a6 := s6.GetOrCreateAddress(dutPort.IPv6)
 	a6.PrefixLength = ygot.Uint8(dutPort.IPv6Len)
-	v := s.GetOrCreateVlan()
-	m := v.GetOrCreateMatch()
 	if index != 0 {
-		m.GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
+		if *deviations.DeprecatedVlanID {
+			s.GetOrCreateVlan().VlanId = oc.UnionUint16(vlanID)
+		} else {
+			s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
+		}
 	}
 	return s
 }

--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -364,8 +364,11 @@ func configureSubinterfaceDUT(t *testing.T, d *telemetry.Device, dutPort *ondatr
 	i := d.GetOrCreateInterface(dutPort.Name())
 	s := i.GetOrCreateSubinterface(index)
 	if vlanID != 0 {
-		//s.GetOrCreateVlan().VlanId is deprecated, use the new leaf
-		s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
+		if *deviations.DeprecatedVlanID {
+			s.GetOrCreateVlan().VlanId = telemetry.UnionUint16(vlanID)
+		} else {
+			s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
+		}
 	}
 
 	sipv4 := s.GetOrCreateIpv4()

--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -236,7 +236,11 @@ func (a *attributes) configSubinterfaceDUT(t *testing.T, intf *telemetry.Interfa
 		if *deviations.InterfaceEnabled {
 			s.Enabled = ygot.Bool(true)
 		}
-		s.GetOrCreateVlan().VlanId = telemetry.UnionUint16(i)
+		if *deviations.DeprecatedVlanID {
+			s.GetOrCreateVlan().VlanId = telemetry.UnionUint16(i)
+		} else {
+			s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(uint16(i))
+		}
 		s4 := s.GetOrCreateIpv4()
 		if *deviations.InterfaceEnabled {
 			s4.Enabled = ygot.Bool(true)

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -97,4 +97,6 @@ var (
 		"Device returns no value for some OpenConfig paths if the operational value equals the default. A fully compliant device should pass regardless of this deviation.")
 
 	StaticProtocolName = flag.String("deviation_static_protocol_name", "DEFAULT", "The name used for the static routing protocol.  The default name in OpenConfig is \"DEFAULT\" but some devices use other names.")
+
+	DeprecatedVlanID = flag.Bool("deviation_deprecated_vlan_id", false, "Device requires using the deprecated openconfig-vlan:vlan/config/vlan-id or openconfig-vlan:vlan/state/vlan-id leaves.")
 )


### PR DESCRIPTION
Vendor support for vlan-id configuration can vary - some support vlan/config/vlan-id and others support the newer vlan/match/single-tagged/config/vlan-id leaf.  This deviation allows us to support both methods.