### PR TITLE
TE 3.2: add a flag to enabl/diable adding a drop route

### DIFF
--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -111,4 +111,6 @@ var (
 
 	ExplicitInterfaceInDefaultVRF = flag.Bool("deviation_explicit_interface_in_default_vrf", false,
 		"Device requires explicit attachment of an interface or subinterface to the default network instance. OpenConfig expects an unattached interface or subinterface to be implicitly part of the default network instance. Fully-compliant devices should pass with and without this deviation.")
+
+	AddDiscardRoute = flag.Bool("deviation_add_discard_route", false, "add a drop discard route for gribi tests so that when the nexthop interface goes down, the device does not attempt to route packets through the default gateway.")
 )

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -114,5 +114,5 @@ var (
 
 	AddDiscardRoute = flag.Bool("deviation_add_discard_route", false, "add a drop discard route for gribi tests so that when the nexthop interface goes down, the device does not attempt to route packets through the default gateway.")
 	
-  ExplicitPortSpeed = flag.Bool("deviation_explicit_port_speed", false, "Device requires port-speed to be set because its default value may not be usable. Fully compliant devices should select the highest speed available based on negotiation.")
+  	ExplicitPortSpeed = flag.Bool("deviation_explicit_port_speed", false, "Device requires port-speed to be set because its default value may not be usable. Fully compliant devices should select the highest speed available based on negotiation.")
 )


### PR DESCRIPTION
This pull simply adds a flag to enable/disable adding drop route. Also, please note that the semantics of drop route is a vendor dependent and the expected behavior may need to be captured by static route tests.