### PR TITLE
Adding Type as GetRequest_CONFIG in GetRequest

### DIFF
--- a/feature/system/gnmi/get/tests/system_gnmi_get_test/system_gnmi_get_test.go
+++ b/feature/system/gnmi/get/tests/system_gnmi_get_test/system_gnmi_get_test.go
@@ -66,6 +66,7 @@ func TestGNMIGet(t *testing.T) {
 			Path: []*gpb.Path{{
 				// empty path indicates the root.
 			}},
+			Type:     gpb.GetRequest_CONFIG,
 			Encoding: gpb.Encoding_JSON_IETF,
 		},
 		wantGetResponse: &gpb.GetResponse{
@@ -85,6 +86,7 @@ func TestGNMIGet(t *testing.T) {
 				Origin: "openconfig",
 			},
 			Path:     []*gpb.Path{{}},
+			Type:     gpb.GetRequest_CONFIG,
 			Encoding: gpb.Encoding_JSON_IETF,
 		},
 		wantGetResponse: &gpb.GetResponse{


### PR DESCRIPTION
Adding Type as GetRequest_CONFIG in GetRequest

Get will return entire snapshot in the GetResponse message if type is not specified and it not supported  in some platforms due to efficiency reason.