### PR TITLE
Implementation proposal for network instance deviation

### DIFF
--- a/feature/interface/staticarp/ate_tests/static_arp_test/static_arp_test.go
+++ b/feature/interface/staticarp/ate_tests/static_arp_test/static_arp_test.go
@@ -153,11 +153,18 @@ func configureDUT(t *testing.T, peermac string) {
 	i1 := &telemetry.Interface{Name: ygot.String(p1.Name())}
 	d.Interface(p1.Name()).Replace(t,
 		configInterfaceDUT(i1, &dutSrc, &ateSrc, peermac))
+	if *deviations.AddSubIntfToNetInst {
+		deviations.SubIntfToNetworkInstance(t, d, i1, 0, *deviations.DefaultNetworkInstance)
+	}
 
 	p2 := dut.Port(t, "port2")
 	i2 := &telemetry.Interface{Name: ygot.String(p2.Name())}
 	d.Interface(p2.Name()).Replace(t,
 		configInterfaceDUT(i2, &dutDst, &ateDst, peermac))
+	if *deviations.AddSubIntfToNetInst {
+		deviations.SubIntfToNetworkInstance(t, d, i2, 0, *deviations.DefaultNetworkInstance)
+	}
+}
 }
 
 func configureATE(t *testing.T) (*ondatra.ATEDevice, *ondatra.ATETopology) {

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -106,6 +106,8 @@ var (
 
 	StaticProtocolName = flag.String("deviation_static_protocol_name", "DEFAULT", "The name used for the static routing protocol.  The default name in OpenConfig is \"DEFAULT\" but some devices use other names.")
 
+	DeprecatedVlanID = flag.Bool("deviation_deprecated_vlan_id", false, "Device requires using the deprecated openconfig-vlan:vlan/config/vlan-id or openconfig-vlan:vlan/state/vlan-id leaves.")
+
 	AddSubIntfToNetInst = flag.Bool("deviation_adding_subintf_to_netowork_instance", true,
 		"Vendor requiring explicitly attaching sub-interface to network-instance, this deviation should be marked true. Default expectation is sub-interface is part of default network-instance implicitly.")
 )

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -63,7 +63,15 @@
 //     go test my_test.go --deviation_interface_enabled=true
 package deviations
 
-import "flag"
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/telemetry"
+	"github.com/openconfig/ygot/ygot"
+)
 
 // Vendor deviation flags.
 var (
@@ -96,7 +104,22 @@ var (
 	MissingValueForDefaults = flag.Bool("deviation_missing_value_for_defaults", false,
 		"Device returns no value for some OpenConfig paths if the operational value equals the default. A fully compliant device should pass regardless of this deviation.")
 
-	StaticProtocolName = flag.String("deviation_static_protocol_name", "DEFAULT", "The name used for the static routing protocol.  The default name in OpenConfig is \"DEFAULT\" but some devices use other names.")
+	StaticProtocolName = flag.String("deviation_static_protocol_name", "static", "The name used for the static routing protocol.  The default name in OpenConfig is \"DEFAULT\" but some devices use other names.")
 
-	DeprecatedVlanID = flag.Bool("deviation_deprecated_vlan_id", false, "Device requires using the deprecated openconfig-vlan:vlan/config/vlan-id or openconfig-vlan:vlan/state/vlan-id leaves.")
+	AddSubIntfToNetInst = flag.Bool("deviation_adding_subintf_to_netowork_instance", true,
+		"Vendor requiring explicitly attaching sub-interface to network-instance, this deviation should be marked true. Default expectation is sub-interface is part of default network-instance implicitly.")
 )
+
+func SubIntfToNetworkInstance(t *testing.T, dconf *ondatra.Config, i *telemetry.Interface, si uint32, inst string) {
+	netInst := &telemetry.NetworkInstance{Name: ygot.String(inst)}
+	netInstIntf, err := netInst.NewInterface(i.GetName())
+	if err != nil {
+		t.Errorf("Error fetching NewInterface for %s", i.GetName())
+	}
+	netInstIntf.Interface = ygot.String(i.GetName())
+	netInstIntf.Subinterface = ygot.Uint32(si)
+	netInstIntf.Id = ygot.String(i.GetName() + "." + fmt.Sprint(si))
+	if i.GetSubinterface(si) != nil {
+		dconf.NetworkInstance(inst).Update(t, netInst)
+	}
+}

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -104,7 +104,7 @@ var (
 	MissingValueForDefaults = flag.Bool("deviation_missing_value_for_defaults", false,
 		"Device returns no value for some OpenConfig paths if the operational value equals the default. A fully compliant device should pass regardless of this deviation.")
 
-	StaticProtocolName = flag.String("deviation_static_protocol_name", "static", "The name used for the static routing protocol.  The default name in OpenConfig is \"DEFAULT\" but some devices use other names.")
+	StaticProtocolName = flag.String("deviation_static_protocol_name", "DEFAULT", "The name used for the static routing protocol.  The default name in OpenConfig is \"DEFAULT\" but some devices use other names.")
 
 	AddSubIntfToNetInst = flag.Bool("deviation_adding_subintf_to_netowork_instance", true,
 		"Vendor requiring explicitly attaching sub-interface to network-instance, this deviation should be marked true. Default expectation is sub-interface is part of default network-instance implicitly.")


### PR DESCRIPTION
Implementation proposal for network instance deviation. Purpose is to allow deviations where interfaces could be assigned to network instances.