### PR TITLE
Adding Encoding JSON_IETF for SEC-3.1_tls_authentication

### DIFF
--- a/feature/experimental/security/aaa/kne_tests/tls_authentication_over_grpc_test/tls_authentication_over_grpc_test.go
+++ b/feature/experimental/security/aaa/kne_tests/tls_authentication_over_grpc_test/tls_authentication_over_grpc_test.go
@@ -139,7 +139,8 @@ func TestAuthentication(t *testing.T) {
 					Elem: []*gpb.PathElem{
 						{Name: "system"}, {Name: "config"}, {Name: "hostname"}}},
 				},
-				Type: gpb.GetRequest_CONFIG,
+				Type:     gpb.GetRequest_CONFIG,
+				Encoding: gpb.Encoding_JSON_IETF,
 			})
 			if tc.wantErr != (err != nil) {
 				if tc.wantErr {


### PR DESCRIPTION
type configuration added for github issue#https://github.com/openconfig/featureprofiles/issues/753