### PR TITLE
TE-3.7: Base Hierarchical NHG Update - Commented out EnabledAddressFamilies variable

### DIFF
--- a/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -233,10 +233,6 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		Name:    ygot.String(vrfName),
 		Enabled: ygot.Bool(true),
 		Type:    telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF,
-		//EnabledAddressFamilies: []telemetry.E_Types_ADDRESS_FAMILY{
-	        //	    telemetry.Types_ADDRESS_FAMILY_IPV4,
-	        //	    telemetry.Types_ADDRESS_FAMILY_IPV6,
-		//},
 	}
 
 	p1VRF := vrf.GetOrCreateInterface(p1.Name())

--- a/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -233,10 +233,10 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		Name:    ygot.String(vrfName),
 		Enabled: ygot.Bool(true),
 		Type:    telemetry.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF,
-		EnabledAddressFamilies: []telemetry.E_Types_ADDRESS_FAMILY{
-			telemetry.Types_ADDRESS_FAMILY_IPV4,
-			telemetry.Types_ADDRESS_FAMILY_IPV6,
-		},
+		//EnabledAddressFamilies: []telemetry.E_Types_ADDRESS_FAMILY{
+	        //	    telemetry.Types_ADDRESS_FAMILY_IPV4,
+	        //	    telemetry.Types_ADDRESS_FAMILY_IPV6,
+		//},
 	}
 
 	p1VRF := vrf.GetOrCreateInterface(p1.Name())


### PR DESCRIPTION
TE-3.7: Base Hierarchical NHG Update - Commented out EnabledAddressFamilies variable .
Reference : https://github.com/openconfig/public/pull/738