### PR TITLE
Update experimental qos_policy_config_test.go

### DIFF
--- a/feature/experimental/qos/ate_tests/qos_policy_config_test/qos_policy_config_test.go
+++ b/feature/experimental/qos/ate_tests/qos_policy_config_test/qos_policy_config_test.go
@@ -110,7 +110,7 @@ func TestQoSPolicyConfig(t *testing.T) {
 		classType:    telemetry.Qos_Classifier_Type_IPV4,
 		termID:       "6",
 		targetGrpoup: "target-group-NC1",
-		dscpSet:      []uint8{4, 5, 6, 7},
+		dscpSet:      []uint8{48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59},
 	}, {
 		desc:         "classifier_ipv6_be1",
 		name:         "dscp_based_classifier_ipv6",
@@ -159,7 +159,7 @@ func TestQoSPolicyConfig(t *testing.T) {
 		classType:    telemetry.Qos_Classifier_Type_IPV6,
 		termID:       "6",
 		targetGrpoup: "target-group-NC1",
-		dscpSet:      []uint8{4, 5, 6, 7},
+		dscpSet:      []uint8{48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59},
 	}}
 
 	t.Logf("qos Classifiers config cases: %v", cases)


### PR DESCRIPTION
Updated both IPv4 and IPv6 NC1 dscp set to []uint8{48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59}