### PR TITLE
P4RT3.2: ExplicitInterfaceInDefaultVRF deviation for Google Discovery Protocol: PacketOut

### DIFF
--- a/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetout_test/google_discovery_protocol_packetout_test.go
+++ b/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetout_test/google_discovery_protocol_packetout_test.go
@@ -234,10 +234,12 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	p1 := dut.Port(t, "port1")
 	i1 := &oc.Interface{Name: ygot.String(p1.Name())}
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutPort1))
+	fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
 
 	p2 := dut.Port(t, "port2")
 	i2 := &oc.Interface{Name: ygot.String(p2.Name())}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutPort2))
+	fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 }
 
 // configureATE configures port1 and port2 on the ATE.


### PR DESCRIPTION
Adding AssignToNetworkInstance call for deviation ExplicitInterfaceInDefaultVRF added via PR-737.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."