### PR TITLE
github workflow add pull request rebase check

### DIFF
--- a/.github/workflows/rebase_check.yml
+++ b/.github/workflows/rebase_check.yml
@@ -1,0 +1,43 @@
+name: Rebase Check
+on:
+  pull_request:
+    # Ignore the rebase check if the pull request touches the checked files.
+    paths-ignore:
+      - go.mod
+      - .github/CODEOWNERS
+      - .github/workflows/pull_request.yml
+
+jobs:
+  check_files:
+    name: Check for outdated files
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout current
+      uses: actions/checkout@v3
+      with:
+        path: current
+    - name: Checkout main
+      uses: actions/checkout@v3
+      with:
+        repository: openconfig/featureprofiles
+        ref: main
+        path: main
+    - name: Check if dependencies and checks are up to date.
+      run: |
+        fail=0
+        # Since GitHub runs pull request checks before the merge, if these
+        # files are not up to date in the pull request, the checks may have a
+        # false positive and break the build after merge.
+        for f in \
+          go.mod \
+          .github/CODEOWNERS \
+          .github/workflows/pull_request.yml
+        do
+          if ! diff -q "current/$f" "main/$f"; then
+            fail=1
+          fi
+        done
+        if ((fail)); then
+          echo "Please rebase your pull request to main and rerun checks."
+          exit 1
+        fi


### PR DESCRIPTION
#728 introduced a build-breaking change (fixed by #840) but it was not caught by pull request checks because the go.mod in the PR is out of date. To mitigate problems due to stale checks, I'm adding a rebase check that requires PR to be rebased if go.mod and checks are out of date.