### PR TITLE
TE-14.1 Fix election id issue

### DIFF
--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -252,14 +252,14 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops []string) []strin
 				WithNetworkInstance(*deviations.DefaultNetworkInstance).
 				WithIndex(index).
 				WithIPAddress(nextHops[i]).
-				WithElectionID(12, 0))
+				WithElectionID(args.electionID.Low, args.electionID.High))
 
 		args.client.Modify().AddEntry(t,
 			fluent.NextHopGroupEntry().
 				WithNetworkInstance(*deviations.DefaultNetworkInstance).
 				WithID(uint64(2)).
 				AddNextHop(index, 64).
-				WithElectionID(12, 0))
+				WithElectionID(args.electionID.Low, args.electionID.High))
 	}
 	time.Sleep(time.Minute)
 	virtualVIPs := createIPv4Entries("198.18.196.1/22")
@@ -270,7 +270,7 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops []string) []strin
 				WithPrefix(virtualVIPs[ip]+"/32").
 				WithNetworkInstance(*deviations.DefaultNetworkInstance).
 				WithNextHopGroup(uint64(2)).
-				WithElectionID(12, 0))
+				WithElectionID(args.electionID.Low, args.electionID.High))
 	}
 	if err := awaitTimeout(args.ctx, args.client, t, time.Minute); err != nil {
 		t.Fatalf("Could not program entries via clientA, got err: %v", err)


### PR DESCRIPTION
The last update to the test missed to update the election id for modify requests. This simply fixes that.
Passing log:
```
********************************************

=== RUN   TestScaling
    gribi_scaling_test.go:422: 
        *** Fetching gRIBI client for SF-D...
        
        
    gribi_scaling_test.go:308: Config for nonDefaultNI at /network-instances/network-instance[name=vrf1]:
        {
          "openconfig-network-instance:config": {
            "enabled": true,
            "enabled-address-families": [
              "openconfig-types:IPV4",
              "openconfig-types:IPV6"
            ],
            "name": "vrf1",
            "type": "openconfig-network-instance-types:L3VRF"
          },
          "openconfig-network-instance:name": "vrf1"
        }
2022/12/06 13:33:09 Test output "TestScaling Config for nonDefaultNI at /network-instances/network-instance[name=vrf1]" is discarded without -outputs_dir.  Please specify -outputs_dir to keep it.
    gribi_scaling_test.go:308: Config for nonDefaultNI at /network-instances/network-instance[name=vrf2]:
        {
          "openconfig-network-instance:config": {
            "enabled": true,
            "enabled-address-families": [
              "openconfig-types:IPV4",
              "openconfig-types:IPV6"
            ],
            "name": "vrf2",
            "type": "openconfig-network-instance-types:L3VRF"
          },
          "openconfig-network-instance:name": "vrf2"
        }
2022/12/06 13:33:09 Test output "TestScaling Config for nonDefaultNI at /network-instances/network-instance[name=vrf2]" is discarded without -outputs_dir.  Please specify -outputs_dir to keep it.
    gribi_scaling_test.go:308: Config for nonDefaultNI at /network-instances/network-instance[name=vrf3]:
        {
          "openconfig-network-instance:config": {
            "enabled": true,
            "enabled-address-families": [
              "openconfig-types:IPV4",
              "openconfig-types:IPV6"
            ],
            "name": "vrf3",
            "type": "openconfig-network-instance-types:L3VRF"
          },
          "openconfig-network-instance:name": "vrf3"
        }
2022/12/06 13:33:10 Test output "TestScaling Config for nonDefaultNI at /network-instances/network-instance[name=vrf3]" is discarded without -outputs_dir.  Please specify -outputs_dir to keep it.
    gribi_scaling_test.go:429: Put port TenGigE0/0/0/4/0 into vrf vrf1
    gribi_scaling_test.go:430: DUT port dut:port1(SF-D:TenGigE0/0/0/4/0) configured
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:348: Put port TenGigE0/0/0/4/1 into vrf DEFAULT
    gribi_scaling_test.go:352: DUT port dut:port2(SF-D:TenGigE0/0/0/4/1) configured
    gribi_scaling_test.go:437: 
        *** Pushing topology to 10.85.84.155...
        
        
    gribi_scaling_test.go:437: 
        *** Starting protocols on 10.85.84.155...
        
        
    gribi_scaling_test.go:459: Trying to be a master with increasing the election id by one on dut.
    gribi_scaling_test.go:459: Learn GRIBI Election ID from dut.
    gribi_scaling_test.go:459: Setting GRIBI Election ID for dut to low=2, high=0
--- PASS: TestScaling (810.84s)
PASS

*** Releasing the testbed...

*** PROPERTY: time.begin -> 1670351496
*** PROPERTY: time.end -> 1670352399
ok      command-line-arguments  920.154s
```