### PR TITLE
TE-3.1: Fix checking for nexthop

### DIFF
--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/base_hierarchical_route_installation_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/base_hierarchical_route_installation_test.go
@@ -308,7 +308,7 @@ func testRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 		nh := gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().NextHop(nhIndexInst).State())
 		// for devices that return  the nexthop with resolving it recursively, e.g., for a->b->c the device returns c
 		if got, want := nh.GetIpAddress(), atePort2.IPv4; got != want {
-			// for devices that return the next hop without resolving it recursively e.g., for a->b->c the device returns b
+			// for devices that return the nexthop without resolving it recursively e.g., for a->b->c the device returns b
 			if got, want := nh.GetIpAddress(), ateIndirectNH; got != want {
 				t.Errorf("next-hop is incorrect: got %v, want %v", got, want)
 			}

--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/base_hierarchical_route_installation_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/base_hierarchical_route_installation_test.go
@@ -306,8 +306,12 @@ func testRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 			t.Errorf("next-hop index is incorrect: got %v, want %v", got, want)
 		}
 		nh := gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().NextHop(nhIndexInst).State())
-		if got, want := nh.GetIpAddress(), ateIndirectNH; got != want {
-			t.Errorf("next-hop is incorrect: got %v, want %v", got, want)
+		// for devices that return  the nexthop with resolving it recursively, e.g., for a->b->c the device returns c
+		if got, want := nh.GetIpAddress(), atePort2.IPv4; got != want {
+			// for devices that return the next hop without resolving it recursively e.g., for a->b->c the device returns b
+			if got, want := nh.GetIpAddress(), ateIndirectNH; got != want {
+				t.Errorf("next-hop is incorrect: got %v, want %v", got, want)
+			}
 		}
 		if nh.GetInterfaceRef().GetInterface() == "" {
 			t.Errorf("next-hop interface-ref/interface not found")

--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/base_hierarchical_route_installation_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/base_hierarchical_route_installation_test.go
@@ -306,7 +306,7 @@ func testRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 			t.Errorf("next-hop index is incorrect: got %v, want %v", got, want)
 		}
 		nh := gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().NextHop(nhIndexInst).State())
-		if got, want := nh.GetIpAddress(), atePort2.IPv4; got != want {
+		if got, want := nh.GetIpAddress(), ateIndirectNH; got != want {
 			t.Errorf("next-hop is incorrect: got %v, want %v", got, want)
 		}
 		if nh.GetInterfaceRef().GetInterface() == "" {

--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/base_hierarchical_route_installation_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/base_hierarchical_route_installation_test.go
@@ -275,6 +275,7 @@ func deleteRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 
 // testRecursiveIPv4Entry verifies recursive IPv4 Entry for 198.51.100.0/24 (a) -> 203.0.113.1/32 (b) -> 192.0.2.6 (c).
 // The IPv4 Entry is verified through AFT Telemetry and Traffic.
+// TODO: the below code checks entries for each level of the hierarchy statically. We need to create a helper function that does the check recursively.
 func testRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 	setupRecursiveIPv4Entry(t, args)
 


### PR DESCRIPTION
Function [testRecursiveIPv4Entry](https://github.com/openconfig/featureprofiles/blob/5890cc99fb3eec7a4738a5bf264611ee9fb00daa/feature/gribi/ate_tests/base_hierarchical_route_installation_test/base_hierarchical_route_installation_test.go#L274) tries to verify that hierarchical gribi entries  198.51.100.0/24 (A) -> 203.0.113.1/32 (B) -> 192.0.2.6 (C) through AFT Telemetry. The nexthop for A (198.51.100.0/24) is 203.0.113.1 (B) without recursive resolution  and is C (192.0.2.6) with recursive resolution. 

The test first checks the nexthop for A and then for C. However, the check of the nexthop for A assumes that the device returns the recursively resolved nexthop via AFT.  This pull fixes this issue by checking if the returned nexthop is B when the check for the C fails.

Please note that since the testRecursiveIPv4Entry already checks the nexthop for B, this changes does not causes any issues for verifying that A can be resolved via C recursively. 