### PR TITLE
gNOI-3.4: Cancel reboot on test failure

### DIFF
--- a/feature/gnoi/system/tests/chassis_reboot_status_and_cancel_test/chassis_reboot_status_and_cancel_test.go
+++ b/feature/gnoi/system/tests/chassis_reboot_status_and_cancel_test/chassis_reboot_status_and_cancel_test.go
@@ -89,11 +89,14 @@ func TestRebootStatus(t *testing.T) {
 
 	statusReq := &spb.RebootStatusRequest{Subcomponents: []*tpb.Path{}}
 	if !*deviations.GNOIStatusWithEmptySubcomponent {
-		supervisors := components.FindComponentsByType(t, dut, oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_CONTROLLER_CARD)
+		controllerCards := components.FindComponentsByType(t, dut, oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_CONTROLLER_CARD)
+		if len(controllerCards) == 0 {
+			t.Fatal("No controller card components found in DUT.")
+		}
 		// the test reboots the chasis, so any subcomponent should be ok to check the status
 		statusReq = &spb.RebootStatusRequest{
 			Subcomponents: []*tpb.Path{
-				components.GetSubcomponentPath(supervisors[0]),
+				components.GetSubcomponentPath(controllerCards[0]),
 			},
 		}
 	}
@@ -102,6 +105,7 @@ func TestRebootStatus(t *testing.T) {
 			if tc.rebootRequest != nil {
 				t.Logf("Send reboot request: %v", tc.rebootRequest)
 				rebootResponse, err := gnoiClient.System().Reboot(context.Background(), tc.rebootRequest)
+				defer gnoiClient.System().CancelReboot(context.Background(), &spb.CancelRebootRequest{})
 				t.Logf("Got reboot response: %v, err: %v", rebootResponse, err)
 				if err != nil {
 					t.Fatalf("Failed to request reboot with unexpected err: %v", err)
@@ -159,17 +163,21 @@ func TestCancelReboot(t *testing.T) {
 
 	t.Logf("Send reboot request: %v", rebootRequest)
 	rebootResponse, err := gnoiClient.System().Reboot(context.Background(), rebootRequest)
+	defer gnoiClient.System().CancelReboot(context.Background(), &spb.CancelRebootRequest{})
 	t.Logf("Got reboot response: %v, err: %v", rebootResponse, err)
 	if err != nil {
 		t.Fatalf("Failed to request reboot with unexpected err: %v", err)
 	}
 	statusReq := &spb.RebootStatusRequest{Subcomponents: []*tpb.Path{}}
 	if !*deviations.GNOIStatusWithEmptySubcomponent {
-		supervisors := components.FindComponentsByType(t, dut, oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_CONTROLLER_CARD)
+		controllerCards := components.FindComponentsByType(t, dut, oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_CONTROLLER_CARD)
+		if len(controllerCards) == 0 {
+			t.Fatal("No controller card components found in DUT.")
+		}
 		// the test reboots the chasis, so any subcomponent should be ok to check the status
 		statusReq = &spb.RebootStatusRequest{
 			Subcomponents: []*tpb.Path{
-				components.GetSubcomponentPath(supervisors[0]),
+				components.GetSubcomponentPath(controllerCards[0]),
 			},
 		}
 	}

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -32,22 +32,21 @@ import (
 
 // FindComponentsByType finds the list of components based on hardware type.
 func FindComponentsByType(t *testing.T, dut *ondatra.DUTDevice, cType oc.E_PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT) []string {
-	components := gnmi.GetAll(t, dut, gnmi.OC().ComponentAny().Name().State())
+	components := gnmi.GetAll[*oc.Component](t, dut, gnmi.OC().ComponentAny().State())
 	var s []string
 	for _, c := range components {
-		lookupType, present := gnmi.Lookup(t, dut, gnmi.OC().Component(c).Type().State()).Val()
-		if !present {
-			t.Logf("Component %s type is missing from telemetry", c)
+		if c.GetType() == nil {
+			t.Logf("Component %s type is missing from telemetry", c.GetName())
 			continue
 		}
-		t.Logf("Component %s has type: %v", c, lookupType)
-		switch v := lookupType.(type) {
+		t.Logf("Component %s has type: %v", c.GetName(), c.GetType())
+		switch v := c.GetType().(type) {
 		case oc.E_PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT:
 			if v == cType {
-				s = append(s, c)
+				s = append(s, c.GetName())
 			}
 		default:
-			t.Logf("Detected non-hardware component: (%T, %v)", lookupType, lookupType)
+			t.Logf("Detected non-hardware component: (%T, %v)", c.GetType(), c.GetType())
 		}
 	}
 	return s


### PR DESCRIPTION
When a reboot test fails, it could leave a pending reboot active scheduled for 2 hours in the future.  For each reboot action, defer a CancelReboot to stop all future reboots.

Additionally, add a check to verify a controller card component exists when building the reboot status request.