### PR TITLE
Apply GNOISubcomponentPath deviation to the related tests

### DIFF
--- a/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
+++ b/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
@@ -100,9 +100,7 @@ func TestStandbyControllerCardReboot(t *testing.T) {
 	rebootSubComponentRequest := &spb.RebootRequest{
 		Method: spb.RebootMethod_COLD,
 		Subcomponents: []*tpb.Path{
-			{
-				Elem: []*tpb.PathElem{{Name: rpStandby}},
-			},
+			components.GetSubcomponentPath(rpStandby),
 		},
 	}
 
@@ -161,9 +159,7 @@ func TestLinecardReboot(t *testing.T) {
 	rebootSubComponentRequest := &spb.RebootRequest{
 		Method: spb.RebootMethod_COLD,
 		Subcomponents: []*tpb.Path{
-			{
-				Elem: []*tpb.PathElem{{Name: removableLinecard}},
-			},
+			components.GetSubcomponentPath(removableLinecard),
 		},
 	}
 

--- a/feature/gribi/ate_tests/supervisor_failure_test/supervisor_failure_test.go
+++ b/feature/gribi/ate_tests/supervisor_failure_test/supervisor_failure_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/openconfig/ygot/ygot"
 
 	spb "github.com/openconfig/gnoi/system"
-	tpb "github.com/openconfig/gnoi/types"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
 	"github.com/openconfig/ygnmi/ygnmi"
@@ -332,9 +331,7 @@ func TestSupFailure(t *testing.T) {
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: &tpb.Path{
-			Elem: []*tpb.PathElem{{Name: secondaryBeforeSwitch}},
-		},
+		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 	switchoverResponse, err := gnoiClient.System().SwitchControlProcessor(context.Background(), switchoverRequest)

--- a/feature/system/gnmi/metadata/tests/annotation_test/annotation_test.go
+++ b/feature/system/gnmi/metadata/tests/annotation_test/annotation_test.go
@@ -109,7 +109,6 @@ func TestGNMIMetadataAnnotation(t *testing.T) {
 		accompaniedPath := gnmi.OC().System().Hostname().Config().PathStruct()
 		accompaniedUpdateVal := gnmi.Get[string](t, dut, gnmi.OC().System().Hostname().Config())
 		gpbSetRequest.Update = append(gpbSetRequest.Update, buildGNMIUpdate(t, accompaniedPath, &accompaniedUpdateVal))
-		
 
 		t.Log("gnmiClient Set metadata annotation")
 		if _, err = gnmiClient.Set(context.Background(), gpbSetRequest); err != nil {


### PR DESCRIPTION
This patch applies  GNOISubcomponentPath to the related tests that use gnoi system APIs. Motivation for GNOISubcomponentPath is discussed in the previous pull https://github.com/openconfig/featureprofiles/pull/717.