### PR TITLE
TE-8.2: Fix the SwitchoverReason from  SYSTEM_INITIATED to USER_INITIATED

### DIFF
--- a/feature/gribi/ate_tests/supervisor_failure_test/supervisor_failure_test.go
+++ b/feature/gribi/ate_tests/supervisor_failure_test/supervisor_failure_test.go
@@ -58,7 +58,7 @@ const (
 	controlcardType     = oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_CONTROLLER_CARD
 	primaryController   = oc.Platform_ComponentRedundantRole_PRIMARY
 	secondaryController = oc.Platform_ComponentRedundantRole_SECONDARY
-	switchTrigger       = oc.PlatformTypes_ComponentRedundantRoleSwitchoverReasonTrigger_SYSTEM_INITIATED
+	switchTrigger       = oc.PlatformTypes_ComponentRedundantRoleSwitchoverReasonTrigger_USER_INITIATED
 	maxSwitchoverTime   = 900
 )
 
@@ -243,7 +243,7 @@ func validateTelemetry(t *testing.T, dut *ondatra.DUTDevice, primaryAfterSwitch 
 		t.Logf("Found lastSwitchoverReason.GetTrigger().String(): %v", lastSwitchoverReason.GetTrigger().String())
 	}
 	if gnmi.Get(t, dut, primary.LastSwitchoverReason().State()).GetTrigger() != switchTrigger {
-		t.Errorf("primary.GetLastSwitchoverReason().GetTrigger(): got %s, want SYSTEM_INITIATED.",
+		t.Errorf("primary.GetLastSwitchoverReason().GetTrigger(): got %s, want USER_INITIATED.",
 			gnmi.Get(t, dut, primary.LastSwitchoverReason().State()).GetTrigger().String())
 	}
 


### PR DESCRIPTION
The test expects the switchover reason to be  SYSTEM_INITIATED, however the switchover is initiated by user and I do not think SYSTEM_INITIATED is the correct reason.  SYSTEM_INITIATED should be set as a reason when the switch over is performed automatically by the device, e.g., when the device switches over from active to standby due to the active rp crash.  Also, this is confirmed in openconfig doc (https://openconfig.net/projects/models/schemadocs/yangdoc/openconfig-platform.html#components-component-state-last-switchover-reason-trigger) 
<img width="737" alt="Screenshot 2022-12-19 at 12 31 20 PM" src="https://user-images.githubusercontent.com/91647529/208486269-e4b209b4-7120-40b8-be31-49f9bd6a9a2c.png">
