### PR TITLE
TE-6.2 : Update route_removal_non_default_vrf_test.go

### DIFF
--- a/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -348,7 +348,6 @@ func networkInstance(t *testing.T, name string) *oc.NetworkInstance {
 	ni.Description = ygot.String("Non Default routing instance created for testing")
 	ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 	ni.Enabled = ygot.Bool(true)
-	ni.EnabledAddressFamilies = []oc.E_Types_ADDRESS_FAMILY{oc.Types_ADDRESS_FAMILY_IPV4, oc.Types_ADDRESS_FAMILY_IPV6}
 	return ni
 }
 


### PR DESCRIPTION
Removed EnabledAddressFamilies from the file route_removal_non_default_vrf_test.go
Reference : https://github.com/openconfig/public/pull/738