### PR TITLE
gNOI-3.3: Add SkipStandbyManagementInterfaceCheck

### DIFF
--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -111,4 +111,7 @@ var (
 
 	ExplicitInterfaceInDefaultVRF = flag.Bool("deviation_explicit_interface_in_default_vrf", false,
 		"Device requires explicit attachment of an interface or subinterface to the default network instance. OpenConfig expects an unattached interface or subinterface to be implicitly part of the default network instance. Fully-compliant devices should pass with and without this deviation.")
+
+	SkipStandbyManagementInterfaceCheck = flag.Bool("deviation_skip_standby_management_interface_check", true,
+		"Device does not generate an event for backup menegment interface after switchover, so suppress the oper-status check for backup managment interface after switchover.")
 )


### PR DESCRIPTION
We have an issue for generating telemetry event for the backup management interface if the streaming start before the standby rp is ready. I wonder if we can have this deviation until the issue is fixed. 