### PR TITLE
TE-3.2: fix migration to use election id handshake

### DIFF
--- a/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/backup_nhg_test.go
+++ b/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/backup_nhg_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openconfig/featureprofiles/internal/attrs"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/featureprofiles/internal/gribi"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
 	"github.com/openconfig/ygnmi/ygnmi"
@@ -237,6 +238,12 @@ func TestIndirectBackupNexthopGroup(t *testing.T) {
 	c.StartSending(ctx, t)
 	if err := awaitTimeout(ctx, c, t, time.Minute); err != nil {
 		t.Fatalf("Await got error during session negotiation: %v", err)
+	}
+	gribi.BecomeLeader(t, c)
+
+	// Flush all entries before test.
+	if err := gribi.FlushAll(c); err != nil {
+		t.Errorf("Cannot flush: %v", err)
 	}
 
 	tcArgs := &testArgs{

--- a/feature/experimental/backup_nhg/otg_tests/backup_nhg_test/backup_nhg_test.go
+++ b/feature/experimental/backup_nhg/otg_tests/backup_nhg_test/backup_nhg_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openconfig/featureprofiles/internal/attrs"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/featureprofiles/internal/gribi"
 	"github.com/openconfig/featureprofiles/internal/otgutils"
 )
 
@@ -137,7 +138,11 @@ func TestDirectBackupNexthopGroup(t *testing.T) {
 	if err := awaitTimeout(ctx, c, t, time.Minute); err != nil {
 		t.Fatalf("Await got error during session negotiation: %v", err)
 	}
-
+	gribi.BecomeLeader(t, c)
+	// Flush all entries before test.
+	if err := gribi.FlushAll(c); err != nil {
+		t.Errorf("Cannot flush: %v", err)
+	}
 	tcArgs := &testArgs{
 		ate:    ate,
 		ateTop: ateTop,

--- a/feature/gribi/ate_tests/weighted_balancing_test/port_flap_rebalanced_test.go
+++ b/feature/gribi/ate_tests/weighted_balancing_test/port_flap_rebalanced_test.go
@@ -117,17 +117,10 @@ func TestPortFlap(t *testing.T) {
 		WithPersistence()
 	c.Start(ctx, t)
 	defer c.Stop(t)
-	defer func() {
-		// Flush all entries after test.
-		if err := gribi.FlushAll(c); err != nil {
-			t.Errorf("Cannot flush: %v", err)
-		}
-	}()
 	c.StartSending(ctx, t)
 	if err := awaitTimeout(ctx, c, t, time.Minute); err != nil {
 		t.Fatalf("Await got error during session negotiation: %v", err)
 	}
-
 	gribi.BecomeLeader(t, c)
 
 	// Flush all entries before test.

--- a/feature/gribi/ate_tests/weighted_balancing_test/port_flap_rebalanced_test.go
+++ b/feature/gribi/ate_tests/weighted_balancing_test/port_flap_rebalanced_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/featureprofiles/internal/gribi"
 	"github.com/openconfig/gribigo/chk"
 	"github.com/openconfig/gribigo/fluent"
 	"github.com/openconfig/ondatra"
@@ -116,16 +117,21 @@ func TestPortFlap(t *testing.T) {
 		WithPersistence()
 	c.Start(ctx, t)
 	defer c.Stop(t)
+	defer func() {
+		// Flush all entries after test.
+		if err := gribi.FlushAll(c); err != nil {
+			t.Errorf("Cannot flush: %v", err)
+		}
+	}()
 	c.StartSending(ctx, t)
 	if err := awaitTimeout(ctx, c, t, time.Minute); err != nil {
 		t.Fatalf("Await got error during session negotiation: %v", err)
 	}
 
-	_, err := c.Flush().
-		WithElectionOverride().
-		WithAllNetworkInstances().
-		Send()
-	if err != nil {
+	gribi.BecomeLeader(t, c)
+
+	// Flush all entries before test.
+	if err := gribi.FlushAll(c); err != nil {
 		t.Errorf("Cannot flush: %v", err)
 	}
 

--- a/feature/gribi/otg_tests/weighted_balancing_test/port_flap_rebalanced_test.go
+++ b/feature/gribi/otg_tests/weighted_balancing_test/port_flap_rebalanced_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/open-traffic-generator/snappi/gosnappi"
+	"github.com/openconfig/featureprofiles/internal/gribi"
 	"github.com/openconfig/gribigo/chk"
 	"github.com/openconfig/gribigo/fluent"
 	"github.com/openconfig/ondatra"
@@ -121,12 +122,10 @@ func TestPortFlap(t *testing.T) {
 	if err := awaitTimeout(ctx, c, t, time.Minute); err != nil {
 		t.Fatalf("Await got error during session negotiation: %v", err)
 	}
+	gribi.BecomeLeader(t, c)
 
-	_, err := c.Flush().
-		WithElectionOverride().
-		WithAllNetworkInstances().
-		Send()
-	if err != nil {
+	// Flush all entries before test.
+	if err := gribi.FlushAll(c); err != nil {
 		t.Errorf("Cannot flush: %v", err)
 	}
 


### PR DESCRIPTION
The upgrade to do automatic election id sync missed to upgrade this test. 