### PR TITLE
Fixes for P4RT-5.2

### DIFF
--- a/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/README.md
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/README.md
@@ -15,14 +15,13 @@ Verify that traceroute packets can be sent by the controller.
 
 *   Enable the P4RT server on the device..
 
-*   Connect a P4RT client and configure the forwarding pipeline. Install
-P4RT table entries required for traceroute.
+*   Connect a P4RT client and configure the forwarding pipeline.
 
-*   Send an IPv4 traceroute reply from the client with submit_to_egress_pipeline metadata  set to true.
+*   Send an IPv4 traceroute reply from the client with submit_to_ingress_pipeline metadata  set to true.
 
-*   Verify that the packet is received on the ATE on the portcorresponding to the routing table in the default VRF.
+*   Verify that the packet is received on the ATE on the port corresponding to the routing table in the default VRF.
 
-*   Repeat with an IPv6 traceroute reply and verify that it is receivedcorrectly by the ATE.
+*   Repeat with an IPv6 traceroute reply and verify that it is received correctly by the ATE.
 
 
 *   Validate:

--- a/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/packetout_test.go
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/packetout_test.go
@@ -63,6 +63,10 @@ func testPacketOut(ctx context.Context, t *testing.T, args *testArgs) {
 	leader := args.leader
 	desc := "PacketOut from Primary Controller"
 	ttls := []int{0, 1}
+	if *deviationTTL0 {
+		ttls = []int{1}
+	}
+
 	//for ipv4
 	t.Run(desc+" ipv4 ", func(t *testing.T) {
 		// Check initial packet counters
@@ -89,8 +93,14 @@ func testPacketOut(ctx context.Context, t *testing.T, args *testArgs) {
 			// Verify InPkts stats to check P4RT stream
 			t.Logf("Received %v packets on ATE port %s", counter1-counter0, port)
 
-			if counter1-counter0 < uint64(float64(packetCounter)*0.95) {
-				t.Fatalf("Not all the packets are received.")
+			if ttl == 0 {
+				if counter1-counter0 > uint64(float64(packetCounter)*0.05) {
+					t.Fatalf("Ttl=0 packets are being forwarded.")
+				}
+			} else {
+				if counter1-counter0 < uint64(float64(packetCounter)*0.95) {
+					t.Fatalf("Not all the packets are received.")
+				}
 			}
 			time.Sleep(20 * time.Second)
 		}
@@ -122,9 +132,14 @@ func testPacketOut(ctx context.Context, t *testing.T, args *testArgs) {
 
 			// Verify InPkts stats to check P4RT stream
 			t.Logf("Received %v packets on ATE port %s", counter1-counter0, port)
-
-			if counter1-counter0 < uint64(float64(packetCounter)*0.95) {
-				t.Fatalf("Not all the packets are received.")
+			if ttl == 0 {
+				if counter1-counter0 > uint64(float64(packetCounter)*0.05) {
+					t.Fatalf("Hoplimit=0 packets are being forwarded.")
+				}
+			} else {
+				if counter1-counter0 < uint64(float64(packetCounter)*0.95) {
+					t.Fatalf("Not all the packets are received.")
+				}
 			}
 
 			time.Sleep(20 * time.Second)

--- a/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/packetout_test.go
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/packetout_test.go
@@ -63,9 +63,6 @@ func testPacketOut(ctx context.Context, t *testing.T, args *testArgs) {
 	leader := args.leader
 	desc := "PacketOut from Primary Controller"
 	ttls := []int{0, 1}
-	if *deviationTTL0 {
-		ttls = []int{1}
-	}
 
 	//for ipv4
 	t.Run(desc+" ipv4 ", func(t *testing.T) {

--- a/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/packetout_test.go
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/packetout_test.go
@@ -63,7 +63,6 @@ func testPacketOut(ctx context.Context, t *testing.T, args *testArgs) {
 	leader := args.leader
 	desc := "PacketOut from Primary Controller"
 	ttls := []int{0, 1}
-
 	//for ipv4
 	t.Run(desc+" ipv4 ", func(t *testing.T) {
 		// Check initial packet counters

--- a/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/traceroute_packetout_test.go
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/traceroute_packetout_test.go
@@ -52,7 +52,6 @@ var (
 	streamName                                 = "p4rt"
 	tracerouteipv4InLayers layers.EthernetType = 0x0800
 	checksum                                   = uint16(200)
-	deviationTTL0                              = flag.Bool("deviation_ttl0", false, "deviation for not supporting ttl0 packet forwarding")
 )
 
 var (

--- a/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/traceroute_packetout_test.go
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/traceroute_packetout_test.go
@@ -52,6 +52,7 @@ var (
 	streamName                                 = "p4rt"
 	tracerouteipv4InLayers layers.EthernetType = 0x0800
 	checksum                                   = uint16(200)
+	deviationTTL0                              = flag.Bool("deviation_ttl0", false, "deviation for not supporting ttl0 packet forwarding")
 )
 
 var (
@@ -276,13 +277,6 @@ func packetTracerouteRequestGet(isIPv4 bool, ttl uint8) []byte {
 	payload := []byte{}
 	payLoadLen := 64
 
-	pktEthipv4 := &layers.Ethernet{
-		EthernetType: tracerouteipv4InLayers,
-		SrcMAC:       net.HardwareAddr{0x00, 0xAA, 0x00, 0xAA, 0x00, 0xAA},
-		// traceroute MAC is 68:F3:8E:64:F3:FC
-		DstMAC: net.HardwareAddr{0x02, 0xF6, 0x65, 0x64, 0x00, 0x08},
-	}
-
 	pktICMP4 := &layers.ICMPv4{
 		TypeCode: layers.ICMPv4TypeTimeExceeded,
 		Checksum: checksum,
@@ -296,14 +290,6 @@ func packetTracerouteRequestGet(isIPv4 bool, ttl uint8) []byte {
 		Protocol: layers.IPProtocolICMPv4,
 	}
 
-	//for ipv6
-	pktEthipv6 := &layers.Ethernet{
-		EthernetType: 0x86DD,
-		SrcMAC:       net.HardwareAddr{0x00, 0xAA, 0x00, 0xAA, 0x00, 0xAA},
-		// traceroute MAC is 68:F3:8E:64:F3:FC (HW)
-		//traceroute MAC is 02:f6:65:64:00:08 (Virtual)
-		DstMAC: net.HardwareAddr{0x68, 0xF3, 0x8E, 0x64, 0xF3, 0xFC},
-	}
 	pktIpv6 := &layers.IPv6{
 		Version:    6,
 		HopLimit:   ttl,
@@ -317,12 +303,12 @@ func packetTracerouteRequestGet(isIPv4 bool, ttl uint8) []byte {
 	}
 	if isIPv4 {
 		gopacket.SerializeLayers(buf, opts,
-			pktEthipv4, pktIpv4, pktICMP4, gopacket.Payload(payload),
+			pktIpv4, pktICMP4, gopacket.Payload(payload),
 		)
 		return buf.Bytes()
 	} else {
 		gopacket.SerializeLayers(buf, opts,
-			pktEthipv6, pktIpv6, gopacket.Payload(payload),
+			pktIpv6, gopacket.Payload(payload),
 		)
 		return buf.Bytes()
 	}
@@ -336,7 +322,7 @@ func (traceroute *TraceroutePacketIO) GetPacketOut(portID uint32, isIPv4 bool, t
 		Payload: packetTracerouteRequestGet(isIPv4, ttl),
 		Metadata: []*p4v1.PacketMetadata{
 			{
-				MetadataId: uint32(2), // "egress_port"
+				MetadataId: uint32(2), // "submit_to_ingress"
 				Value:      []byte{1},
 			},
 		},

--- a/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/traceroute_packetout_test.go
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/traceroute_packetout_test.go
@@ -48,10 +48,9 @@ const (
 )
 
 var (
-	p4InfoFile                                 = flag.String("p4info_file_location", "../../wbb.p4info.pb.txt", "Path to the p4info file.")
-	streamName                                 = "p4rt"
-	tracerouteipv4InLayers layers.EthernetType = 0x0800
-	checksum                                   = uint16(200)
+	p4InfoFile = flag.String("p4info_file_location", "../../wbb.p4info.pb.txt", "Path to the p4info file.")
+	streamName = "p4rt"
+	checksum   = uint16(200)
 )
 
 var (


### PR DESCRIPTION
1. Removed following line from description as its not valid for traceroute packet-out scenario
   Install P4RT table entries required for traceroute.
2. Changed submit_to_egress_pipeline to submit_to_ingress
3. Removed Ethernet Headers from packet as the packet is subjected to FIB lookup in submit_to_ingress scenario before sending out (the packet needs to be an L3 packet).
4. TTL/Hoplimit=0 packets should be dropped by the device.