### PR TITLE
TE-3.6: Remove enabled for static route

### DIFF
--- a/feature/gribi/ate_tests/ack_in_presence_other_routes/route_ack_test.go
+++ b/feature/gribi/ate_tests/ack_in_presence_other_routes/route_ack_test.go
@@ -210,7 +210,6 @@ func configureNetworkInstance(t *testing.T) {
 func configStaticRoute(t *testing.T, dut *ondatra.DUTDevice, prefix string, nexthop string) {
 	ni1 := gnmi.GetConfig(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Config())
 	static := ni1.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
-	static.Enabled = ygot.Bool(true)
 	sr := static.GetOrCreateStatic(prefix)
 	nh := sr.GetOrCreateNextHop("0")
 	nh.NextHop = oc.UnionString(nexthop)

--- a/feature/gribi/otg_tests/ack_in_presence_other_routes/route_ack_test.go
+++ b/feature/gribi/otg_tests/ack_in_presence_other_routes/route_ack_test.go
@@ -239,7 +239,6 @@ func configureNetworkInstance(t *testing.T) {
 func configStaticRoute(t *testing.T, dut *ondatra.DUTDevice, prefix string, nexthop string) {
 	ni1 := gnmi.GetConfig(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Config())
 	static := ni1.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
-	static.Enabled = ygot.Bool(true)
 	sr := static.GetOrCreateStatic(prefix)
 	nh := sr.GetOrCreateNextHop("nhg1")
 	nh.NextHop = oc.UnionString(nexthop)


### PR DESCRIPTION
None of the tests uses enabled leaf to configure static route except this one. This pull removes it. Alternatively, if any of the vendors require enable leaf for static route, I can  change this pull to add a deviation flag instead of removing it. 