### PR TITLE
Uplift rt1.2 for route_policy under neighbor

### DIFF
--- a/feature/bgp/policybase/ate_tests/route_installation_test/route_installation_test.go
+++ b/feature/bgp/policybase/ate_tests/route_installation_test/route_installation_test.go
@@ -167,6 +167,7 @@ func bgpCreateNbr(localAs, peerAs uint32, policy string) *oc.NetworkInstance_Pro
 	global.RouterId = ygot.String(dutDst.IPv4)
 	global.As = ygot.Uint32(localAs)
 	global.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Enabled = ygot.Bool(true)
+	global.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).Enabled = ygot.Bool(true)
 
 	// Note: we have to define the peer group even if we aren't setting any policy because it's
 	// invalid OC for the neighbor to be part of a peer group that doesn't exist.
@@ -487,11 +488,6 @@ func TestEstablish(t *testing.T) {
 	// DUT configurations.
 	t.Logf("Start DUT config load:")
 	dut := ondatra.DUT(t, "dut")
-
-	t.Log("Configure Route Policies")
-	d := &oc.Root{}
-	rpl := configureBGPPolicy(d)
-	gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rpl)
 
 	// Configure interface on the DUT
 	t.Logf("Start DUT interface Config")

--- a/feature/bgp/policybase/ate_tests/route_installation_test/route_installation_test.go
+++ b/feature/bgp/policybase/ate_tests/route_installation_test/route_installation_test.go
@@ -142,7 +142,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 // verifyPortsUp asserts that each port on the device is operating
 func verifyPortsUp(t *testing.T, dev *ondatra.Device) {
 	t.Helper()
-	for _, p := range []*ondatra.Port{dev.Port(t, "port1"), dev.Port(t, "port2")} {
+	for _, p := range dev.Ports() {
 		status := gnmi.Get(t, dev, gnmi.OC().Interface(p.Name()).OperStatus().State())
 		if want := oc.Interface_OperStatus_UP; status != want {
 			t.Errorf("%s Status: got %v, want %v", p, status, want)

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -118,4 +118,8 @@ var (
 	ExplicitPortSpeed = flag.Bool("deviation_explicit_port_speed", false, "Device requires port-speed to be set because its default value may not be usable. Fully compliant devices should select the highest speed available based on negotiation.")
 
 	ExplicitP4RTNodeComponent = flag.Bool("deviation_explicit_p4rt_node_component", false, "Device does not report P4RT node names in the component hierarchy, so use hard coded P4RT node names by passing them through internal/args flags. Fully compliant devices should report the PORT hardware components with the INTEGRATED_CIRCUIT components as their parents, as the P4RT node names.")
+
+	RoutePolicyUnderPeerGroup = flag.Bool("deviation_rpl_under_peergroup", false, "Device requires route-policy configuration under bgp peer-group. Fully-compliant devices should pass with and without this deviation.")
+
+	MissingPrePolicyReceivedRoutes = flag.Bool("deviation_prepolicy_received_routes", false, "Device does not support bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received-pre-policy. Fully-compliant devices should pass with and without this deviation.")
 )


### PR DESCRIPTION
1. Added global address families
2. Added route-policy configuration under neighbor (under deviation if route-policy is not supported under peer group)
3. Fixed verifyPortsUp to check status of ports used in the test.
4. added two deviations