### PR TITLE
Remove `enabled-address-families` configuration and add testing to validate defaults.

### DIFF
--- a/feature/bgp/feature.textproto
+++ b/feature/bgp/feature.textproto
@@ -25,12 +25,6 @@ telemetry_path {
     path: "/network-instances/network-instance/state/enabled"
 }
 config_path {
-    path: "/network-instances/network-instance/config/enabled-address-families"
-}
-telemetry_path {
-    path: "/network-instances/network-instance/state/enabled-address-families"
-}
-config_path {
     path: "/network-instances/network-instance/config/name"
 }
 telemetry_path {

--- a/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -244,10 +244,6 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		Name:    ygot.String(vrfName),
 		Enabled: ygot.Bool(true),
 		Type:    oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF,
-		EnabledAddressFamilies: []oc.E_Types_ADDRESS_FAMILY{
-			oc.Types_ADDRESS_FAMILY_IPV4,
-			oc.Types_ADDRESS_FAMILY_IPV6,
-		},
 	}
 
 	p1VRF := vrf.GetOrCreateInterface(p1.Name())

--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -298,10 +298,6 @@ func createVrf(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root, vrfs []string) 
 			i := d.GetOrCreateNetworkInstance(vrf)
 			i.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 			i.Enabled = ygot.Bool(true)
-			i.EnabledAddressFamilies = []oc.E_Types_ADDRESS_FAMILY{
-				oc.Types_ADDRESS_FAMILY_IPV4,
-				oc.Types_ADDRESS_FAMILY_IPV6,
-			}
 			i.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
 			gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrf).Config(), i)
 			nip := gnmi.OC().NetworkInstance(vrf)
@@ -360,7 +356,6 @@ func configureSubinterfaceDUT(t *testing.T, d *oc.Root, dutPort *ondatra.Port, i
 	if vrf != "" {
 		t.Logf("Put port %s into vrf %s", dutPort.Name(), vrf)
 		d.GetOrCreateNetworkInstance(vrf).GetOrCreateInterface(dutPort.Name())
-		d.GetOrCreateNetworkInstance(vrf).EnabledAddressFamilies = []oc.E_Types_ADDRESS_FAMILY{oc.Types_ADDRESS_FAMILY_IPV4}
 	}
 
 	i := d.GetOrCreateInterface(dutPort.Name())

--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -268,14 +268,12 @@ func (a *attributes) configInterfaceDUT(t *testing.T, d *ondatra.DUTDevice, p *o
 // else configures the Default Network Instance.
 func (a *attributes) configureNetworkInstance(t *testing.T, d *ondatra.DUTDevice, p *ondatra.Port) {
 	t.Helper()
-	addressFamilies := []oc.E_Types_ADDRESS_FAMILY{oc.Types_ADDRESS_FAMILY_IPV4}
 	// Use default NI if not provided
 	if a.networkInstance != "" {
 		ni := &oc.NetworkInstance{
-			Name:                   ygot.String(a.networkInstance),
-			Enabled:                ygot.Bool(true),
-			Type:                   oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF,
-			EnabledAddressFamilies: addressFamilies,
+			Name:    ygot.String(a.networkInstance),
+			Enabled: ygot.Bool(true),
+			Type:    oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF,
 		}
 		i := ni.GetOrCreateInterface(p.Name())
 		i.Interface = ygot.String(p.Name())
@@ -286,7 +284,6 @@ func (a *attributes) configureNetworkInstance(t *testing.T, d *ondatra.DUTDevice
 		fptest.LogQuery(t, "NI", dni.Config(), gnmi.GetConfig(t, d, dni.Config()))
 	} else {
 		dni := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
-		gnmi.Replace(t, d, dni.EnabledAddressFamilies().Config(), addressFamilies)
 		gnmi.Replace(t, d, dni.Interface(p.Name()).Config(), &oc.NetworkInstance_Interface{
 			Id:           ygot.String(p.Name()),
 			Interface:    ygot.String(p.Name()),

--- a/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -348,7 +348,6 @@ func networkInstance(t *testing.T, name string) *oc.NetworkInstance {
 	ni.Description = ygot.String("Non Default routing instance created for testing")
 	ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 	ni.Enabled = ygot.Bool(true)
-	ni.EnabledAddressFamilies = []oc.E_Types_ADDRESS_FAMILY{oc.Types_ADDRESS_FAMILY_IPV4, oc.Types_ADDRESS_FAMILY_IPV6}
 	return ni
 }
 

--- a/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -254,10 +254,6 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		Name:    ygot.String(vrfName),
 		Enabled: ygot.Bool(true),
 		Type:    oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF,
-		EnabledAddressFamilies: []oc.E_Types_ADDRESS_FAMILY{
-			oc.Types_ADDRESS_FAMILY_IPV4,
-			oc.Types_ADDRESS_FAMILY_IPV6,
-		},
 	}
 
 	p1VRF := vrf.GetOrCreateInterface(p1.Name())

--- a/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
@@ -294,10 +294,6 @@ func createVrf(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root, vrfs []string) 
 		i := d.GetOrCreateNetworkInstance(vrf)
 		i.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 		i.Enabled = ygot.Bool(true)
-		i.EnabledAddressFamilies = []oc.E_Types_ADDRESS_FAMILY{
-			oc.Types_ADDRESS_FAMILY_IPV4,
-			oc.Types_ADDRESS_FAMILY_IPV6,
-		}
 		i.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
 		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrf).Config(), i)
 		nip := gnmi.OC().NetworkInstance(vrf)
@@ -356,7 +352,6 @@ func configureSubinterfaceDUT(t *testing.T, d *oc.Root, dutPort *ondatra.Port, i
 	if vrf != "" {
 		t.Logf("Put port %s into vrf %s", dutPort.Name(), vrf)
 		d.GetOrCreateNetworkInstance(vrf).GetOrCreateInterface(dutPort.Name())
-		d.GetOrCreateNetworkInstance(vrf).EnabledAddressFamilies = []oc.E_Types_ADDRESS_FAMILY{oc.Types_ADDRESS_FAMILY_IPV4}
 	}
 
 	i := d.GetOrCreateInterface(dutPort.Name())

--- a/feature/networkinstance/otg_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/otg_tests/defaults_test/defaults_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 
 func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attributes) {
 	t.Helper()
-	ni := d.GetOrCreateNetworkInstance(niName)
+	d.GetOrCreateNetworkInstance(niName)
 
 	ocInt := a.ConfigOCInterface(&oc.Interface{})
 	ocInt.Name = ygot.String(intf)
@@ -46,11 +46,6 @@ func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attribut
 	if err := d.AppendInterface(ocInt); err != nil {
 		t.Fatalf("AddInterface(%v): cannot configure interface %s, %v", ocInt, intf, err)
 	}
-
-	// Assign the interface to a network instance.
-	i := ni.GetOrCreateInterface(intf)
-	i.Interface = ygot.String(intf)
-	i.Subinterface = ygot.Uint32(0)
 }
 
 var (
@@ -96,6 +91,12 @@ func TestDefaultAddressFamilies(t *testing.T) {
 	// Assign two ports into the default network instance.
 	assignPort(t, d, dut.Port(t, "port1").Name(), *deviations.DefaultNetworkInstance, dutPort1)
 	assignPort(t, d, dut.Port(t, "port2").Name(), *deviations.DefaultNetworkInstance, dutPort2)
+
+	if *deviations.ExplicitInterfaceInDefaultVRF {
+		fptest.AssignToNetworkInstance(t, dut, dut.Port(t, "port1").Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, dut.Port(t, "port2").Name(), *deviations.DefaultNetworkInstance, 0)
+	}
+
 	fptest.LogQuery(t, "test configuration", gnmi.OC().Config(), d)
 	gnmi.Update(t, dut, gnmi.OC().Config(), d)
 

--- a/feature/networkinstance/otg_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/otg_tests/defaults_test/defaults_test.go
@@ -1,0 +1,160 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package interface_assignments_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/openconfig/featureprofiles/internal/attrs"
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/featureprofiles/internal/otgutils"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/ygnmi/ygnmi"
+	"github.com/openconfig/ygot/ygot"
+)
+
+func TestMain(m *testing.M) {
+	fptest.RunTests(m)
+}
+
+func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attributes) {
+	t.Helper()
+	ni := d.GetOrCreateNetworkInstance(niName)
+
+	ocInt := a.ConfigOCInterface(&oc.Interface{})
+	ocInt.Name = ygot.String(intf)
+
+	if err := d.AppendInterface(ocInt); err != nil {
+		t.Fatalf("AddInterface(%v): cannot configure interface %s, %v", ocInt, intf, err)
+	}
+
+	// Assign the interface to a network instance.
+	i := ni.GetOrCreateInterface(intf)
+	i.Interface = ygot.String(intf)
+	i.Subinterface = ygot.Uint32(0)
+}
+
+var (
+	dutPort1 = &attrs.Attributes{
+		IPv4:    "192.0.2.0",
+		IPv4Len: 31,
+		IPv6:    "2001:db8::1",
+		IPv6Len: 64,
+	}
+	dutPort2 = &attrs.Attributes{
+		IPv4:    "192.0.2.2",
+		IPv4Len: 31,
+		IPv6:    "2001:db8:1::1",
+		IPv6Len: 64,
+	}
+	atePort1 = &attrs.Attributes{
+		Name:    "port1",
+		IPv4:    "192.0.2.1",
+		IPv4Len: 31,
+		IPv6:    "2001:db8::2",
+		IPv6Len: 64,
+		MAC:     "02:00:01:01:01:01",
+	}
+	atePort2 = &attrs.Attributes{
+		Name:    "port2",
+		IPv4:    "192.0.2.3",
+		IPv4Len: 31,
+		IPv6:    "2001:db8:1::2",
+		IPv6Len: 64,
+		MAC:     "02:00:02:01:01:01",
+	}
+)
+
+// TestDefaultAddressFamilies verifies that both IPv4 and IPv6 are enabled by default without a need for additional
+// configuration within a network instance. It does so by validating that simple IPv4 and IPv6 flows do not experience
+// loss.
+func TestDefaultAddressFamilies(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+
+	d := &oc.Root{}
+	d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE
+
+	// Assign two ports into the default network instance.
+	assignPort(t, d, dut.Port(t, "port1").Name(), *deviations.DefaultNetworkInstance, dutPort1)
+	assignPort(t, d, dut.Port(t, "port2").Name(), *deviations.DefaultNetworkInstance, dutPort2)
+	fptest.LogQuery(t, "test configuration", gnmi.OC().Config(), d)
+	gnmi.Update(t, dut, gnmi.OC().Config(), d)
+
+	ate := ondatra.ATE(t, "ate")
+	top := ate.OTG().NewConfig(t)
+
+	p1 := ate.Port(t, "port1")
+	p2 := ate.Port(t, "port2")
+
+	atePort1.AddToOTG(top, p1, dutPort1)
+	atePort2.AddToOTG(top, p2, dutPort2)
+	// Create an IPv4 flow between ATE port 1 and ATE port 2.
+	v4Flow := top.Flows().Add().SetName("ipv4")
+	v4Flow.Metrics().SetEnable(true)
+	e1 := v4Flow.Packet().Add().Ethernet()
+	e1.Src().SetValue(atePort1.MAC)
+	v4Flow.TxRx().Device().SetTxNames([]string{fmt.Sprintf("%s.IPv4", atePort1.Name)}).SetRxNames([]string{fmt.Sprintf("%s.IPv4", atePort2.Name)})
+	v4 := v4Flow.Packet().Add().Ipv4()
+	v4.Src().SetValue(atePort1.IPv4)
+	v4.Dst().SetValue(atePort2.IPv4)
+
+	// Create an IPv6 flow between ATE port 1 and ATE port 2.
+	v6Flow := top.Flows().Add().SetName("ipv6")
+	v6Flow.Metrics().SetEnable(true)
+	e2 := v6Flow.Packet().Add().Ethernet()
+	e2.Src().SetValue(atePort1.MAC)
+	v6Flow.TxRx().Device().SetTxNames([]string{fmt.Sprintf("%s.IPv6", atePort1.Name)}).SetRxNames([]string{fmt.Sprintf("%s.IPv6", atePort2.Name)})
+	v6 := v6Flow.Packet().Add().Ipv6()
+	v6.Src().SetValue(atePort1.IPv6)
+	v6.Dst().SetValue(atePort2.IPv6)
+
+	ate.OTG().PushConfig(t, top)
+	ate.OTG().StartProtocols(t)
+
+	// TODO(robjs): check with Octavian why this is required.
+	time.Sleep(10 * time.Second)
+	for _, i := range []string{atePort1.Name, atePort2.Name} {
+		t.Logf("checking for ARP on %s", i)
+		gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().Interface(i+".Eth").Ipv4NeighborAny().LinkLayerAddress().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
+			return val.IsPresent()
+		}).Await(t)
+	}
+
+	ate.OTG().StartTraffic(t)
+	time.Sleep(15 * time.Second)
+	ate.OTG().StopTraffic(t)
+
+	otgutils.LogFlowMetrics(t, ate.OTG(), top)
+	otgutils.LogPortMetrics(t, ate.OTG(), top)
+
+	// Check that we did not lose any packets for the IPv4 and IPv6 flows.
+	for _, flow := range []string{"ipv4", "ipv6"} {
+		m := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow).State())
+		tx := m.GetCounters().GetOutPkts()
+		rx := m.GetCounters().GetInPkts()
+		loss := tx - rx
+		lossPct := loss * 100 / tx
+		if got := lossPct; got > 0 {
+			t.Errorf("LossPct for flow %s: got %v, want 0", flow, got)
+		}
+	}
+}


### PR DESCRIPTION
This change supports the discussion in
https://github.com/openconfig/public/pull/738 to remove the
`enabled-address-families` list from the OpenConfig model. This change includes
a feature profile test that validates that IPv4 and IPv6 forwarding works for a
specific network instance (the default) without the need for explicit
configuration.

```
commit 73f54344352d96c18088ef98b67caec71acf0686
Author: Rob Shakir <robjs@google.com>
Date:   Fri Dec 9 18:27:47 2022 -0800

    Validate that IPv4 and IPv6 are enabled by default.
    
     * (A) feature/networkinstance/otg_tests/defaults_test/*
       - Add a test case that validates that by default a device supports
         both IPv4 and IPv6 forwarding within a network instance without
         specific additional configuration.
       - This PR supports the removal of the enabled-address-families
         leaf from the OpenConfig schema.

commit dc4487dae7638d00ea39c00b70df82200e09ee1a
Author: Rob Shakir <robjs@google.com>
Date:   Fri Dec 9 18:45:39 2022 -0800

    Add support for tracking deviation for explicit NI assignment.

commit 5579df60b535f3a51f19cc21903c8d1d2ffb7891
Author: Rob Shakir <robjs@google.com>
Date:   Fri Dec 9 18:48:27 2022 -0800

    Remove all references to EnabledAddressFamilies.
    
     * (M) feature/gribi/*
       - Remove all references to specfying the address familities enabled
         for a particular network instance.

commit 15a3547c899dedf79caf3e603e180a94eb12f9c7
Author: Rob Shakir <robjs@google.com>
Date:   Fri Dec 9 18:49:36 2022 -0800

    Remove reference from feature profile textproto.
```
