### PR TITLE
gNMI-1.10: Telemetry: Basic Check : Adding interface type configuration

### DIFF
--- a/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -37,6 +37,7 @@ var (
 )
 
 const (
+	ethernetCsmacd  = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
 	adminStatusUp   = oc.Interface_AdminStatus_UP
 	adminStatusDown = oc.Interface_AdminStatus_DOWN
 	operStatusUp    = oc.Interface_OperStatus_UP
@@ -172,6 +173,7 @@ func TestInterfaceStatusChange(t *testing.T) {
 		intUpdateTime := 2 * time.Minute
 		t.Run(tc.desc, func(t *testing.T) {
 			i.Enabled = ygot.Bool(tc.IntfStatus)
+			i.Type = ethernetCsmacd
 			gnmi.Replace(t, dut, gnmi.OC().Interface(dp.Name()).Config(), i)
 
 			gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, tc.expectedOperStatus)


### PR DESCRIPTION
gNMI-1.10: Telemetry: Basic Check : Adding interface type configuration
github issue#https://github.com/openconfig/featureprofiles/issues/591