### PR TITLE
TE-11.1: Single Backup NHG test

### DIFF
--- a/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/README.md
+++ b/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/README.md
@@ -9,28 +9,41 @@ containing a single NH.
 
 *   Connect ATE port-1 to DUT port-1, ATE port-2 to DUT port-2, and ATE port-3
     to DUT port-3.
-*   TODO: Create a non-default VRF, VRF-3, which includes DUT port-3.
-*   TODO: Create a static default route in the VRF-3, pointing to ATE port-3.
+*   Create a non-default VRF, VRF-1. Assign DUT port-1 to VRF-1.
+*   All GRIBI NHGs and NHs will be installed to the default VRF.
 *   Connect gRIBI client to DUT with persistence `PRESERVE`, redundancy
     `SINGLE_PRIMARY`, with election ID 1.
-*   Install an IPv4Entry in the default VRF pointing to ATE port-2 for prefix
-    198.51.100.0/24, with a backup nexthop group pointing to ATE port-3 (TODO:
-    change ATE port-3 to VRF-3).
+
+To validate GRIBI backup next hop group behavior:
+
+*   Install a GRIBI IPv4Entry in vrf VRF-1 for the prefix 198.51.100.0/24
+    pointing to ATE port-2, with the backup nexthop group pointing to the
+    default VRF.
+*   Install a GRIBI IPv4Entry in the default VRF for the prefix 198.51.100.0/24
+    pointing to ATE port-3.
 *   Validate:
     *   AFT telemetry shows next-hop-group of DUT port-2 being selected for
         198.51.100.0/24.
     *   Traffic is forwarded to ATE port-2 from ATE port-1.
-*   For each of the following cases, ensure that traffic switches to being
-    forwarded to ATE port-3:
+*   For each of the following cases, ensure that traffic switches to using ATE
+    port-3:
     *   Interface ATE port-2 is disabled.
     *   Interface DUT port-2 is disabled.
-*   Remove all previously installed IPv4Entry routes. Create an entry for
-    198.51.100.0/24 with a next-hop of 192.0.2.254/32. Inject a second entry
-    with 192.0.2.254/32 resolved to ATE port-2. Specify a backup NHG pointing to
-    ATE port-3 (TODO: change ATE port-3 to VRF-3) for the 198.51.100.0/24
-    entry’s NHG.
-    *   Remove the entry for 192.0.2.254/32, and ensure that traffic is
-        forwarded to ATE port-3 for destinations in 198.51.100.0/24.
+
+To validate hierarchical backup next hop group behavior:
+
+*   Remove all previously installed GRIBI entries.
+*   Install a GRIBI IPv4Entry for the prefix 198.51.100.0/24 in vrf VRF-1
+    destined to 192.0.2.254 in the default VRF, with the backup nexthop group
+    pointing to the default VRF.
+*   Install a GRIBI IPv4Entry for the prefix 192.0.2.254/32 in the default VRF
+    destined to ATE port-2.
+*   Install a GRIBI IPv4Entry for the prefix 198.51.100.0/24 in the default VRF
+    destined to ATE port-3.
+*   Validate that traffic is forwarded to ATE port-2 for destinations in
+    198.51.100.0/24.
+*   After removing the IPv4Entry for 192.0.2.254/32, validate that traffic is
+    forwarded to ATE port-3 for destinations in 198.51.100.0/24.
 
 ## Config Parameter coverage
 

--- a/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/backup_nhg_test.go
+++ b/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/backup_nhg_test.go
@@ -302,8 +302,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	}
 
 	vrf := &oc.NetworkInstance{
-		Name:    ygot.String(vrfName),
-		Type:    oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF,
+		Name: ygot.String(vrfName),
+		Type: oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF,
 	}
 	if !*deviations.VRFSelectionPolicyRequired {
 		vrfIntf := vrf.GetOrCreateInterface(p1.Name())

--- a/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/backup_nhg_test.go
+++ b/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/backup_nhg_test.go
@@ -303,11 +303,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 
 	vrf := &oc.NetworkInstance{
 		Name:    ygot.String(vrfName),
-		Enabled: ygot.Bool(true),
 		Type:    oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF,
-		EnabledAddressFamilies: []oc.E_Types_ADDRESS_FAMILY{
-			oc.Types_ADDRESS_FAMILY_IPV4,
-		},
 	}
 	if !*deviations.VRFSelectionPolicyRequired {
 		vrfIntf := vrf.GetOrCreateInterface(p1.Name())

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -116,4 +116,6 @@ var (
 		"Device requires explicit attachment of an interface or subinterface to the default network instance. OpenConfig expects an unattached interface or subinterface to be implicitly part of the default network instance. Fully-compliant devices should pass with and without this deviation.")
 
 	ExplicitPortSpeed = flag.Bool("deviation_explicit_port_speed", false, "Device requires port-speed to be set because its default value may not be usable. Fully compliant devices should select the highest speed available based on negotiation.")
+
+	VRFSelectionPolicyRequired = flag.Bool("deviation_vrf_selection_policy_required", false, "Device requires VRF selection policy for TE capabilities.")
 )


### PR DESCRIPTION
This PR modifies the TE-11.1 Single Backup NHG test plan and code to cover the use case in more detail.

* Traffic should be able to ingress a VRF and the backup NHG should trigger a lookup in a different table.  Previous test plan had traffic ingress at default table and forward into a VRF.
* Update AFT telemetry checks to allow more time for the telemetry to become correct.  There can be some delay between a GRIBI change and when the change is seen in GNMI AFT.
* Add deviation to support traffic ingress via a VRF selection policy if required.
* Add deviation to skip hierarchical backup next hop group test.  If a DUT has a default route present in the default table, the primary path is always valid because it will utilize the default route.  This test requires the DUT to have no default route present to trigger backup NHG use.