### PR TITLE
Deviation to configure interface port-speed explicitly.

### DIFF
--- a/feature/interface/staticarp/ate_tests/static_arp_test/static_arp_test.go
+++ b/feature/interface/staticarp/ate_tests/static_arp_test/static_arp_test.go
@@ -154,7 +154,7 @@ func configureDUT(t *testing.T, peermac string) {
 	i1 := &oc.Interface{Name: ygot.String(p1.Name())}
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutSrc, &ateSrc, peermac))
 	if *deviations.ExplicitPortSpeed {
-		fptest.SetPortSpeed(t, dut, "port1")
+		fptest.SetPortSpeed(t, p1)
 	}
 	if *deviations.ExplicitInterfaceInDefaultVRF {
 		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
@@ -164,7 +164,7 @@ func configureDUT(t *testing.T, peermac string) {
 	i2 := &oc.Interface{Name: ygot.String(p2.Name())}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutDst, &ateDst, peermac))
 	if *deviations.ExplicitPortSpeed {
-		fptest.SetPortSpeed(t, dut, "port2")
+		fptest.SetPortSpeed(t, p2)
 	}
 	if *deviations.ExplicitInterfaceInDefaultVRF {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)

--- a/feature/interface/staticarp/ate_tests/static_arp_test/static_arp_test.go
+++ b/feature/interface/staticarp/ate_tests/static_arp_test/static_arp_test.go
@@ -153,6 +153,9 @@ func configureDUT(t *testing.T, peermac string) {
 	p1 := dut.Port(t, "port1")
 	i1 := &oc.Interface{Name: ygot.String(p1.Name())}
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutSrc, &ateSrc, peermac))
+	if *deviations.ExplicitPortSpeed {
+		fptest.SetPortSpeed(t, dut, "port1")
+	}
 	if *deviations.ExplicitInterfaceInDefaultVRF {
 		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
@@ -160,6 +163,9 @@ func configureDUT(t *testing.T, peermac string) {
 	p2 := dut.Port(t, "port2")
 	i2 := &oc.Interface{Name: ygot.String(p2.Name())}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutDst, &ateDst, peermac))
+	if *deviations.ExplicitPortSpeed {
+		fptest.SetPortSpeed(t, dut, "port2")
+	}
 	if *deviations.ExplicitInterfaceInDefaultVRF {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 	}

--- a/feature/interface/staticarp/otg_tests/static_arp_test/static_arp_test.go
+++ b/feature/interface/staticarp/otg_tests/static_arp_test/static_arp_test.go
@@ -158,6 +158,9 @@ func configureDUT(t *testing.T, peermac string) {
 	i1 := &oc.Interface{Name: ygot.String(p1.Name())}
 	if peermac == "" {
 		gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutSrc, &ateSrc, peermac))
+		if *deviations.ExplicitPortSpeed {
+			fptest.SetPortSpeed(t, dut, "port1")
+		}
 		if *deviations.ExplicitInterfaceInDefaultVRF {
 			fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
 		}
@@ -165,6 +168,9 @@ func configureDUT(t *testing.T, peermac string) {
 	p2 := dut.Port(t, "port2")
 	i2 := &oc.Interface{Name: ygot.String(p2.Name())}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutDst, &ateDst, peermac))
+	if *deviations.ExplicitPortSpeed {
+		fptest.SetPortSpeed(t, dut, "port2")
+	}
 	if *deviations.ExplicitInterfaceInDefaultVRF {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 	}

--- a/feature/interface/staticarp/otg_tests/static_arp_test/static_arp_test.go
+++ b/feature/interface/staticarp/otg_tests/static_arp_test/static_arp_test.go
@@ -159,7 +159,7 @@ func configureDUT(t *testing.T, peermac string) {
 	if peermac == "" {
 		gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutSrc, &ateSrc, peermac))
 		if *deviations.ExplicitPortSpeed {
-			fptest.SetPortSpeed(t, dut, "port1")
+			fptest.SetPortSpeed(t, p1)
 		}
 		if *deviations.ExplicitInterfaceInDefaultVRF {
 			fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
@@ -169,7 +169,7 @@ func configureDUT(t *testing.T, peermac string) {
 	i2 := &oc.Interface{Name: ygot.String(p2.Name())}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutDst, &ateDst, peermac))
 	if *deviations.ExplicitPortSpeed {
-		fptest.SetPortSpeed(t, dut, "port2")
+		fptest.SetPortSpeed(t, p2)
 	}
 	if *deviations.ExplicitInterfaceInDefaultVRF {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -112,5 +112,5 @@ var (
 	ExplicitInterfaceInDefaultVRF = flag.Bool("deviation_explicit_interface_in_default_vrf", false,
 		"Device requires explicit attachment of an interface or subinterface to the default network instance. OpenConfig expects an unattached interface or subinterface to be implicitly part of the default network instance. Fully-compliant devices should pass with and without this deviation.")
 
-	ExplicitPortSpeed = flag.Bool("deviation_explicit_port_speed", false, "Device requiring port-speed reconfiguration, where interface configuration using Replace resets the port-speed to default.")
+	ExplicitPortSpeed = flag.Bool("deviation_explicit_port_speed", false, "Device requires port-speed to be set because its default value may not be usable. Fully compliant devices should select the highest speed available based on negotiation.")
 )

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -111,4 +111,6 @@ var (
 
 	ExplicitInterfaceInDefaultVRF = flag.Bool("deviation_explicit_interface_in_default_vrf", false,
 		"Device requires explicit attachment of an interface or subinterface to the default network instance. OpenConfig expects an unattached interface or subinterface to be implicitly part of the default network instance. Fully-compliant devices should pass with and without this deviation.")
+
+	ExplicitPortSpeed = flag.Bool("deviation_explicit_port_speed", false, "Device requiring port-speed reconfiguration, where interface configuration using Replace resets the port-speed to default.")
 )

--- a/internal/fptest/portspeed.go
+++ b/internal/fptest/portspeed.go
@@ -42,13 +42,11 @@ var portSpeed = map[ondatra.Speed]oc.E_IfEthernet_ETHERNET_SPEED{
 // SetPortSpeed sets the DUT config for the interface port-speed according
 // to ondatra.Prot.Speed()
 func SetPortSpeed(t *testing.T, p *ondatra.Port) {
-	dut := p.Device()
-	ps := p.Speed()
-	if ps == 0 {
-		// Port speed is unspecified. Explicit config not performed
+	speed, ok := portSpeed[p.Speed()]
+	if !ok {
+		// Port speed is unspecified or unrecognized. Explicit config not performed
 		return
 	}
-	speed := portSpeed[ps]
 	t.Logf("Configuring %v port-speed to %v", p.Name(), speed)
-	gnmi.Update(t, dut, gnmi.OC().Interface(p.Name()).Ethernet().PortSpeed().Config(), speed)
+	gnmi.Update(t, p.Device(), gnmi.OC().Interface(p.Name()).Ethernet().PortSpeed().Config(), speed)
 }

--- a/internal/fptest/portspeed.go
+++ b/internal/fptest/portspeed.go
@@ -1,9 +1,23 @@
-// 2022 Nokia.  This code is a Contribution to OpenConfig Feature Profiles
-// project ("Work") made under the Google Software Grant and Corporate
-// Contributor License Agreement ("CLA") and governed by the Apache License 2.0.
-// No other rights or licenses in or to any of Nokia's intellectual property
-// are granted for any other purpose. This code is provided on an "as is" basis
-// without any warranties of any kind.
+// Copyright 2022 Nokia, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This code is a Contribution to OpenConfig Feature Profiles project ("Work")
+// made under the Google Software Grant and Corporate Contributor License
+// Agreement ("CLA") and governed by the Apache License 2.0. No other rights
+// or licenses in or to any of Nokia's intellectual property are granted for
+// any other purpose. This code is provided on an "as is" basis without
+// any warranties of any kind.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,29 +29,26 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	"github.com/openconfig/ygot/ygot"
 )
 
-// Set Port Speed
-func SetPortSpeed(t *testing.T, d *ondatra.DUTDevice, p string) {
-	//
-	var portSpeed = map[ondatra.Speed]oc.E_IfEthernet_ETHERNET_SPEED{
-		ondatra.Speed1Gb:   oc.IfEthernet_ETHERNET_SPEED_SPEED_1GB,
-		ondatra.Speed5Gb:   oc.IfEthernet_ETHERNET_SPEED_SPEED_5GB,
-		ondatra.Speed10Gb:  oc.IfEthernet_ETHERNET_SPEED_SPEED_10GB,
-		ondatra.Speed100Gb: oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB,
-		ondatra.Speed400Gb: oc.IfEthernet_ETHERNET_SPEED_SPEED_400GB,
-	}
-	port := d.Port(t, p)
-	ps := port.Speed()
+var portSpeed = map[ondatra.Speed]oc.E_IfEthernet_ETHERNET_SPEED{
+	ondatra.Speed1Gb:   oc.IfEthernet_ETHERNET_SPEED_SPEED_1GB,
+	ondatra.Speed5Gb:   oc.IfEthernet_ETHERNET_SPEED_SPEED_5GB,
+	ondatra.Speed10Gb:  oc.IfEthernet_ETHERNET_SPEED_SPEED_10GB,
+	ondatra.Speed100Gb: oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB,
+	ondatra.Speed400Gb: oc.IfEthernet_ETHERNET_SPEED_SPEED_400GB,
+}
+
+// SetPortSpeed sets the DUT config for the interface port-speed according
+// to ondatra.Prot.Speed()
+func SetPortSpeed(t *testing.T, p *ondatra.Port) {
+	dut := p.Device()
+	ps := p.Speed()
 	if ps == 0 {
 		// Port speed is unspecified. Explicit config not performed
 		return
 	}
 	speed := portSpeed[ps]
-	t.Logf("Configuring %v port-speed to %v", port.Name(), speed)
-	intf := &oc.Interface{Name: ygot.String(port.Name())}
-	eth := intf.GetOrCreateEthernet()
-	eth.SetPortSpeed(speed)
-	gnmi.Update(t, d, gnmi.OC().Interface(intf.GetName()).Config(), intf)
+	t.Logf("Configuring %v port-speed to %v", p.Name(), speed)
+	gnmi.Update(t, dut, gnmi.OC().Interface(p.Name()).Ethernet().PortSpeed().Config(), speed)
 }

--- a/internal/fptest/portspeed.go
+++ b/internal/fptest/portspeed.go
@@ -1,0 +1,43 @@
+// 2022 Nokia.  This code is a Contribution to OpenConfig Feature Profiles
+// project ("Work") made under the Google Software Grant and Corporate
+// Contributor License Agreement ("CLA") and governed by the Apache License 2.0.
+// No other rights or licenses in or to any of Nokia's intellectual property
+// are granted for any other purpose. This code is provided on an "as is" basis
+// without any warranties of any kind.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package fptest
+
+import (
+	"testing"
+
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+// Set Port Speed
+func SetPortSpeed(t *testing.T, d *ondatra.DUTDevice, p string) {
+	//
+	var portSpeed = map[ondatra.Speed]oc.E_IfEthernet_ETHERNET_SPEED{
+		ondatra.Speed1Gb:   oc.IfEthernet_ETHERNET_SPEED_SPEED_1GB,
+		ondatra.Speed5Gb:   oc.IfEthernet_ETHERNET_SPEED_SPEED_5GB,
+		ondatra.Speed10Gb:  oc.IfEthernet_ETHERNET_SPEED_SPEED_10GB,
+		ondatra.Speed100Gb: oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB,
+		ondatra.Speed400Gb: oc.IfEthernet_ETHERNET_SPEED_SPEED_400GB,
+	}
+	port := d.Port(t, p)
+	ps := port.Speed()
+	if ps == 0 {
+		// Port speed is unspecified. Explicit config not performed
+		return
+	}
+	speed := portSpeed[ps]
+	t.Logf("Configuring %v port-speed to %v", port.Name(), speed)
+	intf := &oc.Interface{Name: ygot.String(port.Name())}
+	eth := intf.GetOrCreateEthernet()
+	eth.SetPortSpeed(speed)
+	gnmi.Update(t, d, gnmi.OC().Interface(intf.GetName()).Config(), intf)
+}


### PR DESCRIPTION
This deviation is for device requiring port-speed reconfiguration, where interface configuration using Replace resets the port-speed to default.
This deviation intent to configure port-speed based on the `ondatra.DUTDevice.Port().Speed()` when deviation is set to true.


"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."