### PR TITLE
P4RT-1.1 - added priority field to expected table entity

### DIFF
--- a/feature/experimental/p4rt/ate_tests/base_p4rt/base_p4rt_test.go
+++ b/feature/experimental/p4rt/ate_tests/base_p4rt/base_p4rt_test.go
@@ -392,6 +392,7 @@ func TestP4rtConnect(t *testing.T) {
 				Type:          p4_v1.Update_INSERT,
 				EtherType:     0x6007,
 				EtherTypeMask: 0xFFFF,
+				Priority:      1,
 			},
 		})
 
@@ -406,6 +407,7 @@ func TestP4rtConnect(t *testing.T) {
 				Type:          p4_v1.Update_INSERT,
 				EtherType:     0x88cc,
 				EtherTypeMask: 0xFFFF,
+				Priority:      1,
 			},
 		})
 		if err := verifyReadReceiveMatch(expected_update, readResp); err != nil {
@@ -416,10 +418,11 @@ func TestP4rtConnect(t *testing.T) {
 		// Construct expected table for traceroute to match with received table entry
 		expected_update = p4rtutils.ACLWbbIngressTableEntryGet([]*p4rtutils.ACLWbbIngressTableEntryInfo{
 			{
-				Type:    p4_v1.Update_INSERT,
-				IsIpv4:  0x1,
-				TTL:     0x1,
-				TTLMask: 0xFF,
+				Type:     p4_v1.Update_INSERT,
+				IsIpv4:   0x1,
+				TTL:      0x1,
+				TTLMask:  0xFF,
+				Priority: 1,
 			},
 		})
 		if err := verifyReadReceiveMatch(expected_update, readResp); err != nil {


### PR DESCRIPTION
Since we are adding Priority while writing table entries, the test is failing because of the missing priority:1 in the expected entity. Added priority to the expected entity inside p4rtutils.ACLWbbIngressTableEntryGet function calls. 

```
Read table.Entity:  &{table_id:33554691 match:<field_id:3 ternary:<value:"`\007" mask:"\377\377" > > action:<action:<action_id:16777480 > > priority:1 }
Expected.Entity:  &{table_id:33554691 match:<field_id:3 ternary:<value:"`\007" mask:"\377\377" > > action:<action:<action_id:16777480 > > }
```

