### PR TITLE
P4RT-5.1 - added fix for IPV6 p4rt-utils table INSERT entries 

### DIFF
--- a/feature/experimental/p4rt/ate_tests/traceroute_packetin_test/packetin_test.go
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetin_test/packetin_test.go
@@ -139,7 +139,7 @@ func testPacketIn(ctx context.Context, t *testing.T, args *testArgs, IsIpv4 bool
 		defer programmTableEntry(leader, args.packetIO, true, IsIpv4)
 	} else {
 		// Insert p4rtutils acl entry on the DUT
-		if err := programmTableEntry(leader, args.packetIO, true, false); err != nil {
+		if err := programmTableEntry(leader, args.packetIO, false, false); err != nil {
 			t.Fatalf("There is error when programming entry")
 		}
 		// Delete p4rtutils acl entry on the device


### PR DESCRIPTION
This is to fix write entry for IPV6 related to P4RT. 
Previously DELETE entry was sent, change to 'false' to imply INSERT entry function. 