### PR TITLE
Project import generated by Copybara.

### DIFF
--- a/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
+++ b/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openconfig/featureprofiles/internal/args"
 	"github.com/openconfig/featureprofiles/internal/components"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/ondatra"
@@ -81,14 +82,18 @@ func TestMain(m *testing.M) {
 func TestStandbyControllerCardReboot(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
-	supervisors := components.FindComponentsByType(t, dut, controlcardType)
-	t.Logf("Found supervisor list: %v", supervisors)
-	// Only perform the standby RP rebooting for the chassis with dual RPs/Supervisors.
-	if len(supervisors) != 2 {
-		t.Skipf("Dual RP/SUP is required on %v: got %v, want 2", dut.Model(), len(supervisors))
+	controllerCards := components.FindComponentsByType(t, dut, controlcardType)
+	t.Logf("Found controller card list: %v", controllerCards)
+
+	if *args.NumControllerCards >= 0 && len(controllerCards) != *args.NumControllerCards {
+		t.Errorf("Incorrect number of controller cards: got %v, want exactly %v (specified by flag)", len(controllerCards), *args.NumControllerCards)
 	}
 
-	rpStandby, rpActive := findStandbyRP(t, dut, supervisors)
+	if got, want := len(controllerCards), 2; got < want {
+		t.Skipf("Not enough controller cards for the test on %v: got %v, want at least %v", dut.Model(), got, want)
+	}
+
+	rpStandby, rpActive := findStandbyRP(t, dut, controllerCards)
 	t.Logf("Detected rpStandby: %v, rpActive: %v", rpStandby, rpActive)
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
@@ -126,8 +131,13 @@ func TestLinecardReboot(t *testing.T) {
 
 	lcs := components.FindComponentsByType(t, dut, linecardType)
 	t.Logf("Found linecard list: %v", lcs)
+
+	if *args.NumLinecards >= 0 && len(lcs) != *args.NumLinecards {
+		t.Errorf("Incorrect number of linecards: got %v, want exactly %v (specified by flag)", len(lcs), *args.NumLinecards)
+	}
+
 	if got := len(lcs); got == 0 {
-		t.Errorf("Get number of Linecards on %v: got %v, want > 0", dut.Model(), got)
+		t.Skipf("Not enough linecards for the test on %v: got %v, want > 0", dut.Model(), got)
 	}
 
 	t.Logf("Find a removable line card to reboot.")

--- a/feature/gnoi/system/tests/supervisor_switchover_test/supervisor_switchover_test.go
+++ b/feature/gnoi/system/tests/supervisor_switchover_test/supervisor_switchover_test.go
@@ -73,18 +73,18 @@ func TestMain(m *testing.M) {
 func TestSupervisorSwitchover(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
-	supervisors := components.FindComponentsByType(t, dut, controlcardType)
-	t.Logf("Found supervisor list: %v", supervisors)
+	controllerCards := components.FindComponentsByType(t, dut, controlcardType)
+	t.Logf("Found controller card list: %v", controllerCards)
 
-	if *args.NumSupervisors >= 0 && len(supervisors) != *args.NumSupervisors {
-		t.Errorf("Incorrect number of RP/SUPs: got %v, want exactly %v (specified by flag)", len(supervisors), *args.NumSupervisors)
+	if *args.NumControllerCards >= 0 && len(controllerCards) != *args.NumControllerCards {
+		t.Errorf("Incorrect number of controller cards: got %v, want exactly %v (specified by flag)", len(controllerCards), *args.NumControllerCards)
 	}
 
-	if got, want := len(supervisors), 2; got < want {
-		t.Skipf("Not enough RP/SUPs for the test on %v: got %v, want at least %v", dut.Model(), got, want)
+	if got, want := len(controllerCards), 2; got < want {
+		t.Skipf("Not enough controller cards for the test on %v: got %v, want at least %v", dut.Model(), got, want)
 	}
 
-	rpStandbyBeforeSwitch, rpActiveBeforeSwitch := findStandbyRP(t, dut, supervisors)
+	rpStandbyBeforeSwitch, rpActiveBeforeSwitch := findStandbyRP(t, dut, controllerCards)
 	t.Logf("Detected rpStandby: %v, rpActive: %v", rpStandbyBeforeSwitch, rpActiveBeforeSwitch)
 
 	switchoverReady := gnmi.OC().Component(rpActiveBeforeSwitch).SwitchoverReady()
@@ -144,7 +144,7 @@ func TestSupervisorSwitchover(t *testing.T) {
 	}
 	t.Logf("RP switchover time: %.2f seconds", time.Since(startSwitchover).Seconds())
 
-	rpStandbyAfterSwitch, rpActiveAfterSwitch := findStandbyRP(t, dut, supervisors)
+	rpStandbyAfterSwitch, rpActiveAfterSwitch := findStandbyRP(t, dut, controllerCards)
 	t.Logf("Found standbyRP after switchover: %v, activeRP: %v", rpStandbyAfterSwitch, rpActiveAfterSwitch)
 
 	if got, want := rpActiveAfterSwitch, rpStandbyBeforeSwitch; got != want {

--- a/internal/args/args.go
+++ b/internal/args/args.go
@@ -24,5 +24,6 @@ import (
 
 // Global test flags.
 var (
-	NumSupervisors = flag.Int("arg_num_supervisors", -1, "The expected number of RP/SUPs. Some devices with a single supervisor report 0, which is a valid expected value. Expectation is not checked for values < 0.")
+	NumControllerCards = flag.Int("arg_num_controller_cards", -1, "The expected number of controller cards. Some devices with a single controller report 0, which is a valid expected value. Expectation is not checked for values < 0.")
+	NumLinecards       = flag.Int("arg_num_linecards", -1, "The expected number of linecards. Some devices with a single linecard report 0, which is a valid expected value. Expectation is not checked for values < 0.")
 )


### PR DESCRIPTION
PiperOrigin-RevId: 496441459

Adding support of `arg_num_control_cards` and `arg_num_linecards` flags in *per_component_reboot_test* similarly to https://github.com/openconfig/featureprofiles/pull/914].

Also, replacing the existing `arg_num_supervisors` with `arg_num_control_cards`.