### PR TITLE
Enhance networkinstances defaults_test 

### DIFF
--- a/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
@@ -1,0 +1,168 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package interface_assignments_test
+
+import (
+	"testing"
+	"time"
+
+	"google3/third_party/golang/ygot/ygot/ygot"
+	"google3/third_party/openconfig/featureprofiles/internal/attrs/attrs"
+	"google3/third_party/openconfig/featureprofiles/internal/deviations/deviations"
+	"google3/third_party/openconfig/featureprofiles/internal/fptest/fptest"
+	"google3/third_party/openconfig/ondatra/gnmi/gnmi"
+	"google3/third_party/openconfig/ondatra/gnmi/oc/oc"
+	"google3/third_party/openconfig/ondatra/ondatra"
+)
+
+func TestMain(m *testing.M) {
+	fptest.RunTests(m)
+}
+
+func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attributes) {
+	t.Helper()
+	ni := d.GetOrCreateNetworkInstance(niName)
+	if niName != *deviations.DefaultNetworkInstance {
+		ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
+	}
+	// ni.EnabledAddressFamilies = []oc.E_Types_ADDRESS_FAMILY{oc.Types_ADDRESS_FAMILY_IPV4, oc.Types_ADDRESS_FAMILY_IPV6}
+	if niName != *deviations.DefaultNetworkInstance || *deviations.ExplicitInterfaceInDefaultVRF {
+		niIntf := ni.GetOrCreateInterface(intf)
+		niIntf.Interface = ygot.String(intf)
+		niIntf.Subinterface = ygot.Uint32(0)
+	}
+
+	ocInt := a.ConfigOCInterface(&oc.Interface{})
+	ocInt.Name = ygot.String(intf)
+
+	if err := d.AppendInterface(ocInt); err != nil {
+		t.Fatalf("AddInterface(%v): cannot configure interface %s, %v", ocInt, intf, err)
+	}
+}
+
+var (
+	dutPort1 = &attrs.Attributes{
+		IPv4:    "192.0.2.0",
+		IPv4Len: 31,
+		IPv6:    "2001:db8::1",
+		IPv6Len: 64,
+	}
+	dutPort2 = &attrs.Attributes{
+		IPv4:    "192.0.2.2",
+		IPv4Len: 31,
+		IPv6:    "2001:db8:1::1",
+		IPv6Len: 64,
+	}
+	atePort1 = &attrs.Attributes{
+		Name:    "port1",
+		IPv4:    "192.0.2.1",
+		IPv4Len: 31,
+		IPv6:    "2001:db8::2",
+		IPv6Len: 64,
+		MAC:     "02:00:01:01:01:01",
+	}
+	atePort2 = &attrs.Attributes{
+		Name:    "port2",
+		IPv4:    "192.0.2.3",
+		IPv4Len: 31,
+		IPv6:    "2001:db8:1::2",
+		IPv6Len: 64,
+		MAC:     "02:00:02:01:01:01",
+	}
+)
+
+// TestDefaultAddressFamilies verifies that both IPv4 and IPv6 are enabled by default without a need for additional
+// configuration within a network instance. It does so by validating that simple IPv4 and IPv6 flows do not experience
+// loss.
+func TestDefaultAddressFamilies(t *testing.T) {
+	ate := ondatra.ATE(t, "ate")
+	top := ate.Topology().New()
+
+	p1 := ate.Port(t, "port1")
+	p2 := ate.Port(t, "port2")
+
+	i1 := atePort1.AddToATE(top, p1, dutPort1)
+	i2 := atePort2.AddToATE(top, p2, dutPort2)
+	// Create an IPv4 flow between ATE port 1 and ATE port 2.
+	ipHeader := ondatra.NewIPv4Header().
+		WithSrcAddress(atePort1.IPv4).
+		WithDstAddress(atePort2.IPv4)
+	v4Flow := ate.Traffic().NewFlow("ipv4").
+		WithSrcEndpoints(i1).
+		WithDstEndpoints(i2).
+		WithHeaders(ondatra.NewEthernetHeader().WithSrcAddress(atePort1.MAC), ipHeader)
+
+	// Create an IPv6 flow between ATE port 1 and ATE port 2.
+	ip6Header := ondatra.NewIPv6Header().
+		WithSrcAddress(atePort1.IPv6).
+		WithDstAddress(atePort2.IPv6)
+	v6Flow := ate.Traffic().NewFlow("ipv6").
+		WithSrcEndpoints(i1).
+		WithDstEndpoints(i2).
+		WithHeaders(ondatra.NewEthernetHeader().WithSrcAddress(atePort1.MAC), ip6Header)
+
+	// Push ATE config.
+	top.Push(t)
+
+	cases := []struct {
+		desc   string
+		niName string
+	}{
+		{
+			desc:   "Default network instance",
+			niName: *deviations.DefaultNetworkInstance,
+		},
+		{
+			desc:   "Non default network instance",
+			niName: "xyz",
+		},
+	}
+	dut := ondatra.DUT(t, "dut")
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Reset DUT config.
+			dut.Config().New().WithText("").Push(t)
+			d := &oc.Root{}
+			// Assign two ports into the network instance.
+			assignPort(t, d, dut.Port(t, "port1").Name(), tc.niName, dutPort1)
+			assignPort(t, d, dut.Port(t, "port2").Name(), tc.niName, dutPort2)
+
+			fptest.LogQuery(t, "test configuration", gnmi.OC().Config(), d)
+			gnmi.Update(t, dut, gnmi.OC().Config(), d)
+
+			top.StartProtocols(t)
+			time.Sleep(10 * time.Second)
+
+			ate.Traffic().Start(t, v4Flow, v6Flow)
+			time.Sleep(15 * time.Second)
+			ate.Traffic().Stop(t)
+
+			// Check that we did not lose any packets for the IPv4 and IPv6 flows.
+			for _, flow := range []string{"ipv4", "ipv6"} {
+				m := gnmi.Get(t, ate, gnmi.OC().Flow(flow).State())
+				tx := m.GetCounters().GetOutPkts()
+				rx := m.GetCounters().GetInPkts()
+				loss := tx - rx
+				lossPct := loss * 100 / tx
+				if got := lossPct; got > 0 {
+					t.Errorf("LossPct for flow %s: got %v, want 0", flow, got)
+				}
+			}
+			top.StopProtocols(t)
+		})
+	}
+}

--- a/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/ygot/ygot/ygot"
 	"github.com/openconfig/featureprofiles/internal/attrs/attrs"
 	"github.com/openconfig/featureprofiles/internal/deviations/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest/fptest"
 	"github.com/openconfig/ondatra/gnmi/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc/oc"
 	"github.com/openconfig/ondatra/ondatra"
+	"github.com/openconfig/ygot/ygot"
 )
 
 func TestMain(m *testing.M) {

--- a/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
@@ -14,19 +14,19 @@
  limitations under the License.
 */
 
-package interface_assignments_test
+package ni_address_families_test
 
 import (
 	"testing"
 	"time"
 
-	"google3/third_party/golang/ygot/ygot/ygot"
-	"google3/third_party/openconfig/featureprofiles/internal/attrs/attrs"
-	"google3/third_party/openconfig/featureprofiles/internal/deviations/deviations"
-	"google3/third_party/openconfig/featureprofiles/internal/fptest/fptest"
-	"google3/third_party/openconfig/ondatra/gnmi/gnmi"
-	"google3/third_party/openconfig/ondatra/gnmi/oc/oc"
-	"google3/third_party/openconfig/ondatra/ondatra"
+	"github.com/golang/ygot/ygot/ygot"
+	"github.com/openconfig/featureprofiles/internal/attrs/attrs"
+	"github.com/openconfig/featureprofiles/internal/deviations/deviations"
+	"github.com/openconfig/featureprofiles/internal/fptest/fptest"
+	"github.com/openconfig/ondatra/gnmi/gnmi"
+	"github.com/openconfig/ondatra/gnmi/oc/oc"
+	"github.com/openconfig/ondatra/ondatra"
 )
 
 func TestMain(m *testing.M) {
@@ -39,7 +39,6 @@ func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attribut
 	if niName != *deviations.DefaultNetworkInstance {
 		ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 	}
-	// ni.EnabledAddressFamilies = []oc.E_Types_ADDRESS_FAMILY{oc.Types_ADDRESS_FAMILY_IPV4, oc.Types_ADDRESS_FAMILY_IPV6}
 	if niName != *deviations.DefaultNetworkInstance || *deviations.ExplicitInterfaceInDefaultVRF {
 		niIntf := ni.GetOrCreateInterface(intf)
 		niIntf.Interface = ygot.String(intf)

--- a/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openconfig/featureprofiles/internal/attrs/attrs"
-	"github.com/openconfig/featureprofiles/internal/deviations/deviations"
-	"github.com/openconfig/featureprofiles/internal/fptest/fptest"
+	"github.com/openconfig/featureprofiles/internal/attrs"
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc/oc"
-	"github.com/openconfig/ondatra/ondatra"
 	"github.com/openconfig/ygot/ygot"
 )
 

--- a/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/ondatra"
-	"github.com/openconfig/ondatra/gnmi/gnmi"
-	"github.com/openconfig/ondatra/gnmi/oc/oc"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/ondatra/gnmi/oc"
 	"github.com/openconfig/ygot/ygot"
 )
 

--- a/feature/networkinstance/otg_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/otg_tests/defaults_test/defaults_test.go
@@ -21,15 +21,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openconfig/featureprofiles/internal/attrs"
-	"github.com/openconfig/featureprofiles/internal/deviations"
-	"github.com/openconfig/featureprofiles/internal/fptest"
-	"github.com/openconfig/featureprofiles/internal/otgutils"
-	"github.com/openconfig/ondatra"
-	"github.com/openconfig/ondatra/gnmi"
-	"github.com/openconfig/ondatra/gnmi/oc"
-	"github.com/openconfig/ygnmi/ygnmi"
-	"github.com/openconfig/ygot/ygot"
+	"google3/third_party/golang/ygot/ygot/ygot"
+	"google3/third_party/openconfig/featureprofiles/internal/attrs/attrs"
+	"google3/third_party/openconfig/featureprofiles/internal/deviations/deviations"
+	"google3/third_party/openconfig/featureprofiles/internal/fptest/fptest"
+	"google3/third_party/openconfig/featureprofiles/internal/otgutils/otgutils"
+	"google3/third_party/openconfig/ondatra/gnmi/gnmi"
+	"google3/third_party/openconfig/ondatra/gnmi/oc/oc"
+	"google3/third_party/openconfig/ondatra/ondatra"
+	"google3/third_party/openconfig/ygnmi/ygnmi/ygnmi"
 )
 
 func TestMain(m *testing.M) {
@@ -38,7 +38,16 @@ func TestMain(m *testing.M) {
 
 func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attributes) {
 	t.Helper()
-	d.GetOrCreateNetworkInstance(niName)
+	ni := d.GetOrCreateNetworkInstance(niName)
+	if niName != *deviations.DefaultNetworkInstance {
+		ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
+	}
+	// ni.EnabledAddressFamilies = []oc.E_Types_ADDRESS_FAMILY{oc.Types_ADDRESS_FAMILY_IPV4, oc.Types_ADDRESS_FAMILY_IPV6}
+	if niName != *deviations.DefaultNetworkInstance || *deviations.ExplicitInterfaceInDefaultVRF {
+		niIntf := ni.GetOrCreateInterface(intf)
+		niIntf.Interface = ygot.String(intf)
+		niIntf.Subinterface = ygot.Uint32(0)
+	}
 
 	ocInt := a.ConfigOCInterface(&oc.Interface{})
 	ocInt.Name = ygot.String(intf)
@@ -83,23 +92,6 @@ var (
 // configuration within a network instance. It does so by validating that simple IPv4 and IPv6 flows do not experience
 // loss.
 func TestDefaultAddressFamilies(t *testing.T) {
-	dut := ondatra.DUT(t, "dut")
-
-	d := &oc.Root{}
-	d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE
-
-	// Assign two ports into the default network instance.
-	assignPort(t, d, dut.Port(t, "port1").Name(), *deviations.DefaultNetworkInstance, dutPort1)
-	assignPort(t, d, dut.Port(t, "port2").Name(), *deviations.DefaultNetworkInstance, dutPort2)
-
-	if *deviations.ExplicitInterfaceInDefaultVRF {
-		fptest.AssignToNetworkInstance(t, dut, dut.Port(t, "port1").Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, dut.Port(t, "port2").Name(), *deviations.DefaultNetworkInstance, 0)
-	}
-
-	fptest.LogQuery(t, "test configuration", gnmi.OC().Config(), d)
-	gnmi.Update(t, dut, gnmi.OC().Config(), d)
-
 	ate := ondatra.ATE(t, "ate")
 	top := ate.OTG().NewConfig(t)
 
@@ -129,33 +121,63 @@ func TestDefaultAddressFamilies(t *testing.T) {
 	v6.Dst().SetValue(atePort2.IPv6)
 
 	ate.OTG().PushConfig(t, top)
-	ate.OTG().StartProtocols(t)
 
-	// TODO(robjs): check with Octavian why this is required.
-	time.Sleep(10 * time.Second)
-	for _, i := range []string{atePort1.Name, atePort2.Name} {
-		t.Logf("checking for ARP on %s", i)
-		gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().Interface(i+".Eth").Ipv4NeighborAny().LinkLayerAddress().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-			return val.IsPresent()
-		}).Await(t)
+	cases := []struct {
+		desc   string
+		niName string
+	}{
+		{
+			desc:   "Default network instance",
+			niName: *deviations.DefaultNetworkInstance,
+		},
+		{
+			desc:   "Non default network instance",
+			niName: "xyz",
+		},
 	}
+	dut := ondatra.DUT(t, "dut")
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Reset DUT config.
+			dut.Config().New().WithText("").Push(t)
+			d := &oc.Root{}
+			// Assign two ports into the network instance.
+			assignPort(t, d, dut.Port(t, "port1").Name(), tc.niName, dutPort1)
+			assignPort(t, d, dut.Port(t, "port2").Name(), tc.niName, dutPort2)
 
-	ate.OTG().StartTraffic(t)
-	time.Sleep(15 * time.Second)
-	ate.OTG().StopTraffic(t)
+			fptest.LogQuery(t, "test configuration", gnmi.OC().Config(), d)
+			gnmi.Update(t, dut, gnmi.OC().Config(), d)
 
-	otgutils.LogFlowMetrics(t, ate.OTG(), top)
-	otgutils.LogPortMetrics(t, ate.OTG(), top)
+			ate.OTG().StartProtocols(t)
 
-	// Check that we did not lose any packets for the IPv4 and IPv6 flows.
-	for _, flow := range []string{"ipv4", "ipv6"} {
-		m := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow).State())
-		tx := m.GetCounters().GetOutPkts()
-		rx := m.GetCounters().GetInPkts()
-		loss := tx - rx
-		lossPct := loss * 100 / tx
-		if got := lossPct; got > 0 {
-			t.Errorf("LossPct for flow %s: got %v, want 0", flow, got)
-		}
+			// TODO(robjs): check with Octavian why this is required.
+			time.Sleep(10 * time.Second)
+			for _, i := range []string{atePort1.Name, atePort2.Name} {
+				t.Logf("checking for ARP on %s", i)
+				gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().Interface(i+".Eth").Ipv4NeighborAny().LinkLayerAddress().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
+					return val.IsPresent()
+				}).Await(t)
+			}
+
+			ate.OTG().StartTraffic(t)
+			time.Sleep(15 * time.Second)
+			ate.OTG().StopTraffic(t)
+
+			otgutils.LogFlowMetrics(t, ate.OTG(), top)
+			otgutils.LogPortMetrics(t, ate.OTG(), top)
+
+			// Check that we did not lose any packets for the IPv4 and IPv6 flows.
+			for _, flow := range []string{"ipv4", "ipv6"} {
+				m := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow).State())
+				tx := m.GetCounters().GetOutPkts()
+				rx := m.GetCounters().GetInPkts()
+				loss := tx - rx
+				lossPct := loss * 100 / tx
+				if got := lossPct; got > 0 {
+					t.Errorf("LossPct for flow %s: got %v, want 0", flow, got)
+				}
+			}
+			ate.OTG().StopProtocols(t)
+		})
 	}
 }

--- a/feature/networkinstance/otg_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/otg_tests/defaults_test/defaults_test.go
@@ -14,22 +14,22 @@
  limitations under the License.
 */
 
-package interface_assignments_test
+package ni_address_families_test
 
 import (
 	"fmt"
 	"testing"
 	"time"
 
-	"google3/third_party/golang/ygot/ygot/ygot"
-	"google3/third_party/openconfig/featureprofiles/internal/attrs/attrs"
-	"google3/third_party/openconfig/featureprofiles/internal/deviations/deviations"
-	"google3/third_party/openconfig/featureprofiles/internal/fptest/fptest"
-	"google3/third_party/openconfig/featureprofiles/internal/otgutils/otgutils"
-	"google3/third_party/openconfig/ondatra/gnmi/gnmi"
-	"google3/third_party/openconfig/ondatra/gnmi/oc/oc"
-	"google3/third_party/openconfig/ondatra/ondatra"
-	"google3/third_party/openconfig/ygnmi/ygnmi/ygnmi"
+	"github.com/openconfig/featureprofiles/internal/attrs"
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/featureprofiles/internal/otgutils"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/ygnmi/ygnmi"
+	"github.com/openconfig/ygot/ygot"
 )
 
 func TestMain(m *testing.M) {
@@ -42,7 +42,6 @@ func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attribut
 	if niName != *deviations.DefaultNetworkInstance {
 		ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 	}
-	// ni.EnabledAddressFamilies = []oc.E_Types_ADDRESS_FAMILY{oc.Types_ADDRESS_FAMILY_IPV4, oc.Types_ADDRESS_FAMILY_IPV6}
 	if niName != *deviations.DefaultNetworkInstance || *deviations.ExplicitInterfaceInDefaultVRF {
 		niIntf := ni.GetOrCreateInterface(intf)
 		niIntf.Interface = ygot.String(intf)


### PR DESCRIPTION
1. Update otg test to cover non-default vrf.
2. Add equivalent ate test.