### PR TITLE
DSCP Rules for VRF Selection Test: Set network instance type to L3VRF

### DIFF
--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -195,6 +195,7 @@ func configNetworkInstance(t *testing.T, dut *ondatra.DUTDevice, vrfname string,
 	// create vrf and apply on subinterface
 	v := &oc.NetworkInstance{
 		Name: ygot.String(vrfname),
+		Type: oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF,
 	}
 	vi := v.GetOrCreateInterface(intfname + "." + strconv.Itoa(int(subint)))
 	vi.Subinterface = ygot.Uint32(subint)

--- a/feature/system/gnmi/metadata/tests/annotation_test/annotation_test.go
+++ b/feature/system/gnmi/metadata/tests/annotation_test/annotation_test.go
@@ -109,7 +109,6 @@ func TestGNMIMetadataAnnotation(t *testing.T) {
 		accompaniedPath := gnmi.OC().System().Hostname().Config().PathStruct()
 		accompaniedUpdateVal := gnmi.Get[string](t, dut, gnmi.OC().System().Hostname().Config())
 		gpbSetRequest.Update = append(gpbSetRequest.Update, buildGNMIUpdate(t, accompaniedPath, &accompaniedUpdateVal))
-		
 
 		t.Log("gnmiClient Set metadata annotation")
 		if _, err = gnmiClient.Set(context.Background(), gpbSetRequest); err != nil {


### PR DESCRIPTION
PiperOrigin-RevId: 499558489

Set network instance type while creating L3 VRF