### PR TITLE
gNOI-3.1: Cancel reboot on test failure

### DIFF
--- a/feature/gnoi/system/tests/complete_chassis_reboot/complete_chassis_reboot_test.go
+++ b/feature/gnoi/system/tests/complete_chassis_reboot/complete_chassis_reboot_test.go
@@ -122,6 +122,7 @@ func TestChassisReboot(t *testing.T) {
 
 			t.Logf("Send reboot request: %v", tc.rebootRequest)
 			rebootResponse, err := gnoiClient.System().Reboot(context.Background(), tc.rebootRequest)
+			defer gnoiClient.System().CancelReboot(context.Background(), &spb.CancelRebootRequest{})
 			t.Logf("Got reboot response: %v, err: %v", rebootResponse, err)
 			if err != nil {
 				t.Fatalf("Failed to reboot chassis with unexpected err: %v", err)


### PR DESCRIPTION
When a reboot test fails, it could leave a pending reboot active scheduled for 2 hours in the future. For each reboot action, defer a CancelReboot to stop all future reboots.