### PR TITLE
LLDP disabled change

### DIFF
--- a/feature/lldp/tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
+++ b/feature/lldp/tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
@@ -140,7 +140,7 @@ func verifyNodeTelemetry(t *testing.T, node, peer gnmi.DeviceOrOpts, nodePort, p
 		if _, ok := gnmi.Watch(t, node, interfacePath.State(), time.Minute, func(val *ygnmi.Value[*oc.Lldp_Interface]) bool {
 			intf, present := val.Val()
 			if !present {
-				return false
+				return true
 			}
 			gotLen = len(intf.Neighbor)
 			return gotLen == 0


### PR DESCRIPTION
Changed the return value if `!present`, when `!lldpEnabled`. Both `intf` and `present` shouldn't be defined here.