### PR TITLE
Fix quattro-tl group name and add OTG owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,11 @@
 # the repo. Unless a later match takes precedence,
 # @openconfig/featureprofiles-maintainers will be requested for
 # review when someone opens a pull request.
-*       @openconfig/featureprofiles-maintainers @openconfig/featureprofiles-quattro
+*       @openconfig/featureprofiles-maintainers @openconfig/featureprofiles-quattro-tl
+
+# reviewers for tests which are ported from ate-tests to 
+# otg-tests may be reviewed by this team
+**/otg-tests/**    @openconfig/featureprofiles-maintainers-otg
 
 # Order is important; the last matching pattern takes the most
 # precedence.


### PR DESCRIPTION
Fix team name for featureprofiles-quattro-tl 
Add new owner/group which is configured to be autoassigned for reviews in **/otg-tests/** folders. 