### PR TITLE
GitHub Action: protoc: Use token to avoid API rate limits

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,6 +23,7 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
         version: '3.x'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Lint protobufs
       run: |
         go install github.com/googleapis/api-linter/cmd/api-linter@latest


### PR DESCRIPTION
We are seeing issues where the GitHub action `arduino/setup-protoc@v1` fails due to an API rate limit:

```
Error: API rate limit exceeded for 172.177.246.179. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```

This change adds an API key to get around this.

Example:
https://github.com/openconfig/featureprofiles/actions/runs/3895957137/jobs/6651901328
https://github.com/openconfig/featureprofiles/actions/runs/3887341411/jobs/6633493259