### PR TITLE
add map for multiple vendor naming convention

### DIFF
--- a/feature/gnoi/system/tests/copying_debug_files_test/copying_debug_files_test.go
+++ b/feature/gnoi/system/tests/copying_debug_files_test/copying_debug_files_test.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	bgpProcName = map[ondatra.Vendor]string{
-		ondatra.NOKIA: "sr_bgp_mgr",
+		ondatra.NOKIA:  "sr_bgp_mgr",
 		ondatra.ARISTA: "bgp",
 	}
 )

--- a/feature/gnoi/system/tests/copying_debug_files_test/copying_debug_files_test.go
+++ b/feature/gnoi/system/tests/copying_debug_files_test/copying_debug_files_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/openconfig/ondatra"
 )
 
-const (
-	process = "bgp"
+var (
+	bgpProcName = map[ondatra.Vendor]string{
+		ondatra.NOKIA: "sr_bgp_mgr",
+	}
 )
 
 func TestMain(m *testing.M) {
@@ -54,15 +56,17 @@ func TestCopyingDebugFiles(t *testing.T) {
 
 	dut := ondatra.DUT(t, "dut")
 	gnoiClient := dut.RawAPIs().GNOI().New(t)
-
+	if _, ok := bgpProcName[dut.Vendor()]; !ok {
+		t.Fatalf("Please add support for vendor %v in var bgpProcName", dut.Vendor())
+	}
 	killProcessRequest := &spb.KillProcessRequest{
 		Signal:  spb.KillProcessRequest_SIGNAL_KILL,
-		Name:    process,
+		Name:    bgpProcName[dut.Vendor()],
 		Restart: true,
 	}
 	processKillResponse, err := gnoiClient.System().KillProcess(context.Background(), killProcessRequest)
 	if err != nil {
-		t.Fatalf("Failed to restart process %v with unexpected err: %v", process, err)
+		t.Fatalf("Failed to restart process %v with unexpected err: %v", bgpProcName[dut.Vendor()], err)
 	}
 
 	t.Logf("gnoiClient.System().KillProcess() response: %v, err: %v", processKillResponse, err)
@@ -87,6 +91,6 @@ func TestCopyingDebugFiles(t *testing.T) {
 	t.Logf("Error: %v", err)
 	t.Logf("Response: %v", (validResponse))
 	if err != nil {
-		t.Fatalf("Unexpected error on healthz get response after restart of %v: %v", process, err)
+		t.Fatalf("Unexpected error on healthz get response after restart of %v: %v", bgpProcName[dut.Vendor()], err)
 	}
 }

--- a/feature/gnoi/system/tests/copying_debug_files_test/copying_debug_files_test.go
+++ b/feature/gnoi/system/tests/copying_debug_files_test/copying_debug_files_test.go
@@ -28,6 +28,7 @@ import (
 var (
 	bgpProcName = map[ondatra.Vendor]string{
 		ondatra.NOKIA: "sr_bgp_mgr",
+		ondatra.ARISTA: "bgp",
 	}
 )
 


### PR DESCRIPTION
There's an additional caveat that I've found with this test. It expects that the BGP process is running, certain vendors might only run certain processes when they're in use. Perhaps the purpose is to run this test after the BGP tests have ran in featureprofiles?