### PR TITLE
P4RT node name mapping for Cisco 8xxx

### DIFF
--- a/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
+++ b/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
@@ -195,7 +195,7 @@ func explicitP4RTNodes() map[string]string {
 
 // inferP4RTNodesCisco infers the P4RT node name from the port name and device model
 // for Cisco devices.
-func inferP4RTNodesCisco(t *testing.T, dut *ondatra.DUTDevice) map[string]string {
+func inferP4RTNodesCisco(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
 	t.Helper()
 	npus := []int{0, 1, 2}
 	pranges := []int{11, 23, 35}
@@ -219,7 +219,7 @@ func inferP4RTNodesCisco(t *testing.T, dut *ondatra.DUTDevice) map[string]string
 
 // P4RTNodesByPort returns a map of <portID>:<P4RTNodeName> for the reserved ondatra
 // ports using the component and the interface OC tree.
-func P4RTNodesByPort(t *testing.T, dut *ondatra.DUTDevice) map[string]string {
+func P4RTNodesByPort(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
 	t.Helper()
 	if *deviations.ExplicitP4RTNodeComponent {
 		if dut.Vendor() == ondatra.CISCO {

--- a/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
+++ b/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
@@ -200,9 +200,9 @@ func inferP4RTNodesCisco(t *testing.T, dut *ondatra.DUTDevice) map[string]string
 	npus := []int{0, 1, 2}
 	pranges := []int{11, 23, 35}
 	res := make(map[string]string)
-	dist := dut.Model() == "" || strings.HasPrefix(dut.Model(), "CISCO-88")
+	isModular := dut.Model() == "" || strings.HasPrefix(dut.Model(), "CISCO-88")
 	for _, p := range dut.Ports() {
-		if dist {
+		if isModular {
 			parts := strings.Split(p.Name(), "/")
 			pnum, err := strconv.Atoi(parts[3])
 			if err != nil {

--- a/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
+++ b/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
@@ -222,8 +222,6 @@ func inferP4RTNodesCisco(t *testing.T, dut *ondatra.DUTDevice) map[string]string
 func P4RTNodesByPort(t *testing.T, dut *ondatra.DUTDevice) map[string]string {
 	t.Helper()
 	if *deviations.ExplicitP4RTNodeComponent {
-		fmt.Printf("dut.Vendor(): %v\n", dut.Vendor())
-		fmt.Printf("dut.Model(): %v\n", dut.Model())
 		if dut.Vendor() == ondatra.CISCO {
 			return inferP4RTNodesCisco(t, dut)
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openconfig/featureprofiles
 go 1.19
 
 require (
-	github.com/cisco-open/go-p4 v0.0.0-20230112214152-c0d31345dd63
+	github.com/cisco-open/go-p4 v0.0.0-20230117234941-7359c630de78
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/golang/glog v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,7 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cisco-open/go-p4 v0.0.0-20230112214152-c0d31345dd63 h1:xNc1dCd0T1reQm02OOtdxwlDRQIyOmikfUshIhxCt+w=
 github.com/cisco-open/go-p4 v0.0.0-20230112214152-c0d31345dd63/go.mod h1:4UO27WqDmTRciV5tk6nXVHM+YUT2tvoQBwwnF2X5mwM=
+github.com/cisco-open/go-p4 v0.0.0-20230117234941-7359c630de78/go.mod h1:4UO27WqDmTRciV5tk6nXVHM+YUT2tvoQBwwnF2X5mwM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,7 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cisco-open/go-p4 v0.0.0-20230112214152-c0d31345dd63 h1:xNc1dCd0T1reQm02OOtdxwlDRQIyOmikfUshIhxCt+w=
 github.com/cisco-open/go-p4 v0.0.0-20230112214152-c0d31345dd63/go.mod h1:4UO27WqDmTRciV5tk6nXVHM+YUT2tvoQBwwnF2X5mwM=
+github.com/cisco-open/go-p4 v0.0.0-20230117234941-7359c630de78 h1:NznY39q/P7LWPs+86R1wvdxCcsbs8imn6Y30OIxr7ds=
 github.com/cisco-open/go-p4 v0.0.0-20230117234941-7359c630de78/go.mod h1:4UO27WqDmTRciV5tk6nXVHM+YUT2tvoQBwwnF2X5mwM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
This PR changes explicitP4RTNodes to compute p4rt node names for CISCO devices based on the model number when -deviation_explicit_p4rt_node_component is set.