### PR TITLE
Update telemetry_basic_check_test.go

### DIFF
--- a/feature/gnmi/ate_tests/telemetry_basic_check_test/README.md
+++ b/feature/gnmi/ate_tests/telemetry_basic_check_test/README.md
@@ -59,17 +59,6 @@ following features:
 
     *   Check some counters are updated correctly.
 
-*   QoS counters
-
-    *   Send the traffic with all forwarding class NC1, AF4, AF3, AF2, AF1 and
-        BE1 over the DUT
-    *   Check the QoS queue counters exist and are updated correctly
-        *   /qos/interfaces/interface/output/queues/queue/state/transmit-pkts
-        *   TODO:
-            /qos/interfaces/interface/output/queues/queue/state/transmit-octets
-        *   TODO:
-            /qos/interfaces/interface/output/queues/queue/state/dropped-pkts
-
 *   Component
 
     *   Check the following component paths exists


### PR DESCRIPTION
Deleted QoS counter update test case to avoid the extra maintenance efforts as new QoS tests have been created and have more coverage.

This test coverage is now provided by https://github.com/openconfig/featureprofiles/tree/main/feature/experimental/qos/ate_tests/qos_output_queue_counters_test