### PR TITLE
Update experimental mixed_sp_wrr_traffic_test.go with traffic run time 120 seconds

### DIFF
--- a/feature/experimental/qos/ate_tests/mixed_sp_wrr_traffic_test/mixed_sp_wrr_traffic_test.go
+++ b/feature/experimental/qos/ate_tests/mixed_sp_wrr_traffic_test/mixed_sp_wrr_traffic_test.go
@@ -544,7 +544,7 @@ func TestMixedSPWrrTraffic(t *testing.T) {
 			t.Logf("Running traffic 2 on DUT interfaces: %s => %s ", dp2.Name(), dp3.Name())
 			t.Logf("Sending traffic flows: \n%v\n\n", trafficFlows)
 			ate.Traffic().Start(t, flows...)
-			time.Sleep(10 * time.Second)
+			time.Sleep(120 * time.Second)
 			ate.Traffic().Stop(t)
 			time.Sleep(30 * time.Second)
 


### PR DESCRIPTION
Increased traffic run time to 120 seconds to have stable test result