### PR TITLE
Added deviation for adding vlan for all subinterfaces

### DIFF
--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -343,7 +343,7 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 	for i := 0; i <= nextHopCount; i++ {
 		vlanID := uint16(i)
 		// As per yang model, valid vlan range is 1-4094 - https://github.com/openconfig/public/blob/b34db05e8cf2efe69df3762d4bbd80665e1f9e79/release/models/vlan/openconfig-vlan-types.yang#L133
-		// Without below deviation, vlan-id 0 is being used for subinterface 0. The deviation is to start with valid vlan-id of 1 for subinterface 0. 
+		// Without below deviation, vlan-id 0 is being used for subinterface 0. The deviation is to start with valid vlan-id of 1 for subinterface 0.
 		if *deviations.NoMixOfTaggedAndUntaggedSubinterfaces {
 			vlanID = uint16(i) + 1
 		}

--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -342,7 +342,7 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 	nextHopCount := 63 // nextHopCount specifies number of nextHop IPs needed.
 	for i := 0; i <= nextHopCount; i++ {
 		//yang file using  vlan rang 1-4094 https://github.com/openconfig/public/blob/b34db05e8cf2efe69df3762d4bbd80665e1f9e79/release/models/vlan/openconfig-vlan-types.yang#L133
-		vlanID := uint16(i) + 1
+		vlanID := uint16(i)
 		if *deviations.NoMixOfTaggedAndUntaggedSubinterfaces {
 			vlanID = uint16(i) + 1
 		}

--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -62,9 +62,9 @@ const (
 	IPBlock1      = "198.18.0.1/18"   // IPBlock1 represents the ipv4 entries in VRF1
 	IPBlock2      = "198.18.64.1/18"  // IPBlock2 represents the ipv4 entries in VRF2
 	IPBlock3      = "198.18.128.1/18" // IPBlock3 represents the ipv4 entries in VRF3
-	nhID1         = 2                 // nhID1 is the starting nh Index for entries in VRF1
-	nhID2         = 1002              // nhID2 is the starting nh Index for entries in VRF2
-	nhID3         = 18502             // nhID3 is the starting nh Index for entries in VRF3
+	nhID1         = 65                // nhID1 is the starting nh Index for entries in VRF1
+	nhID2         = 1065              // nhID2 is the starting nh Index for entries in VRF2
+	nhID3         = 18565             // nhID3 is the starting nh Index for entries in VRF3
 	tunnelSrcIP   = "198.18.204.1"    // tunnelSrcIP represents Source IP of IPinIP Tunnel
 	tunnelDstIP   = "198.18.208.1"    // tunnelDstIP represents Dest IP of IPinIP Tunnel
 )
@@ -341,11 +341,16 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 	nextHops := []string{}
 	nextHopCount := 63 // nextHopCount specifies number of nextHop IPs needed.
 	for i := 0; i <= nextHopCount; i++ {
-		vlanID := uint16(i)
+		//yang file using  vlan rang 1-4094 https://github.com/openconfig/public/blob/b34db05e8cf2efe69df3762d4bbd80665e1f9e79/release/models/vlan/openconfig-vlan-types.yang#L133
+		vlanID := uint16(i) + 1
+		if *deviations.NoMixOfTaggedAndUntaggedSubinterfaces {
+			vlanID = uint16(i) + 1
+		}
 		name := fmt.Sprintf(`dst%d`, i)
 		Index := uint32(i)
-		ateIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 1))
-		dutIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 2))
+		ipIndex := i - 1
+		ateIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * ipIndex) + 1))
+		dutIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * ipIndex) + 2))
 		configureSubinterfaceDUT(t, d, dutPort, Index, vlanID, dutIPv4, *deviations.DefaultNetworkInstance)
 		configureATE(t, top, atePort, name, vlanID, dutIPv4, ateIPv4+"/30")
 		nextHops = append(nextHops, ateIPv4)
@@ -424,6 +429,8 @@ func TestScaling(t *testing.T) {
 	ap1 := ate.Port(t, "port1")
 	top := ate.Topology().New()
 	vrfs := []string{*deviations.DefaultNetworkInstance, vrf1, vrf2, vrf3}
+	dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+	gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 	createVrf(t, dut, d, vrfs)
 	// configure an L3 subinterface of no vlan tagging under DUT port#1
 	configureSubinterfaceDUT(t, d, dp1, 0, 0, dutPort1.IPv4, vrf1)

--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -348,10 +348,10 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 			vlanID = uint16(i) + 1
 		}
 		name := fmt.Sprintf(`dst%d`, i)
-		index := uint32(i)
+		Index := uint32(i)
 		ateIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 1))
 		dutIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 2))
-		configureSubinterfaceDUT(t, d, dutPort, index, vlanID, dutIPv4, *deviations.DefaultNetworkInstance)
+		configureSubinterfaceDUT(t, d, dutPort, Index, vlanID, dutIPv4, *deviations.DefaultNetworkInstance)
 		configureATE(t, top, atePort, name, vlanID, dutIPv4, ateIPv4+"/30")
 		nextHops = append(nextHops, ateIPv4)
 	}

--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -341,16 +341,17 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 	nextHops := []string{}
 	nextHopCount := 63 // nextHopCount specifies number of nextHop IPs needed.
 	for i := 0; i <= nextHopCount; i++ {
-		//yang file using  vlan rang 1-4094 https://github.com/openconfig/public/blob/b34db05e8cf2efe69df3762d4bbd80665e1f9e79/release/models/vlan/openconfig-vlan-types.yang#L133
 		vlanID := uint16(i)
+		// As per yang model, valid vlan range is 1-4094 - https://github.com/openconfig/public/blob/b34db05e8cf2efe69df3762d4bbd80665e1f9e79/release/models/vlan/openconfig-vlan-types.yang#L133
+		// Without below deviation, vlan-id 0 is being used for subinterface 0. The deviation is to start with valid vlan-id of 1 for subinterface 0. 
 		if *deviations.NoMixOfTaggedAndUntaggedSubinterfaces {
 			vlanID = uint16(i) + 1
 		}
 		name := fmt.Sprintf(`dst%d`, i)
-		Index := uint32(i)
+		index := uint32(i)
 		ateIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 1))
 		dutIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 2))
-		configureSubinterfaceDUT(t, d, dutPort, Index, vlanID, dutIPv4, *deviations.DefaultNetworkInstance)
+		configureSubinterfaceDUT(t, d, dutPort, index, vlanID, dutIPv4, *deviations.DefaultNetworkInstance)
 		configureATE(t, top, atePort, name, vlanID, dutIPv4, ateIPv4+"/30")
 		nextHops = append(nextHops, ateIPv4)
 	}

--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -348,9 +348,8 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 		}
 		name := fmt.Sprintf(`dst%d`, i)
 		Index := uint32(i)
-		ipIndex := i - 1
-		ateIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * ipIndex) + 1))
-		dutIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * ipIndex) + 2))
+		ateIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 1))
+		dutIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 2))
 		configureSubinterfaceDUT(t, d, dutPort, Index, vlanID, dutIPv4, *deviations.DefaultNetworkInstance)
 		configureATE(t, top, atePort, name, vlanID, dutIPv4, ateIPv4+"/30")
 		nextHops = append(nextHops, ateIPv4)

--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -62,9 +62,9 @@ const (
 	IPBlock1      = "198.18.0.1/18"   // IPBlock1 represents the ipv4 entries in VRF1
 	IPBlock2      = "198.18.64.1/18"  // IPBlock2 represents the ipv4 entries in VRF2
 	IPBlock3      = "198.18.128.1/18" // IPBlock3 represents the ipv4 entries in VRF3
-	nhID1         = 65                // nhID1 is the starting nh Index for entries in VRF1
-	nhID2         = 1065              // nhID2 is the starting nh Index for entries in VRF2
-	nhID3         = 18565             // nhID3 is the starting nh Index for entries in VRF3
+	nhID1         = 2                 // nhID1 is the starting nh Index for entries in VRF1
+	nhID2         = 1002              // nhID2 is the starting nh Index for entries in VRF2
+	nhID3         = 18502             // nhID3 is the starting nh Index for entries in VRF3
 	tunnelSrcIP   = "198.18.204.1"    // tunnelSrcIP represents Source IP of IPinIP Tunnel
 	tunnelDstIP   = "198.18.208.1"    // tunnelDstIP represents Dest IP of IPinIP Tunnel
 )
@@ -428,8 +428,6 @@ func TestScaling(t *testing.T) {
 	ap1 := ate.Port(t, "port1")
 	top := ate.Topology().New()
 	vrfs := []string{*deviations.DefaultNetworkInstance, vrf1, vrf2, vrf3}
-	dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
-	gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 	createVrf(t, dut, d, vrfs)
 	// configure an L3 subinterface of no vlan tagging under DUT port#1
 	configureSubinterfaceDUT(t, d, dp1, 0, 0, dutPort1.IPv4, vrf1)

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -159,5 +159,5 @@ var (
 		"Don't set isis instance enable flag on the device if value is true, Default value is false and instance enable flag is set")
 
 	NoMixOfTaggedAndUntaggedSubinterfaces = flag.Bool("deviation_no_mix_of_tagged_and_untagged_subinterfaces", false,
-		"Device does not support mix of tagged and untagged subinterfaces")
+		"Use this deviation when the device does not support a mix of tagged and untagged subinterfaces")
 )

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -157,4 +157,7 @@ var (
 
 	ISISInstanceEnabledNotRequired = flag.Bool("deviation_isis_instance_enabled_not_required", false,
 		"Don't set isis instance enable flag on the device if value is true, Default value is false and instance enable flag is set")
+
+	NoMixOfTaggedAndUntaggedSubinterfaces = flag.Bool("deviation_no_mix_of_tagged_and_untagged_subinterfaces", false,
+		"Device does not support mix of tagged and untagged subinterfaces")
 )


### PR DESCRIPTION
Changes:
  For dutPort2 and atePort2, unit 0 subinterface is configured without vlan(vlan-id 0). Added deviation to configure vlan for all subinterfaces to avoid mix of tagged and untagged subinterfaces.
