### PR TITLE
Renamed deviation ExplicitInterfaceRefInPolicyForwarding to ExplicitInterfaceRefDefinition

### DIFF
--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -499,7 +499,7 @@ func TestPBR(t *testing.T) {
 			pfIntf := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreatePolicyForwarding().GetOrCreateInterface(p1)
 			pfIntfConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Interface(p1)
 
-			if *deviations.ExplicitInterfaceRefInPolicyForwarding {
+			if *deviations.ExplicitInterfaceRefDefinition {
 				pfIntf.GetOrCreateInterfaceRef().Interface = ygot.String(p1)
 				pfIntf.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 				pfIntf.SetApplyVrfSelectionPolicy(args.policyName)

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -158,7 +158,7 @@ var (
 	ISISInstanceEnabledNotRequired = flag.Bool("deviation_isis_instance_enabled_not_required", false,
 		"Don't set isis instance enable flag on the device if value is true, Default value is false and instance enable flag is set")
 
-        ExplicitInterfaceRefDefinition = flag.Bool("deviation_explicit_interface_ref_definition", false, "Device requires explicit interface ref configuration when applying features to interface")
+	ExplicitInterfaceRefDefinition = flag.Bool("deviation_explicit_interface_ref_definition", false, "Device requires explicit interface ref configuration when applying features to interface")
 
 	NoMixOfTaggedAndUntaggedSubinterfaces = flag.Bool("deviation_no_mix_of_tagged_and_untagged_subinterfaces", false,
 		"Use this deviation when the device does not support a mix of tagged and untagged subinterfaces")

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -158,7 +158,7 @@ var (
 	ISISInstanceEnabledNotRequired = flag.Bool("deviation_isis_instance_enabled_not_required", false,
 		"Don't set isis instance enable flag on the device if value is true, Default value is false and instance enable flag is set")
 
-	ExplicitInterfaceRefInPolicyForwarding = flag.Bool("deviation_explicit_interface_ref_in_policy_forwarding", false, "Device requires interface ref config when applying vrf-selection-policy")
+        ExplicitInterfaceRefDefinition = flag.Bool("deviation_explicit_interface_ref_definition", false, "Device requires explicit interface ref configuration when applying features to interface")
 
 	NoMixOfTaggedAndUntaggedSubinterfaces = flag.Bool("deviation_no_mix_of_tagged_and_untagged_subinterfaces", false,
 		"Use this deviation when the device does not support a mix of tagged and untagged subinterfaces")


### PR DESCRIPTION
Renamed deviation ExplicitInterfaceRefInPolicyForwarding to ExplicitInterfaceRefDefinition since it is applicable under different OC hierarchies as well