### PR TITLE
RT-5.2: Aggregate Interfaces - Adding interface type ethernetCsmacd

### DIFF
--- a/feature/interface/aggregate/otg_tests/aggregate_test/aggregate_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_test/aggregate_test.go
@@ -380,6 +380,8 @@ func (tc *testCase) setDutInterfaceWithState(t testing.TB, p *ondatra.Port, stat
 	dc := gnmi.OC()
 	i := &oc.Interface{}
 	i.Enabled = ygot.Bool(state)
+	i.Type = ethernetCsmacd
+	i.Name = ygot.String(p.Name())
 	gnmi.Update(t, tc.dut, dc.Interface(p.Name()).Config(), i)
 }
 


### PR DESCRIPTION
Added interface type ethernetCsmacd in setDUTInterfaceWithState