### PR TITLE
TE-3.7: Moving Interface creation before it is attached to VRF.

### DIFF
--- a/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -248,9 +248,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	p1VRF := vrf.GetOrCreateInterface(p1.Name())
 	p1VRF.Interface = ygot.String(p1.Name())
 	p1VRF.Subinterface = ygot.Uint32(0)
+	gnmi.Update(t, dut, d.Interface(p1.Name()).Config(), dutPort1.NewOCInterface(p1.Name()))
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrfName).Config(), vrf)
 
-	gnmi.Update(t, dut, d.Interface(p1.Name()).Config(), dutPort1.NewOCInterface(p1.Name()))
 	gnmi.Update(t, dut, d.Interface(p2.Name()).Config(), dutPort2.NewOCInterface(p2.Name()))
 	gnmi.Update(t, dut, d.Interface(p3.Name()).Config(), dutPort3.NewOCInterface(p3.Name()))
 	if *deviations.ExplicitIPv6EnableForGRIBI {


### PR DESCRIPTION
Moving `port1` interface creation before it is added to to `VRF-1`

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."