### PR TITLE
TE-6.2: Moving ATE protocol start after DUT NI configuration 

### DIFF
--- a/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -102,8 +102,8 @@ func TestRouteRemovalNonDefaultVRFFlush(t *testing.T) {
 	ate := ondatra.ATE(t, "ate")
 	ateTop := configureATE(t, ate)
 
-	ateTop.Push(t).StartProtocols(t)
 	configureNetworkInstance(t, dut)
+	ateTop.Push(t).StartProtocols(t)
 
 	// Configure the gRIBI client clientA and make it leader.
 	clientA := &gribi.Client{


### PR DESCRIPTION
The interface comes up after it is attached to network-instance, thus moving NI configuration before ATE protocol start. 

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."