### PR TITLE
Tweak p4rt utils for nokia

### DIFF
--- a/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
+++ b/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
@@ -198,7 +198,7 @@ var nokiaPortNameRE = regexp.MustCompile("ethernet-([0-9]+)/([0-9]+)")
 
 // inferP4RTNodesNokia infers the P4RT node name from the port name for Nokia devices.
 func inferP4RTNodesNokia(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
-	// both if P4RT NodeName1 and NodeName2 are explicitly specified by a user - return explicit values
+	// if both P4RT NodeName1 and NodeName2 are explicitly specified by a user - return explicit values
 	if *args.P4RTNodeName1 != "" && *args.P4RTNodeName2 != "" {
 		return explicitP4RTNodes()
 	}

--- a/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
+++ b/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
@@ -198,6 +198,9 @@ var nokiaPortNameRE = regexp.MustCompile("ethernet-([0-9]+)/([0-9]+)")
 
 // inferP4RTNodesNokia infers the P4RT node name from the port name for Nokia devices.
 func inferP4RTNodesNokia(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
+	if *args.P4RTNodeName1 != "" && *args.P4RTNodeName2 != "" {
+		return explicitP4RTNodes()
+	}
 	res := make(map[string]string)
 	for _, p := range dut.Ports() {
 		m := nokiaPortNameRE.FindStringSubmatch(p.Name())
@@ -259,9 +262,6 @@ func P4RTNodesByPort(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
 		case ondatra.CISCO:
 			return inferP4RTNodesCisco(t, dut)
 		case ondatra.NOKIA:
-			if *args.P4RTNodeName1 != "" && *args.P4RTNodeName2 != "" {
-				return explicitP4RTNodes()
-			}
 			return inferP4RTNodesNokia(t, dut)
 		default:
 			return explicitP4RTNodes()

--- a/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
+++ b/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
@@ -198,9 +198,11 @@ var nokiaPortNameRE = regexp.MustCompile("ethernet-([0-9]+)/([0-9]+)")
 
 // inferP4RTNodesNokia infers the P4RT node name from the port name for Nokia devices.
 func inferP4RTNodesNokia(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
+	// both if P4RT NodeName1 and NodeName2 are explicitly specified by a user - return explicit values
 	if *args.P4RTNodeName1 != "" && *args.P4RTNodeName2 != "" {
 		return explicitP4RTNodes()
 	}
+
 	res := make(map[string]string)
 	for _, p := range dut.Ports() {
 		m := nokiaPortNameRE.FindStringSubmatch(p.Name())

--- a/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
+++ b/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
@@ -259,6 +259,9 @@ func P4RTNodesByPort(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
 		case ondatra.CISCO:
 			return inferP4RTNodesCisco(t, dut)
 		case ondatra.NOKIA:
+			if *args.P4RTNodeName1 != "" && *args.P4RTNodeName2 != "" {
+				return explicitP4RTNodes()
+			}
 			return inferP4RTNodesNokia(t, dut)
 		default:
 			return explicitP4RTNodes()


### PR DESCRIPTION
Hi @Ankur19,
I added a small change on top of #1106 - if a user provided explicit P4RT node names, they will be used instead of inferred names.
Otherwise we default to inferred.
This allows us to use linecards with different interface/asic layouts internally 