### PR TITLE
OTG RT2.1: Fix for Retrieving port name using Eth.Connection

### DIFF
--- a/feature/experimental/isis/otg_tests/internal/session/session.go
+++ b/feature/experimental/isis/otg_tests/internal/session/session.go
@@ -313,7 +313,7 @@ func (s *TestSession) MustATEInterface(t testing.TB, portID string) gosnappi.Dev
 	}
 	for _, d := range s.ATETop.Devices().Items() {
 		Eth := d.Ethernets().Items()[0]
-		if Eth.PortName() == portID {
+		if Eth.Connection().PortName() == portID {
 			return d
 		}
 	}


### PR DESCRIPTION
"The Connection specification for portName on Ethernet object instead of direct portName" is changed with reference commit id  https://github.com/open-traffic-generator/featureprofiles/commit/04f106f81b85b7060d3c2100e1b397419a97b49d

This PR helps to align with the above commit

resolves #589 