### PR TITLE
Adding Deviation for gRIBI state under network instance.

### DIFF
--- a/feature/gribi/ate_tests/gribigo_compliance_test/gribigo_compliance_test.go
+++ b/feature/gribi/ate_tests/gribigo_compliance_test/gribigo_compliance_test.go
@@ -190,7 +190,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-
+	if *deviations.ExplicitGribiUnderNetworkInstance{
+		fptest.EnableGribiUnderNetworkInstance(t, dut, *nonDefaultNI)
+	}
 	d := &oc.Root{}
 	ni := d.GetOrCreateNetworkInstance(*nonDefaultNI)
 	ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF

--- a/feature/gribi/otg_tests/gribigo_compliance_test/gribigo_compliance_test.go
+++ b/feature/gribi/otg_tests/gribigo_compliance_test/gribigo_compliance_test.go
@@ -172,7 +172,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-
+	if *deviations.ExplicitGribiUnderNetworkInstance{
+		fptest.EnableGribiUnderNetworkInstance(t, dut, *nonDefaultNI)
+	}
 	d := &oc.Root{}
 	ni := d.GetOrCreateNetworkInstance(*nonDefaultNI)
 	ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -165,4 +165,7 @@ var (
 
 	BGPStateActiveACLDeny = flag.Bool("deviation_bgp_state_active_acl_deny", false,
 		"Device requires bgp state to be active after ACL deny policy")
+
+	ExplicitGribiUnderNetworkInstance = flag.Bool("deviation_explicit_gribi_under_network_instance", false, 
+	    "Device requires gribi-protocol to be enabled under network-instance.")
 )


### PR DESCRIPTION
Adding deviation for Nokia since it's required to have gRIBI enabled in a given Network instance. Using CLI Origin to push the config since it's only accessible through native models.

This code is a Contribution to the OpenConfig Feature Profiles project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an “as is” basis without any warranties of any kind.