### PR TITLE
oc-1.2 update to support ExplicitPortSpeed & ExplicitInterfaceInDefaultVRF deviations

### DIFF
--- a/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
@@ -147,10 +147,12 @@ func TestDefaultAddressFamilies(t *testing.T) {
 			}
 			d := &oc.Root{}
 			// Assign two ports into the network instance.
-			assignPort(t, d, dut.Port(t, "port1").Name(), tc.niName, dutPort1)
-			defer unassignPort(t, dut, dutP1.Name(), tc.niName)
-			assignPort(t, d, dut.Port(t, "port2").Name(), tc.niName, dutPort2)
-			defer unassignPort(t, dut, dutP2.Name(), tc.niName)
+			assignPort(t, d, dutP1.Name(), tc.niName, dutPort1)
+			assignPort(t, d, dutP2.Name(), tc.niName, dutPort2)
+			if *deviations.ExplicitInterfaceInDefaultVRF {
+				defer unassignPort(t, dut, dutP1.Name(), tc.niName)
+				defer unassignPort(t, dut, dutP2.Name(), tc.niName)
+			}
 
 			fptest.LogQuery(t, "test configuration", gnmi.OC().Config(), d)
 			gnmi.Update(t, dut, gnmi.OC().Config(), d)

--- a/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
@@ -53,6 +53,12 @@ func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attribut
 	}
 }
 
+func unassignPort(t *testing.T, dut *ondatra.DUTDevice, intf, niName string) {
+	t.Helper()
+	in := gnmi.OC().NetworkInstance(niName).Interface(intf).Config()
+	gnmi.Delete(t, dut, in)
+}
+
 var (
 	dutPort1 = &attrs.Attributes{
 		IPv4:    "192.0.2.0",
@@ -131,12 +137,20 @@ func TestDefaultAddressFamilies(t *testing.T) {
 		},
 	}
 	dut := ondatra.DUT(t, "dut")
+	dutP1 := dut.Port(t, "port1")
+	dutP2 := dut.Port(t, "port2")
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
+			if *deviations.ExplicitPortSpeed {
+				fptest.SetPortSpeed(t, dutP1)
+				fptest.SetPortSpeed(t, dutP2)
+			}
 			d := &oc.Root{}
 			// Assign two ports into the network instance.
 			assignPort(t, d, dut.Port(t, "port1").Name(), tc.niName, dutPort1)
+			defer unassignPort(t, dut, dutP1.Name(), tc.niName)
 			assignPort(t, d, dut.Port(t, "port2").Name(), tc.niName, dutPort2)
+			defer unassignPort(t, dut, dutP2.Name(), tc.niName)
 
 			fptest.LogQuery(t, "test configuration", gnmi.OC().Config(), d)
 			gnmi.Update(t, dut, gnmi.OC().Config(), d)

--- a/internal/fptest/portspeed.go
+++ b/internal/fptest/portspeed.go
@@ -24,11 +24,11 @@
 package fptest
 
 import (
-	"testing"
-
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	"testing"
+	"time"
 )
 
 var portSpeed = map[ondatra.Speed]oc.E_IfEthernet_ETHERNET_SPEED{
@@ -49,4 +49,5 @@ func SetPortSpeed(t *testing.T, p *ondatra.Port) {
 	}
 	t.Logf("Configuring %v port-speed to %v", p.Name(), speed)
 	gnmi.Update(t, p.Device(), gnmi.OC().Interface(p.Name()).Ethernet().PortSpeed().Config(), speed)
+	time.Sleep(time.Second * 3)
 }

--- a/internal/fptest/portspeed.go
+++ b/internal/fptest/portspeed.go
@@ -24,11 +24,11 @@
 package fptest
 
 import (
+	"testing"
+
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	"testing"
-	"time"
 )
 
 var portSpeed = map[ondatra.Speed]oc.E_IfEthernet_ETHERNET_SPEED{
@@ -49,5 +49,4 @@ func SetPortSpeed(t *testing.T, p *ondatra.Port) {
 	}
 	t.Logf("Configuring %v port-speed to %v", p.Name(), speed)
 	gnmi.Update(t, p.Device(), gnmi.OC().Interface(p.Name()).Ethernet().PortSpeed().Config(), speed)
-	time.Sleep(time.Second * 3)
 }


### PR DESCRIPTION
In this pr we introduce two changes:
1) when ExplicitInterfaceInDefaultVRF is used, we need to unassign interfaces from the default vrf before they can be assigned to a custom vrf.
unassignPort() function is added for this purpose, which is called only when ExplicitInterfaceInDefaultVRF is true
2) added 	fptest.SetPortSpeed() function calls when ExplicitPortSpeed is true