### PR TITLE
Update ExplicitPortSpeed deviation

### DIFF
--- a/internal/fptest/portspeed.go
+++ b/internal/fptest/portspeed.go
@@ -25,6 +25,7 @@ package fptest
 
 import (
 	"testing"
+	"time"
 
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
@@ -49,4 +50,5 @@ func SetPortSpeed(t *testing.T, p *ondatra.Port) {
 	}
 	t.Logf("Configuring %v port-speed to %v", p.Name(), speed)
 	gnmi.Update(t, p.Device(), gnmi.OC().Interface(p.Name()).Ethernet().PortSpeed().Config(), speed)
+	time.Sleep(time.Second * 3)
 }


### PR DESCRIPTION
This PR adds small (3-second) delay to fptest.SetPortSpeed() function that is used by ExplicitPortSpeed deviation.
This allows for a brief convergence window between an interface reconfiguration with a speed change (e.g. 400G->100G) and initiating traffic streams from ATE