### PR TITLE
GNMI-1.13: Updating vendor based transceiverMAP and transceiverName

### DIFF
--- a/feature/platform/tests/optics_power_and_bias_current_test/optics_power_and_bias_current_test.go
+++ b/feature/platform/tests/optics_power_and_bias_current_test/optics_power_and_bias_current_test.go
@@ -182,6 +182,7 @@ func findTransceiverName(dut *ondatra.DUTDevice, interfaceName string) (string, 
 			ondatra.ARISTA:  " transceiver",
 			ondatra.CISCO:   "",
 			ondatra.JUNIPER: "",
+			ondatra.NOKIA:   "-transceiver",
 		}
 	)
 	transceiverName := interfaceName
@@ -193,7 +194,9 @@ func findTransceiverName(dut *ondatra.DUTDevice, interfaceName string) (string, 
 		interfaceSplit := strings.Split(interfaceName, "/")
 		interfaceSplitres := interfaceSplit[:len(interfaceSplit)-1]
 		transceiverName = strings.Join(interfaceSplitres, "/") + name
-
+		if dut.Vendor() == ondatra.NOKIA {
+			transceiverName = interfaceName + name
+		}
 	}
 	return transceiverName, nil
 }


### PR DESCRIPTION
Appending value for `ondatra.Nokia` into `transceiverMap` variable and updating `transceiverName` accordingly.


"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."