### PR TITLE
RT-1.1: Base BGP Session Parameters: Support additional deviations

### DIFF
--- a/feature/experimental/bgp/ate_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
+++ b/feature/experimental/bgp/ate_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
@@ -101,12 +101,29 @@ type bgpTestParams struct {
 	peerIP                      string
 }
 
+// bgpClearConfig removes all BGP configuration from the DUT.
+func bgpClearConfig(t *testing.T, dut *ondatra.DUTDevice) {
+	resetBatch := &gnmi.SetBatch{}
+	gnmi.BatchDelete(resetBatch, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Config())
+
+	tablePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).TableAny()
+	for _, table := range gnmi.LookupAll[*oc.NetworkInstance_Table](t, dut, tablePath.Config()) {
+		if val, ok := table.Val(); ok {
+			if val.GetProtocol() == oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP {
+				t.Logf("FOUND PROTOCOL=%v %v\n", val.GetAddressFamily(), val.GetProtocol())
+				gnmi.BatchDelete(resetBatch, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Table(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, val.GetAddressFamily()).Config())
+			}
+		}
+	}
+	resetBatch.Set(t, dut)
+}
+
 // bgpCreateNbr creates a BGP object with neighbors pointing to ate and returns bgp object.
 func bgpCreateNbr(bgpParams *bgpTestParams) *oc.NetworkInstance_Protocol {
 	d := &oc.Root{}
 	ni1 := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
-	ni_proto := ni1.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
-	bgp := ni_proto.GetOrCreateBgp()
+	niProto := ni1.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
+	bgp := niProto.GetOrCreateBgp()
 	global := bgp.GetOrCreateGlobal()
 	global.As = ygot.Uint32(bgpParams.localAS)
 
@@ -135,7 +152,7 @@ func bgpCreateNbr(bgpParams *bgpTestParams) *oc.NetworkInstance_Protocol {
 	}
 
 	nv4.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Enabled = ygot.Bool(true)
-	return ni_proto
+	return niProto
 }
 
 // Verify BGP capabilities like route refresh as32 and mpbgp.
@@ -259,7 +276,7 @@ func TestEstablishAndDisconnect(t *testing.T) {
 	statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	nbrPath := statePath.Neighbor(ateAttrs.IPv4)
 
-	gnmi.Delete(t, dut, dutConfPath.Config())
+	bgpClearConfig(t, dut)
 	dutConf := bgpCreateNbr(&bgpTestParams{localAS: dutAS, peerAS: ateAS})
 	gnmi.Replace(t, dut, dutConfPath.Config(), dutConf)
 	// Configure Md5 auth password.
@@ -309,7 +326,7 @@ func TestEstablishAndDisconnect(t *testing.T) {
 
 	// Clear config on DUT and ATE
 	topo.StopProtocols(t)
-	gnmi.Delete(t, dut, dutConfPath.Config())
+	bgpClearConfig(t, dut)
 }
 
 // TestPassword is to verify md5 authentication password on DUT.
@@ -333,7 +350,7 @@ func TestPassword(t *testing.T) {
 	statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	nbrPath := statePath.Neighbor(ateAttrs.IPv4)
 
-	gnmi.Delete(t, dut, dutConfPath.Config())
+	bgpClearConfig(t, dut)
 	dutConf := bgpCreateNbr(&bgpTestParams{localAS: dutAS, peerAS: ateAS})
 	gnmi.Replace(t, dut, dutConfPath.Config(), dutConf)
 	t.Log("Configure matching Md5 auth password on DUT")
@@ -349,7 +366,7 @@ func TestPassword(t *testing.T) {
 	iDut1 := topo.AddInterface(ateAttrs.Name).WithPort(port1)
 	iDut1.IPv4().WithAddress(ateAttrs.IPv4CIDR()).WithDefaultGateway(dutAttrs.IPv4)
 	bgpDut1 := iDut1.BGP()
-	bgpDut1.AddPeer().WithPeerAddress(dutAttrs.IPv4).WithLocalASN(ateAS).WithTypeExternal().
+	bgpPeer := bgpDut1.AddPeer().WithPeerAddress(dutAttrs.IPv4).WithLocalASN(ateAS).WithTypeExternal().
 		WithMD5Key(authPassword).WithHoldTime(ateHoldTime)
 
 	t.Log("Pushing config to ATE and starting protocols...")
@@ -362,24 +379,35 @@ func TestPassword(t *testing.T) {
 
 	t.Log("Configure mismatching md5 auth password on DUT")
 	gnmi.Replace(t, dut, dutConfPath.Bgp().Neighbor(ateAttrs.IPv4).AuthPassword().Config(), "PASSWORDNEGSCENARIO")
-	t.Log("Wait till hold time expires...")
-	time.Sleep(time.Second * dutHoldTime)
 
-	t.Log("Verify BGP session state : Should not be in ESTABLISHED state when passwords does not match")
-	status := gnmi.Get(t, dut, nbrPath.SessionState().State())
-	if status == oc.Bgp_Neighbor_SessionState_ESTABLISHED {
-		t.Log("BGP Adjacency is UP when passwords are not matching")
-		t.Errorf("Md5 authentication verification failed, %v", status)
+	// If the DUT will not fail a BGP session when the BGP MD5 key configuration changes,
+	// change the key from the ATE side to time out the session.
+	if *deviations.BGPMD5RequiresReset {
+		bgpPeer.WithMD5Key("PASSWORDNEGSCENARIO-ATE")
+		topo.UpdateBGPPeerStates(t)
+	}
+	t.Log("Wait till hold time expires: BGP should not be in ESTABLISHED state when passwords do not match.")
+	_, ok := gnmi.Watch(t, dut, nbrPath.SessionState().State(), (dutHoldTime+10)*time.Second, func(val *ygnmi.Value[oc.E_Bgp_Neighbor_SessionState]) bool {
+		state, ok := val.Val()
+		return ok && state != oc.Bgp_Neighbor_SessionState_ESTABLISHED
+	}).Await(t)
+	if !ok {
+		fptest.LogQuery(t, "BGP reported state", nbrPath.State(), gnmi.Get(t, dut, nbrPath.State()))
+		t.Error("BGP Adjacency is ESTABLISHED when passwords are not matching")
 	}
 
 	t.Log("Revert md5 auth password on DUT to match with ATE.")
 	gnmi.Replace(t, dut, dutConfPath.Bgp().Neighbor(ateAttrs.IPv4).AuthPassword().Config(), authPassword)
+	if *deviations.BGPMD5RequiresReset {
+		bgpPeer.WithMD5Key(authPassword)
+		topo.UpdateBGPPeerStates(t)
+	}
 	t.Log("Verify BGP session state : Should be ESTABLISHED")
 	gnmi.Await(t, dut, nbrPath.SessionState().State(), time.Second*50, oc.Bgp_Neighbor_SessionState_ESTABLISHED)
 
 	// Clear config on DUT and ATE
 	topo.StopProtocols(t)
-	gnmi.Delete(t, dut, dutConfPath.Config())
+	bgpClearConfig(t, dut)
 }
 
 // TestParameters is to verify normal session establishment and termination
@@ -400,10 +428,9 @@ func TestParameters(t *testing.T) {
 	nbrPath := statePath.Neighbor(ateIP)
 
 	cases := []struct {
-		name      string
-		dutConf   *oc.NetworkInstance_Protocol
-		ateConf   *ondatra.ATETopology
-		wantState *oc.NetworkInstance_Protocol_Bgp
+		name    string
+		dutConf *oc.NetworkInstance_Protocol
+		ateConf *ondatra.ATETopology
 	}{
 		{
 			name:    "Test the eBGP session establishment: Global AS",
@@ -429,7 +456,7 @@ func TestParameters(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Log("Clear BGP Configs on DUT")
-			gnmi.Delete(t, dut, dutConfPath.Config())
+			bgpClearConfig(t, dut)
 			t.Log("Configure BGP Configs on DUT")
 			gnmi.Replace(t, dut, dutConfPath.Config(), tc.dutConf)
 			fptest.LogQuery(t, "DUT BGP Config ", dutConfPath.Config(), gnmi.GetConfig(t, dut, dutConfPath.Config()))
@@ -440,6 +467,11 @@ func TestParameters(t *testing.T) {
 			gnmi.Await(t, dut, nbrPath.SessionState().State(), time.Second*100, oc.Bgp_Neighbor_SessionState_ESTABLISHED)
 			stateDut := gnmi.Get(t, dut, statePath.State())
 			wantState := tc.dutConf.Bgp
+			if *deviations.MissingValueForDefaults {
+				wantState.GetOrCreateGlobal().GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).AfiSafiName = 0
+				wantState.GetOrCreateGlobal().GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Enabled = nil
+				wantState.GetOrCreateNeighbor(ateAttrs.IPv4).Enabled = nil
+			}
 			confirm.State(t, wantState, stateDut)
 			t.Log("Clear BGP Configs on ATE")
 			tc.ateConf.StopProtocols(t)

--- a/feature/experimental/bgp/ate_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
+++ b/feature/experimental/bgp/ate_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
@@ -110,7 +110,6 @@ func bgpClearConfig(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, table := range gnmi.LookupAll[*oc.NetworkInstance_Table](t, dut, tablePath.Config()) {
 		if val, ok := table.Val(); ok {
 			if val.GetProtocol() == oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP {
-				t.Logf("FOUND PROTOCOL=%v %v\n", val.GetAddressFamily(), val.GetProtocol())
 				gnmi.BatchDelete(resetBatch, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Table(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, val.GetAddressFamily()).Config())
 			}
 		}

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -181,4 +181,6 @@ var (
 
 	BGPTrafficTolerance = flag.Int("deviation_bgp_tolerance_value", 0,
 		"Allowed tolerance for BGP traffic flow while comparing for pass or fail condition.")
+
+	BGPMD5RequiresReset = flag.Bool("deviation_bgp_md5_requires_reset", false, "Device requires a BGP session reset to utilize a new MD5 key")
 )


### PR DESCRIPTION

* Add deviation to handle BGP MD5 config changes.  This is required for devices which do not immediately use a new BGP MD5 password with an ESTABLISHED BGP session.
* Add test support for existing MissingValueForDefaults deviation.
* When deleting BGP protocol configuration, remove the /network-instances/network-instance/tables/table and /network-instances/network-instance/protocols/protocol paths together.