### PR TITLE
P4RT-5.1 - wait for packets

### DIFF
--- a/feature/experimental/p4rt/ate_tests/traceroute_packetin_test/packetin_test.go
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetin_test/packetin_test.go
@@ -178,7 +178,7 @@ func testPacketIn(ctx context.Context, t *testing.T, args *testArgs, IsIpv4 bool
 		t.Run(test.desc, func(t *testing.T) {
 			// Extract packets from PacketIn message sent to p4rt client
 			wantPktCnt := int(txPackets[0])
-			packets := fetchPackets(ctx, t, test.client, wantPktCnt, 10*time.Second)
+			packets := fetchPackets(ctx, t, test.client, wantPktCnt, 30*time.Second)
 
 			if !test.expectPass {
 				if len(packets) > 0 {


### PR DESCRIPTION
Currently, the test iterates a fixed number of times trying to fetch at least one packet from the p4rt client to pass. The test fails if the packets are delayed. This PR changes the test to align with P4RT-7.1:
- Query ATE for tx packets count
- Try to receive the expected packets for a duration