### PR TITLE
Add functional tests for gRIBI MPLS support.

### DIFF
--- a/feature/gribi/mpls/tests/compliance.go
+++ b/feature/gribi/mpls/tests/compliance.go
@@ -1,0 +1,409 @@
+// Package gribi_mpls_compliance_test defines additional compliance
+// tests for gRIBI that relate to programming MPLS entries.
+package gribi_mpls_compliance_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/openconfig/gribigo/chk"
+	"github.com/openconfig/gribigo/client"
+	"github.com/openconfig/gribigo/compliance"
+	"github.com/openconfig/gribigo/constants"
+	"github.com/openconfig/gribigo/fluent"
+	"go.uber.org/atomic"
+)
+
+var (
+	// electionID is the global election ID used between test cases.
+	electionID = atomic.Uint64{}
+)
+
+func init() {
+	// Ensure that the election ID starts at 1.
+	electionID.Store(1)
+}
+
+// flushServer removes all entries from the server and can be called between
+// test cases in order to remove the server's RIB contents.
+func flushServer(c *fluent.GRIBIClient, t *testing.T) {
+	ctx := context.Background()
+	c.Start(ctx, t)
+	defer c.Stop(t)
+
+	if _, err := c.Flush().
+		WithElectionOverride().
+		WithAllNetworkInstances().
+		Send(); err != nil {
+		t.Fatalf("could not remove all entries from server, got: %v", err)
+	}
+}
+
+// TrafficFunc defines a function that can be run following the compliance
+// test. Functions are called with two arguments, a testing.T that is called
+// with test results, and the packet's label stack.
+type TrafficFunc func(t *testing.T, labelStack []uint32)
+
+// modify performs a set of operations (in ops) on the supplied gRIBI client,
+// reporting errors via t.
+func modify(ctx context.Context, t *testing.T, c *fluent.GRIBIClient, ops []func()) []*client.OpResult {
+	c.Connection().
+		WithRedundancyMode(fluent.ElectedPrimaryClient).
+		WithInitialElectionID(electionID.Load(), 0)
+
+	return compliance.DoModifyOps(c, t, ops, fluent.InstalledInRIB, false)
+}
+
+// EgressLabelStack defines a test that programs a DUT via gRIBI with a
+// label forwarding entry within defaultNIName, with a label stack with
+// numLabels in it, starting at baseLabel. After the DUT has been programmed
+// if trafficFunc is non-nil it is run to validate the dataplane.
+func EgressLabelStack(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, baseLabel, numLabels int, trafficFunc TrafficFunc) {
+	defer electionID.Inc()
+	defer flushServer(c, t)
+
+	labels := []uint32{}
+	for n := 1; n <= numLabels; n++ {
+		labels = append(labels, uint32(baseLabel+n))
+	}
+	// add a label that is the top of the stack that is
+	// the one that is forwarded on.
+	labels = append(labels, uint32(32768))
+
+	ops := []func(){
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopEntry().
+					WithNetworkInstance(defaultNIName).
+					WithIndex(1).
+					WithIPAddress("192.0.2.2").
+					WithPushedLabelStack(labels...))
+
+			c.Modify().AddEntry(t,
+				fluent.NextHopGroupEntry().
+					WithNetworkInstance(defaultNIName).
+					WithID(1).
+					AddNextHop(1, 1))
+
+			c.Modify().AddEntry(t,
+				fluent.LabelEntry().
+					WithLabel(100).
+					WithNetworkInstance(defaultNIName).
+					WithNextHopGroup(1))
+		},
+	}
+
+	res := modify(context.Background(), t, c, ops)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithMPLSOperation(100).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopGroupOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	if trafficFunc != nil {
+		t.Run(fmt.Sprintf("%d labels, traffic test", numLabels), func(t *testing.T) {
+			trafficFunc(t, labels)
+		})
+	}
+}
+
+// PushToIPPacket programs a gRIBI entry for an ingress LER function whereby MPLS labels are
+// pushed to an IP packet. The entries are programmed into defaultNIName, with the stack
+// imposed being a stack of numLabels labels, starting with baseLabel. After the programming
+// has been verified trafficFunc is run to allow validation of the dataplane.
+func PushToIPPacket(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, baseLabel, numLabels int, trafficFunc TrafficFunc) {
+	defer electionID.Inc()
+	defer flushServer(c, t)
+
+	c.Connection().
+		WithRedundancyMode(fluent.ElectedPrimaryClient).
+		WithInitialElectionID(electionID.Load(), 0)
+
+	labels := []uint32{}
+	for n := 1; n <= numLabels; n++ {
+		labels = append(labels, uint32(baseLabel+n))
+	}
+
+	ops := []func(){
+		// Set up, ensure that the label that we will use to forward is resolvable.
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopEntry().
+					WithNetworkInstance(defaultNIName).
+					WithIndex(1).
+					WithPushedLabelStack(labels...))
+
+			c.Modify().AddEntry(t,
+				fluent.NextHopGroupEntry().
+					WithNetworkInstance(defaultNIName).
+					WithID(1).
+					AddNextHop(1, 1))
+
+			c.Modify().AddEntry(t,
+				fluent.IPv4Entry().
+					WithPrefix("10.0.0.0/24").
+					WithNetworkInstance(defaultNIName).
+					WithNextHopGroupNetworkInstance(defaultNIName).
+					WithNextHopGroup(1))
+		},
+	}
+
+	res := modify(context.Background(), t, c, ops)
+	t.Logf("received gRIBI results from server, %v", res)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithIPv4Operation("10.0.0.0/24").
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopGroupOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	if trafficFunc != nil {
+		t.Run(fmt.Sprintf("%d label push, traffic test", numLabels), func(t *testing.T) {
+			trafficFunc(t, labels)
+		})
+	}
+}
+
+// PopTopLabel creates a test whereby the top label of an input packet is popped. The
+// next-hop specifying the pop is referenced by an IPv4Entry for the 10.0.0.0/24 prefix
+// and an MPLS label forwarding entry with outer label 100.
+func PopTopLabel(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, trafficFunc TrafficFunc) {
+	defer electionID.Inc()
+	defer flushServer(c, t)
+
+	ops := []func(){
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopEntry().
+					WithNetworkInstance(defaultNIName).
+					WithIndex(1).
+					WithIPAddress("192.0.2.2").
+					WithPopTopLabel())
+
+			c.Modify().AddEntry(t,
+				fluent.NextHopGroupEntry().
+					WithNetworkInstance(defaultNIName).
+					WithID(1).
+					AddNextHop(1, 1))
+
+			// Specify MPLS label that is pointed to our pop next-hop.
+			c.Modify().AddEntry(t,
+				fluent.LabelEntry().
+					WithLabel(100).
+					WithNetworkInstance(defaultNIName).
+					WithNextHopGroupNetworkInstance(defaultNIName).
+					WithNextHopGroup(1))
+
+			// Specify IP prefix that is pointed to our pop next-hop.
+			c.Modify().AddEntry(t,
+				fluent.IPv4Entry().
+					WithPrefix("10.0.0.0/24").
+					WithNetworkInstance(defaultNIName).
+					WithNextHopGroup(1))
+		},
+	}
+
+	res := modify(context.Background(), t, c, ops)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithIPv4Operation("10.0.0.0/24").
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopGroupOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	if trafficFunc != nil {
+		t.Run("pop-top-label, traffic test", func(t *testing.T) {
+			trafficFunc(t, nil)
+		})
+	}
+}
+
+// PopNLabels programs a gRIBI server with a LFIB entry matching label 100
+// that pops the labels specified in popLabels from the stack. If trafficFunc
+// is non-nil it is called after the gRIBI programming is verified.
+func PopNLabels(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, popLabels []uint32, trafficFunc TrafficFunc) {
+	defer electionID.Inc()
+	defer flushServer(c, t)
+
+	ops := []func(){
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopEntry().
+					WithNetworkInstance(defaultNIName).
+					WithIndex(1).
+					WithIPAddress("192.0.2.2"))
+
+			c.Modify().AddEntry(t,
+				fluent.NextHopGroupEntry().
+					WithNetworkInstance(defaultNIName).
+					WithID(1).
+					AddNextHop(1, 1))
+
+			c.Modify().AddEntry(t,
+				fluent.LabelEntry().
+					WithLabel(100).
+					WithPoppedLabelStack(popLabels...).
+					WithNetworkInstance(defaultNIName).
+					WithNextHopGroup(1))
+		},
+	}
+
+	res := modify(context.Background(), t, c, ops)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithMPLSOperation(100).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopGroupOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	if trafficFunc != nil {
+		t.Run("pop-n-labels, traffic test", func(t *testing.T) {
+			trafficFunc(t, nil)
+		})
+	}
+}
+
+// PopOnePushN implements a test whereby one (the top) label is popped, and N labels as specified
+// by pushLabels are pushed to the stack for an input MPLS packet. Two LFIB entries (100 and 200)
+// are created. If trafficFunc is non-nil it is called after the gRIBI programming has been validated.
+func PopOnePushN(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, pushLabels []uint32, trafficFunc TrafficFunc) {
+	defer electionID.Inc()
+	defer flushServer(c, t)
+
+	ops := []func(){
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopEntry().
+					WithNetworkInstance(defaultNIName).
+					WithIndex(1).
+					WithIPAddress("192.0.2.2").
+					WithPopTopLabel().
+					WithPushedLabelStack(pushLabels...))
+
+			c.Modify().AddEntry(t,
+				fluent.NextHopGroupEntry().
+					WithNetworkInstance(defaultNIName).
+					WithID(1).
+					AddNextHop(1, 1))
+
+			for _, label := range []uint32{100, 200} {
+				c.Modify().AddEntry(t,
+					fluent.LabelEntry().
+						WithLabel(label).
+						WithNetworkInstance(defaultNIName).
+						WithNextHopGroup(1))
+			}
+		},
+	}
+
+	res := modify(context.Background(), t, c, ops)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopGroupOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	for _, label := range []uint64{100, 200} {
+		chk.HasResult(t, res,
+			fluent.OperationResult().
+				WithMPLSOperation(label).
+				WithProgrammingResult(fluent.InstalledInRIB).
+				WithOperationType(constants.Add).
+				AsResult(),
+			chk.IgnoreOperationID())
+	}
+
+	if trafficFunc != nil {
+		t.Run("pop-one-push-N, traffic test", func(t *testing.T) {
+			trafficFunc(t, nil)
+		})
+	}
+}

--- a/feature/gribi/mpls/tests/compliance_test.go
+++ b/feature/gribi/mpls/tests/compliance_test.go
@@ -1,0 +1,107 @@
+package gribi_mpls_compliance_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/gribigo/fluent"
+	"github.com/openconfig/ondatra"
+)
+
+const (
+	// defNIName specifies the default network instance name to be used.
+	defNIName = "default"
+	// baseLabel specifies the lower bound label used within a stack.
+	baseLabel = 42
+)
+
+func TestMain(m *testing.M) {
+	fptest.RunTests(m)
+}
+
+// Test cases to write:
+//	* push(N) labels, N = 1-20.
+//	* pop(1) - terminating action
+//	* pop(1) + push(N)
+//	* pop(all) + push(N)
+
+// TestMPLSLabelPushDepth validates the gRIBI actions that are used to push N labels onto
+// a packet as part of routing towards a next-hop. Note that this test does not
+// validate against the dataplane, but solely the gRIBI control-plane support.
+func TestMPLSLabelPushDepth(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	gribic := dut.RawAPIs().GRIBI().Default(t)
+	c := fluent.NewClient()
+	c.Connection().WithStub(gribic)
+
+	baseLabel := 42
+	for i := 1; i <= 20; i++ {
+		t.Run(fmt.Sprintf("push %d labels", i), func(t *testing.T) {
+			EgressLabelStack(t, c, defNIName, baseLabel, i, nil)
+		})
+	}
+}
+
+// TestMPLSPushToIP validates the gRIBI actions that are used to push N labels onto
+// an IP packet. Note that this test does not validate against the dataplane.
+func TestMPLSPushToIP(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	gribic := dut.RawAPIs().GRIBI().Default(t)
+	c := fluent.NewClient()
+	c.Connection().WithStub(gribic)
+
+	baseLabel := 42
+	numLabels := 20
+	for i := 1; i <= numLabels; i++ {
+		t.Run(fmt.Sprintf("push %d labels to IP", i), func(t *testing.T) {
+			PushToIPPacket(t, c, defNIName, baseLabel, i, nil)
+		})
+	}
+}
+
+// TestPopTopLabel validates the gRIBI actions that are used to pop the top label
+// when specified in a next-hop.
+func TestPopTopLabel(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	gribic := dut.RawAPIs().GRIBI().Default(t)
+	c := fluent.NewClient()
+	c.Connection().WithStub(gribic)
+
+	PopTopLabel(t, c, defNIName, nil)
+}
+
+// TestPopNLabels validates the gRIBI actions that are used to pop N labels from a
+// label stack when specified in a next-hop.
+func TestPopNLabels(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	gribic := dut.RawAPIs().GRIBI().Default(t)
+	c := fluent.NewClient()
+	c.Connection().WithStub(gribic)
+
+	for _, stack := range [][]uint32{{100}, {100, 42}, {100, 42, 43, 44, 45}} {
+		t.Run(fmt.Sprintf("pop N labels, stack %v", stack), func(t *testing.T) {
+			PopNLabels(t, c, defNIName, stack, nil)
+		})
+	}
+}
+
+// TestPopOnePushN validates the gRIBI actions that are used to pop 1 label and then
+// push N when specified in a next-hop.
+func TestPopOnePushN(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	gribic := dut.RawAPIs().GRIBI().Default(t)
+	c := fluent.NewClient()
+	c.Connection().WithStub(gribic)
+
+	stacks := [][]uint32{
+		{100}, // swap for label 100, pop+push for label 200
+		{100, 200, 300, 400},
+		{100, 200, 300, 400, 500, 600},
+	}
+	for _, stack := range stacks {
+		t.Run(fmt.Sprintf("pop one, push N, stack: %v", stack), func(t *testing.T) {
+			PopOnePushN(t, c, defNIName, stack, nil)
+		})
+	}
+}


### PR DESCRIPTION
```
 * (M) mpls/tests/compliance.go
 * (M) mpls/tests/compliance_test.go
  - Add testing for MPLS support for gRIBI. These tests operate only at
    the gRIBI layer and extend the set of compliance tests that are to
    be implemented. They do not use OTG or ATE.
```
