### PR TITLE
TE-3.7 and TE-6.2: Enabling "ExplicitGribiUnderNetworkInstance" deviation

### DIFF
--- a/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -266,6 +266,10 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
+	if *deviations.ExplicitGribiUnderNetworkInstance {
+		fptest.EnableGribiUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGribiUnderNetworkInstance(t, dut, vrfName)
+	}
 }
 
 // createFlow returns a flow from atePort1 to the dstPfx, expected to arrive on ATE interface dsts.

--- a/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -323,7 +323,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	if *deviations.ExplicitInterfaceInDefaultVRF {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-
+	if *deviations.ExplicitGribiUnderNetworkInstance {
+		fptest.EnableGribiUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+	}
 }
 
 // configureATE configures port1, port2 on the ATE.
@@ -356,6 +358,9 @@ func configureNetworkInstance(t *testing.T, dut *ondatra.DUTDevice) {
 	niIntf.Interface = ygot.String(p1.Name())
 
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(nonDefaultVRF).Config(), nonDefaultNI)
+	if *deviations.ExplicitGribiUnderNetworkInstance {
+		fptest.EnableGribiUnderNetworkInstance(t, dut, nonDefaultVRF)
+	}
 }
 
 // networkInstance creates an OpenConfig network instance with the specified name

--- a/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -278,6 +278,10 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
+	if *deviations.ExplicitGribiUnderNetworkInstance {
+		fptest.EnableGribiUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGribiUnderNetworkInstance(t, dut, vrfName)
+	}
 }
 
 // createFlow returns a flow from atePort1 to the dstPfx, expected to arrive on ATE interface dsts.

--- a/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -311,7 +311,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	if *deviations.ExplicitInterfaceInDefaultVRF {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-
+	if *deviations.ExplicitGribiUnderNetworkInstance {
+		fptest.EnableGribiUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+	}
 }
 
 // configureATE configures port1, port2 on the ATE.
@@ -348,6 +350,9 @@ func configureNetworkInstance(t *testing.T, dut *ondatra.DUTDevice) {
 	niIntf.Interface = ygot.String(p1.Name())
 
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(nonDefaultVRF).Config(), nonDefaultNI)
+	if *deviations.ExplicitGribiUnderNetworkInstance {
+		fptest.EnableGribiUnderNetworkInstance(t, dut, nonDefaultVRF)
+	}
 }
 
 // networkInstance creates an OpenConfig network instance with the specified name

--- a/internal/fptest/networkinstance.go
+++ b/internal/fptest/networkinstance.go
@@ -46,7 +46,7 @@ func AssignToNetworkInstance(t testing.TB, d *ondatra.DUTDevice, i string, ni st
 	}
 }
 
-// EnableGribiOnNetworkInstance enables Gribi protocol under network instance.
+// EnableGribiUnderNetworkInstance enables Gribi protocol under network instance.
 func EnableGribiUnderNetworkInstance(t testing.TB, d *ondatra.DUTDevice, ni string) {
 	t.Helper()
 	if ni == "" {


### PR DESCRIPTION
Adding deviation to enable gribi explicitly under network-instance.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."