### PR TITLE
Adding MissingIsisInterfaceAfiSafiEnable deviation to gNMI-1.2

### DIFF
--- a/feature/experimental/system/gnmi/benchmarking/ate_tests/internal/setup/setup.go
+++ b/feature/experimental/system/gnmi/benchmarking/ate_tests/internal/setup/setup.go
@@ -200,7 +200,10 @@ func BuildBenchmarkingConfig(t *testing.T) *oc.Root {
 
 		isisIntfLevelAfi := isisIntfLevel.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST)
 		isisIntfLevelAfi.Metric = ygot.Uint32(200)
-		isisIntfLevelAfi.Enabled = ygot.Bool(true)
+		// Configure ISIS enable flag at interface level
+		if *deviations.MissingIsisInterfaceAfiSafiEnable {
+			isisIntfLevelAfi.Enabled = ygot.Bool(true)
+		}
 	}
 	p := gnmi.OC()
 	fptest.LogQuery(t, "DUT", p.Config(), d)

--- a/feature/experimental/system/gnmi/benchmarking/ate_tests/internal/setup/setup.go
+++ b/feature/experimental/system/gnmi/benchmarking/ate_tests/internal/setup/setup.go
@@ -200,8 +200,11 @@ func BuildBenchmarkingConfig(t *testing.T) *oc.Root {
 
 		isisIntfLevelAfi := isisIntfLevel.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST)
 		isisIntfLevelAfi.Metric = ygot.Uint32(200)
-		// Configure ISIS enable flag at interface level
+
+		// Configure ISIS AfiSafi enable flag at the global level
 		if *deviations.MissingIsisInterfaceAfiSafiEnable {
+			isisIntf.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled = ygot.Bool(true)
+		} else {
 			isisIntfLevelAfi.Enabled = ygot.Bool(true)
 		}
 	}


### PR DESCRIPTION
- Adding MissingIsisInterfaceAfiSafiEnable deviation for ISIS configs to gNMI-1.2