### PR TITLE
Renaming GribiUnderNetworkInstance to GRIBIUnderNetworkInstance

### DIFF
--- a/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -266,9 +266,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-	if *deviations.ExplicitGribiUnderNetworkInstance {
-		fptest.EnableGribiUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
-		fptest.EnableGribiUnderNetworkInstance(t, dut, vrfName)
+	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrfName)
 	}
 }
 

--- a/feature/gribi/ate_tests/gribigo_compliance_test/gribigo_compliance_test.go
+++ b/feature/gribi/ate_tests/gribigo_compliance_test/gribigo_compliance_test.go
@@ -194,9 +194,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	ni := d.GetOrCreateNetworkInstance(*nonDefaultNI)
 	ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*nonDefaultNI).Config(), ni)
-	if *deviations.ExplicitGribiUnderNetworkInstance {
-		fptest.EnableGribiUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
-		fptest.EnableGribiUnderNetworkInstance(t, dut, *nonDefaultNI)
+	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *nonDefaultNI)
 	}
 	nip := gnmi.OC().NetworkInstance(*nonDefaultNI)
 	fptest.LogQuery(t, "nonDefaultNI", nip.Config(), gnmi.GetConfig(t, dut, nip.Config()))

--- a/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -323,8 +323,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	if *deviations.ExplicitInterfaceInDefaultVRF {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-	if *deviations.ExplicitGribiUnderNetworkInstance {
-		fptest.EnableGribiUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 	}
 }
 
@@ -358,8 +358,8 @@ func configureNetworkInstance(t *testing.T, dut *ondatra.DUTDevice) {
 	niIntf.Interface = ygot.String(p1.Name())
 
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(nonDefaultVRF).Config(), nonDefaultNI)
-	if *deviations.ExplicitGribiUnderNetworkInstance {
-		fptest.EnableGribiUnderNetworkInstance(t, dut, nonDefaultVRF)
+	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, nonDefaultVRF)
 	}
 }
 

--- a/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -278,9 +278,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-	if *deviations.ExplicitGribiUnderNetworkInstance {
-		fptest.EnableGribiUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
-		fptest.EnableGribiUnderNetworkInstance(t, dut, vrfName)
+	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrfName)
 	}
 }
 

--- a/feature/gribi/otg_tests/gribigo_compliance_test/gribigo_compliance_test.go
+++ b/feature/gribi/otg_tests/gribigo_compliance_test/gribigo_compliance_test.go
@@ -176,9 +176,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	ni := d.GetOrCreateNetworkInstance(*nonDefaultNI)
 	ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*nonDefaultNI).Config(), ni)
-	if *deviations.ExplicitGribiUnderNetworkInstance {
-		fptest.EnableGribiUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
-		fptest.EnableGribiUnderNetworkInstance(t, dut, *nonDefaultNI)
+	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *nonDefaultNI)
 	}
 
 	nip := gnmi.OC().NetworkInstance(*nonDefaultNI)

--- a/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -311,8 +311,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	if *deviations.ExplicitInterfaceInDefaultVRF {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-	if *deviations.ExplicitGribiUnderNetworkInstance {
-		fptest.EnableGribiUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 	}
 }
 
@@ -350,8 +350,8 @@ func configureNetworkInstance(t *testing.T, dut *ondatra.DUTDevice) {
 	niIntf.Interface = ygot.String(p1.Name())
 
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(nonDefaultVRF).Config(), nonDefaultNI)
-	if *deviations.ExplicitGribiUnderNetworkInstance {
-		fptest.EnableGribiUnderNetworkInstance(t, dut, nonDefaultVRF)
+	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, nonDefaultVRF)
 	}
 }
 

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -182,7 +182,7 @@ var (
 	BGPTrafficTolerance = flag.Int("deviation_bgp_tolerance_value", 0,
 		"Allowed tolerance for BGP traffic flow while comparing for pass or fail condition.")
 
-	ExplicitGribiUnderNetworkInstance = flag.Bool("deviation_explicit_gribi_under_network_instance", false,
+	ExplicitGRIBIUnderNetworkInstance = flag.Bool("deviation_explicit_gribi_under_network_instance", false,
 		"Device requires gribi-protocol to be enabled under network-instance.")
 
 	BGPMD5RequiresReset = flag.Bool("deviation_bgp_md5_requires_reset", false, "Device requires a BGP session reset to utilize a new MD5 key")

--- a/internal/fptest/networkinstance.go
+++ b/internal/fptest/networkinstance.go
@@ -46,8 +46,8 @@ func AssignToNetworkInstance(t testing.TB, d *ondatra.DUTDevice, i string, ni st
 	}
 }
 
-// EnableGribiUnderNetworkInstance enables Gribi protocol under network instance.
-func EnableGribiUnderNetworkInstance(t testing.TB, d *ondatra.DUTDevice, ni string) {
+// EnableGRIBIUnderNetworkInstance enables GRIBI protocol under network instance.
+func EnableGRIBIUnderNetworkInstance(t testing.TB, d *ondatra.DUTDevice, ni string) {
 	t.Helper()
 	if ni == "" {
 		t.Fatalf("Network instance not provided for gRIBI protocol definition")


### PR DESCRIPTION
Changes are made for 2 usage -
   1. For variable - ExplicitGRIBIUnderNetworkInstance
   2. For function - EnableGRIBIUnderNetworkInstance
  
Reference - https://github.com/openconfig/featureprofiles/pull/1222#discussion_r1128242618

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."