### PR TITLE
gnoi-3.3: use gnmi.Watch.Await() to retrieve LastSwitchoverTime

### DIFF
--- a/feature/gnoi/system/tests/supervisor_switchover_test/supervisor_switchover_test.go
+++ b/feature/gnoi/system/tests/supervisor_switchover_test/supervisor_switchover_test.go
@@ -180,10 +180,12 @@ func TestSupervisorSwitchover(t *testing.T) {
 
 	t.Log("Validate OC Switchover time/reason.")
 	activeRP := gnmi.OC().Component(rpActiveAfterSwitch)
-	if got, want := gnmi.Lookup(t, dut, activeRP.LastSwitchoverTime().State()).IsPresent(), true; got != want {
-		t.Errorf("activeRP.LastSwitchoverTime().Lookup(t).IsPresent(): got %v, want %v", got, want)
+
+	swTime, swTimePresent := gnmi.Watch(t, dut, activeRP.LastSwitchoverTime().State(), 1*time.Minute, func(val *ygnmi.Value[uint64]) bool { return val.IsPresent() }).Await(t)
+	if !swTimePresent {
+		t.Errorf("activeRP.LastSwitchoverTime().Watch(t).IsPresent(): got %v, want %v", swTimePresent, !swTimePresent)
 	} else {
-		t.Logf("Found activeRP.LastSwitchoverTime(): %v", gnmi.Get(t, dut, activeRP.LastSwitchoverTime().State()))
+		t.Logf("Found activeRP.LastSwitchoverTime(): %v", swTime)
 	}
 
 	if got, want := gnmi.Lookup(t, dut, activeRP.LastSwitchoverReason().State()).IsPresent(), true; got != want {


### PR DESCRIPTION
- Replace gnmi.Lookup with Gnmi.Watch().Await() for LastSwitchoverTime retrieval after performing a switchover

---
<sup>
This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.</sup>