### PR TITLE
Updated test step for ATE port-2 and DUT port-2 config with subinterface indices

### DIFF
--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/README.md
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/README.md
@@ -13,20 +13,17 @@ Configure ATE and DUT:
 
 *   Create a non-default VRF (VRF-1) that includes DUT port-1.
 
-*   For DUT port-2 interface, create a subinterface with Index 0 and IPv4
-    address 192.0.2.5, not in a VLAN.
+*   On DUT port-2 and ATE port-2 create 18 L3 sub-interfaces each with a /30
+    subnet as below:
 
-*   For ATE port-2, create a subinterface with IPv4 address 192.0.2.6 and
-    Default Gateway of 192.0.2.5, not in a VLAN.
+    *   On DUT port-2, create subinterfaces with indices 1 to 18 mapped to VLAN
+        IDs 1 to 18 and corressponding IPv4 addresses 192.0.2.5, 192.0.2.9, ...,
+        192.0.2.73 respectively.
 
-*   Repeat for 18 more subinterfaces in a VLAN configuration:
-
-    *   For DUT port-2, subinterfaces indices 1...18 with VLAN IDs 1...18 and
-        corresponding IPv4 addresses 192.0.2.9 ... 192.0.2.73
-
-    *   For ATE port-2, subinterfaces with VLAN IDs 1...18 and corresponding
-        IPv4 addresses 192.0.2.10 ... 192.0.2.79 with default gateways of
-        192.0.2.9 ... 192.0.2.78
+    *   On ATE port-2, create subinterfaces with indices 1 to 18 mapped to VLAN
+        IDs 1 to 18 and corresponding IPv4 addresses 192.0.2.6, 192.0.2.10, ...,
+        192.0.2.74 and default gateways as 192.0.2.5, 192.0.2.9, ..., 192.0.2.73
+        respectively.
 
 Test case for basic hierarchical weight:
 


### PR DESCRIPTION
Updated test step for ATE port-2 and DUT port-2 config with subinterface indices. This is duplicate of PR#1086. Raised this PR as 1086 is having CLA issue. 