### PR TITLE
Update experimental bursty_traffic_test.go to check TransmitOctets and DroppedOctets counters

### DIFF
--- a/feature/experimental/qos/ate_tests/bursty_traffic_test/README.md
+++ b/feature/experimental/qos/ate_tests/bursty_traffic_test/README.md
@@ -32,9 +32,8 @@ Verify that DUT does not drop bursty traffic.
 
     *   NC1 will have strict priority queues
         *   AF4/AF3/AF2/AF1/BE1/BE0 will use WRR queues.
-    *   NC1 and AF4 will have strict priority queues with NC1 having higher
-        priority.
-        *   AF3, AF2, AF1, BE1 and BE0 will use WRR queues.
+    *   NC1 will have strict priority queue.
+        *   AF4, AF3, AF2, AF1, BE1 and BE0 will use WRR queues.
 
 *   Test results should be independent of the location of interfaces. For
     example, 2 input interfaces and output interface could be located on
@@ -66,8 +65,8 @@ Verify that DUT does not drop bursty traffic.
 
     *   Configure strict priority queues for NC1 and AF4 with NC1 having higher
         priority.
-    *   Configure WRR for AF3, AF2, AF1, BE0 and BE1 with weight 32, 16, 8, 4
-        and 1 respectively.
+    *   Configure WRR for AF4, AF3, AF2, AF1, BE0 and BE1 with weight 48, 12, 8,
+        4, 1 and 1 respectively.
 
 *   Verify that there is no traffic loss with bursty traffic
 


### PR DESCRIPTION
QoS: Check TransmitOctets and DroppedOctets counters are updated in addition to TransmitPkts and DroppedPkts

- TransmitPkts
- TransmitOctets
- DroppedPkts
- DroppedOctets

The change is similar to https://github.com/openconfig/featureprofiles/pull/1219