### PR TITLE
TE-11.3: Enabling deviation, updating NH index to integer and adding network-instance for DECAP lookup

### DIFF
--- a/feature/experimental/gribi/ate_tests/backup_nhg_action/backup_nhg_action_test.go
+++ b/feature/experimental/gribi/ate_tests/backup_nhg_action/backup_nhg_action_test.go
@@ -246,7 +246,7 @@ func testBackupDecap(ctx context.Context, t *testing.T, args *testArgs) {
 	t.Logf("Adding NH %d with atePort2 via gRIBI", NH1ID)
 	args.client.AddNH(t, NH1ID, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
 	t.Logf("Adding NH %d as decap and NHGs %d, %d via gRIBI", NH2ID, NH1ID, NH2ID)
-	args.client.AddNH(t, NH2ID, "Decap", *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHOptions{VrfName: *deviations.DefaultNetworkInstance})
+	args.client.AddNH(t, NH2ID, "Decap", *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
 	args.client.AddNHG(t, NH2ID, map[uint64]uint64{NH2ID: 100}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
 	args.client.AddNHG(t, NH1ID, map[uint64]uint64{NH1ID: 100}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: NH2ID})
 	t.Logf("Adding an IPv4Entry for %s with primary atePort2, backup as Decap via gRIBI", primaryTunnelDstIP)
@@ -286,7 +286,7 @@ func testDecapEncap(ctx context.Context, t *testing.T, args *testArgs) {
 	args.client.AddIPv4(t, secondaryTunnelDstIP+"/"+mask, NH3ID, vrfName, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
 
 	t.Logf("Adding NH %d as decap and NHG %d via gRIBI", NH2ID, NH2ID)
-	args.client.AddNH(t, NH2ID, "Decap", *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHOptions{VrfName: *deviations.DefaultNetworkInstance})
+	args.client.AddNH(t, NH2ID, "Decap", *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
 	args.client.AddNHG(t, NH2ID, map[uint64]uint64{NH2ID: 100}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
 
 	t.Logf("Adding NH %d as DecapEncap and NHG %d via gRIBI", NH1ID, NH1ID)

--- a/internal/gribi/gribi.go
+++ b/internal/gribi/gribi.go
@@ -202,11 +202,14 @@ func (c *Client) AddNH(t testing.TB, nhIndex uint64, address, instance string, e
 	t.Helper()
 	switch address {
 	case "Decap":
-		c.fluentC.Modify().AddEntry(t,
-			fluent.NextHopEntry().
-				WithNetworkInstance(instance).
-				WithIndex(nhIndex).
-				WithDecapsulateHeader(fluent.IPinIP))
+		NH := fluent.NextHopEntry().
+			WithNetworkInstance(instance).
+			WithIndex(nhIndex).
+			WithDecapsulateHeader(fluent.IPinIP)
+		for _, opt := range opts {
+			NH = NH.WithNextHopNetworkInstance(opt.VrfName)
+		}
+		c.fluentC.Modify().AddEntry(t, NH)
 	case "DecapEncap":
 		NH := fluent.NextHopEntry().
 			WithNetworkInstance(instance).

--- a/internal/gribi/gribi.go
+++ b/internal/gribi/gribi.go
@@ -202,14 +202,11 @@ func (c *Client) AddNH(t testing.TB, nhIndex uint64, address, instance string, e
 	t.Helper()
 	switch address {
 	case "Decap":
-		NH := fluent.NextHopEntry().
-			WithNetworkInstance(instance).
-			WithIndex(nhIndex).
-			WithDecapsulateHeader(fluent.IPinIP)
-		for _, opt := range opts {
-			NH = NH.WithNextHopNetworkInstance(opt.VrfName)
-		}
-		c.fluentC.Modify().AddEntry(t, NH)
+		c.fluentC.Modify().AddEntry(t,
+			fluent.NextHopEntry().
+				WithNetworkInstance(instance).
+				WithIndex(nhIndex).
+				WithDecapsulateHeader(fluent.IPinIP))
 	case "DecapEncap":
 		NH := fluent.NextHopEntry().
 			WithNetworkInstance(instance).


### PR DESCRIPTION
There are 2 changes made here -
   1. Enabling following deviations - 
           - `ExplicitInterfaceInDefaultVRF`
           - `ExplicitPortSpeed` 
           - `ExplicitGRIBIUnderNetworkInstance`
   2. Updating static-route NextHop index to an integer

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."