### PR TITLE
TE-3.2: Enabling ExplicitPortSpeed deviation

### DIFF
--- a/feature/gribi/ate_tests/weighted_balancing_test/setup_test.go
+++ b/feature/gribi/ate_tests/weighted_balancing_test/setup_test.go
@@ -181,6 +181,11 @@ func configureDUT(t testing.TB, dut *ondatra.DUTDevice) {
 			fptest.AssignToNetworkInstance(t, dut, dp.Name(), *deviations.DefaultNetworkInstance, 0)
 		}
 	}
+	if *deviations.ExplicitPortSpeed {
+		for _, dp := range dut.Ports() {
+			fptest.SetPortSpeed(t, dp)
+		}
+	}
 }
 
 // configureATE configures the topology of the ATE.

--- a/internal/fptest/portspeed.go
+++ b/internal/fptest/portspeed.go
@@ -42,7 +42,7 @@ var portSpeed = map[ondatra.Speed]oc.E_IfEthernet_ETHERNET_SPEED{
 
 // SetPortSpeed sets the DUT config for the interface port-speed according
 // to ondatra.Prot.Speed()
-func SetPortSpeed(t *testing.T, p *ondatra.Port) {
+func SetPortSpeed(t testing.TB, p *ondatra.Port) {
 	speed, ok := portSpeed[p.Speed()]
 	if !ok {
 		// Port speed is unspecified or unrecognized. Explicit config not performed


### PR DESCRIPTION

Enabling ExplicitPortSpeed deviation for TE-3.2, to achieve this `SetPortSpeed` function needs to be updated to accept `testing.TB` , similar to change made for another deviation - https://github.com/openconfig/featureprofiles/pull/948#issuecomment-1385848941.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."