### PR TITLE
New deviation flag for include the IP config enabled explicitly when …

### DIFF
--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -198,6 +198,13 @@ func configNetworkInstance(t *testing.T, dut *ondatra.DUTDevice, vrfname string,
 	} else {
 		si.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
 	}
+
+	// When create vlan sub interface, include the IP config enabled explicitly
+	if *deviations.VlanSubInterfaceIPConfigEnabled {
+		s4 := si.GetOrCreateIpv4()
+		s4.Enabled = ygot.Bool(true)
+	}
+
 	gnmi.Replace(t, dut, gnmi.OC().Interface(intfname).Subinterface(subint).Config(), si)
 
 	// create vrf and apply on subinterface

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -194,6 +194,13 @@ func configNetworkInstance(t *testing.T, dut *ondatra.DUTDevice, vrfname string,
 	// create empty subinterface
 	si := &oc.Interface_Subinterface{}
 	si.Index = ygot.Uint32(subint)
+
+	// When create vlan sub interface, include the IP config enabled explicitly
+	if *deviations.VlanSubInterfaceIPConfigEnabled {
+		s4 := si.GetOrCreateIpv4()
+		s4.Enabled = ygot.Bool(true)
+	}
+
 	gnmi.Replace(t, dut, gnmi.OC().Interface(intfname).Subinterface(subint).Config(), si)
 
 	// create vrf and apply on subinterface

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -186,4 +186,6 @@ var (
 		"Device requires gribi-protocol to be enabled under network-instance.")
 
 	BGPMD5RequiresReset = flag.Bool("deviation_bgp_md5_requires_reset", false, "Device requires a BGP session reset to utilize a new MD5 key")
+
+	VlanSubInterfaceIPConfigEnabled = flag.Bool("deviation_vlan_sub_interface_ip_config_enabled", false, "When create vlan sub interface, include the IP config enabled explicitly")
 )


### PR DESCRIPTION
…create vlan sub interface

With this new deviation flag, the IP config enabled element could be turned on of off depends on vendor and/or platform whatever applicable.
