### PR TITLE
Add link qualification GNOI client to Ondatra binding

### DIFF
--- a/topologies/binding/gnoi.go
+++ b/topologies/binding/gnoi.go
@@ -29,6 +29,7 @@ import (
 	mpb "github.com/openconfig/gnoi/mpls"
 	ospb "github.com/openconfig/gnoi/os"
 	otpb "github.com/openconfig/gnoi/otdr"
+	plqpb "github.com/openconfig/gnoi/packet_link_qualification"
 	spb "github.com/openconfig/gnoi/system"
 	wpb "github.com/openconfig/gnoi/wavelength_router"
 )
@@ -57,6 +58,9 @@ func (g gnoiConn) Interface() ipb.InterfaceClient {
 }
 func (g gnoiConn) Layer2() lpb.Layer2Client {
 	return lpb.NewLayer2Client(g.conn)
+}
+func (g gnoiConn) LinkQualification() plqpb.LinkQualificationClient {
+	return plqpb.NewLinkQualificationClient(g.conn)
 }
 func (g gnoiConn) MPLS() mpb.MPLSClient  { return mpb.NewMPLSClient(g.conn) }
 func (g gnoiConn) OS() ospb.OSClient     { return ospb.NewOSClient(g.conn) }


### PR DESCRIPTION
The [Packet-based Link Qualification](https://github.com/openconfig/featureprofiles/blob/main/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/README.md) test needs the GNOI LinkQualification service.