### PR TITLE
RT-5.1: Enabling deviation ExplicitInterfaceInDefaultVRF and ExplicitPortSpeed

### DIFF
--- a/feature/interface/singleton/ate_tests/singleton_test/singleton_test.go
+++ b/feature/interface/singleton/ate_tests/singleton_test/singleton_test.go
@@ -60,7 +60,7 @@ var (
 		Desc:    "DUT to ATE source",
 		IPv4:    "192.0.2.1",
 		IPv6:    "2001:db8::1",
-		MAC:     "02:1a:c0:00:02:01", // 02:1a+192.0.2.1
+		MAC:     "02:1A:C0:00:02:01", // 02:1a+192.0.2.1
 		IPv4Len: plen4,
 		IPv6Len: plen6,
 	}
@@ -77,7 +77,7 @@ var (
 		Desc:    "DUT to ATE destination",
 		IPv4:    "192.0.2.5",
 		IPv6:    "2001:db8::5",
-		MAC:     "02:1a:c0:00:02:05", // 02:1a+192.0.2.5
+		MAC:     "02:1A:C0:00:02:05", // 02:1a+192.0.2.5
 		IPv4Len: plen4,
 		IPv6Len: plen6,
 	}
@@ -162,6 +162,15 @@ func (tc *testCase) configureDUT(t *testing.T) {
 	di2 := d.Interface(p2.Name())
 	fptest.LogQuery(t, p2.String(), di2.Config(), tc.duti2)
 	gnmi.Replace(t, tc.dut, di2.Config(), tc.duti2)
+
+	if *deviations.ExplicitInterfaceInDefaultVRF {
+		fptest.AssignToNetworkInstance(t, tc.dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+	}
+	if *deviations.ExplicitPortSpeed {
+		fptest.SetPortSpeed(t, p1)
+		fptest.SetPortSpeed(t, p2)
+	}
 }
 
 func (tc *testCase) configInterfaceATE(ap *ondatra.Port, atea, duta *attrs.Attributes) {

--- a/feature/interface/singleton/ate_tests/singleton_test/singleton_test.go
+++ b/feature/interface/singleton/ate_tests/singleton_test/singleton_test.go
@@ -60,7 +60,7 @@ var (
 		Desc:    "DUT to ATE source",
 		IPv4:    "192.0.2.1",
 		IPv6:    "2001:db8::1",
-		MAC:     "02:1A:C0:00:02:01", // 02:1a+192.0.2.1
+		MAC:     "02:1a:c0:00:02:01", // 02:1a+192.0.2.1
 		IPv4Len: plen4,
 		IPv6Len: plen6,
 	}
@@ -77,7 +77,7 @@ var (
 		Desc:    "DUT to ATE destination",
 		IPv4:    "192.0.2.5",
 		IPv6:    "2001:db8::5",
-		MAC:     "02:1A:C0:00:02:05", // 02:1a+192.0.2.5
+		MAC:     "02:1a:c0:00:02:05", // 02:1a+192.0.2.5
 		IPv4Len: plen4,
 		IPv6Len: plen6,
 	}

--- a/feature/interface/singleton/otg_tests/singleton_test/singleton_test.go
+++ b/feature/interface/singleton/otg_tests/singleton_test/singleton_test.go
@@ -144,6 +144,15 @@ func (tc *testCase) configureDUT(t *testing.T) {
 	di2 := d.Interface(p2.Name())
 	fptest.LogQuery(t, p2.String(), di2.Config(), tc.duti2)
 	gnmi.Replace(t, tc.dut, di2.Config(), tc.duti2)
+
+	if *deviations.ExplicitInterfaceInDefaultVRF {
+		fptest.AssignToNetworkInstance(t, tc.dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+	}
+	if *deviations.ExplicitPortSpeed {
+		fptest.SetPortSpeed(t, p1)
+		fptest.SetPortSpeed(t, p2)
+	}
 }
 
 func (tc *testCase) configureATE(t *testing.T) {


### PR DESCRIPTION

There are 2 changes -
 1. Adding deviations ExplicitInterfaceInDefaultVRF and  ExplicitPortSpeed
 2. Fixing mac-address to upper-case

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."