### PR TITLE
TE-11.3: Setting DefaultNetworkInstance on the device 

### DIFF
--- a/feature/experimental/gribi/ate_tests/backup_nhg_action/backup_nhg_action_test.go
+++ b/feature/experimental/gribi/ate_tests/backup_nhg_action/backup_nhg_action_test.go
@@ -173,6 +173,8 @@ func TestBackupNHGAction(t *testing.T) {
 
 	// Configure DUT
 	configureDUT(t, dut)
+	dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+	gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 	configureNetworkInstance(t, dut)
 	addStaticRoute(t, dut)
 


### PR DESCRIPTION
Network instance type is set to "DEFAULT".
It is mandatory for user to specify type of network instance. For DEFAULT network instance type is "DEFAULT"