### PR TITLE
rt-3.2: update case#3 to skip the test if PF config is rejected

### DIFF
--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -439,7 +439,6 @@ func TestPBR(t *testing.T) {
 				getIPinIPFlow(args, dstEndPointVlan10, "ipinipd10", 10),
 				getIPinIPFlow(args, dstEndPointVlan20, "ipinipd20", 20),
 				getIPinIPFlow(args, dstEndPointVlan30, "ipinipd30", 30)},
-			rejectable: false,
 		},
 		{
 			name: "RT3.2 Case2",
@@ -461,7 +460,6 @@ func TestPBR(t *testing.T) {
 				getIPinIPFlow(args, dstEndPointVlan30, "ipinipd30", 30),
 				getIPinIPFlow(args, dstEndPointVlan30, "ipinipd31", 31),
 				getIPinIPFlow(args, dstEndPointVlan30, "ipinipd32", 32)},
-			rejectable: false,
 		},
 		{
 			name: "RT3.2 Case3",
@@ -498,7 +496,6 @@ func TestPBR(t *testing.T) {
 				getIPinIPFlow(args, dstEndPointVlan20, "ipinipd11v20", 11),
 				getIPinIPFlow(args, dstEndPointVlan20, "ipinipd12v20", 12),
 				getIPinIPFlow(args, dstEndPointVlan20, "ipinipd20", 20)},
-			rejectable: false,
 		},
 	}
 	for _, tc := range cases {
@@ -509,14 +506,14 @@ func TestPBR(t *testing.T) {
 			//configure pbr policy-forwarding
 			dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
 			gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
-			if tc.rejectable {
-				if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
-					gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
-				}); errMsg != nil {
+			errMsg := testt.CaptureFatal(t, func(t testing.TB) {
+				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
+			})
+			if errMsg != nil {
+				if tc.rejectable {
 					t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: %s", tc.name, *errMsg)
 				}
-			} else {
-				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
+				t.Fatalf("PolicyForwarding config update failed: %v", *errMsg)
 			}
 			// defer cleaning policy-forwarding
 			defer gnmi.Delete(t, args.dut, pfpath.Config())

--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -509,14 +509,10 @@ func TestPBR(t *testing.T) {
 			//configure pbr policy-forwarding
 			dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
 			gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
-			if tc.rejectable {
-				if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
-					gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
-				}); errMsg != nil {
-					t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: \n%q", tc.name, *errMsg)
-				}
-			} else {
+			if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
 				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
+			}); errMsg != nil && tc.rejectable {
+				t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: \n%q", tc.name, *errMsg)
 			}
 			// defer cleaning policy-forwarding
 			defer gnmi.Delete(t, args.dut, pfpath.Config())

--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -513,7 +513,7 @@ func TestPBR(t *testing.T) {
 				if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
 					gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
 				}); errMsg != nil {
-					t.Skipf("Skipping test case %v, PolicyForwarding config was rejected with an error: %s", tc.desc, *errMsg)
+					t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: \n%q", tc.name, *errMsg)
 				}
 			} else {
 				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)

--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -509,10 +509,14 @@ func TestPBR(t *testing.T) {
 			//configure pbr policy-forwarding
 			dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
 			gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
-			if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
+			if tc.rejectable {
+				if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
+					gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
+				}); errMsg != nil {
+					t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: %s", tc.name, *errMsg)
+				}
+			} else {
 				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
-			}); errMsg != nil && tc.rejectable {
-				t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: %s", tc.name, *errMsg)
 			}
 			// defer cleaning policy-forwarding
 			defer gnmi.Delete(t, args.dut, pfpath.Config())

--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -17,7 +17,6 @@
 package policy_based_vrf_selection_test
 
 import (
-	"github.com/openconfig/testt"
 	"strconv"
 	"testing"
 	"time"
@@ -28,6 +27,7 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/testt"
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )

--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -512,7 +512,7 @@ func TestPBR(t *testing.T) {
 			if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
 				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
 			}); errMsg != nil && tc.rejectable {
-				t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: \n%q", tc.name, *errMsg)
+				t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: %s", tc.name, *errMsg)
 			}
 			// defer cleaning policy-forwarding
 			defer gnmi.Delete(t, args.dut, pfpath.Config())

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -510,7 +510,7 @@ func TestPBR(t *testing.T) {
 			if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
 				gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
 			}); errMsg != nil && tc.rejectable {
-				t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: \n%q", tc.name, *errMsg)
+				t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: %s", tc.name, *errMsg)
 			}
 
 			// defer cleaning policy-forwarding

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -514,7 +514,7 @@ func TestPBR(t *testing.T) {
 					t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: %s", tc.name, *errMsg)
 				}
 			} else {
-				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
+				gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
 			}
 			// defer cleaning policy-forwarding
 			defer gnmi.Delete(t, args.dut, pfpath.Config())

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -17,6 +17,7 @@
 package policy_based_vrf_selection_test
 
 import (
+	"github.com/openconfig/testt"
 	"strconv"
 	"testing"
 	"time"
@@ -29,7 +30,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	"github.com/openconfig/testt"
 	"github.com/openconfig/ygot/ygot"
 )
 
@@ -507,12 +507,15 @@ func TestPBR(t *testing.T) {
 			pfpath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding()
 
 			//configure pbr policy-forwarding
-			if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
-				gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
-			}); errMsg != nil && tc.rejectable {
-				t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: %s", tc.name, *errMsg)
+			if tc.rejectable {
+				if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
+					gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
+				}); errMsg != nil {
+					t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: %s", tc.name, *errMsg)
+				}
+			} else {
+				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
 			}
-
 			// defer cleaning policy-forwarding
 			defer gnmi.Delete(t, args.dut, pfpath.Config())
 

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -439,7 +439,6 @@ func TestPBR(t *testing.T) {
 				getIPinIPFlow(args, atePort1, atePort2Vlan10, "ipinipd10", 10),
 				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd20", 20),
 				getIPinIPFlow(args, atePort1, atePort2Vlan30, "ipinipd30", 30)},
-			rejectable: false,
 		},
 		{
 			name: "RT3.2 Case2",
@@ -461,7 +460,6 @@ func TestPBR(t *testing.T) {
 				getIPinIPFlow(args, atePort1, atePort2Vlan30, "ipinipd30", 30),
 				getIPinIPFlow(args, atePort1, atePort2Vlan30, "ipinipd31", 31),
 				getIPinIPFlow(args, atePort1, atePort2Vlan30, "ipinipd32", 32)},
-			rejectable: false,
 		},
 		{
 			name: "RT3.2 Case3",
@@ -498,7 +496,6 @@ func TestPBR(t *testing.T) {
 				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd11v20", 11),
 				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd12v20", 12),
 				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd20", 20)},
-			rejectable: false,
 		},
 	}
 	for _, tc := range cases {
@@ -507,14 +504,14 @@ func TestPBR(t *testing.T) {
 			pfpath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding()
 
 			//configure pbr policy-forwarding
-			if tc.rejectable {
-				if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
-					gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
-				}); errMsg != nil {
+			errMsg := testt.CaptureFatal(t, func(t testing.TB) {
+				gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
+			})
+			if errMsg != nil {
+				if tc.rejectable {
 					t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: %s", tc.name, *errMsg)
 				}
-			} else {
-				gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
+				t.Fatalf("PolicyForwarding config update failed: %v", *errMsg)
 			}
 			// defer cleaning policy-forwarding
 			defer gnmi.Delete(t, args.dut, pfpath.Config())

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -507,15 +507,12 @@ func TestPBR(t *testing.T) {
 			pfpath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding()
 
 			//configure pbr policy-forwarding
-			if tc.rejectable {
-				if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
-					gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
-				}); errMsg != nil {
-					t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: \n%q", tc.name, *errMsg)
-				}
-			} else {
+			if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
 				gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
+			}); errMsg != nil && tc.rejectable {
+				t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: \n%q", tc.name, *errMsg)
 			}
+
 			// defer cleaning policy-forwarding
 			defer gnmi.Delete(t, args.dut, pfpath.Config())
 

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -17,7 +17,6 @@
 package policy_based_vrf_selection_test
 
 import (
-	"github.com/openconfig/testt"
 	"strconv"
 	"testing"
 	"time"
@@ -30,6 +29,7 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/testt"
 	"github.com/openconfig/ygot/ygot"
 )
 

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -511,7 +511,7 @@ func TestPBR(t *testing.T) {
 				if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
 					gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
 				}); errMsg != nil {
-					t.Skipf("Skipping test case %v, PolicyForwarding config was rejected with an error: %s", tc.desc, *errMsg)
+					t.Skipf("Skipping test case %q, PolicyForwarding config was rejected with an error: \n%q", tc.name, *errMsg)
 				}
 			} else {
 				gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)


### PR DESCRIPTION
Test case#3 (duplicated DSCP values) updated according to the new README (#1272).

We introduce a new bool flag "rejectable" that indicates that the test case can be skipped if PF config is rejected by a DUT

---
<sup>
This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.</sup>