### PR TITLE
te-3.3: update interface config / vrf binding logic

### DIFF
--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -247,14 +247,6 @@ func (a *attributes) configSubinterfaceDUT(t *testing.T, intf *oc.Interface) {
 		} else {
 			s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(uint16(i))
 		}
-		//ip := a.ip(uint8(i))
-		//s4 := s.GetOrCreateIpv4()
-		//if *deviations.InterfaceEnabled && !*deviations.IPv4MissingEnabled {
-		//	s4.Enabled = ygot.Bool(true)
-		//}
-		//s4a := s4.GetOrCreateAddress(ip)
-		//s4a.PrefixLength = ygot.Uint8(a.IPv4Len)
-		//t.Logf("Adding DUT Subinterface with ID: %d, Vlan ID: %d and IPv4 address: %s", i, i, ip)
 	}
 }
 


### PR DESCRIPTION
This PR refactors ConfigureDUT() logic to create subinterfaces first before they are assigned to network-instances, followed by L3 subif configuration
---
<sup>
This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.
</sup>