### PR TITLE
Pin openconfig/public repo when validating paths using a bash file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 openconfig_public:
-	git clone https://github.com/openconfig/public.git openconfig_public
+	tools/clone_oc_public.sh openconfig_public v1
 
 .PHONY: validate_paths
 validate_paths: openconfig_public proto/feature_go_proto/feature.pb.go

--- a/tools/clone_oc_public.sh
+++ b/tools/clone_oc_public.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+git clone https://github.com/openconfig/public.git $1
+cd $1
+branch=$(git tag -l "$2*" | sort -V | tail -1)
+git checkout $branch


### PR DESCRIPTION
This seems the cleanest way to do this. While having all the dependencies in `go.mod` would be nice, it is not possible to have the `require` in `go.mod` without making openconfig/public have a `go.mod` file, and even if we could do that, `go mod vendor` will download all dependencies for the module, and that doesn't seem right just to maintain a view of a non-Go repo.