### PR TITLE
RT-5.1: Updating mac-address comparison to ignore-case

### DIFF
--- a/feature/interface/singleton/ate_tests/singleton_test/singleton_test.go
+++ b/feature/interface/singleton/ate_tests/singleton_test/singleton_test.go
@@ -16,6 +16,7 @@ package singleton_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -220,6 +221,9 @@ func (tc *testCase) verifyInterfaceDUT(
 	// Mac address value is still not populated in di. Hence getting using gnmi get method
 	diMacAddress := gnmi.Get(t, tc.dut, dip.Ethernet().MacAddress().State())
 	di.GetOrCreateEthernet().MacAddress = &diMacAddress
+
+	wantdi.GetOrCreateEthernet().SetMacAddress(strings.ToUpper(wantdi.GetOrCreateEthernet().GetMacAddress()))
+	di.GetOrCreateEthernet().SetMacAddress(strings.ToUpper(di.GetOrCreateEthernet().GetMacAddress()))
 
 	confirm.State(t, wantdi, di)
 

--- a/feature/interface/singleton/otg_tests/singleton_test/singleton_test.go
+++ b/feature/interface/singleton/otg_tests/singleton_test/singleton_test.go
@@ -16,6 +16,7 @@ package singleton_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -226,6 +227,9 @@ func (tc *testCase) verifyInterfaceDUT(
 	// Mac address value is still not populated in di. Hence getting using gnmi get method
 	diMacAddress := gnmi.Get(t, tc.dut, dip.Ethernet().MacAddress().State())
 	di.GetOrCreateEthernet().MacAddress = &diMacAddress
+
+	wantdi.GetOrCreateEthernet().SetMacAddress(strings.ToUpper(wantdi.GetOrCreateEthernet().GetMacAddress()))
+	di.GetOrCreateEthernet().SetMacAddress(strings.ToUpper(di.GetOrCreateEthernet().GetMacAddress()))
 
 	confirm.State(t, wantdi, di)
 


### PR DESCRIPTION

To compare actual mac-address value and ignore upper/lower case, updating both `want` and `got` mac-address to upper-case before `ygot.Diff` is called.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."