### PR TITLE
Replicate missed deviation from backup_nhg_action ATE test

### DIFF
--- a/feature/experimental/gribi/otg_tests/backup_nhg_action/backup_nhg_action_test.go
+++ b/feature/experimental/gribi/otg_tests/backup_nhg_action/backup_nhg_action_test.go
@@ -174,10 +174,19 @@ func TestBackupNHGAction(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
 	// Configure DUT
-	configureDUT(t, dut)
+	if !*deviations.InterfaceConfigVrfBeforeAddress {
+		configureDUT(t, dut)
+	}
+
 	dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
 	gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 	configureNetworkInstance(t, dut)
+
+	// For interface configuration, Arista prefers config Vrf first then the IP address
+	if *deviations.InterfaceConfigVrfBeforeAddress {
+		configureDUT(t, dut)
+	}
+
 	addStaticRoute(t, dut)
 
 	// Configure ATE


### PR DESCRIPTION
- Add the deviations.InterfaceConfigVrfBeforeAddress logic that was added to the ATE version of the test shortly before the OTG version merged.