### PR TITLE
Feature files are just those named feature.textproto

### DIFF
--- a/tools/validate_paths.go
+++ b/tools/validate_paths.go
@@ -291,7 +291,7 @@ func featureFiles() ([]string, error) {
 			if e.IsDir() {
 				return nil
 			}
-			if strings.HasSuffix(e.Name(), ".textproto") {
+			if e.Name() == "feature.textproto" {
 				files = append(files, path)
 			}
 			return nil


### PR DESCRIPTION
This avoids running the validate_paths check on metadata.textproto files