### PR TITLE
Moving deviation flag P4RTMissingDelete to an accessor method

### DIFF
--- a/feature/experimental/p4rt/tests/p4rt_election/p4rt_election_test.go
+++ b/feature/experimental/p4rt/tests/p4rt_election/p4rt_election_test.go
@@ -278,7 +278,7 @@ func canWrite(t *testing.T, args *testArgs) (bool, error) {
 		}
 		return false, writeErr
 	}
-	if !*deviations.P4RTMissingDelete {
+	if !deviations.P4RTMissingDelete(ondatra.DUT(t, "dut")) {
 		if writeErr = writeTableEntry(args, t, pktIO, true); writeErr != nil {
 			t.Errorf("Error deleting table entry (highID %d, lowID %d): %v", args.highID, args.lowID, writeErr)
 		}

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -69,12 +69,14 @@ import (
 	"github.com/openconfig/ondatra"
 )
 
-// P4RTMissingDelete adds deviation for device that does not support delete mode in P4RT write requests.
-func P4RTMissingDelete(dut *ondatra.DUTDevice) bool {
+// P4RTMissingDelete returns whether the device does not support delete mode in P4RT write requests.
+func P4RTMissingDelete(_ *ondatra.DUTDevice) bool {
 	return *p4rtMissingDelete
 }
 
 // Vendor deviation flags.
+// All new flags should not be exported (define them in lowercase) and accessed
+// from tests through a public accessors like those above.
 var (
 	BannerDelimiter = flag.String("deviation_banner_delimiter", "",
 		"Device requires the banner to have a delimiter character. Full OpenConfig compliant devices should work without delimiter.")

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -65,7 +65,14 @@ package deviations
 
 import (
 	"flag"
+
+	"github.com/openconfig/ondatra"
 )
+
+// P4RTMissingDelete adds deviation for device that does not support delete mode in P4RT write requests.
+func P4RTMissingDelete(dut *ondatra.DUTDevice) bool {
+	return *p4rtMissingDelete
+}
 
 // Vendor deviation flags.
 var (
@@ -203,7 +210,7 @@ var (
 
 	SchedulerInputParamsUnsupported = flag.Bool("deviation_scheduler_input_params_unsupported", false, "Device does not support scheduler input parameters")
 
-	P4RTMissingDelete = flag.Bool("deviation_p4rt_missing_delete", false, "Device does not support delete mode in P4RT write requests")
+	p4rtMissingDelete = flag.Bool("deviation_p4rt_missing_delete", false, "Device does not support delete mode in P4RT write requests")
 
 	NetworkInstanceTableDeletionRequired = flag.Bool("deviation_network_instance_table_deletion_required", false,
 		"Set to true for device requiring explicit deletion of network-instance table, default is false")


### PR DESCRIPTION
Moving deviation flag P4RTMissingDelete to an accessor method. Tests which require deviation should call these methods instead of the deviation flags.