### PR TITLE
TE-1.2: add deviation for /system/mac-address/state

### DIFF
--- a/feature/experimental/interface/my_station_mac/ate_tests/my_station_mac_test/my_station_mac_test.go
+++ b/feature/experimental/interface/my_station_mac/ate_tests/my_station_mac_test/my_station_mac_test.go
@@ -196,9 +196,11 @@ func TestMyStationMAC(t *testing.T) {
 	t.Logf("Configure MyStationMAC")
 	gnmi.Replace(t, dut, gnmi.OC().System().MacAddress().RoutingMac().Config(), myStationMAC)
 
-	t.Logf("Verify configured MyStationMAC through telemetry")
-	if got := gnmi.Get(t, dut, gnmi.OC().System().MacAddress().RoutingMac().State()); strings.ToUpper(got) != myStationMAC {
-		t.Errorf("MyStationMAC got %v, want %v", got, myStationMAC)
+	if !*deviations.MacAddressMissing {
+		t.Logf("Verify configured MyStationMAC through telemetry")
+		if got := gnmi.Get(t, dut, gnmi.OC().System().MacAddress().RoutingMac().State()); strings.ToUpper(got) != myStationMAC {
+			t.Errorf("MyStationMAC got %v, want %v", got, myStationMAC)
+		}
 	}
 
 	t.Logf("Verify traffic flow")

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -222,4 +222,5 @@ var (
 
 	ISISRestartSuppressUnsupported = flag.Bool("deviation_isis_restart_suppress_unsupported", false,
 		"Device skip isis restart-suppress check if value is true, Default value is false")
+	MacAddressMissing = flag.Bool("deviation_mac_address_missing", false, "Device does not support /system/mac-address/state.")
 )

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -222,5 +222,6 @@ var (
 
 	ISISRestartSuppressUnsupported = flag.Bool("deviation_isis_restart_suppress_unsupported", false,
 		"Device skip isis restart-suppress check if value is true, Default value is false")
+
 	MacAddressMissing = flag.Bool("deviation_mac_address_missing", false, "Device does not support /system/mac-address/state.")
 )


### PR DESCRIPTION
Adds -deviation_mac_address_missing for devices that do not support /system/mac-address/state