### PR TITLE
some of the checks should be skipped for Arista_7280 which is Not a m…

### DIFF
--- a/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -451,7 +451,7 @@ func TestComponentParent(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 
-			if len(compList[tc.desc]) == 0 && dut.Model() == "DCS-7280CR3K-32D4" {
+			if len(compList[tc.desc]) == 0 && *deviations.SkipUnsupportedModelDCS_7280CR3K_32D4 {
 				t.Skipf("Test of %v is skipped due to hardware platform compatibility", tc.componentType)
 			}
 
@@ -545,7 +545,7 @@ func TestCPU(t *testing.T) {
 func TestSupervisorLastRebootInfo(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
-	if dut.Model() == "DCS-7280CR3K-32D4" {
+	if *deviations.SkipUnsupportedModelDCS_7280CR3K_32D4 {
 		t.Skipf("Test is skipped due to hardware platform compatibility")
 	}
 

--- a/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -451,7 +451,7 @@ func TestComponentParent(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 
-			if len(compList[tc.desc]) == 0 && *deviations.SkipUnsupportedModelDCS_7280CR3K_32D4 {
+			if len(compList[tc.desc]) == 0 && dut.Model() == "DCS-7280CR3K-32D4" {
 				t.Skipf("Test of %v is skipped due to hardware platform compatibility", tc.componentType)
 			}
 
@@ -545,7 +545,7 @@ func TestCPU(t *testing.T) {
 func TestSupervisorLastRebootInfo(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
-	if *deviations.SkipUnsupportedModelDCS_7280CR3K_32D4 {
+	if dut.Model() == "DCS-7280CR3K-32D4" {
 		t.Skipf("Test is skipped due to hardware platform compatibility")
 	}
 

--- a/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -450,6 +450,11 @@ func TestComponentParent(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
+
+			if len(compList[tc.desc]) == 0 && dut.Model() == "DCS-7280CR3K-32D4" {
+				t.Skipf("Test of %v is skipped due to hardware platform compatibility", tc.componentType)
+			}
+
 			t.Logf("Found component list for type %v : %v", tc.componentType, compList[tc.desc])
 			if len(compList[tc.desc]) == 0 {
 				t.Fatalf("Get component list for %q: got 0, want > 0", dut.Model())
@@ -539,6 +544,10 @@ func TestCPU(t *testing.T) {
 
 func TestSupervisorLastRebootInfo(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
+
+	if dut.Model() == "DCS-7280CR3K-32D4" {
+		t.Skipf("Test is skipped due to hardware platform compatibility")
+	}
 
 	cards := components.FindComponentsByType(t, dut, supervisorType)
 	t.Logf("Found card list: %v", cards)

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -231,4 +231,6 @@ var (
 	MacAddressMissing = flag.Bool("deviation_mac_address_missing", false, "Device does not support /system/mac-address/state.")
 
 	gribiMACOverrideWithStaticARP = flag.Bool("deviation_gribi_mac_override_with_static_arp", false, "Set to true for device not supporting programming a gribi flow with a next-hop entry of mac-address only, default is false")
+
+	SkipUnsupportedModelDCS_7280CR3K_32D4 = flag.Bool("deviation_skip_unsupported_model_DCS_7280CR3K_32D4", false, "Device model DCS-7280CR3K-32D4 does not have certain hardware components")
 )

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -231,6 +231,4 @@ var (
 	MacAddressMissing = flag.Bool("deviation_mac_address_missing", false, "Device does not support /system/mac-address/state.")
 
 	gribiMACOverrideWithStaticARP = flag.Bool("deviation_gribi_mac_override_with_static_arp", false, "Set to true for device not supporting programming a gribi flow with a next-hop entry of mac-address only, default is false")
-
-	SkipUnsupportedModelDCS_7280CR3K_32D4 = flag.Bool("deviation_skip_unsupported_model_DCS_7280CR3K_32D4", false, "Device model DCS-7280CR3K-32D4 does not have certain hardware components")
 )


### PR DESCRIPTION
…odular system

Some of the checks in this test is mainly for the modular & chassis styled systems, so they should be skipped in the DUT model like Arista DCS-7280CR3K-32D4

These checks include:
"Fabric"
"Linecard"
"Supervisor"

For Arista DCS-7280CR3K-32D4, They are not in the returned telemetry states.
