### PR TITLE
RT-1.4 Adding Native SRL ACL compatibility

### DIFF
--- a/feature/bgp/gracefulrestart/ate_tests/bgp_graceful_restart_test/bgp_graceful_restart_test.go
+++ b/feature/bgp/gracefulrestart/ate_tests/bgp_graceful_restart_test/bgp_graceful_restart_test.go
@@ -722,7 +722,7 @@ func TestTrafficWithGracefulRestartSpeaker(t *testing.T) {
 	t.Run("VerifyTrafficPasswithGRTimerWithAclApplied", func(t *testing.T) {
 		t.Log("Configure Acl to block BGP on port 179")
 		const stopDuration = 45 * time.Second
-		if deviations.UseNativeACLConfig(dut) {
+		if deviations.UseVendorNativeACLConfig(dut) {
 			configACLNative(t, dut, aclName)
 			configACLInterfaceNative(t, dut, ifName)
 		} else {
@@ -775,7 +775,7 @@ func TestTrafficWithGracefulRestartSpeaker(t *testing.T) {
 
 	t.Run("RemoveAclInterface", func(t *testing.T) {
 		t.Log("Removing Acl on the interface to restore BGP GR. Traffic should now pass!")
-		if deviations.UseNativeACLConfig(dut) {
+		if deviations.UseVendorNativeACLConfig(dut) {
 			configAdmitAllACLNative(t, dut, aclName)
 			configACLInterfaceNative(t, dut, ifName)
 		} else {

--- a/feature/bgp/gracefulrestart/ate_tests/bgp_graceful_restart_test/bgp_graceful_restart_test.go
+++ b/feature/bgp/gracefulrestart/ate_tests/bgp_graceful_restart_test/bgp_graceful_restart_test.go
@@ -15,12 +15,15 @@
 package bgp_graceful_restart_test
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/openconfig/featureprofiles/internal/attrs"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
@@ -460,6 +463,217 @@ func configACLInterface(t *testing.T, iFace *oc.Acl_Interface, ifName string) *a
 	return aclConf
 }
 
+// Helper function to replicate configACL() configs in NOKIA native model
+// Define the values for each ACL entry and marshal for json encoding.
+// Then craft a gNMI set Request to update the changes.
+func configACLNative(t testing.TB, d *ondatra.DUTDevice, name string) {
+	t.Helper()
+	switch d.Vendor() {
+	case ondatra.NOKIA:
+		var aclEntry10Val = []any{
+			map[string]any{
+				"action": map[string]any{
+					"drop": map[string]any{},
+				},
+				"match": map[string]any{
+					"destination-ip": map[string]any{
+						"prefix": ateDstCIDR,
+					},
+					"source-ip": map[string]any{
+						"prefix": aclNullPrefix,
+					},
+				},
+			},
+		}
+		entry10Update, err := json.Marshal(aclEntry10Val)
+		if err != nil {
+			t.Fatalf("Error with json Marshal: %v", err)
+		}
+
+		var aclEntry20Val = []any{
+			map[string]any{
+				"action": map[string]any{
+					"drop": map[string]any{},
+				},
+				"match": map[string]any{
+					"source-ip": map[string]any{
+						"prefix": ateDstCIDR,
+					},
+					"destination-ip": map[string]any{
+						"prefix": aclNullPrefix,
+					},
+				},
+			},
+		}
+		entry20Update, err := json.Marshal(aclEntry20Val)
+		if err != nil {
+			t.Fatalf("Error with json Marshal: %v", err)
+		}
+
+		var aclEntry30Val = []any{
+			map[string]any{
+				"action": map[string]any{
+					"accept": map[string]any{},
+				},
+				"match": map[string]any{
+					"source-ip": map[string]any{
+						"prefix": aclNullPrefix,
+					},
+					"destination-ip": map[string]any{
+						"prefix": aclNullPrefix,
+					},
+				},
+			},
+		}
+		entry30Update, err := json.Marshal(aclEntry30Val)
+		if err != nil {
+			t.Fatalf("Error with json Marshal: %v", err)
+		}
+
+		gpbSetRequest := &gpb.SetRequest{
+			Prefix: &gpb.Path{
+				Origin: "srl",
+			},
+			Update: []*gpb.Update{
+				{
+					Path: &gpb.Path{
+						Elem: []*gpb.PathElem{
+							{Name: "acl"},
+							{Name: "ipv4-filter", Key: map[string]string{"name": name}},
+							{Name: "entry", Key: map[string]string{"sequence-id": "10"}},
+						},
+					},
+					Val: &gpb.TypedValue{
+						Value: &gpb.TypedValue_JsonIetfVal{
+							JsonIetfVal: entry10Update,
+						},
+					},
+				},
+				{
+					Path: &gpb.Path{
+						Elem: []*gpb.PathElem{
+							{Name: "acl"},
+							{Name: "ipv4-filter", Key: map[string]string{"name": name}},
+							{Name: "entry", Key: map[string]string{"sequence-id": "20"}},
+						},
+					},
+					Val: &gpb.TypedValue{
+						Value: &gpb.TypedValue_JsonIetfVal{
+							JsonIetfVal: entry20Update,
+						},
+					},
+				},
+				{
+					Path: &gpb.Path{
+						Elem: []*gpb.PathElem{
+							{Name: "acl"},
+							{Name: "ipv4-filter", Key: map[string]string{"name": name}},
+							{Name: "entry", Key: map[string]string{"sequence-id": "30"}},
+						},
+					},
+					Val: &gpb.TypedValue{
+						Value: &gpb.TypedValue_JsonIetfVal{
+							JsonIetfVal: entry30Update,
+						},
+					},
+				},
+			},
+		}
+		gnmiClient := d.RawAPIs().GNMI().Default(t)
+		if _, err := gnmiClient.Set(context.Background(), gpbSetRequest); err != nil {
+			t.Fatalf("Unexpected error configuring SRL ACL: %v", err)
+		}
+	default:
+		t.Fatalf("Got vendor: %s, want: NOKIA", d.Vendor())
+	}
+}
+
+// Helper function to replicate AdminAllACL() configs in NOKIA native model
+// Remove ACL entries 10, 20
+// Then craft a gNMI set Request to update the changes.
+func configAdmitAllACLNative(t testing.TB, d *ondatra.DUTDevice, name string) {
+	t.Helper()
+	switch d.Vendor() {
+	case ondatra.NOKIA:
+		gpbDelRequest := &gpb.SetRequest{
+			Prefix: &gpb.Path{
+				Origin: "srl",
+			},
+			Delete: []*gpb.Path{
+				{
+					Elem: []*gpb.PathElem{
+						{Name: "acl"},
+						{Name: "ipv4-filter", Key: map[string]string{"name": name}},
+						{Name: "entry", Key: map[string]string{"sequence-id": "10"}},
+					},
+				},
+				{
+					Elem: []*gpb.PathElem{
+						{Name: "acl"},
+						{Name: "ipv4-filter", Key: map[string]string{"name": name}},
+						{Name: "entry", Key: map[string]string{"sequence-id": "20"}},
+					},
+				},
+			},
+		}
+		gnmiClient := d.RawAPIs().GNMI().Default(t)
+		if _, err := gnmiClient.Set(context.Background(), gpbDelRequest); err != nil {
+			t.Fatalf("Unexpected error removing SRL ACL: %v", err)
+		}
+	default:
+		t.Fatalf("Got vendor: %s, want: NOKIA", d.Vendor())
+	}
+}
+
+// Helper function to replicate configACLInterface
+// Set ACL at interface ingress
+// Then craft a gNMI set Request to update the changes.
+func configACLInterfaceNative(t *testing.T, d *ondatra.DUTDevice, ifName string) {
+	t.Helper()
+	switch d.Vendor() {
+	case ondatra.NOKIA:
+		var interfaceAclVal = []any{
+			map[string]any{
+				"ipv4-filter": []any{
+					aclName,
+				},
+			},
+		}
+		interfaceAclUpdate, err := json.Marshal(interfaceAclVal)
+		if err != nil {
+			t.Fatalf("Error with json Marshal: %v", err)
+		}
+		gpbSetRequest := &gpb.SetRequest{
+			Prefix: &gpb.Path{
+				Origin: "srl",
+			},
+			Update: []*gpb.Update{
+				{
+					Path: &gpb.Path{
+						Elem: []*gpb.PathElem{
+							{Name: "interface", Key: map[string]string{"name": ifName}},
+							{Name: "subinterface", Key: map[string]string{"index": "0"}},
+							{Name: "acl"},
+							{Name: "input"},
+						},
+					},
+					Val: &gpb.TypedValue{
+						Value: &gpb.TypedValue_JsonIetfVal{
+							JsonIetfVal: interfaceAclUpdate,
+						},
+					},
+				},
+			},
+		}
+		gnmiClient := d.RawAPIs().GNMI().Default(t)
+		if _, err := gnmiClient.Set(context.Background(), gpbSetRequest); err != nil {
+			t.Fatalf("Unexpected error configuring interface ACL: %v", err)
+		}
+	default:
+		t.Fatalf("Got vendor: %s, want: NOKIA", d.Vendor())
+	}
+}
+
 func TestTrafficWithGracefulRestartSpeaker(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	ate := ondatra.ATE(t, "ate")
@@ -508,14 +722,19 @@ func TestTrafficWithGracefulRestartSpeaker(t *testing.T) {
 	t.Run("VerifyTrafficPasswithGRTimerWithAclApplied", func(t *testing.T) {
 		t.Log("Configure Acl to block BGP on port 179")
 		const stopDuration = 45 * time.Second
-		gnmi.Replace(t, dut, gnmi.OC().Acl().AclSet(aclName, oc.Acl_ACL_TYPE_ACL_IPV4).Config(), configACL(d, aclName))
-		aclConf := configACLInterface(t, iFace, ifName)
+		if !*deviations.UseNativeACLConfiguration {
+			gnmi.Replace(t, dut, gnmi.OC().Acl().AclSet(aclName, oc.Acl_ACL_TYPE_ACL_IPV4).Config(), configACL(d, aclName))
+			aclConf := configACLInterface(t, iFace, ifName)
+			gnmi.Replace(t, dut, aclConf.Config(), iFace)
+		} else {
+			configACLNative(t, dut, aclName)
+			configACLInterfaceNative(t, dut, ifName)
+		}
 		t.Log("Starting traffic")
 		ate.Traffic().Start(t, allFlows...)
 		startTime := time.Now()
 		t.Log("Trigger Graceful Restart on ATE")
 		ate.Actions().NewBGPGracefulRestart().WithRestartTime(grRestartTime).WithPeers(bgpPeer).Send(t)
-		gnmi.Replace(t, dut, aclConf.Config(), iFace)
 		replaceDuration := time.Since(startTime)
 		time.Sleep(grTimer - stopDuration - replaceDuration)
 		t.Log("Send Traffic while GR timer counting down. Traffic should pass as BGP GR is enabled!")
@@ -556,9 +775,14 @@ func TestTrafficWithGracefulRestartSpeaker(t *testing.T) {
 
 	t.Run("RemoveAclInterface", func(t *testing.T) {
 		t.Log("Removing Acl on the interface to restore BGP GR. Traffic should now pass!")
-		gnmi.Replace(t, dut, gnmi.OC().Acl().AclSet(aclName, oc.Acl_ACL_TYPE_ACL_IPV4).Config(), configAdmitAllACL(d, aclName))
-		aclPath := configACLInterface(t, iFace, ifName)
-		gnmi.Replace(t, dut, aclPath.Config(), iFace)
+		if !*deviations.UseNativeACLConfiguration {
+			gnmi.Replace(t, dut, gnmi.OC().Acl().AclSet(aclName, oc.Acl_ACL_TYPE_ACL_IPV4).Config(), configAdmitAllACL(d, aclName))
+			aclPath := configACLInterface(t, iFace, ifName)
+			gnmi.Replace(t, dut, aclPath.Config(), iFace)
+		} else {
+			configAdmitAllACLNative(t, dut, aclName)
+			configACLInterfaceNative(t, dut, ifName)
+		}
 	})
 
 	t.Run("VerifyBGPEstablished", func(t *testing.T) {

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -105,8 +105,8 @@ func MacAddressMissing(_ *ondatra.DUTDevice) bool {
 }
 
 // UseNativeACLConfig returns whether a device requires native model to configure ACL, specifically for RT-1.4.
-func UseNativeACLConfig(_ *ondatra.DUTDevice) bool {
-	return *UseNativeACLConfiguration
+func UseVendorNativeACLConfig(_ *ondatra.DUTDevice) bool {
+	return *UseVendorNativeACLConfiguration
 }
 
 // Vendor deviation flags.
@@ -264,5 +264,5 @@ var (
 
 	missingBgpLastNotificationErrorCode = flag.Bool("deviation_missing_bgp_last_notification_error_code", false, "Set to true to skip check for bgp/neighbors/neighbor/state/messages/received/last-notification-error-code leaf missing case")
 
-	UseNativeACLConfiguration = flag.Bool("deviation_use_native_acl_config", false, "Configure ACLs using native model specifically for RT-1.4")
+	UseVendorNativeACLConfiguration = flag.Bool("deviation_use_vendor_native_acl_config", false, "Configure ACLs using vendor native model specifically for RT-1.4")
 )

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -231,4 +231,6 @@ var (
 	MacAddressMissing = flag.Bool("deviation_mac_address_missing", false, "Device does not support /system/mac-address/state.")
 
 	gribiMACOverrideWithStaticARP = flag.Bool("deviation_gribi_mac_override_with_static_arp", false, "Set to true for device not supporting programming a gribi flow with a next-hop entry of mac-address only, default is false")
+
+	UseNativeACLConfiguration = flag.Bool("deviation_use_native_acl_config", false, "Configure ACLs using native model specifically for RT-1.4")
 )


### PR DESCRIPTION
- Added `configACLNative()`, `configAdmitAllACLNative()`, `configACLInterfaceNative()` for ACL configurations on native SRL model
- Added a Deviation flag `deviation_use_native_acl_config` to enable using the above mentioned functions

This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.