### PR TITLE
Moving deviation flag MacAddressMissing to an accessor method.

### DIFF
--- a/feature/experimental/interface/my_station_mac/ate_tests/my_station_mac_test/my_station_mac_test.go
+++ b/feature/experimental/interface/my_station_mac/ate_tests/my_station_mac_test/my_station_mac_test.go
@@ -196,7 +196,7 @@ func TestMyStationMAC(t *testing.T) {
 	t.Logf("Configure MyStationMAC")
 	gnmi.Replace(t, dut, gnmi.OC().System().MacAddress().RoutingMac().Config(), myStationMAC)
 
-	if !*deviations.MacAddressMissing {
+	if !deviations.MacAddressMissing(dut) {
 		t.Logf("Verify configured MyStationMAC through telemetry")
 		if got := gnmi.Get(t, dut, gnmi.OC().System().MacAddress().RoutingMac().State()); strings.ToUpper(got) != myStationMAC {
 			t.Errorf("MyStationMAC got %v, want %v", got, myStationMAC)

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -79,6 +79,11 @@ func GRIBIMACOverrideWithStaticARP(_ *ondatra.DUTDevice) bool {
 	return *gribiMACOverrideWithStaticARP
 }
 
+// MacAddressMissing returns whether device does not support /system/mac-address/state
+func MacAddressMissing(_ *ondatra.DUTDevice) bool {
+	return *macAddressMissing
+}
+
 // Vendor deviation flags.
 // All new flags should not be exported (define them in lowercase) and accessed
 // from tests through a public accessors like those above.
@@ -228,7 +233,7 @@ var (
 	ISISRestartSuppressUnsupported = flag.Bool("deviation_isis_restart_suppress_unsupported", false,
 		"Device skip isis restart-suppress check if value is true, Default value is false")
 
-	MacAddressMissing = flag.Bool("deviation_mac_address_missing", false, "Device does not support /system/mac-address/state.")
+	macAddressMissing = flag.Bool("deviation_mac_address_missing", false, "Device does not support /system/mac-address/state.")
 
 	gribiMACOverrideWithStaticARP = flag.Bool("deviation_gribi_mac_override_with_static_arp", false, "Set to true for device not supporting programming a gribi flow with a next-hop entry of mac-address only, default is false")
 )


### PR DESCRIPTION
PiperOrigin-RevId: 522245643
Moving deviation flag MacAddressMissing to an accessor method.