### PR TITLE
Moving deviation flags BGPPrefixOverlimit and BGPTrafficTolerance to an accessor method

### DIFF
--- a/feature/bgp/prefixlimit/ate_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
+++ b/feature/bgp/prefixlimit/ate_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
@@ -408,7 +408,7 @@ func (tc *testCase) verifyNoPacketLoss(t *testing.T, ate *ondatra.ATEDevice, all
 	captureTrafficStats(t, ate)
 	for _, flow := range allFlows {
 		lossPct := gnmi.Get(t, ate, gnmi.OC().Flow(flow.Name()).LossPct().State())
-		if lossPct > float32(*deviations.BGPTrafficTolerance) {
+		if lossPct > float32(deviations.BGPTrafficTolerance(ondatra.DUT(t, "dut"))) {
 			t.Errorf("Traffic Loss Pct for Flow %s: got %v, want 0", flow.Name(), lossPct)
 		} else {
 			t.Logf("Traffic Test Passed! Got %v loss", lossPct)
@@ -420,7 +420,7 @@ func (tc *testCase) verifyPacketLoss(t *testing.T, ate *ondatra.ATEDevice, allFl
 	captureTrafficStats(t, ate)
 	for _, flow := range allFlows {
 		lossPct := gnmi.Get(t, ate, gnmi.OC().Flow(flow.Name()).LossPct().State())
-		if lossPct >= (100-float32(*deviations.BGPTrafficTolerance)) && lossPct <= 100 {
+		if lossPct >= (100-float32(deviations.BGPTrafficTolerance(ondatra.DUT(t, "dut")))) && lossPct <= 100 {
 			t.Logf("Traffic Test Passed! Loss seen as expected: got %v, want 100%% ", lossPct)
 		} else {
 			t.Errorf("Traffic %s is expected to fail: got %v, want 100%% failure", flow.Name(), lossPct)
@@ -517,7 +517,7 @@ func (tc *testCase) run(t *testing.T, conf *config, dut *ondatra.DUTDevice, ate 
 		})
 	} else {
 		t.Run("verifyPacketLoss", func(t *testing.T) {
-			if !*deviations.BGPPrefixOverlimit && tc.name == "OverLimit" {
+			if !deviations.BGPPrefixOverlimit(dut) && tc.name == "OverLimit" {
 				tc.verifyPacketLoss(t, ate, conf.allFlows)
 			}
 		})

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -79,6 +79,16 @@ func GRIBIMACOverrideWithStaticARP(_ *ondatra.DUTDevice) bool {
 	return *gribiMACOverrideWithStaticARP
 }
 
+// BGPPrefixOverlimit returns whether the BGP prefix overlimit retry timer is supported.
+func BGPPrefixOverlimit(_ *ondatra.DUTDevice) bool {
+	return *bgpPrefixOverlimit
+}
+
+// BGPTrafficTolerance returns the allowed tolerance for BGP traffic flow while comparing for pass or fail conditions.
+func BGPTrafficTolerance(_ *ondatra.DUTDevice) int {
+	return *bgpTrafficTolerance
+}
+
 // Vendor deviation flags.
 // All new flags should not be exported (define them in lowercase) and accessed
 // from tests through a public accessors like those above.
@@ -200,9 +210,9 @@ var (
 
 	InterfaceConfigVrfBeforeAddress = flag.Bool("deviation_interface_config_vrf_before_address", false, "When configuring interface, config Vrf prior config IP address")
 
-	BGPPrefixOverlimit = flag.Bool("deviation_bgp_prefix_overlimit", false, "BGP prefix overlimit retry timer support.")
+	bgpPrefixOverlimit = flag.Bool("deviation_bgp_prefix_overlimit", false, "BGP prefix overlimit retry timer support.")
 
-	BGPTrafficTolerance = flag.Int("deviation_bgp_tolerance_value", 0,
+	bgpTrafficTolerance = flag.Int("deviation_bgp_tolerance_value", 0,
 		"Allowed tolerance for BGP traffic flow while comparing for pass or fail condition.")
 
 	ExplicitGRIBIUnderNetworkInstance = flag.Bool("deviation_explicit_gribi_under_network_instance", false,


### PR DESCRIPTION
PiperOrigin-RevId: 522249454
Moving deviation flags BGPPrefixOverlimit and BGPTrafficTolerance to an accessor method. 

Both deviations flags are only used in the `bgp_prefix_limit_test`