### PR TITLE
DP-1.14 : QoS basic test - Adding required QoS config

### DIFF
--- a/feature/experimental/qos/ate_tests/qos_basic_test/qos_basic_test.go
+++ b/feature/experimental/qos/ate_tests/qos_basic_test/qos_basic_test.go
@@ -1313,6 +1313,7 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
 	}
 
+    if deviations.ECNProfileRequiredDefinition(dut) {
 	t.Logf("Create qos queue management profile config")
 	ecnConfig := struct {
 		profileName               string
@@ -1337,7 +1338,7 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 	uniform.SetMaxThreshold(ecnConfig.maxThreshold)
 	uniform.SetMaxDropProbabilityPercent(ecnConfig.maxDropProbabilityPercent)
 	gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
-
+}
 	t.Logf("Create qos Classifiers config")
 	classifiers := []struct {
 		desc        string

--- a/feature/experimental/qos/ate_tests/qos_basic_test/qos_basic_test.go
+++ b/feature/experimental/qos/ate_tests/qos_basic_test/qos_basic_test.go
@@ -1492,7 +1492,6 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority bool
 		priority    oc.E_Scheduler_Priority
 		inputID     string
-		inputType   oc.E_Input_InputType
 		setWeight   bool
 		weight      uint64
 		queueName   string
@@ -1503,7 +1502,6 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "BE1",
-		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(1),
 		queueName:   "6",
 		targetGroup: "target-group-BE1",
@@ -1513,7 +1511,6 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "BE0",
-		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(1),
 		queueName:   "0",
 		targetGroup: "target-group-BE0",
@@ -1523,7 +1520,6 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "AF1",
-		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(4),
 		queueName:   "4",
 		targetGroup: "target-group-AF1",
@@ -1533,7 +1529,6 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "AF2",
-		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(8),
 		queueName:   "1",
 		targetGroup: "target-group-AF2",
@@ -1543,7 +1538,6 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "AF3",
-		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(12),
 		queueName:   "5",
 		targetGroup: "target-group-AF3",
@@ -1553,7 +1547,6 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "AF4",
-		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(48),
 		queueName:   "2",
 		targetGroup: "target-group-AF4",
@@ -1564,7 +1557,6 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 		setWeight:   false,
 		priority:    oc.Scheduler_Priority_STRICT,
 		inputID:     "NC1",
-		inputType:   oc.Input_InputType_QUEUE,
 		queueName:   "3",
 		targetGroup: "target-group-NC1",
 	}}
@@ -1580,7 +1572,7 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 		}
 		input := s.GetOrCreateInput(tc.inputID)
 		input.SetId(tc.inputID)
-		input.SetInputType(tc.inputType)
+		input.SetInputType(oc.Input_InputType_QUEUE)
 		input.SetQueue(tc.queueName)
 		if tc.setWeight {
 			input.SetWeight(tc.weight)
@@ -1590,45 +1582,29 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 
 	t.Logf("Create qos output interface config")
 	schedulerIntfs := []struct {
-		desc       string
-		queueName  string
-		scheduler  string
-		ecnProfile string
+		desc      string
+		queueName string
 	}{{
-		desc:       "output-interface-BE1",
-		queueName:  "6",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-BE1",
+		queueName: "6",
 	}, {
-		desc:       "output-interface-BE0",
-		queueName:  "0",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-BE0",
+		queueName: "0",
 	}, {
-		desc:       "output-interface-AF1",
-		queueName:  "4",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-AF1",
+		queueName: "4",
 	}, {
-		desc:       "output-interface-AF2",
-		queueName:  "1",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-AF2",
+		queueName: "1",
 	}, {
-		desc:       "output-interface-AF3",
-		queueName:  "5",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-AF3",
+		queueName: "5",
 	}, {
-		desc:       "output-interface-AF4",
-		queueName:  "2",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-AF4",
+		queueName: "2",
 	}, {
-		desc:       "output-interface-NC1",
-		queueName:  "3",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-NC1",
+		queueName: "3",
 	}}
 
 	t.Logf("qos output interface config: %v", schedulerIntfs)
@@ -1640,10 +1616,10 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 		}
 		output := i.GetOrCreateOutput()
 		schedulerPolicy := output.GetOrCreateSchedulerPolicy()
-		schedulerPolicy.SetName(tc.scheduler)
+		schedulerPolicy.SetName("scheduler")
 		queue := output.GetOrCreateQueue(tc.queueName)
 		queue.SetName(tc.queueName)
-		queue.SetQueueManagementProfile(tc.ecnProfile)
+		queue.SetQueueManagementProfile("ECNProfile")
 		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
 	}
 }

--- a/feature/experimental/qos/ate_tests/qos_basic_test/qos_basic_test.go
+++ b/feature/experimental/qos/ate_tests/qos_basic_test/qos_basic_test.go
@@ -792,7 +792,6 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority bool
 		priority    oc.E_Scheduler_Priority
 		inputID     string
-		inputType   oc.E_Input_InputType
 		setWeight   bool
 		weight      uint64
 		queueName   string
@@ -803,7 +802,6 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "BE1",
-		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(1),
 		queueName:   "BE1",
 		targetGroup: "target-group-BE1",
@@ -813,7 +811,6 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "BE0",
-		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(1),
 		queueName:   "BE0",
 		targetGroup: "target-group-BE0",
@@ -823,7 +820,6 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "AF1",
-		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(4),
 		queueName:   "AF1",
 		targetGroup: "target-group-AF1",
@@ -833,7 +829,6 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "AF2",
-		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(8),
 		queueName:   "AF2",
 		targetGroup: "target-group-AF2",
@@ -843,7 +838,6 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "AF3",
-		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(12),
 		queueName:   "AF3",
 		targetGroup: "target-group-AF3",
@@ -853,7 +847,6 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "AF4",
-		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(48),
 		queueName:   "AF4",
 		targetGroup: "target-group-AF4",
@@ -864,7 +857,6 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setWeight:   false,
 		priority:    oc.Scheduler_Priority_STRICT,
 		inputID:     "NC1",
-		inputType:   oc.Input_InputType_QUEUE,
 		queueName:   "NC1",
 		targetGroup: "target-group-NC1",
 	}}
@@ -880,7 +872,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		}
 		input := s.GetOrCreateInput(tc.inputID)
 		input.SetId(tc.inputID)
-		input.SetInputType(tc.inputType)
+		input.SetInputType(oc.Input_InputType_QUEUE)
 		input.SetQueue(tc.queueName)
 		if tc.setWeight {
 			input.SetWeight(tc.weight)
@@ -895,41 +887,30 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		scheduler  string
 		ecnProfile string
 	}{{
-		desc:       "output-interface-BE1",
-		queueName:  "BE1",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-BE1",
+		queueName: "BE1",
 	}, {
-		desc:       "output-interface-BE0",
-		queueName:  "BE0",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-BE0",
+		queueName: "BE0",
 	}, {
-		desc:       "output-interface-AF1",
-		queueName:  "AF1",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-AF1",
+		queueName: "AF1",
 	}, {
-		desc:       "output-interface-AF2",
-		queueName:  "AF2",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-AF2",
+		queueName: "AF2",
 	}, {
-		desc:       "output-interface-AF3",
-		queueName:  "AF3",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-AF3",
+		queueName: "AF3",
 	}, {
-		desc:       "output-interface-AF4",
-		queueName:  "AF4",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-AF4",
+		queueName: "AF4",
 	}, {
-		desc:       "output-interface-NC1",
-		queueName:  "NC1",
-		scheduler:  "scheduler",
-		ecnProfile: "ECNProfile",
+		desc:      "output-interface-NC1",
+		queueName: "NC1",
 	}}
+
+	scheduler := string("scheduler")
+	ecnProfile := string("ecnProfile")
 
 	t.Logf("qos output interface config: %v", schedulerIntfs)
 	for _, tc := range schedulerIntfs {
@@ -937,10 +918,10 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		i.SetInterfaceId(dp3.Name())
 		output := i.GetOrCreateOutput()
 		schedulerPolicy := output.GetOrCreateSchedulerPolicy()
-		schedulerPolicy.SetName(tc.scheduler)
+		schedulerPolicy.SetName(scheduler)
 		queue := output.GetOrCreateQueue(tc.queueName)
 		queue.SetName(tc.queueName)
-		queue.SetQueueManagementProfile(tc.ecnProfile)
+		queue.SetQueueManagementProfile(ecnProfile)
 		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
 	}
 }
@@ -1315,28 +1296,21 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 
 	if deviations.ECNProfileRequiredDefinition(dut) {
 		t.Logf("Create qos queue management profile config")
-		ecnConfig := struct {
-			profileName               string
-			ecnEnabled                bool
-			minThreshold              uint64
-			maxThreshold              uint64
-			maxDropProbabilityPercent uint8
-		}{
-			profileName:               "ECNProfile",
-			ecnEnabled:                true,
-			minThreshold:              uint64(0),
-			maxThreshold:              uint64(55),
-			maxDropProbabilityPercent: uint8(25),
-		}
-		t.Logf("qos queue management profile config: %v", ecnConfig)
-		queueMgmtProfile := q.GetOrCreateQueueManagementProfile(ecnConfig.profileName)
-		queueMgmtProfile.SetName("ECNProfile")
+
+		profileName := string("ECNProfile")
+		ecnEnabled := bool(true)
+		minThreshold := uint64(0)
+		maxThreshold := uint64(55)
+		maxDropProbabilityPercent := uint8(25)
+
+		queueMgmtProfile := q.GetOrCreateQueueManagementProfile(profileName)
+		queueMgmtProfile.SetName(profileName)
 		wred := queueMgmtProfile.GetOrCreateWred()
 		uniform := wred.GetOrCreateUniform()
-		uniform.SetEnableEcn(ecnConfig.ecnEnabled)
-		uniform.SetMinThreshold(ecnConfig.minThreshold)
-		uniform.SetMaxThreshold(ecnConfig.maxThreshold)
-		uniform.SetMaxDropProbabilityPercent(ecnConfig.maxDropProbabilityPercent)
+		uniform.SetEnableEcn(ecnEnabled)
+		uniform.SetMinThreshold(minThreshold)
+		uniform.SetMaxThreshold(maxThreshold)
+		uniform.SetMaxDropProbabilityPercent(maxDropProbabilityPercent)
 		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
 	}
 	t.Logf("Create qos Classifiers config")
@@ -1476,22 +1450,22 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 		inputClassifierType oc.E_Input_Classifier_Type
 		classifier          string
 	}{{
-		desc:                "Input Classifier Type IPV4",
+		desc:                "Input Classifier Type IPV4 for interface 1",
 		intf:                dp1.Name(),
 		inputClassifierType: oc.Input_Classifier_Type_IPV4,
 		classifier:          "dscp_based_classifier_ipv4",
 	}, {
-		desc:                "Input Classifier Type IPV6",
+		desc:                "Input Classifier Type IPV6 for interface 1",
 		intf:                dp1.Name(),
 		inputClassifierType: oc.Input_Classifier_Type_IPV6,
 		classifier:          "dscp_based_classifier_ipv6",
 	}, {
-		desc:                "Input Classifier Type IPV4",
+		desc:                "Input Classifier Type IPV4 for interface 2",
 		intf:                dp2.Name(),
 		inputClassifierType: oc.Input_Classifier_Type_IPV4,
 		classifier:          "dscp_based_classifier_ipv4",
 	}, {
-		desc:                "Input Classifier Type IPV6",
+		desc:                "Input Classifier Type IPV6 for interface 2",
 		intf:                dp2.Name(),
 		inputClassifierType: oc.Input_Classifier_Type_IPV6,
 		classifier:          "dscp_based_classifier_ipv6",

--- a/feature/experimental/qos/ate_tests/qos_basic_test/qos_basic_test.go
+++ b/feature/experimental/qos/ate_tests/qos_basic_test/qos_basic_test.go
@@ -1313,32 +1313,32 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
 	}
 
-    if deviations.ECNProfileRequiredDefinition(dut) {
-	t.Logf("Create qos queue management profile config")
-	ecnConfig := struct {
-		profileName               string
-		ecnEnabled                bool
-		minThreshold              uint64
-		maxThreshold              uint64
-		maxDropProbabilityPercent uint8
-	}{
-		profileName:               "ECNProfile",
-		ecnEnabled:                true,
-		minThreshold:              uint64(0),
-		maxThreshold:              uint64(55),
-		maxDropProbabilityPercent: uint8(25),
+	if deviations.ECNProfileRequiredDefinition(dut) {
+		t.Logf("Create qos queue management profile config")
+		ecnConfig := struct {
+			profileName               string
+			ecnEnabled                bool
+			minThreshold              uint64
+			maxThreshold              uint64
+			maxDropProbabilityPercent uint8
+		}{
+			profileName:               "ECNProfile",
+			ecnEnabled:                true,
+			minThreshold:              uint64(0),
+			maxThreshold:              uint64(55),
+			maxDropProbabilityPercent: uint8(25),
+		}
+		t.Logf("qos queue management profile config: %v", ecnConfig)
+		queueMgmtProfile := q.GetOrCreateQueueManagementProfile(ecnConfig.profileName)
+		queueMgmtProfile.SetName("ECNProfile")
+		wred := queueMgmtProfile.GetOrCreateWred()
+		uniform := wred.GetOrCreateUniform()
+		uniform.SetEnableEcn(ecnConfig.ecnEnabled)
+		uniform.SetMinThreshold(ecnConfig.minThreshold)
+		uniform.SetMaxThreshold(ecnConfig.maxThreshold)
+		uniform.SetMaxDropProbabilityPercent(ecnConfig.maxDropProbabilityPercent)
+		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
 	}
-	t.Logf("qos queue management profile config: %v", ecnConfig)
-	queueMgmtProfile := q.GetOrCreateQueueManagementProfile(ecnConfig.profileName)
-	queueMgmtProfile.SetName("ECNProfile")
-	wred := queueMgmtProfile.GetOrCreateWred()
-	uniform := wred.GetOrCreateUniform()
-	uniform.SetEnableEcn(ecnConfig.ecnEnabled)
-	uniform.SetMinThreshold(ecnConfig.minThreshold)
-	uniform.SetMaxThreshold(ecnConfig.maxThreshold)
-	uniform.SetMaxDropProbabilityPercent(ecnConfig.maxDropProbabilityPercent)
-	gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
-}
 	t.Logf("Create qos Classifiers config")
 	classifiers := []struct {
 		desc        string

--- a/feature/experimental/qos/ate_tests/qos_basic_test/qos_basic_test.go
+++ b/feature/experimental/qos/ate_tests/qos_basic_test/qos_basic_test.go
@@ -792,6 +792,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority bool
 		priority    oc.E_Scheduler_Priority
 		inputID     string
+		inputType   oc.E_Input_InputType
 		setWeight   bool
 		weight      uint64
 		queueName   string
@@ -802,6 +803,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "BE1",
+		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(1),
 		queueName:   "BE1",
 		targetGroup: "target-group-BE1",
@@ -811,6 +813,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "BE0",
+		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(1),
 		queueName:   "BE0",
 		targetGroup: "target-group-BE0",
@@ -820,6 +823,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "AF1",
+		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(4),
 		queueName:   "AF1",
 		targetGroup: "target-group-AF1",
@@ -829,6 +833,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "AF2",
+		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(8),
 		queueName:   "AF2",
 		targetGroup: "target-group-AF2",
@@ -838,6 +843,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "AF3",
+		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(12),
 		queueName:   "AF3",
 		targetGroup: "target-group-AF3",
@@ -847,6 +853,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setPriority: false,
 		setWeight:   true,
 		inputID:     "AF4",
+		inputType:   oc.Input_InputType_QUEUE,
 		weight:      uint64(48),
 		queueName:   "AF4",
 		targetGroup: "target-group-AF4",
@@ -857,6 +864,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		setWeight:   false,
 		priority:    oc.Scheduler_Priority_STRICT,
 		inputID:     "NC1",
+		inputType:   oc.Input_InputType_QUEUE,
 		queueName:   "NC1",
 		targetGroup: "target-group-NC1",
 	}}
@@ -872,7 +880,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		}
 		input := s.GetOrCreateInput(tc.inputID)
 		input.SetId(tc.inputID)
-		input.SetInputType(oc.Input_InputType_QUEUE)
+		input.SetInputType(tc.inputType)
 		input.SetQueue(tc.queueName)
 		if tc.setWeight {
 			input.SetWeight(tc.weight)
@@ -887,30 +895,41 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		scheduler  string
 		ecnProfile string
 	}{{
-		desc:      "output-interface-BE1",
-		queueName: "BE1",
+		desc:       "output-interface-BE1",
+		queueName:  "BE1",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
 	}, {
-		desc:      "output-interface-BE0",
-		queueName: "BE0",
+		desc:       "output-interface-BE0",
+		queueName:  "BE0",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
 	}, {
-		desc:      "output-interface-AF1",
-		queueName: "AF1",
+		desc:       "output-interface-AF1",
+		queueName:  "AF1",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
 	}, {
-		desc:      "output-interface-AF2",
-		queueName: "AF2",
+		desc:       "output-interface-AF2",
+		queueName:  "AF2",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
 	}, {
-		desc:      "output-interface-AF3",
-		queueName: "AF3",
+		desc:       "output-interface-AF3",
+		queueName:  "AF3",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
 	}, {
-		desc:      "output-interface-AF4",
-		queueName: "AF4",
+		desc:       "output-interface-AF4",
+		queueName:  "AF4",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
 	}, {
-		desc:      "output-interface-NC1",
-		queueName: "NC1",
+		desc:       "output-interface-NC1",
+		queueName:  "NC1",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
 	}}
-
-	scheduler := string("scheduler")
-	ecnProfile := string("ecnProfile")
 
 	t.Logf("qos output interface config: %v", schedulerIntfs)
 	for _, tc := range schedulerIntfs {
@@ -918,10 +937,10 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		i.SetInterfaceId(dp3.Name())
 		output := i.GetOrCreateOutput()
 		schedulerPolicy := output.GetOrCreateSchedulerPolicy()
-		schedulerPolicy.SetName(scheduler)
+		schedulerPolicy.SetName(tc.scheduler)
 		queue := output.GetOrCreateQueue(tc.queueName)
 		queue.SetName(tc.queueName)
-		queue.SetQueueManagementProfile(ecnProfile)
+		queue.SetQueueManagementProfile(tc.ecnProfile)
 		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
 	}
 }

--- a/feature/experimental/qos/ate_tests/qos_basic_test/qos_basic_test.go
+++ b/feature/experimental/qos/ate_tests/qos_basic_test/qos_basic_test.go
@@ -69,6 +69,8 @@ func TestBasicConfigWithTraffic(t *testing.T) {
 	switch dut.Vendor() {
 	case ondatra.CISCO:
 		ConfigureCiscoQos(t, dut)
+	case ondatra.JUNIPER:
+		ConfigureJuniperQos(t, dut)
 	default:
 		ConfigureQoS(t, dut)
 	}
@@ -1256,6 +1258,417 @@ func ConfigureCiscoQos(t *testing.T, dut *ondatra.DUTDevice) {
 		schedulerPolicy.SetName(tc.scheduler)
 		queue := output.GetOrCreateQueue(tc.queueName)
 		queue.SetName(tc.queueName)
+		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
+	}
+}
+func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
+	t.Helper()
+	dp1 := dut.Port(t, "port1")
+	dp2 := dut.Port(t, "port2")
+	dp3 := dut.Port(t, "port3")
+	d := &oc.Root{}
+	q := d.GetOrCreateQos()
+
+	forwardingGroups := []struct {
+		desc        string
+		queueName   string
+		targetGroup string
+	}{{
+		desc:        "forwarding-group-BE1",
+		queueName:   "6",
+		targetGroup: "target-group-BE1",
+	}, {
+		desc:        "forwarding-group-BE0",
+		queueName:   "0",
+		targetGroup: "target-group-BE0",
+	}, {
+		desc:        "forwarding-group-AF1",
+		queueName:   "4",
+		targetGroup: "target-group-AF1",
+	}, {
+		desc:        "forwarding-group-AF2",
+		queueName:   "1",
+		targetGroup: "target-group-AF2",
+	}, {
+		desc:        "forwarding-group-AF3",
+		queueName:   "5",
+		targetGroup: "target-group-AF3",
+	}, {
+		desc:        "forwarding-group-AF4",
+		queueName:   "2",
+		targetGroup: "target-group-AF4",
+	}, {
+		desc:        "forwarding-group-NC1",
+		queueName:   "3",
+		targetGroup: "target-group-NC1",
+	}}
+
+	t.Logf("qos forwarding groups config: %v", forwardingGroups)
+	for _, tc := range forwardingGroups {
+		fwdGroup := q.GetOrCreateForwardingGroup(tc.targetGroup)
+		fwdGroup.SetName(tc.targetGroup)
+		fwdGroup.SetOutputQueue(tc.queueName)
+		queue := q.GetOrCreateQueue(tc.queueName)
+		queue.SetName(tc.queueName)
+		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
+	}
+
+	t.Logf("Create qos queue management profile config")
+	ecnConfig := struct {
+		profileName               string
+		ecnEnabled                bool
+		minThreshold              uint64
+		maxThreshold              uint64
+		maxDropProbabilityPercent uint8
+	}{
+		profileName:               "ECNProfile",
+		ecnEnabled:                true,
+		minThreshold:              uint64(0),
+		maxThreshold:              uint64(55),
+		maxDropProbabilityPercent: uint8(25),
+	}
+	t.Logf("qos queue management profile config: %v", ecnConfig)
+	queueMgmtProfile := q.GetOrCreateQueueManagementProfile(ecnConfig.profileName)
+	queueMgmtProfile.SetName("ECNProfile")
+	wred := queueMgmtProfile.GetOrCreateWred()
+	uniform := wred.GetOrCreateUniform()
+	uniform.SetEnableEcn(ecnConfig.ecnEnabled)
+	uniform.SetMinThreshold(ecnConfig.minThreshold)
+	uniform.SetMaxThreshold(ecnConfig.maxThreshold)
+	uniform.SetMaxDropProbabilityPercent(ecnConfig.maxDropProbabilityPercent)
+	gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
+
+	t.Logf("Create qos Classifiers config")
+	classifiers := []struct {
+		desc        string
+		name        string
+		classType   oc.E_Qos_Classifier_Type
+		termID      string
+		targetGroup string
+		dscpSet     []uint8
+	}{{
+		desc:        "classifier_ipv4_be1",
+		name:        "dscp_based_classifier_ipv4",
+		classType:   oc.Qos_Classifier_Type_IPV4,
+		termID:      "0",
+		targetGroup: "target-group-BE1",
+		dscpSet:     []uint8{0, 1, 2, 3},
+	}, {
+		desc:        "classifier_ipv4_be0",
+		name:        "dscp_based_classifier_ipv4",
+		classType:   oc.Qos_Classifier_Type_IPV4,
+		termID:      "1",
+		targetGroup: "target-group-BE0",
+		dscpSet:     []uint8{4, 5, 6, 7},
+	}, {
+		desc:        "classifier_ipv4_af1",
+		name:        "dscp_based_classifier_ipv4",
+		classType:   oc.Qos_Classifier_Type_IPV4,
+		termID:      "2",
+		targetGroup: "target-group-AF1",
+		dscpSet:     []uint8{8, 9, 10, 11},
+	}, {
+		desc:        "classifier_ipv4_af2",
+		name:        "dscp_based_classifier_ipv4",
+		classType:   oc.Qos_Classifier_Type_IPV4,
+		termID:      "3",
+		targetGroup: "target-group-AF2",
+		dscpSet:     []uint8{16, 17, 18, 19},
+	}, {
+		desc:        "classifier_ipv4_af3",
+		name:        "dscp_based_classifier_ipv4",
+		classType:   oc.Qos_Classifier_Type_IPV4,
+		termID:      "4",
+		targetGroup: "target-group-AF3",
+		dscpSet:     []uint8{24, 25, 26, 27},
+	}, {
+		desc:        "classifier_ipv4_af4",
+		name:        "dscp_based_classifier_ipv4",
+		classType:   oc.Qos_Classifier_Type_IPV4,
+		termID:      "5",
+		targetGroup: "target-group-AF4",
+		dscpSet:     []uint8{32, 33, 34, 35},
+	}, {
+		desc:        "classifier_ipv4_nc1",
+		name:        "dscp_based_classifier_ipv4",
+		classType:   oc.Qos_Classifier_Type_IPV4,
+		termID:      "6",
+		targetGroup: "target-group-NC1",
+		dscpSet:     []uint8{48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59},
+	}, {
+		desc:        "classifier_ipv6_be1",
+		name:        "dscp_based_classifier_ipv6",
+		classType:   oc.Qos_Classifier_Type_IPV6,
+		termID:      "0",
+		targetGroup: "target-group-BE1",
+		dscpSet:     []uint8{0, 1, 2, 3},
+	}, {
+		desc:        "classifier_ipv6_be0",
+		name:        "dscp_based_classifier_ipv6",
+		classType:   oc.Qos_Classifier_Type_IPV6,
+		termID:      "1",
+		targetGroup: "target-group-BE0",
+		dscpSet:     []uint8{4, 5, 6, 7},
+	}, {
+		desc:        "classifier_ipv6_af1",
+		name:        "dscp_based_classifier_ipv6",
+		classType:   oc.Qos_Classifier_Type_IPV6,
+		termID:      "2",
+		targetGroup: "target-group-AF1",
+		dscpSet:     []uint8{8, 9, 10, 11},
+	}, {
+		desc:        "classifier_ipv6_af2",
+		name:        "dscp_based_classifier_ipv6",
+		classType:   oc.Qos_Classifier_Type_IPV6,
+		termID:      "3",
+		targetGroup: "target-group-AF2",
+		dscpSet:     []uint8{16, 17, 18, 19},
+	}, {
+		desc:        "classifier_ipv6_af3",
+		name:        "dscp_based_classifier_ipv6",
+		classType:   oc.Qos_Classifier_Type_IPV6,
+		termID:      "4",
+		targetGroup: "target-group-AF3",
+		dscpSet:     []uint8{24, 25, 26, 27},
+	}, {
+		desc:        "classifier_ipv6_af4",
+		name:        "dscp_based_classifier_ipv6",
+		classType:   oc.Qos_Classifier_Type_IPV6,
+		termID:      "5",
+		targetGroup: "target-group-AF4",
+		dscpSet:     []uint8{32, 33, 34, 35},
+	}, {
+		desc:        "classifier_ipv6_nc1",
+		name:        "dscp_based_classifier_ipv6",
+		classType:   oc.Qos_Classifier_Type_IPV6,
+		termID:      "6",
+		targetGroup: "target-group-NC1",
+		dscpSet:     []uint8{48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59},
+	}}
+
+	t.Logf("qos Classifiers config: %v", classifiers)
+	for _, tc := range classifiers {
+		classifier := q.GetOrCreateClassifier(tc.name)
+		classifier.SetName(tc.name)
+		classifier.SetType(tc.classType)
+		term, err := classifier.NewTerm(tc.termID)
+		if err != nil {
+			t.Fatalf("Failed to create classifier.NewTerm(): %v", err)
+		}
+
+		term.SetId(tc.termID)
+		action := term.GetOrCreateActions()
+		action.SetTargetGroup(tc.targetGroup)
+		condition := term.GetOrCreateConditions()
+		if tc.name == "dscp_based_classifier_ipv4" {
+			condition.GetOrCreateIpv4().SetDscpSet(tc.dscpSet)
+		} else if tc.name == "dscp_based_classifier_ipv6" {
+			condition.GetOrCreateIpv6().SetDscpSet(tc.dscpSet)
+		}
+		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
+	}
+
+	t.Logf("Create qos input classifier config")
+	classifierIntfs := []struct {
+		desc                string
+		intf                string
+		inputClassifierType oc.E_Input_Classifier_Type
+		classifier          string
+	}{{
+		desc:                "Input Classifier Type IPV4",
+		intf:                dp1.Name(),
+		inputClassifierType: oc.Input_Classifier_Type_IPV4,
+		classifier:          "dscp_based_classifier_ipv4",
+	}, {
+		desc:                "Input Classifier Type IPV6",
+		intf:                dp1.Name(),
+		inputClassifierType: oc.Input_Classifier_Type_IPV6,
+		classifier:          "dscp_based_classifier_ipv6",
+	}, {
+		desc:                "Input Classifier Type IPV4",
+		intf:                dp2.Name(),
+		inputClassifierType: oc.Input_Classifier_Type_IPV4,
+		classifier:          "dscp_based_classifier_ipv4",
+	}, {
+		desc:                "Input Classifier Type IPV6",
+		intf:                dp2.Name(),
+		inputClassifierType: oc.Input_Classifier_Type_IPV6,
+		classifier:          "dscp_based_classifier_ipv6",
+	}}
+
+	t.Logf("qos input classifier config: %v", classifierIntfs)
+	for _, tc := range classifierIntfs {
+		i := q.GetOrCreateInterface(tc.intf)
+		i.SetInterfaceId(tc.intf)
+		if *deviations.ExplicitInterfaceRefDefinition {
+			i.GetOrCreateInterfaceRef().Interface = ygot.String(tc.intf)
+			i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
+		}
+		c := i.GetOrCreateInput().GetOrCreateClassifier(tc.inputClassifierType)
+		c.SetType(tc.inputClassifierType)
+		c.SetName(tc.classifier)
+		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
+	}
+
+	t.Logf("Create qos scheduler policies config")
+	schedulerPolicies := []struct {
+		desc        string
+		sequence    uint32
+		setPriority bool
+		priority    oc.E_Scheduler_Priority
+		inputID     string
+		inputType   oc.E_Input_InputType
+		setWeight   bool
+		weight      uint64
+		queueName   string
+		targetGroup string
+	}{{
+		desc:        "scheduler-policy-BE1",
+		sequence:    uint32(1),
+		setPriority: false,
+		setWeight:   true,
+		inputID:     "BE1",
+		inputType:   oc.Input_InputType_QUEUE,
+		weight:      uint64(1),
+		queueName:   "6",
+		targetGroup: "target-group-BE1",
+	}, {
+		desc:        "scheduler-policy-BE0",
+		sequence:    uint32(1),
+		setPriority: false,
+		setWeight:   true,
+		inputID:     "BE0",
+		inputType:   oc.Input_InputType_QUEUE,
+		weight:      uint64(1),
+		queueName:   "0",
+		targetGroup: "target-group-BE0",
+	}, {
+		desc:        "scheduler-policy-AF1",
+		sequence:    uint32(1),
+		setPriority: false,
+		setWeight:   true,
+		inputID:     "AF1",
+		inputType:   oc.Input_InputType_QUEUE,
+		weight:      uint64(4),
+		queueName:   "4",
+		targetGroup: "target-group-AF1",
+	}, {
+		desc:        "scheduler-policy-AF2",
+		sequence:    uint32(1),
+		setPriority: false,
+		setWeight:   true,
+		inputID:     "AF2",
+		inputType:   oc.Input_InputType_QUEUE,
+		weight:      uint64(8),
+		queueName:   "1",
+		targetGroup: "target-group-AF2",
+	}, {
+		desc:        "scheduler-policy-AF3",
+		sequence:    uint32(1),
+		setPriority: false,
+		setWeight:   true,
+		inputID:     "AF3",
+		inputType:   oc.Input_InputType_QUEUE,
+		weight:      uint64(12),
+		queueName:   "5",
+		targetGroup: "target-group-AF3",
+	}, {
+		desc:        "scheduler-policy-AF4",
+		sequence:    uint32(1),
+		setPriority: false,
+		setWeight:   true,
+		inputID:     "AF4",
+		inputType:   oc.Input_InputType_QUEUE,
+		weight:      uint64(48),
+		queueName:   "2",
+		targetGroup: "target-group-AF4",
+	}, {
+		desc:        "scheduler-policy-NC1",
+		sequence:    uint32(0),
+		setPriority: true,
+		setWeight:   false,
+		priority:    oc.Scheduler_Priority_STRICT,
+		inputID:     "NC1",
+		inputType:   oc.Input_InputType_QUEUE,
+		queueName:   "3",
+		targetGroup: "target-group-NC1",
+	}}
+
+	schedulerPolicy := q.GetOrCreateSchedulerPolicy("scheduler")
+	schedulerPolicy.SetName("scheduler")
+	t.Logf("qos scheduler policies config: %v", schedulerPolicies)
+	for _, tc := range schedulerPolicies {
+		s := schedulerPolicy.GetOrCreateScheduler(tc.sequence)
+		s.SetSequence(tc.sequence)
+		if tc.setPriority {
+			s.SetPriority(tc.priority)
+		}
+		input := s.GetOrCreateInput(tc.inputID)
+		input.SetId(tc.inputID)
+		input.SetInputType(tc.inputType)
+		input.SetQueue(tc.queueName)
+		if tc.setWeight {
+			input.SetWeight(tc.weight)
+		}
+		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
+	}
+
+	t.Logf("Create qos output interface config")
+	schedulerIntfs := []struct {
+		desc       string
+		queueName  string
+		scheduler  string
+		ecnProfile string
+	}{{
+		desc:       "output-interface-BE1",
+		queueName:  "6",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
+	}, {
+		desc:       "output-interface-BE0",
+		queueName:  "0",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
+	}, {
+		desc:       "output-interface-AF1",
+		queueName:  "4",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
+	}, {
+		desc:       "output-interface-AF2",
+		queueName:  "1",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
+	}, {
+		desc:       "output-interface-AF3",
+		queueName:  "5",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
+	}, {
+		desc:       "output-interface-AF4",
+		queueName:  "2",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
+	}, {
+		desc:       "output-interface-NC1",
+		queueName:  "3",
+		scheduler:  "scheduler",
+		ecnProfile: "ECNProfile",
+	}}
+
+	t.Logf("qos output interface config: %v", schedulerIntfs)
+	for _, tc := range schedulerIntfs {
+		i := q.GetOrCreateInterface(dp3.Name())
+		i.SetInterfaceId(dp3.Name())
+		if *deviations.ExplicitInterfaceRefDefinition {
+			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp3.Name())
+		}
+		output := i.GetOrCreateOutput()
+		schedulerPolicy := output.GetOrCreateSchedulerPolicy()
+		schedulerPolicy.SetName(tc.scheduler)
+		queue := output.GetOrCreateQueue(tc.queueName)
+		queue.SetName(tc.queueName)
+		queue.SetQueueManagementProfile(tc.ecnProfile)
 		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
 	}
 }

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+/// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -134,10 +134,11 @@ func ComponentsSoftwareModuleUnsupported(_ *ondatra.DUTDevice) bool {
 	return *componentsSoftwareModuleUnsupported
 }
 
-// ECNProfileRequiredDefinition returns whether the device requires all the required config for ECN.
+// ECNProfileRequiredDefinition returns whether the device requires additional config for ECN.
 func ECNProfileRequiredDefinition(_ *ondatra.DUTDevice) bool {
 	return *ecnProfileRequiredDefinition
 }
+
 // Vendor deviation flags.
 // All new flags should not be exported (define them in lowercase) and accessed
 // from tests through a public accessors like those above.
@@ -305,5 +306,5 @@ var (
 
 	componentsSoftwareModuleUnsupported = flag.Bool("deviation_components_software_module_unsupported", false, "Set true for Device that does not support software module components, default is false.")
 
-	ecnProfileRequiredDefinition = flag.Bool("deviation_ecn_profile_required_definition", false, "Providing all the required config for ECN")
+	ecnProfileRequiredDefinition = flag.Bool("deviation_ecn_profile_required_definition", false, "device requires additional config for ECN")
 )

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -137,6 +137,7 @@ func ComponentsSoftwareModuleUnsupported(_ *ondatra.DUTDevice) bool {
 // SchedulerInputWeightLimit returns whether the device does not support weight above 100.
 func SchedulerInputWeightLimit(_ *ondatra.DUTDevice) bool {
 	return *schedulerInputWeightLimit
+}
 
 // ECNProfileRequiredDefinition returns whether the device requires additional config for ECN.
 func ECNProfileRequiredDefinition(_ *ondatra.DUTDevice) bool {
@@ -313,6 +314,5 @@ var (
 
 	schedulerInputWeightLimit = flag.Bool("deviation_scheduler_input_weight_limit", false, "device does not support weight above 100")
 
-  ecnProfileRequiredDefinition = flag.Bool("deviation_ecn_profile_required_definition", false, "device requires additional config for ECN")
-
+	ecnProfileRequiredDefinition = flag.Bool("deviation_ecn_profile_required_definition", false, "device requires additional config for ECN")
 )

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -134,6 +134,10 @@ func ComponentsSoftwareModuleUnsupported(_ *ondatra.DUTDevice) bool {
 	return *componentsSoftwareModuleUnsupported
 }
 
+// ECNProfileRequiredDefinition returns whether the device requires all the required config for ECN.
+func ECNProfileRequiredDefinition(_ *ondatra.DUTDevice) bool {
+	return *ecnProfileRequiredDefinition
+}
 // Vendor deviation flags.
 // All new flags should not be exported (define them in lowercase) and accessed
 // from tests through a public accessors like those above.
@@ -300,4 +304,6 @@ var (
 	backplaneFacingCapacityUnsupported = flag.Bool("deviation_backplane_facing_capacity_unsupported", false, "Device does not support backplane-facing-capacity leaves for some of the components. Set this flag to skip checking the leaves.")
 
 	componentsSoftwareModuleUnsupported = flag.Bool("deviation_components_software_module_unsupported", false, "Set true for Device that does not support software module components, default is false.")
+
+	ecnProfileRequiredDefinition = flag.Bool("deviation_ecn_profile_required_definition", false, "Providing all the required config for ECN")
 )

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1,4 +1,4 @@
-/// Copyright 2022 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
DP-1.14 : QoS basic test - Adding required QoS config.
 
1. Pull request https://github.com/openconfig/featureprofiles/pull/1385 got closed by accident, Opening this pull request with similar changes.
2. Added Queue ID as required by Juniper. 
    Other pull request containing such changes: https://github.com/openconfig/featureprofiles/pull/1087
    Related OC model change: https://github.com/openconfig/public/pull/772 
3. Introducing new deviation - ECNProfileRequiredDefinition
* Using percentages instead of bytes for min-threshold 
Related OC model pull request(pending): https://github.com/openconfig/public/pull/688
* Adding max-threshold and max-drop-probability-percent for ECN config.
4. Included existing deviation  ExplicitInterfaceRefDefinition for interface configuration under QoS(classifier and scheduler)
