### PR TITLE
Change `make openconfig_public` to update in lock-step with new OC releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 openconfig_public:
-	tools/clone_oc_public.sh openconfig_public v1
+	tools/clone_oc_public.sh openconfig_public
 
 .PHONY: validate_paths
 validate_paths: openconfig_public proto/feature_go_proto/feature.pb.go

--- a/tools/clone_oc_public.sh
+++ b/tools/clone_oc_public.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# Usage: clone_oc_public.sh local_dir version_prefix
+# Usage: clone_oc_public.sh local_dir_name
 set -e
 git clone https://github.com/openconfig/public.git "$1"
 cd "$1"
-branch="$(git tag -l "$2.*" | sort -V | tail -1)"
+# presence of "-" indicates prelease https://semver.org/#spec-item-9
+branch="$(git tag -l | grep -v "-" | sort -V | tail -1)"
 git checkout "$branch"
+echo "Using github.com/openconfig/public branch: $branch"


### PR DESCRIPTION
I don't think it's necessary to require manual intervention when it comes to updating major OC releases. We can start to provide failure signals as soon as a new version of OC has been released. Affected PRs will be given signal to update themselves, and repo maintainers are given a signal to start fix existing tests.