### PR TITLE
P4RT: update P4RTNodesByPort to support breakout ports

### DIFF
--- a/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
+++ b/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
@@ -270,7 +270,7 @@ func P4RTNodesByPort(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
 		}
 	}
 
-	ports := make(map[string][]string) // <hardware-port>:<portID>
+	ports := make(map[string][]string) // <hardware-port>:[<portID>]
 	for _, p := range dut.Ports() {
 		hp := gnmi.Lookup(t, dut, gnmi.OC().Interface(p.Name()).HardwarePort().State())
 		if v, ok := hp.Val(); ok {

--- a/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
+++ b/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
@@ -270,11 +270,15 @@ func P4RTNodesByPort(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
 		}
 	}
 
-	ports := make(map[string]string) // <hardware-port>:<portID>
+	ports := make(map[string][]string) // <hardware-port>:<portID>
 	for _, p := range dut.Ports() {
 		hp := gnmi.Lookup(t, dut, gnmi.OC().Interface(p.Name()).HardwarePort().State())
 		if v, ok := hp.Val(); ok {
-			ports[v] = p.ID()
+			if _, ok = ports[v]; !ok {
+				ports[v] = []string{p.ID()}
+			} else {
+				ports[v] = append(ports[v], p.ID())
+			}
 		}
 	}
 	nodes := make(map[string]string) // <hardware-port>:<p4rtComponentName>
@@ -294,7 +298,9 @@ func P4RTNodesByPort(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
 		if ct != oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_INTEGRATED_CIRCUIT {
 			continue
 		}
-		res[ports[k]] = v
+		for _, p := range ports[k] {
+			res[p] = v
+		}
 	}
 	return res
 }

--- a/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
+++ b/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
@@ -23,9 +23,7 @@ package p4rtutils
 import (
 	"fmt"
 	"regexp"
-	"sort"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/cisco-open/go-p4/p4rt_client"
@@ -231,38 +229,12 @@ func inferP4RTNodesNokia(t testing.TB, dut *ondatra.DUTDevice) map[string]string
 	return res
 }
 
-// inferP4RTNodesCisco infers the P4RT node name from the port name and device model
-// for Cisco devices.
-func inferP4RTNodesCisco(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
-	t.Helper()
-	npus := []int{0, 1, 2}
-	pranges := []int{11, 23, 35}
-	res := make(map[string]string)
-	isModular := dut.Model() == "" || strings.HasPrefix(dut.Model(), "CISCO-88")
-	for _, p := range dut.Ports() {
-		if isModular {
-			parts := strings.Split(p.Name(), "/")
-			pnum, err := strconv.Atoi(parts[3])
-			if err != nil {
-				t.Fatalf("Error parsing port name: %v", err)
-			}
-			npu := npus[sort.SearchInts(pranges, pnum)]
-			res[p.ID()] = fmt.Sprintf("0/%s/CPU0-NPU%d", parts[1], npu)
-		} else {
-			res[p.ID()] = "0/RP0/CPU0-NPU0"
-		}
-	}
-	return res
-}
-
 // P4RTNodesByPort returns a map of <portID>:<P4RTNodeName> for the reserved ondatra
 // ports using the component and the interface OC tree.
 func P4RTNodesByPort(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
 	t.Helper()
 	if *deviations.ExplicitP4RTNodeComponent {
 		switch dut.Vendor() {
-		case ondatra.CISCO:
-			return inferP4RTNodesCisco(t, dut)
 		case ondatra.NOKIA:
 			return inferP4RTNodesNokia(t, dut)
 		default:

--- a/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -18,9 +18,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
-	"sort"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -930,38 +928,12 @@ func inferP4RTNodesNokia(t testing.TB, dut *ondatra.DUTDevice) map[string]string
 	return res
 }
 
-// inferP4RTNodesCisco infers the P4RT node name from the port name and device model
-// for Cisco devices.
-func inferP4RTNodesCisco(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
-	t.Helper()
-	npus := []int{0, 1, 2}
-	pranges := []int{11, 23, 35}
-	res := make(map[string]string)
-	isModular := dut.Model() == "" || strings.HasPrefix(dut.Model(), "CISCO-88")
-	for _, p := range dut.Ports() {
-		if isModular {
-			parts := strings.Split(p.Name(), "/")
-			pnum, err := strconv.Atoi(parts[3])
-			if err != nil {
-				t.Fatalf("Error parsing port name: %v", err)
-			}
-			npu := npus[sort.SearchInts(pranges, pnum)]
-			res[p.ID()] = fmt.Sprintf("0/%s/CPU0-NPU%d", parts[1], npu)
-		} else {
-			res[p.ID()] = "0/RP0/CPU0-NPU0"
-		}
-	}
-	return res
-}
-
 // P4RTNodesByPort returns a map of <portID>:<P4RTNodeName> for the reserved ondatra
 // ports using the component and the interface OC tree.
 func P4RTNodesByPort(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
 	t.Helper()
 	if *deviations.ExplicitP4RTNodeComponent {
 		switch dut.Vendor() {
-		case ondatra.CISCO:
-			return inferP4RTNodesCisco(t, dut)
 		case ondatra.NOKIA:
 			return inferP4RTNodesNokia(t, dut)
 		default:


### PR DESCRIPTION
This PR updates P4RTNodesByPort and the P4RT subtests of gNMI-1.10 to allow multiple ports to map to the same hardware-port. It also remove inferP4RTNodeName for CISCO.