### PR TITLE
TE-14.1 - OTG: Fixed nexthop address for instance vrf3

### DIFF
--- a/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
@@ -171,7 +171,7 @@ func installEntries(t *testing.T, ips []string, nexthops []string, index routesP
 			nh := fluent.NextHopEntry().
 				WithNetworkInstance(*deviations.DefaultNetworkInstance).
 				WithIndex(ind).
-				WithIPinIP(tunnelSrcIP, tunnelDstIP).
+				WithIPinIP(tunnelSrcIP, ateAddr).
 				WithDecapsulateHeader(fluent.IPinIP).
 				WithEncapsulateHeader(fluent.IPinIP).
 				WithNextHopNetworkInstance(vrf1).


### PR DESCRIPTION
Porting changes from #1356 to OTG location

As per testplan , nexthop address for instance "vrf3" should not be >> tunnelDstIP = "198.18.208.1"