### PR TITLE
Fix OC-1.2: Default Address Families Test failure due to ip address configuration missing

### DIFF
--- a/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
@@ -33,7 +33,7 @@ func TestMain(m *testing.M) {
 	fptest.RunTests(m)
 }
 
-func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attributes) {
+func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attributes, dut *ondatra.DUTDevice) {
 	t.Helper()
 	ni := d.GetOrCreateNetworkInstance(niName)
 	if niName != *deviations.DefaultNetworkInstance {
@@ -43,6 +43,13 @@ func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attribut
 		niIntf := ni.GetOrCreateInterface(intf)
 		niIntf.Interface = ygot.String(intf)
 		niIntf.Subinterface = ygot.Uint32(0)
+	}
+
+	// For vendors that require n/w instance definition and interface in
+	// a n/w instance set before the address configuration, set nwInstance +
+	// interface creation in the nwInstance first.
+	if *deviations.InterfaceConfigVrfBeforeAddress {
+		gnmi.Update(t, dut, gnmi.OC().Config(), d)
 	}
 
 	ocInt := a.ConfigOCInterface(&oc.Interface{})
@@ -157,10 +164,10 @@ func TestDefaultAddressFamilies(t *testing.T) {
 
 			d := &oc.Root{}
 			// Assign two ports into the network instance & unnasign them at the end of the test
-			assignPort(t, d, dutP1.Name(), tc.niName, dutPort1)
+			assignPort(t, d, dutP1.Name(), tc.niName, dutPort1, dut)
 			defer unassignPort(t, dut, dutP1.Name(), tc.niName)
 
-			assignPort(t, d, dutP2.Name(), tc.niName, dutPort2)
+			assignPort(t, d, dutP2.Name(), tc.niName, dutPort2, dut)
 			defer unassignPort(t, dut, dutP2.Name(), tc.niName)
 
 			fptest.LogQuery(t, "test configuration", gnmi.OC().Config(), d)


### PR DESCRIPTION
In EOS, the interface ip address in removed when the interface is configured under a new network instance and hence the ip address configuration for that inteface needs to be pushed again. This caused an issue in the test where the dut interface ip address is not present when gnmi.update was done with a configuration that had 1 - new non default nwInstance configuration
2 - interface configuration in that non default nwInstance 3 - interface ip address configuration
when the interfaces were configured under default nwInstance with the same ipaddress before.

Due to the above behavior in EOS, I have added a new deviation check that causes the test do a gnmi update for (1) and (2) first followed by gnmi update for (3)