### PR TITLE
RT-3.2: OTG: Changed the ATE source MAC  from "01:00:02:01:01:01" to "00:12:01:00:00:01"

### DIFF
--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -79,7 +79,7 @@ var (
 
 	atePort2 = attrs.Attributes{
 		Name:    "atePort2",
-		MAC:     "01:00:02:01:01:01",
+		MAC:     "00:12:01:00:00:01",
 		IPv4:    "192.0.2.6",
 		IPv4Len: ipv4PrefixLen,
 		IPv6:    "2001:0db8::192:0:2:6",
@@ -97,7 +97,7 @@ var (
 
 	atePort2Vlan10 = attrs.Attributes{
 		Name:    "atePort2Vlan10",
-		MAC:     "01:00:02:01:01:01",
+		MAC:     "00:12:01:00:00:01",
 		IPv4:    "192.0.2.10",
 		IPv4Len: ipv4PrefixLen,
 		IPv6:    "2001:0db8::192:0:2:a",
@@ -115,7 +115,7 @@ var (
 
 	atePort2Vlan20 = attrs.Attributes{
 		Name:    "atePort2Vlan20",
-		MAC:     "01:00:02:01:01:01",
+		MAC:     "00:12:01:00:00:01",
 		IPv4:    "192.0.2.14",
 		IPv4Len: ipv4PrefixLen,
 		IPv6:    "2001:0db8::192:0:2:e",
@@ -133,7 +133,7 @@ var (
 
 	atePort2Vlan30 = attrs.Attributes{
 		Name:    "atePort2Vlan30",
-		MAC:     "01:00:02:01:01:01",
+		MAC:     "00:12:01:00:00:01",
 		IPv4:    "192.0.2.18",
 		IPv4Len: ipv4PrefixLen,
 		IPv6:    "2001:0db8::192:0:2:12",


### PR DESCRIPTION
Changed the ATE source MAC  from "01:00:02:01:01:01" to "00:12:01:00:00:01".

01:00:02:01:01:01 is a group address and source MAC must not be a group address. In the Source Address field, the first bit is reserved and set to 0. When MAC "01:00:02:01:01:01" is used, there are is no ARP reply being sent from DUT since "01:00:02:01:01:01" is a group address.
Please refer to - IEEE 802.3-2002, Section 3.2.3(b) - https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=988967

