### PR TITLE
Remove GRIBIPreserveOnly deviation

### DIFF
--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -195,8 +195,6 @@ var (
 	OmitL2MTU = flag.Bool("deviation_omit_l2_mtu", false,
 		"Device does not support setting the L2 MTU, so omit it.  OpenConfig allows a device to enforce that L2 MTU, which has a default value of 1514, must be set to a higher value than L3 MTU, so a full OpenConfig compliant device may fail with the deviation.")
 
-	GRIBIPreserveOnly = flag.Bool("deviation_gribi_preserve_only", false, "Device does not support gRIBI client with persistence DELETE, so this skips the optional test cases in DELETE mode.  However, tests explicitly testing DELETE mode will still run.  Full gRIBI compliant devices should pass both with and without this deviation.")
-
 	GRIBIRIBAckOnly = flag.Bool("deviation_gribi_riback_only", false, "Device only supports RIB ack, so tests that normally expect FIB_ACK will allow just RIB_ACK.  Full gRIBI compliant devices should pass both with and without this deviation.")
 
 	MissingValueForDefaults = flag.Bool("deviation_missing_value_for_defaults", false,


### PR DESCRIPTION
Remove GRIBIPreserveOnly deviation flag since it is not used by tests anymore.