### PR TITLE
TE-3.3-uprev: Opened PR to address CLA check failing for PR 1417

### DIFF
--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/README.md
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/README.md
@@ -34,7 +34,7 @@ Test case for basic hierarchical weight:
 *   Establish gRIBI client connection with DUT with PERSISTENCE, make it become
     leader and install the following Entries:
 
-    *   IPv4Entry 198.18.196.0/22 in VRF-1, pointing to NextHopGroup(NHG#1) in
+    *   IPv4Entry 203.0.113.0/32 in VRF-1, pointing to NextHopGroup(NHG#1) in
         default VRF, with two NextHops(NH#1, NH#2) in default VRF:
 
         *   NH#1 with weight:1, pointing to 192.0.2.111
@@ -65,7 +65,7 @@ Test case for basic hierarchical weight:
 
     *   NH101: (3/4) * (5/8) = 46.87% traffic received by ATE port-2 VLAN 4
 
-    *   A deviation of 0.5% is allowed for each VLAN for now, since we only test
+    *   A tolerance of 0.2% is allowed for each VLAN for now, since we only test
         for 2 mins.
 
 Test case for hierarchical weight in boundary scenarios, with maximum expected
@@ -74,7 +74,7 @@ WCMP width of 16 nexthops:
 *   Flush previous gRIBI Entries for all NIs and establish a new connection with
     DUT with PERSISTENCE and install the following Entries:
 
-    *   IPv4Entry 198.18.196.0/22 in VRF-1, pointing to NextHopGroup(NHG#1) in
+    *   IPv4Entry 203.0.113.0/32 in VRF-1, pointing to NextHopGroup(NHG#1) in
         default VRF, with two NextHops(NH#1, NH#2) in default VRF:
 
         *   NH#1 with weight:1, pointing to 192.0.2.111
@@ -90,27 +90,29 @@ WCMP width of 16 nexthops:
 
     *   IPv4Entry 192.0.2.222/32 in default VRF, pointing to NextHopGroup(NHG#3)
         in default VRF, with 16 NextHops(NH#100, NH#101, ..., NH#115), all with
-        weight: 1, in default VRF:
+        weight: 16 except NHG#100 is of weight 1, in default VRF:
 
         *   NH#100 with weight:1, pointing to 192.0.2.18
 
-        *   NH#101 with weight:1, pointing to 192.0.2.22
+        *   NH#101 with weight:16, pointing to 192.0.2.22
 
         *   ...
 
-        *   NH#115 with weight:1, pointing to 192.0.2.79
+        *   NH#115 with weight:16, pointing to 192.0.2.79
 
 *   Validate with traffic:
 
-    *   NH10: (1/32) * (3/8) = 1.171% traffic received by ATE port-2 VLAN 1
+    *   NH10: (1/32) * (3/8) ~ 1.171% traffic received by ATE port-2 VLAN 1
 
-    *   NH11: (1/32) * (5/8) = 1.953% traffic received by ATE port-2 VLAN 2
+    *   NH11: (1/32) * (5/8) ~ 1.953% traffic received by ATE port-2 VLAN 2
 
-    *   for each VLAN ID in 3...18:
+    *   NH100: (31/32) * (1/241) ~ 0.402% traffic received by ATE port-2 VLAN 3
 
-        *   NH: (31/32) * (1/16) ~ 6.05% traffic received by ATE port-2 VLAN ID
+    *   for each VLAN ID in 4...18:
 
-    *   A deviation of 0.5% is allowed for each VLAN for now, since we only test
+        *   NH: (31/32) * (16/241) ~ 6.432% traffic received by ATE port-2 VLAN ID
+
+    *   A tolerance of 0.2% is allowed for each VLAN for now, since we only test
         for 2 mins.
 
 ## Config Parameter Coverage

--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -52,8 +52,8 @@ type nhInfo struct {
 const (
 	ipv4EntryPrefix   = "203.0.113.0/32"
 	ipv4FlowIP        = "203.0.113.0"
-	innerSrcIpv4Start = "198.51.0.0"
-	innerDstIpv4Start = "198.52.0.0"
+	innerSrcIpv4Start = "198.18.0.0"
+	innerDstIpv4Start = "198.19.0.0"
 	ipv4PrefixLen     = 30
 	ipv4FlowCount     = 65000
 	nhEntryIP1        = "192.0.2.111"

--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -50,18 +50,17 @@ type nhInfo struct {
 }
 
 const (
-	ipv4PrefixLen   = 30
-	ipv4EntryPrefix = "198.18.192.0/21"
-	ipv4FlowIPStart = "198.18.192.0"
-	ipv4FlowIPEnd   = "198.18.199.255"
-	ipv4FlowCount   = 2048
-	nhEntryIP1      = "192.0.2.111"
-	nhEntryIP2      = "192.0.2.222"
-	nonDefaultVRF   = "VRF-1"
-	// 'deviation' is the maximum difference that is allowed between the observed
-	// traffic distribution and the required traffic distribution.
-	deviation  = 1
-	policyName = "redirect-to-VRF1"
+	ipv4EntryPrefix   = "203.0.113.0/32"
+	ipv4FlowIP        = "203.0.113.0"
+	innerSrcIpv4Start = "198.51.0.0"
+	innerDstIpv4Start = "198.52.0.0"
+	ipv4PrefixLen     = 30
+	ipv4FlowCount     = 65000
+	nhEntryIP1        = "192.0.2.111"
+	nhEntryIP2        = "192.0.2.222"
+	nonDefaultVRF     = "VRF-1"
+	policyName        = "redirect-to-VRF1"
+	ipipProtocol      = 4
 )
 
 var (
@@ -115,6 +114,9 @@ var (
 		2: cidr(nhEntryIP1, 32),
 		3: cidr(nhEntryIP2, 32),
 	}
+	// 'deviation' is the maximum difference that is allowed between the observed
+	// traffic distribution and the required traffic distribution.
+	tolerance = 0.2
 )
 
 func TestMain(m *testing.M) {
@@ -341,7 +343,7 @@ func configurePBF() *oc.NetworkInstance_PolicyForwarding {
 	pf := ni.GetOrCreatePolicyForwarding()
 	vrfPolicy := pf.GetOrCreatePolicy(policyName)
 	vrfPolicy.SetType(oc.Policy_Type_VRF_SELECTION_POLICY)
-	vrfPolicy.GetOrCreateRule(1).GetOrCreateIpv4().SourceAddress = ygot.String(atePort1.IPv4 + "/32")
+	vrfPolicy.GetOrCreateRule(1).GetOrCreateIpv4().Protocol = oc.UnionUint8(ipipProtocol)
 	vrfPolicy.GetOrCreateRule(1).GetOrCreateAction().NetworkInstance = ygot.String(nonDefaultVRF)
 	return pf
 }
@@ -412,10 +414,10 @@ func testTraffic(t *testing.T, ate *ondatra.ATEDevice, top *ondatra.ATETopology)
 	ethHeader := ondatra.NewEthernetHeader()
 	ipv4Header := ondatra.NewIPv4Header()
 	ipv4Header.WithSrcAddress(atePort1.IPv4)
-	ipv4Header.DstAddressRange().
-		WithMin(ipv4FlowIPStart).
-		WithMax(ipv4FlowIPEnd).
-		WithCount(ipv4FlowCount)
+	ipv4Header.WithDstAddress(ipv4FlowIP)
+	innerIpv4Header := ondatra.NewIPv4Header()
+	innerIpv4Header.SrcAddressRange().WithMin(innerSrcIpv4Start).WithCount(ipv4FlowCount).WithStep("0.0.0.1")
+	innerIpv4Header.DstAddressRange().WithMin(innerDstIpv4Start).WithCount(ipv4FlowCount).WithStep("0.0.0.1")
 
 	// Ethernet header:
 	//   - Destination MAC (6 octets)
@@ -425,7 +427,7 @@ func testTraffic(t *testing.T, ate *ondatra.ATEDevice, top *ondatra.ATETopology)
 	flow := ate.Traffic().NewFlow("flow").
 		WithSrcEndpoints(srcEndPoint).
 		WithDstEndpoints(dstEndPoints...).
-		WithHeaders(ethHeader, ipv4Header)
+		WithHeaders(ethHeader, ipv4Header, innerIpv4Header)
 
 	// VlanID is the last 12 bits in the 802.1q VLAN tag.
 	// Offset for VlanID: ((6+6+4) * 8)-12 = 116.
@@ -522,7 +524,7 @@ func testBasicHierarchicalWeight(ctx context.Context, t *testing.T, dut *ondatra
 	}
 	t.Run("testTraffic", func(t *testing.T) {
 		got := testTraffic(t, ate, top)
-		if diff := cmp.Diff(wantWeights, got, cmpopts.EquateApprox(0, deviation)); diff != "" {
+		if diff := cmp.Diff(wantWeights, got, cmpopts.EquateApprox(0, tolerance)); diff != "" {
 			t.Errorf("Packet distribution ratios -want,+got:\n%s", diff)
 		}
 	})
@@ -566,7 +568,11 @@ func testHierarchicalWeightBoundaryScenario(ctx context.Context, t *testing.T, d
 	for i := 0; i < 16; i++ {
 		nh := nextHopEntry(nhIdx, defaultVRF, atePort2.ip(uint8(3+i)))
 		gribiEntries = append(gribiEntries, nh)
-		nextHopWeights = append(nextHopWeights, nhInfo{index: nhIdx, weight: 1})
+		if nhIdx == 100 {
+			nextHopWeights = append(nextHopWeights, nhInfo{index: nhIdx, weight: 1})
+		} else {
+			nextHopWeights = append(nextHopWeights, nhInfo{index: nhIdx, weight: 16})
+		}
 		nhIdx++
 	}
 	nhg3 := nextHopGroupEntry(3, defaultVRF, nextHopWeights)
@@ -602,14 +608,19 @@ func testHierarchicalWeightBoundaryScenario(ctx context.Context, t *testing.T, d
 	wantWeights := map[string]float64{
 		"1": 1.171,
 		"2": 1.953,
+		"3": 0.402,
 	}
-	// 6.05 weight for vlans 3 to 18.
-	for i := 3; i <= 18; i++ {
-		wantWeights[strconv.Itoa(i)] = 6.05
+	// 6.432 weight for vlans 4 to 18.
+	for i := 4; i <= 18; i++ {
+		wantWeights[strconv.Itoa(i)] = 6.432
 	}
 	t.Run("testTraffic", func(t *testing.T) {
 		got := testTraffic(t, ate, top)
-		if diff := cmp.Diff(wantWeights, got, cmpopts.EquateApprox(0, deviation)); diff != "" {
+
+		if deviations.UCMPTrafficTolerance(dut) != tolerance {
+			tolerance = deviations.UCMPTrafficTolerance(dut)
+		}
+		if diff := cmp.Diff(wantWeights, got, cmpopts.EquateApprox(0, tolerance)); diff != "" {
 			t.Errorf("Packet distribution ratios -want,+got:\n%s", diff)
 		}
 	})
@@ -617,7 +628,7 @@ func testHierarchicalWeightBoundaryScenario(ctx context.Context, t *testing.T, d
 	t.Run("validateAFTWeights", func(t *testing.T) {
 		for nhg, weights := range map[uint64][]uint64{
 			2: {3, 5},
-			3: {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+			3: {1, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16},
 		} {
 			got := aftNextHopWeights(t, dut, nhg, defaultVRF)
 			ok := cmp.Equal(weights, got, cmpopts.SortSlices(func(a, b uint64) bool { return a < b }))

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -164,6 +164,11 @@ func FanOperStatusUnsupported(_ *ondatra.DUTDevice) bool {
 	return *fanOperStatusUnsupported
 }
 
+// UCMPTrafficTolerance returns the allowed tolerance for BGP traffic flow while comparing for pass or fail conditions.
+func UCMPTrafficTolerance(_ *ondatra.DUTDevice) float64 {
+	return *ucmpTrafficTolerance
+}
+
 // Vendor deviation flags.
 // All new flags should not be exported (define them in lowercase) and accessed
 // from tests through a public accessors like those above.
@@ -336,4 +341,6 @@ var (
 	ipv6DiscardedPktsUnsupported = flag.Bool("deviation_ipv6_discarded_pkts_unsupported", false, "Set true for device that does not support interface ipv6 discarded packet statistics, default is false")
 
 	fanOperStatusUnsupported = flag.Bool("deviation_fan_oper_status_unsupported", false, "Device does not support oper-status leaves for some of the fan components. Set this flag to skip checking the leaf.")
+
+	ucmpTrafficTolerance = flag.Float64("deviation_ucmp_traffic_tolerance", 0.2, "Set it to expected ucmp traffic tolerance, default is 0.2")
 )


### PR DESCRIPTION
Opened PR to address CLA check failure for PR https://github.com/openconfig/featureprofiles/pull/1417

PR is based on a request to enhance TE3.3 based on https://github.com/openconfig/featureprofiles/pull/1133 and https://github.com/openconfig/featureprofiles/pull/1239


Issues addressed:
- Case1: Basic hierarchical weight, changed tolerance to 0.2
- Case2: Hierarchical weight in boundary scenarios, changed the programming to 16 NHs
- For better UCMP results, added ipinip flow with inner 64k prefixes
- Update PBR to match ipinip flow
- Added deviation "ucmpTrafficTolerance" for Case 2 tolerance (need to run TC with 1.5 tolerance for us)