### PR TITLE
fixed static route NH index 

### DIFF
--- a/feature/gribi/otg_tests/ack_in_presence_other_routes/route_ack_test.go
+++ b/feature/gribi/otg_tests/ack_in_presence_other_routes/route_ack_test.go
@@ -153,6 +153,10 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, dut.Port(t, "port2"))
 		fptest.SetPortSpeed(t, dut.Port(t, "port3"))
 	}
+
+	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+	}
 }
 
 // configureATE configures port1, port2 and port3 on the ATE.
@@ -248,7 +252,7 @@ func configStaticRoute(t *testing.T, dut *ondatra.DUTDevice, prefix string, next
 	ni1 := gnmi.GetConfig(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Config())
 	static := ni1.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
 	sr := static.GetOrCreateStatic(prefix)
-	nh := sr.GetOrCreateNextHop("nhg1")
+	nh := sr.GetOrCreateNextHop("0")
 	nh.NextHop = oc.UnionString(nexthop)
 	gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName).Config(), static)
 }


### PR DESCRIPTION
1. fixed static route NH index to be inline with ATE test 
2. updated with deviation ExplicitGRIBIUnderNetworkInstance

This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an as is basis without any warranties of any kind.