### PR TITLE
Moving deviation flag NTPAssociationTypeRequired to accessor method

### DIFF
--- a/feature/system/ntp/tests/system_ntp_test/server_test.go
+++ b/feature/system/ntp/tests/system_ntp_test/server_test.go
@@ -44,7 +44,7 @@ func TestNtpServerConfigurability(t *testing.T) {
 			ntpServer := oc.System_Ntp_Server{
 				Address: &testCase.address,
 			}
-			if *deviations.NTPAssociationTypeRequired {
+			if deviations.NTPAssociationTypeRequired(dut) {
 				ntpServer.AssociationType = oc.Server_AssociationType_SERVER
 			}
 			gnmi.Replace(t, dut, config.Server(testCase.address).Config(), &ntpServer)

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+f// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -184,6 +184,12 @@ func HierarchicalWeightResolutionTolerance(_ *ondatra.DUTDevice) float64 {
 	return *hierarchicalWeightResolutionTolerance
 }
 
+// NTPAssociationTypeRequired returns if device requires NTP association-type to be explicitly set.
+// OpenConfig defaults the association-type to SERVER if not set.
+func NTPAssociationTypeRequired(_ *ondatra.DUTDevice) bool {
+	return *ntpAssociationTypeRequired
+}
+
 // Vendor deviation flags.
 // All new flags should not be exported (define them in lowercase) and accessed
 // from tests through a public accessors like those above.
@@ -191,7 +197,7 @@ var (
 	BannerDelimiter = flag.String("deviation_banner_delimiter", "",
 		"Device requires the banner to have a delimiter character. Full OpenConfig compliant devices should work without delimiter.")
 
-	NTPAssociationTypeRequired = flag.Bool("deviation_ntp_association_type_required", false,
+	ntpAssociationTypeRequired = flag.Bool("deviation_ntp_association_type_required", false,
 		"Device requires NTP association-type to be explicitly set.  OpenConfig defaults the association-type to SERVER if not set.")
 
 	InterfaceEnabled = flag.Bool("deviation_interface_enabled", false,

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1,4 +1,4 @@
-f// Copyright 2022 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Moving deviation flag NTPAssociationTypeRequired to accessor method