### PR TITLE
Fix presubmit for cisco 8000e

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -31,7 +31,7 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type n2-standard-8 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c "echo 'user ALL=(ALL:ALL) ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_8000e 2>&1
+      - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_8000e 2>&1
   - id: cisco_xrd
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
@@ -42,7 +42,7 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c "echo 'user ALL=(ALL:ALL) ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_xrd 2>&1
+      - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_xrd 2>&1
   - id: nokia_srlinux
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -9,43 +9,40 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c "usermod -a -G root user"; sudo -iu user /tmp/workspace/cloudbuild/test.sh arista_ceos
+      - COMMAND=sudo su -c "usermod -a -G root user"; sudo -iu user /tmp/workspace/cloudbuild/test.sh arista_ceos 2>&1
   - id: juniper_cptx
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
     allowFailure: true
     env:
-      - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-juniper-cptx-$BUILD_ID
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-16 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c "usermod -a -G root user"; sudo -iu user /tmp/workspace/cloudbuild/test.sh juniper_cptx
+      - COMMAND=sudo su -c "usermod -a -G root user"; sudo -iu user /tmp/workspace/cloudbuild/test.sh juniper_cptx 2>&1
   - id: cisco_8000e
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
     allowFailure: true
     env:
-      - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-cisco-8000e-$BUILD_ID
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type n2-standard-8 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c "sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_8000e"
+      - COMMAND=sudo su -c "echo 'user ALL=(ALL:ALL) ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_8000e 2>&1
   - id: cisco_xrd
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
     allowFailure: true
     env:
-      - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-cisco-xrd-$BUILD_ID
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c "sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_xrd"
+      - COMMAND=sudo su -c "echo 'user ALL=(ALL:ALL) ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_xrd 2>&1
   - id: nokia_srlinux
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -56,7 +56,7 @@ steps:
       - REMOTE_WORKSPACE=/tmp/workspace
       - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh nokia_srlinux 2>&1
 
-timeout: 1800s
+timeout: 2700s
 
 options:
   pool:

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -7,10 +7,10 @@ steps:
       - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-arista-ceos-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo -iu user /tmp/workspace/cloudbuild/test.sh arista_ceos
+      - COMMAND=sudo su -c su user -c /tmp/workspace/cloudbuild/test.sh arista_ceos
   - id: juniper_cptx
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
@@ -22,7 +22,7 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-16 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo -iu user /tmp/workspace/cloudbuild/test.sh juniper_cptx
+      - COMMAND=sudo su -c su user -c /tmp/workspace/cloudbuild/test.sh juniper_cptx
   - id: cisco_8000e
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
@@ -31,7 +31,7 @@ steps:
       - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-cisco-8000e-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-8 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type n2-standard-8 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
       - COMMAND=sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_8000e
@@ -43,7 +43,7 @@ steps:
       - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-cisco-xrd-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
       - COMMAND=sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_xrd
@@ -55,7 +55,7 @@ steps:
       - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-nokia-srlinux-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
       - COMMAND=sudo -iu user /tmp/workspace/cloudbuild/test.sh nokia_srlinux

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c "cd /home/user; /tmp/workspace/cloudbuild/test.sh arista_ceos"
+      - COMMAND=sudo -iu user sudo /tmp/workspace/cloudbuild/test.sh arista_ceos
   - id: juniper_cptx
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
@@ -21,7 +21,7 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-16 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c su user -c "cd ~; /tmp/workspace/cloudbuild/test.sh juniper_cptx"
+      - COMMAND=sudo -iu user sudo /tmp/workspace/cloudbuild/test.sh juniper_cptx
   - id: cisco_8000e
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -4,13 +4,12 @@ steps:
     waitFor: ["-"]
     allowFailure: true
     env:
-      - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-arista-ceos-$BUILD_ID
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c su user -c "cd ~; /tmp/workspace/cloudbuild/test.sh arista_ceos"
+      - COMMAND=sudo su -c "cd /home/user; /tmp/workspace/cloudbuild/test.sh arista_ceos"
   - id: juniper_cptx
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c su user -c /tmp/workspace/cloudbuild/test.sh arista_ceos
+      - COMMAND=sudo su -c su user -c "cd ~; /tmp/workspace/cloudbuild/test.sh arista_ceos"
   - id: juniper_cptx
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
@@ -22,7 +22,7 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-16 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c su user -c /tmp/workspace/cloudbuild/test.sh juniper_cptx
+      - COMMAND=sudo su -c su user -c "cd ~; /tmp/workspace/cloudbuild/test.sh juniper_cptx"
   - id: cisco_8000e
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
@@ -34,7 +34,7 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type n2-standard-8 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_8000e
+      - COMMAND=sudo su -c "sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_8000e"
   - id: cisco_xrd
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
@@ -43,10 +43,10 @@ steps:
       - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-cisco-xrd-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_xrd
+      - COMMAND=sudo su -c "sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_xrd"
   - id: nokia_srlinux
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -6,10 +6,10 @@ steps:
     env:
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-arista-ceos-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c "usermod -a -G root user"; sudo -iu user /tmp/workspace/cloudbuild/test.sh arista_ceos 2>&1
+      - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh arista_ceos 2>&1
   - id: juniper_cptx
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
@@ -20,7 +20,7 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-16 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c "usermod -a -G root user"; sudo -iu user /tmp/workspace/cloudbuild/test.sh juniper_cptx 2>&1
+      - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh juniper_cptx 2>&1
   - id: cisco_8000e
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
@@ -28,7 +28,7 @@ steps:
     env:
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-cisco-8000e-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type n2-standard-8 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-8 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
       - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_8000e 2>&1
@@ -51,12 +51,12 @@ steps:
       - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-nokia-srlinux-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo -iu user /tmp/workspace/cloudbuild/test.sh nokia_srlinux
+      - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh nokia_srlinux 2>&1
 
-timeout: 2700s
+timeout: 1800s
 
 options:
   pool:

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -31,7 +31,7 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type n2-standard-8 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_8000e 2>&1
+      - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_8000e 2>&1
   - id: cisco_xrd
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
@@ -42,7 +42,7 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_xrd 2>&1
+      - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/test.sh cisco_xrd 2>&1
   - id: nokia_srlinux
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne-untested --machine-type e2-standard-4 --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo -iu user sudo /tmp/workspace/cloudbuild/test.sh arista_ceos
+      - COMMAND=sudo su -c "usermod -a -G root user"; sudo -iu user /tmp/workspace/cloudbuild/test.sh arista_ceos
   - id: juniper_cptx
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]
@@ -21,7 +21,7 @@ steps:
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-16 --boot-disk-size 100GB --enable-nested-virtualization --preemptible
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo -iu user sudo /tmp/workspace/cloudbuild/test.sh juniper_cptx
+      - COMMAND=sudo su -c "usermod -a -G root user"; sudo -iu user /tmp/workspace/cloudbuild/test.sh juniper_cptx
   - id: cisco_8000e
     name: gcr.io/$PROJECT_ID/remote-builder
     waitFor: ["-"]

--- a/test.md
+++ b/test.md
@@ -1,0 +1,1 @@
+This is a file

--- a/test.md
+++ b/test.md
@@ -1,1 +1,0 @@
-This is a file


### PR DESCRIPTION
Fixes the presubmit, 8000e now passes. Due to os-login, by default non-root users need to provide a password to sudo. sudo is required for 8000e due to limitations around kernel.pid_max (see https://github.com/openconfig/kne/tree/main/examples/cisco/8000e#check-perquisites-and-create-a-kne-topology-using-topology-8000e-ixiapbtxt). This change allows the user the test runs as to be able to sudo without providing a password to fix the issue.