### PR TITLE
Move telemetry deviation to accessor

### DIFF
--- a/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -145,10 +145,10 @@ func TestInterfaceOperStatus(t *testing.T) {
 }
 
 func TestInterfacePhysicalChannel(t *testing.T) {
-	if *deviations.MissingInterfacePhysicalChannel {
+	dut := ondatra.DUT(t, "dut")
+	if deviations.MissingInterfacePhysicalChannel(dut) {
 		t.Skip("Test is skipped due to MissingInterfacePhysicalChannel deviation")
 	}
-	dut := ondatra.DUT(t, "dut")
 	dp := dut.Port(t, "port1")
 
 	phyChannel := gnmi.Get(t, dut, gnmi.OC().Interface(dp.Name()).PhysicalChannel().State())
@@ -205,10 +205,10 @@ func TestInterfaceStatusChange(t *testing.T) {
 }
 
 func TestHardwarePort(t *testing.T) {
-	if *deviations.MissingInterfaceHardwarePort {
+	dut := ondatra.DUT(t, "dut")
+	if deviations.MissingInterfaceHardwarePort(dut) {
 		t.Skip("Test is skipped due to MissingInterfaceHardwarePort deviation")
 	}
-	dut := ondatra.DUT(t, "dut")
 	dp := dut.Port(t, "port1")
 
 	// Verify HardwarePort leaf is present under interface.
@@ -519,7 +519,7 @@ func TestCPU(t *testing.T) {
 	for _, cpu := range cpus {
 		t.Logf("Validate CPU: %s", cpu)
 		component := gnmi.OC().Component(cpu)
-		if !*deviations.MissingCPUMfgName {
+		if !deviations.MissingCPUMfgName(dut) {
 			if !gnmi.Lookup(t, dut, component.MfgName().State()).IsPresent() {
 				t.Errorf("component.MfgName().Lookup(t).IsPresent() for %q: got false, want true", cpu)
 			} else {

--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -149,10 +149,10 @@ func TestInterfaceOperStatus(t *testing.T) {
 }
 
 func TestInterfacePhysicalChannel(t *testing.T) {
-	if *deviations.MissingInterfacePhysicalChannel {
+	dut := ondatra.DUT(t, "dut")
+	if deviations.MissingInterfacePhysicalChannel(dut) {
 		t.Skip("Test is skipped due to MissingInterfacePhysicalChannel deviation")
 	}
-	dut := ondatra.DUT(t, "dut")
 	dp := dut.Port(t, "port1")
 
 	phyChannel := gnmi.Get(t, dut, gnmi.OC().Interface(dp.Name()).PhysicalChannel().State())
@@ -209,11 +209,10 @@ func TestInterfaceStatusChange(t *testing.T) {
 }
 
 func TestHardwarePort(t *testing.T) {
-	if *deviations.MissingInterfaceHardwarePort {
+	dut := ondatra.DUT(t, "dut")
+	if deviations.MissingInterfaceHardwarePort(dut) {
 		t.Skip("Test is skipped due to MissingInterfaceHardwarePort deviation")
 	}
-
-	dut := ondatra.DUT(t, "dut")
 	dp := dut.Port(t, "port1")
 
 	// Verify HardwarePort leaf is present under interface.
@@ -525,7 +524,7 @@ func TestCPU(t *testing.T) {
 	for _, cpu := range cpus {
 		t.Logf("Validate CPU: %s", cpu)
 		component := gnmi.OC().Component(cpu)
-		if !*deviations.MissingCPUMfgName {
+		if !deviations.MissingCPUMfgName(dut) {
 			if !gnmi.Lookup(t, dut, component.MfgName().State()).IsPresent() {
 				t.Errorf("component.MfgName().Lookup(t).IsPresent() for %q: got false, want true", cpu)
 			} else {

--- a/feature/gribi/ate_tests/ipv4_entry_test/ipv4_entry_test.go
+++ b/feature/gribi/ate_tests/ipv4_entry_test/ipv4_entry_test.go
@@ -331,7 +331,7 @@ func TestIPv4Entry(t *testing.T) {
 						conn.WithPersistence()
 					}
 
-					if !*deviations.GRIBIRIBAckOnly {
+					if !deviations.GRIBIRIBAckOnly(dut) {
 						// The main difference WithFIBACK() made was that we are now expecting
 						// fluent.InstalledInFIB in []*client.OpResult, as opposed to
 						// fluent.InstalledInRIB.

--- a/feature/gribi/ate_tests/ordering_ack_test/ordering_ack_test.go
+++ b/feature/gribi/ate_tests/ordering_ack_test/ordering_ack_test.go
@@ -499,7 +499,7 @@ func TestOrderingACK(t *testing.T) {
 					WithRedundancyMode(fluent.ElectedPrimaryClient).
 					WithInitialElectionID(1 /* low */, 0 /* hi */) // ID must be > 0.
 
-				if !*deviations.GRIBIRIBAckOnly {
+				if !deviations.GRIBIRIBAckOnly(dut) {
 					// The main difference WithFIBACK() made was that we are now expecting
 					// fluent.InstalledInFIB in []*client.OpResult, as opposed to
 					// fluent.InstalledInRIB.
@@ -522,7 +522,7 @@ func TestOrderingACK(t *testing.T) {
 
 				args := &testArgs{ctx: ctx, c: c, dut: dut, ate: ate, top: top}
 				args.wantInstalled = fluent.InstalledInFIB
-				if *deviations.GRIBIRIBAckOnly {
+				if deviations.GRIBIRIBAckOnly(dut) {
 					args.wantInstalled = fluent.InstalledInRIB
 				}
 				tc.fn(t, args)

--- a/feature/gribi/otg_tests/ipv4_entry_test/ipv4_entry_test.go
+++ b/feature/gribi/otg_tests/ipv4_entry_test/ipv4_entry_test.go
@@ -302,7 +302,7 @@ func TestIPv4Entry(t *testing.T) {
 						conn.WithPersistence()
 					}
 
-					if !*deviations.GRIBIRIBAckOnly {
+					if !deviations.GRIBIRIBAckOnly(dut) {
 						// The main difference WithFIBACK() made was that we are now expecting
 						// fluent.InstalledInFIB in []*client.OpResult, as opposed to
 						// fluent.InstalledInRIB.

--- a/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
+++ b/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
@@ -518,7 +518,7 @@ func TestOrderingACK(t *testing.T) {
 					WithRedundancyMode(fluent.ElectedPrimaryClient).
 					WithInitialElectionID(1 /* low */, 0 /* hi */) // ID must be > 0.
 
-				if !*deviations.GRIBIRIBAckOnly {
+				if !deviations.GRIBIRIBAckOnly(dut) {
 					// The main difference WithFIBACK() made was that we are now expecting
 					// fluent.InstalledInFIB in []*client.OpResult, as opposed to
 					// fluent.InstalledInRIB.
@@ -541,7 +541,7 @@ func TestOrderingACK(t *testing.T) {
 
 				args := &testArgs{ctx: ctx, c: c, dut: dut, ate: ate, top: top}
 				args.wantInstalled = fluent.InstalledInFIB
-				if *deviations.GRIBIRIBAckOnly {
+				if deviations.GRIBIRIBAckOnly(dut) {
 					args.wantInstalled = fluent.InstalledInRIB
 				}
 				tc.fn(t, args)

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -196,6 +196,12 @@ func NTPAssociationTypeRequired(_ *ondatra.DUTDevice) bool {
 	return *ntpAssociationTypeRequired
 }
 
+// GRIBIRIBAckOnly returns if device only supports RIB ack, so tests that normally expect FIB_ACK will allow just RIB_ACK.
+// Full gRIBI compliant devices should pass both with and without this deviation.
+func GRIBIRIBAckOnly(_ *ondatra.DUTDevice) bool {
+	return *gRIBIRIBAckOnly
+}
+
 // Vendor deviation flags.
 // All new flags should not be exported (define them in lowercase) and accessed
 // from tests through a public accessors like those above.
@@ -227,7 +233,7 @@ var (
 	OmitL2MTU = flag.Bool("deviation_omit_l2_mtu", false,
 		"Device does not support setting the L2 MTU, so omit it.  OpenConfig allows a device to enforce that L2 MTU, which has a default value of 1514, must be set to a higher value than L3 MTU, so a full OpenConfig compliant device may fail with the deviation.")
 
-	GRIBIRIBAckOnly = flag.Bool("deviation_gribi_riback_only", false, "Device only supports RIB ack, so tests that normally expect FIB_ACK will allow just RIB_ACK.  Full gRIBI compliant devices should pass both with and without this deviation.")
+	gRIBIRIBAckOnly = flag.Bool("deviation_gribi_riback_only", false, "Device only supports RIB ack, so tests that normally expect FIB_ACK will allow just RIB_ACK.  Full gRIBI compliant devices should pass both with and without this deviation.")
 
 	MissingValueForDefaults = flag.Bool("deviation_missing_value_for_defaults", false,
 		"Device returns no value for some OpenConfig paths if the operational value equals the default. A fully compliant device should pass regardless of this deviation.")

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -202,6 +202,24 @@ func GRIBIRIBAckOnly(_ *ondatra.DUTDevice) bool {
 	return *gRIBIRIBAckOnly
 }
 
+// MissingInterfacePhysicalChannel returns if device does not support interface/physicalchannel leaf.
+// Set this flag to skip checking the leaf.
+func MissingInterfacePhysicalChannel(_ *ondatra.DUTDevice) bool {
+	return *missingInterfacePhysicalChannel
+}
+
+// MissingInterfaceHardwarePort returns if device does not support interface/hardwareport leaf.
+// Set this flag to skip checking the leaf.
+func MissingInterfaceHardwarePort(_ *ondatra.DUTDevice) bool {
+	return *missingInterfaceHardwarePort
+}
+
+// MissingCPUMfgName returns if device does not support component/MfgName leaf for CPU components.
+// Set this flag to skip skip checking the leaf.
+func MissingCPUMfgName(_ *ondatra.DUTDevice) bool {
+	return *missingCPUMfgName
+}
+
 // Vendor deviation flags.
 // All new flags should not be exported (define them in lowercase) and accessed
 // from tests through a public accessors like those above.
@@ -299,13 +317,13 @@ var (
 	LLDPInterfaceConfigOverrideGlobal = flag.Bool("deviation_lldp_interface_config_override_global", false,
 		"Set this flag for LLDP interface config to override the global config,expect neighbours are seen when lldp is disabled globally but enabled on interface")
 
-	MissingInterfacePhysicalChannel = flag.Bool("deviation_missing_interface_physical_channel", false,
+	missingInterfacePhysicalChannel = flag.Bool("deviation_missing_interface_physical_channel", false,
 		"Device does not support interface/physicalchannel leaf. Set this flag to skip checking the leaf.")
 
-	MissingInterfaceHardwarePort = flag.Bool("deviation_missing_interface_hardware_port", false,
+	missingInterfaceHardwarePort = flag.Bool("deviation_missing_interface_hardware_port", false,
 		"Device does not support interface/hardwareport leaf. Set this flag to skip checking the leaf.")
 
-	MissingCPUMfgName = flag.Bool("deviation_missing_cpu_mfgName", false,
+	missingCPUMfgName = flag.Bool("deviation_missing_cpu_mfgName", false,
 		"Device does not support component/MfgName leaf for CPU components. Set this flag to skip skip checking the leaf.")
 
 	InterfaceConfigVrfBeforeAddress = flag.Bool("deviation_interface_config_vrf_before_address", false, "When configuring interface, config Vrf prior config IP address")


### PR DESCRIPTION
Move MissingInterfacePhysicalChannel, MissingInterfaceHardwarePort, MissingCPUMfgName flags to accessor.