### PR TITLE
Fix P4RT-2.1: P4RT Election test failure for EOS

### DIFF
--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -223,5 +223,7 @@ var (
 	ISISRestartSuppressUnsupported = flag.Bool("deviation_isis_restart_suppress_unsupported", false,
 		"Device skip isis restart-suppress check if value is true, Default value is false")
 
-	MacAddressMissing = flag.Bool("deviation_mac_address_missing", false, "Device does not support /system/mac-address/state.")
+	MacAddressMissing                 = flag.Bool("deviation_mac_address_missing", false, "Device does not support /system/mac-address/state.")
+	P4rtZeroElectionIdAllowed         = flag.Bool("deviation_p4rt_zero_election_id_allowed", false, "Device for allowing zero election id in P4RT server")
+	P4rtBackupArbitrationResponseCode = flag.Bool("deviation_bkup_arbitration_resp_code", false, "Device sets ALREADY_EXISTS status code for all backup client responses")
 )


### PR DESCRIPTION
In EOS, P4RT-2.1: P4RT Election test was failing for the following reasons
1 - EOS allows 0 election id as valid for primary arbitration messages. A deviation has been added to the test to expect different status code in TestUnsetElectionid. Also the test has been updated to allow SetForwardingPipelineConfig from a primary with election id of 0

2 - EOS always sends ALREADY_EXISTS in status code to secondary clients in
    the response to primaryAribitrationMessage when the election id
    is lesser than the current/previous primary election id. According
    to P4RT specification, ALREADY_EXISTS status is set when primary is
    present and NOT_FOUND is set when there is no primary. I am adding a
    deviation to expect ALREADY_EXISTS instead of NOT_FOUND status until
    EOS behavior is updated.

The test needs to be run with the following deviations with EOS:
-deviation_interface_enabled
-deviation_p4rt_missing_delete
-deviation_p4rt_zero_election_id_allowed
-deviation_bkup_arbitration_resp_code
