### PR TITLE
Move TraceRouteL4ProtocolUDP and TraceRouteFragmentation to accessors

### DIFF
--- a/feature/gnoi/system/tests/traceroute_test/traceroute_test.go
+++ b/feature/gnoi/system/tests/traceroute_test/traceroute_test.go
@@ -244,7 +244,7 @@ func TestGNOITraceroute(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			time.Sleep(1 * time.Second) // some devices do not allow back to back traceroute to prevent flooding
-			if *deviations.TraceRouteL4ProtocolUDP {
+			if deviations.TraceRouteL4ProtocolUDP(dut) {
 				if tc.defaultL4Protocol {
 					tc.traceRequest.L4Protocol = spb.TracerouteRequest_UDP
 				}
@@ -252,7 +252,7 @@ func TestGNOITraceroute(t *testing.T) {
 					t.Skip("Test is skiped due to the TraceRouteL4ProtocolUDP deviation")
 				}
 			}
-			if *deviations.TraceRouteFragmentation {
+			if deviations.TraceRouteFragmentation(dut) {
 				if tc.traceRequest.DoNotFragment {
 					t.Skip("Test is skiped due to the TraceRouteFragmentation deviation")
 				}

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -217,6 +217,16 @@ func MissingCPUMfgName(_ *ondatra.DUTDevice) bool {
 	return *missingCPUMfgName
 }
 
+// TraceRouteL4ProtocolUDP returns if device only support UDP as l4 protocol for traceroute.
+func TraceRouteL4ProtocolUDP(_ *ondatra.DUTDevice) bool {
+	return *traceRouteL4ProtocolUDP
+}
+
+// TraceRouteFragmentation returns if device does not support fragmentation bit for traceroute.
+func TraceRouteFragmentation(_ *ondatra.DUTDevice) bool {
+	return *traceRouteFragmentation
+}
+
 // SubinterfacePacketCountersMissing returns if device is missing subinterface packet counters for IPv4/IPv6,
 // so the test will skip checking them.
 // Full OpenConfig compliant devices should pass both with and without this deviation.
@@ -285,9 +295,9 @@ var (
 
 	RoutePolicyUnderNeighborAfiSafi = flag.Bool("deviation_rpl_under_neighbor_afisafi", false, "Device requires route-policy configuration under bgp neighbor afisafi. Fully-compliant devices should pass with this deviation set to true.")
 
-	TraceRouteL4ProtocolUDP = flag.Bool("deviation_traceroute_l4_protocol_udp", false, "Device only support UDP as l4 protocol for traceroute. Use this flag to set default l4 protocol as UDP and skip the tests explictly use TCP or ICMP.")
+	traceRouteL4ProtocolUDP = flag.Bool("deviation_traceroute_l4_protocol_udp", false, "Device only support UDP as l4 protocol for traceroute. Use this flag to set default l4 protocol as UDP and skip the tests explictly use TCP or ICMP.")
 
-	TraceRouteFragmentation = flag.Bool("deviation_traceroute_fragmentation", false, "Device does not support fragmentation bit for traceroute.")
+	traceRouteFragmentation = flag.Bool("deviation_traceroute_fragmentation", false, "Device does not support fragmentation bit for traceroute.")
 
 	ConnectRetry = flag.Bool("deviation_connect_retry", false, "Connect-retry is not supported /bgp/neighbors/neighbor/timers/config/connect-retry.")
 


### PR DESCRIPTION
Move TraceRouteL4ProtocolUDP and TraceRouteFragmentation to accessor methods