### PR TITLE
gNMI-1.4: Telemetry Inventory Test - runtime improvements

### DIFF
--- a/feature/platform/ate_tests/telemetry_inventory_test/telemetry_inventory_test.go
+++ b/feature/platform/ate_tests/telemetry_inventory_test/telemetry_inventory_test.go
@@ -124,9 +124,9 @@ const (
 )
 
 // use this map to cache related components used in subtests to run the test faster.
-var componentsByType map[string][]string
+var componentsByType map[string][]*oc.Component
 
-func TestHardwarecards(t *testing.T) {
+func TestHardwareCards(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
 	cases := []struct {
@@ -261,17 +261,16 @@ func TestHardwarecards(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			cards := components[tc.desc]
-			t.Logf("Found card list for %v: %v", tc.desc, cards)
-
+			t.Logf("%s components count: %d", tc.desc, len(cards))
 			if len(cards) == 0 {
-				t.Fatalf("Get card list for %q) on %v: got 0, want > 0", tc.desc, dut.Model())
+				t.Fatalf("Components list for %s on %v: got 0, want > 0", tc.desc, dut.Model())
 			}
 			ValidateComponentState(t, dut, cards, tc.cardFields)
 		})
 	}
 }
 
-func findComponentsListByType(t *testing.T, dut *ondatra.DUTDevice) map[string][]string {
+func findComponentsListByType(t *testing.T, dut *ondatra.DUTDevice) map[string][]*oc.Component {
 	t.Helper()
 	componentType := map[string]oc.E_PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT{
 		"Chassis":     chassisType,
@@ -287,7 +286,7 @@ func findComponentsListByType(t *testing.T, dut *ondatra.DUTDevice) map[string][
 	if len(componentsByType) != 0 {
 		return componentsByType
 	}
-	componentsByType = make(map[string][]string)
+	componentsByType = make(map[string][]*oc.Component)
 	components := gnmi.GetAll(t, dut, gnmi.OC().ComponentAny().State())
 	for compName := range componentType {
 		for _, c := range components {
@@ -312,7 +311,7 @@ func findComponentsListByType(t *testing.T, dut *ondatra.DUTDevice) map[string][
 				}
 
 			}
-			componentsByType[compName] = append(componentsByType[compName], c.GetName())
+			componentsByType[compName] = append(componentsByType[compName], c)
 		}
 	}
 	return componentsByType
@@ -349,46 +348,63 @@ func TestSwitchChip(t *testing.T) {
 	components := findComponentsListByType(t, dut)
 	cards := components["SwitchChip"]
 	if len(cards) == 0 {
-		t.Fatalf("Get SwitchChip card list for %q): got 0, want > 0", dut.Model())
+		t.Fatalf("Get SwitchChip card list for %q: got 0, want > 0", dut.Model())
+	} else {
+		t.Logf("SwitchChip components count: %d", len(cards))
 	}
-	t.Logf("Found SwitchChip list: %v", cards)
 
 	ValidateComponentState(t, dut, cards, cardFields)
 
 	for _, card := range cards {
-		t.Logf("Validate card %s", card)
-		component := gnmi.OC().Component(card)
 
-		if deviations.BackplaneFacingCapacityUnsupported(dut) && regexp.MustCompile("NPU[0-9]$").Match([]byte(card)) {
+		if card.Name == nil {
+			t.Errorf("Encountered SwitchChip component with no Name")
+			continue
+		}
+
+		cName := card.GetName()
+		t.Logf("Validate SwitchChip %s", cName)
+
+		if deviations.BackplaneFacingCapacityUnsupported(dut) && regexp.MustCompile("NPU[0-9]$").Match([]byte(card.GetName())) {
 			// Vendor does not support backplane-facing-capacity for nodes named 'NPU'.
+			t.Logf("Skipping check for BackplanceFacingCapacity due to deviation BackplaneFacingCapacityUnsupported")
 			continue
 		} else {
 			// For SwitchChip, check OC integrated-circuit paths.
-			bpCapacity := component.IntegratedCircuit().BackplaneFacingCapacity()
 
-			totalCapacity := gnmi.Get(t, dut, bpCapacity.TotalOperationalCapacity().State())
-			t.Logf("Hardware card %s totalCapacity: %d", card, totalCapacity)
-			if totalCapacity <= 0 {
-				t.Errorf("bpCapacity.TotalOperationalCapacity().Get(t) for %q): got %v, want > 0", card, totalCapacity)
+			// TotalOperationalCapacity
+			if card.IntegratedCircuit.BackplaneFacingCapacity.TotalOperationalCapacity == nil {
+				t.Errorf("SwitchChip %s totalOperationalCapacity: got none, want > 0", cName)
+			}
+			totalOperCapacity := card.GetIntegratedCircuit().GetBackplaneFacingCapacity().GetTotalOperationalCapacity()
+			t.Logf("SwitchChip %s totalOperationalCapacity: %d", cName, totalOperCapacity)
+			if totalOperCapacity <= 0 {
+				t.Errorf("SwitchChip %s totalOperationalCapacity: got %v, want > 0", cName, totalOperCapacity)
 			}
 
-			total := gnmi.Get(t, dut, bpCapacity.Total().State())
-			t.Logf("Hardware card %s total: %d", card, totalCapacity)
-			if total <= 0 {
-				t.Errorf("bpCapacity.Total().Get(t) for %q): got %v, want > 0", card, total)
+			// Total
+			if card.IntegratedCircuit.BackplaneFacingCapacity.Total == nil {
+				t.Errorf("SwitchChip %s totalCapacity: got none, want > 0", cName)
+			}
+			totalCapacity := card.GetIntegratedCircuit().GetBackplaneFacingCapacity().GetTotal()
+			t.Logf("SwitchChip %s totalCapacity: %d", cName, totalCapacity)
+			if totalCapacity == 0 {
+				t.Errorf("SwitchChip %s totalCapacity: got %v, want > 0", cName, totalCapacity)
 			}
 
-			if !gnmi.Lookup(t, dut, bpCapacity.AvailablePct().State()).IsPresent() {
-				t.Errorf("bpCapacity.AvailablePct() for %q): got none, want >= 0", card)
+			// AvailablePct
+			if card.IntegratedCircuit.BackplaneFacingCapacity.AvailablePct == nil {
+				t.Errorf("SwitchChip %s availablePct: got none, want >= 0", cName)
 			}
-			availablePct := gnmi.Get(t, dut, bpCapacity.AvailablePct().State())
-			t.Logf("Hardware card %s availablePct: %d", card, availablePct)
+			availablePct := card.GetIntegratedCircuit().GetBackplaneFacingCapacity().GetAvailablePct()
+			t.Logf("SwitchChip %s availablePct: %d", cName, availablePct)
 
-			if !gnmi.Lookup(t, dut, bpCapacity.ConsumedCapacity().State()).IsPresent() {
-				t.Errorf("bpCapacity.ConsumedCapacity() for %q): got none, want >= 0", card)
+			// ConsumedCapacity
+			if card.IntegratedCircuit.BackplaneFacingCapacity.ConsumedCapacity == nil {
+				t.Errorf("SwitchChip %s consumedCapacity: got none, want >= 0", cName)
 			}
-			consumedCapacity := gnmi.Get(t, dut, bpCapacity.ConsumedCapacity().State())
-			t.Logf("Hardware card %s consumedCapacity: %d", card, consumedCapacity)
+			consumedCapacity := card.GetIntegratedCircuit().GetBackplaneFacingCapacity().GetConsumedCapacity()
+			t.Logf("SwitchChip %s consumedCapacity: %d", cName, consumedCapacity)
 		}
 	}
 }
@@ -398,223 +414,227 @@ func TestTempSensor(t *testing.T) {
 	sensors := findComponentsListByType(t, dut)["TempSensor"]
 	if len(sensors) == 0 {
 		t.Fatalf("Get TempSensor list for %q: got 0, want > 0", dut.Model())
+	} else {
+		t.Logf("TempSensor components count: %d", len(sensors))
 	}
-	t.Logf("Found TempSensor list: %v", sensors)
 
 	for _, sensor := range sensors {
-		t.Logf("Validate card %s", sensor)
-		component := gnmi.OC().Component(sensor)
 
-		if !gnmi.Lookup(t, dut, component.Id().State()).IsPresent() {
+		if sensor.Name == nil {
+			t.Errorf("Encountered a sensor with no Name")
+			continue
+		}
+
+		sName := sensor.GetName()
+		t.Logf("Validate sensor %s", sName)
+
+		if sensor.GetId() == "" {
 			// Just log the result using Logf instead of Errorf.
-			t.Logf("component.Id().Lookup(t) for %q: got false, want true", sensor)
+			t.Logf("TempSensor %s: Id is empty", sName)
 		} else {
-			t.Logf("TempSensor %s Id: %s", sensor, gnmi.Get(t, dut, component.Id().State()))
+			t.Logf("TempSensor %s Id: %s", sName, sensor.GetId())
 		}
 
-		if !gnmi.Lookup(t, dut, component.Name().State()).IsPresent() {
-			t.Errorf("component.Name().Lookup(t) for %q: got false, want true", sensor)
-		} else {
-			t.Logf("TempSensor %s Name: %s", sensor, gnmi.Get(t, dut, component.Name().State()))
-		}
-
-		if !gnmi.Lookup(t, dut, component.Type().State()).IsPresent() {
-			t.Errorf("component.Type().Lookup(t) for %q: got false, want true", sensor)
+		if sensor.Type == nil {
+			t.Errorf("TempSensor %s: Type is empty", sName)
 			want := componentType["tempsensor"]
-			got := fmt.Sprintf("%v", gnmi.Get(t, dut, component.Type().State()))
+			got := fmt.Sprintf("%v", sensor.GetType())
 			if want != got {
-				t.Errorf("component.Type().Val(t) for %q: got %v, want %v", sensor, got, want)
+				t.Errorf("Type for TempSensor %s: got %v, want %v", sName, got, want)
 			}
 		} else {
-			t.Logf("TempSensor %s Type: %s", sensor, gnmi.Get(t, dut, component.Type().State()))
+			t.Logf("TempSensor %s Type: %s", sName, sensor.GetType())
 		}
 
-		if !gnmi.Lookup(t, dut, component.Temperature().Instant().State()).IsPresent() {
-			t.Errorf("Temperature().Instant().Lookup(t) for %q: got false, want true", sensor)
+		if sensor.Temperature.Instant == nil {
+			t.Errorf("TempSensor %s: Temperature instant is nil", sName)
 		} else {
-			t.Logf("TempSensor %s Temperature instant: %v", sensor, gnmi.Get(t, dut, component.Temperature().Instant().State()))
+			t.Logf("TempSensor %s Temperature instant: %v", sName, sensor.GetTemperature().GetInstant())
 		}
 
-		if !gnmi.Lookup(t, dut, component.Temperature().AlarmStatus().State()).IsPresent() {
-			t.Errorf("Temperature().AlarmStatus().Lookup(t) for %q: got false, want true", sensor)
+		if sensor.Temperature.AlarmStatus == nil {
+			t.Errorf("TempSensor %s: Temperature AlarmStatus is nil", sName)
 		} else {
-			t.Logf("TempSensor %s Temperature AlarmStatus: %v", sensor, gnmi.Get(t, dut, component.Temperature().AlarmStatus().State()))
+			t.Logf("TempSensor %s Temperature AlarmStatus: %v", sName, sensor.GetTemperature().GetAlarmStatus())
 		}
 
-		if !gnmi.Lookup(t, dut, component.Temperature().Max().State()).IsPresent() {
-			t.Errorf("Temperature().Max().Lookup(t) for %q: got false, want true", sensor)
+		if sensor.Temperature.Max == nil {
+			t.Errorf("TempSensor %s: Temperature Max is nil", sName)
 		} else {
-			t.Logf("TempSensor %s Temperature Max: %v", sensor, gnmi.Get(t, dut, component.Temperature().Max().State()))
+			t.Logf("TempSensor %s Temperature Max: %v", sName, sensor.GetTemperature().GetMax())
 		}
 
-		if !gnmi.Lookup(t, dut, component.Temperature().MaxTime().State()).IsPresent() {
-			t.Errorf("Temperature().MaxTime().Lookup(t) for %q: got false, want true", sensor)
+		if sensor.Temperature.MaxTime == nil {
+			t.Errorf("TempSensor %s: Temperature MaxTime is nil", sName)
 		} else {
-			t.Logf("TempSensor %s Temperature MaxTime: %v", sensor, gnmi.Get(t, dut, component.Temperature().MaxTime().State()))
+			t.Logf("TempSensor %s Temperature MaxTime: %v", sName, sensor.GetTemperature().GetMaxTime())
 		}
+
 	}
 }
 
-func ValidateComponentState(t *testing.T, dut *ondatra.DUTDevice, cards []string, p properties) {
+func ValidateComponentState(t *testing.T, dut *ondatra.DUTDevice, cards []*oc.Component, p properties) {
 	t.Helper()
-
 	for _, card := range cards {
-		t.Logf("Validate card %s", card)
-		component := gnmi.OC().Component(card)
+		if card.Name == nil {
+			t.Errorf("Encountered a component with no Name")
+			continue
+		}
+
+		cName := card.GetName()
+		t.Logf("Validate component %s", cName)
 
 		// For transceiver, only check the transceiver with optics installed.
-		if strings.Contains(card, "transceiver") {
-			if gnmi.Lookup(t, dut, component.MfgName().State()).IsPresent() {
-				t.Logf("Optics is detected in %s with expected parent: %s", card, gnmi.Lookup(t, dut, component.Parent().State()))
+		if strings.Contains(cName, "transceiver") {
+			if card.GetMfgName() != "" {
+				t.Logf("Optics is detected in %s with expected parent: %s", cName, card.GetParent())
 			} else {
-				t.Logf("Optics is not installed in %s, skip testing this transceiver", card)
+				t.Logf("Optics is not installed in %s, skip testing this transceiver", cName)
 				continue
 			}
 		}
 
 		if p.descriptionValidation {
-			description := gnmi.Get(t, dut, component.Description().State())
-			t.Logf("Hardware card %s Description: %s", card, description)
+			description := card.GetDescription()
+			t.Logf("Component %s Description: %s", cName, description)
 			if description == "" {
-				t.Errorf("component.Description().Get(t) for %q): got empty string, want non-empty string", card)
+				t.Errorf("Component %s Description: got empty string, want non-empty string", cName)
 			}
 		}
 
 		if p.idValidation {
 			if deviations.SwitchChipIDUnsupported(dut) {
-				t.Logf("Skipping check for switch chip id unsupport")
+				t.Logf("Skipping check for Id due to deviation SwitChipIDUnsupported")
 			} else {
-				id := gnmi.Get(t, dut, component.Id().State())
-				t.Logf("Hardware card %s Id: %s", card, id)
+				id := card.GetId()
+				t.Logf("Component %s Id: %s", cName, id)
 				if id == "" {
-					t.Errorf("component.Id().Get(t) for %q): got empty string, want non-empty string", card)
+					t.Errorf("Component %s Id: got empty string, want non-empty string", cName)
 				}
 			}
 		}
 
 		if p.nameValidation {
-			name := gnmi.Get(t, dut, component.Name().State())
-			t.Logf("Hardware card %s Name: %s", card, name)
+			name := card.GetName()
+			t.Logf("Component %s Name: %s", cName, name)
 			if name == "" {
-				t.Errorf("component.Name().Get(t) for %q): got empty string, want non-empty string", card)
+				t.Errorf("Encountered empty Name for component %s", cName)
 			}
 		}
 
 		if p.partNoValidation {
-			partNo := gnmi.Lookup(t, dut, component.PartNo().State())
-			t.Logf("Hardware card %s PartNo: %v", card, partNo)
-			if !partNo.IsPresent() {
-				if gnmi.Get(t, dut, component.Type().State()) == fanType {
-					fanTray := gnmi.Get(t, dut, component.Parent().State())
+			partNo := card.PartNo
+			t.Logf("Component %s PartNo: %v", cName, partNo)
+			if partNo == nil {
+				if card.GetType() == fanType {
+					fanTray := card.GetParent()
 					fanTrayPartNo := gnmi.Lookup(t, dut, gnmi.OC().Component(fanTray).PartNo().State())
-					t.Logf("Hardware card %s (parent of %s) PartNo: %v", fanTray, card, fanTrayPartNo)
-					if !fanTrayPartNo.IsPresent() {
-						t.Errorf("component.PartNo().Get(t) for %q and its parent): got empty string, want non-empty string", card)
+					fanTrayPartNoVal, ftpnPresent := fanTrayPartNo.Val()
+					if !ftpnPresent {
+						t.Errorf("PartNo for Component %s and its parent: got empty string, want non-empty string", cName)
 					}
+					t.Logf("Component %s (parent of %s) PartNo: %v", fanTray, cName, fanTrayPartNoVal)
 				} else {
-					t.Errorf("component.PartNo().Get(t) for %q): got empty string, want non-empty string", card)
+					t.Errorf("PartNo for Component %s: got empty string, want non-empty string", cName)
 				}
 			}
 		}
 
 		if p.serialNoValidation {
-			serialNo := gnmi.Lookup(t, dut, component.SerialNo().State())
-			t.Logf("Hardware card %s serialNo: %s", card, serialNo)
-			if !serialNo.IsPresent() {
-				if gnmi.Get(t, dut, component.Type().State()) == fanType {
-					fanTray := gnmi.Get(t, dut, component.Parent().State())
-					fanTraySErialNo := gnmi.Lookup(t, dut, gnmi.OC().Component(fanTray).SerialNo().State())
-					t.Logf("Hardware card %s (parent of %s) PartNo: %v", fanTray, card, fanTraySErialNo)
-					if !fanTraySErialNo.IsPresent() {
-						t.Errorf("component.SerialNo().Get(t) for %q and its parent): got empty string, want non-empty string", card)
+			serialNo := card.SerialNo
+			t.Logf("Component %s SerialNo: %v", cName, serialNo)
+			if serialNo == nil {
+				if card.GetType() == fanType {
+					fanTray := card.GetParent()
+					fanTraySerialNo := gnmi.Lookup(t, dut, gnmi.OC().Component(fanTray).SerialNo().State())
+					fanTraySerialNoVal, ftsnPresent := fanTraySerialNo.Val()
+					if !ftsnPresent {
+						t.Errorf("SerialNo for Component %s and its parent: got empty string, want non-empty string", cName)
 					}
+					t.Logf("Component %s (parent of %s) SerialNo: %v", fanTray, cName, fanTraySerialNoVal)
 				} else {
-					t.Errorf("component.SerialNo().Get(t) for %q): got empty string, want non-empty string", card)
+					t.Errorf("SerialNo for Component %s: got empty string, want non-empty string", cName)
 				}
 			}
 		}
 
 		if p.mfgNameValidation {
-			mfgName := gnmi.Get(t, dut, component.MfgName().State())
-			t.Logf("Hardware card %s mfgName: %s", card, mfgName)
+			mfgName := card.GetMfgName()
+			t.Logf("Component %s MfgName: %s", cName, mfgName)
 			if mfgName == "" {
-				t.Errorf("Get mfgName for %q): got empty string, want non-empty string", card)
+				t.Errorf("Component %s MfgName: got empty string, want non-empty string", cName)
 			}
 		}
 
 		if p.mfgDateValidation {
-			mfgDate := gnmi.Get(t, dut, component.MfgDate().State())
-			t.Logf("Hardware card %s mfgDate: %s", card, mfgDate)
+			mfgDate := card.GetMfgDate()
 			if mfgDate == "" {
-				t.Errorf("component.MfgName().Get(t) for %q): got empty string, want non-empty string", card)
+				t.Errorf("Component %s MfgDate: got empty string, want non-empty string", cName)
 			}
+			t.Logf("Component %s MfgDate: %s", cName, mfgDate)
 		}
 
 		if p.swVerValidation {
 			// Only a subset of cards are expected to report Software Version.
-			sw, present := gnmi.Lookup(t, dut, component.SoftwareVersion().State()).Val()
-			if present {
-				t.Logf("Hardware card %s SoftwareVersion: %s", card, sw)
-				if sw == "" {
-					t.Errorf("component.SoftwareVersion().Get(t) for %q): got empty string, want non-empty string", card)
-				}
-			} else {
-				t.Errorf("component.SoftwareVersion().Lookup(t) for %q): got no value.", card)
+			swVer := card.GetSoftwareVersion()
+			if swVer == "" {
+				t.Errorf("Component %s SoftwareVersion: got empty string, want non-empty string", cName)
 			}
+			t.Logf("Component %s SoftwareVersion: %s", cName, swVer)
 		}
 
 		if p.hwVerValidation {
-			hardwareVersion := gnmi.Get(t, dut, component.HardwareVersion().State())
-			t.Logf("Hardware card %s hardwareVersion: %s", card, hardwareVersion)
-			if hardwareVersion == "" {
-				t.Errorf("component.HardwareVersion().Get(t) for %q): got empty string, want non-empty string", card)
+			hwVer := card.GetHardwareVersion()
+			if hwVer == "" {
+				t.Errorf("Component %s HardwareVersion: got empty string, want non-empty string", cName)
 			}
+			t.Logf("Component %s HardwareVersion: %s", cName, hwVer)
 		}
 
 		if p.fwVerValidation {
-			firmwareVersion := gnmi.Get(t, dut, component.FirmwareVersion().State())
-			t.Logf("Hardware card %s FirmwareVersion: %s", card, firmwareVersion)
-			if firmwareVersion == "" {
-				t.Errorf("component.FirmwareVersion().Get(t) for %q): got empty string, want non-empty string", card)
+			fwVer := card.GetFirmwareVersion()
+			if fwVer == "" {
+				t.Errorf("Component %s FirmwareVersion: got empty string, want non-empty string", cName)
 			}
+			t.Logf("Component %s FirmwareVersion: %s", cName, fwVer)
 		}
 
 		if p.rrValidation {
-			redundantRole := gnmi.Get(t, dut, component.RedundantRole().State()).String()
-			t.Logf("Hardware card %s RedundantRole: %s", card, redundantRole)
+			redundantRole := card.GetRedundantRole().String()
+			t.Logf("Hardware card %s RedundantRole: %s", cName, redundantRole)
 			if redundantRole != "PRIMARY" && redundantRole != "SECONDARY" {
-				t.Errorf("component.RedundantRole().Get(t) for %q): got %v, want %v", card, redundantRole, p.operStatus)
+				t.Errorf("Component %s RedundantRole: got %s, want %v", cName, redundantRole, p.operStatus)
 			}
 		}
 
 		if p.operStatus != "" {
-			if deviations.FanOperStatusUnsupported(dut) && strings.Contains(card, "Fan") {
+			if deviations.FanOperStatusUnsupported(dut) && strings.Contains(cName, "Fan") {
 				t.Logf("Skipping check for fan oper-status due to deviation FanOperStatusUnsupported")
 			} else {
-				operStatus := gnmi.Get(t, dut, component.OperStatus().State()).String()
-				t.Logf("Hardware card %s OperStatus: %s", card, operStatus)
-				if operStatus != activeStatus {
-					t.Errorf("component.OperStatus().Get(t) for %q): got %v, want %v", card, operStatus, p.operStatus)
+				operStatus := card.GetOperStatus().String()
+				t.Logf("Component %s OperStatus: %s", cName, operStatus)
+				if operStatus != p.operStatus {
+					t.Errorf("Component %s OperStatus: got %s, want %s", cName, operStatus, p.operStatus)
 				}
 			}
 		}
 
 		if p.parentValidation {
-			cur := card
+			cur := cName
 			for {
 				val := gnmi.Lookup(t, dut, gnmi.OC().Component(cur).Parent().State())
 				parent, present := val.Val()
 				if !present {
-					t.Errorf("Hardware card %s Parent: Chassis component NOT found in the hierarchy tree of component", card)
+					t.Errorf("Component %s Parent: Chassis component NOT found in the hierarchy tree of component", cName)
 					break
 				}
 				parentType := gnmi.Get(t, dut, gnmi.OC().Component(parent).Type().State())
 				if parentType == chassisType {
-					t.Logf("Hardware card %s Parent: Found chassis component in the hierarchy tree of component", card)
+					t.Logf("Component %s Parent: Found chassis component in the hierarchy tree of component", cName)
 					break
 				}
 				if parent == cur {
-					t.Errorf("Hardware card %s Parent: Chassis component NOT found in the hierarchy tree of component", card)
+					t.Errorf("Component %s Parent: Chassis component NOT found in the hierarchy tree of component", cName)
 					break
 				}
 				cur = parent
@@ -622,10 +642,10 @@ func ValidateComponentState(t *testing.T, dut *ondatra.DUTDevice, cards []string
 		}
 
 		if p.pType != nil {
-			ptype := gnmi.Get(t, dut, component.Type().State())
-			t.Logf("Hardware card %s type: %v", card, ptype)
+			ptype := card.GetType()
+			t.Logf("Component %s Type: %v", cName, ptype)
 			if ptype != p.pType {
-				t.Errorf("component.Type().Get(t) for %q): got %v, want %v", card, ptype, p.pType)
+				t.Errorf("Component %s Type: got %v, want %v", cName, ptype, p.pType)
 			}
 		}
 	}


### PR DESCRIPTION
This Pull Req is bringing in run time improvements to gNMI-1.4 (Telemetry Inventory Test) as detailed below:
- Function 'findComponentsListByType' does a gNMI Subscribe for 'All Components', orders the components by type and returns the names of the components (ordered by type)
- Testcases TestHardwarecards and TestSwitchChip obtain the component names from the above, pass the names on to the function 'ValidateComponentState' which subsequently runs multiple gNMI Subscribe operations for verifying the data under each component
- Depending on the number of components of a given type present on the DUT, the number of gNMI operations could end up being quite high leading to increased script run time

Optimization proposed in this Pull Req:
- Modify the function 'findComponentsListByType' to return the ordered list of components with all information intact and as received from the 'gNMI Subscribe for All Components' call (instead of returning just the component names ordered by type)
- Modify test cases TestHardwareCards and TestSwitchChip to use the data as is from the returned Components data structure; pass the Components data set as is to the function 'ValidateComponentState' and verify the necessary fields

Verification steps involving fetching parent nodes or walking up the Component tree from a given node will still continue to execute the necessary gNMI Subscribe operations as needed. 