### PR TITLE
Move DeprecatedVlanID to accessor method

### DIFF
--- a/feature/experimental/gribi/ate_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
+++ b/feature/experimental/gribi/ate_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
@@ -286,7 +286,7 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 		Index := uint32(i) + 1
 		ateIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 1))
 		dutIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 2))
-		configureSubinterfaceDUT(t, d, dutPort, Index, vlanID, dutIPv4)
+		configureSubinterfaceDUT(t, d, dutPort, Index, vlanID, dutIPv4, dut)
 		configureATE(t, top, atePort, name, vlanID, dutIPv4, ateIPv4+"/30")
 		nextHops = append(nextHops, ateIPv4)
 	}
@@ -302,13 +302,13 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 }
 
 // configureSubinterfaceDUT configures a single DUT layer 3 sub-interface.
-func configureSubinterfaceDUT(t *testing.T, d *oc.Root, dutPort *ondatra.Port, index uint32, vlanID uint16, dutIPv4 string) {
+func configureSubinterfaceDUT(t *testing.T, d *oc.Root, dutPort *ondatra.Port, index uint32, vlanID uint16, dutIPv4 string, dut *ondatra.DUTDevice) {
 	t.Helper()
 
 	i := d.GetOrCreateInterface(dutPort.Name())
 	s := i.GetOrCreateSubinterface(index)
 	if vlanID != 0 {
-		if *deviations.DeprecatedVlanID {
+		if deviations.DeprecatedVlanID(dut) {
 			s.GetOrCreateVlan().VlanId = oc.UnionUint16(vlanID)
 		} else {
 			s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
@@ -491,7 +491,7 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 	ap1 := ate.Port(t, "port1")
 	top := ate.Topology().New()
 	// configure DUT port#1 - source port.
-	configureSubinterfaceDUT(t, d, dp1, 0, 0, dutPort1.IPv4)
+	configureSubinterfaceDUT(t, d, dp1, 0, 0, dutPort1.IPv4, dut)
 	configureInterfaceDUT(t, dp1, d, "src")
 	configureATE(t, top, ap1, "src", 0, dutPort1.IPv4, atePort1.IPv4CIDR())
 	pushConfig(t, dut, dp1, d)

--- a/feature/experimental/gribi/ate_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
+++ b/feature/experimental/gribi/ate_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
@@ -248,7 +248,7 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 		Index := uint32(i)
 		ateIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 1))
 		dutIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 2))
-		configureSubinterfaceDUT(t, d, dutPort, Index, vlanID, dutIPv4)
+		configureSubinterfaceDUT(t, d, dutPort, Index, vlanID, dutIPv4, dut)
 		configureATE(t, top, atePort, name, vlanID, dutIPv4, ateIPv4+"/30")
 		nextHops = append(nextHops, ateIPv4)
 	}
@@ -264,13 +264,13 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 }
 
 // configureSubinterfaceDUT configures a single DUT layer 3 sub-interface.
-func configureSubinterfaceDUT(t *testing.T, d *oc.Root, dutPort *ondatra.Port, index uint32, vlanID uint16, dutIPv4 string) {
+func configureSubinterfaceDUT(t *testing.T, d *oc.Root, dutPort *ondatra.Port, index uint32, vlanID uint16, dutIPv4 string, dut *ondatra.DUTDevice) {
 	t.Helper()
 
 	i := d.GetOrCreateInterface(dutPort.Name())
 	s := i.GetOrCreateSubinterface(index)
 	if vlanID != 0 {
-		if *deviations.DeprecatedVlanID {
+		if deviations.DeprecatedVlanID(dut) {
 			s.GetOrCreateVlan().VlanId = oc.UnionUint16(vlanID)
 		} else {
 			s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
@@ -460,7 +460,7 @@ func TestRouteRemovalDuringFailover(t *testing.T) {
 	ap1 := ate.Port(t, "port1")
 	top := ate.Topology().New()
 	// configure DUT port#1 - source port.
-	configureSubinterfaceDUT(t, d, dp1, 0, 0, dutPort1.IPv4)
+	configureSubinterfaceDUT(t, d, dp1, 0, 0, dutPort1.IPv4, dut)
 	configureInterfaceDUT(t, dp1, d, "src")
 	configureATE(t, top, ap1, "src", 0, dutPort1.IPv4, atePort1.IPv4CIDR())
 	pushConfig(t, dut, dp1, d)

--- a/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
+++ b/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
@@ -289,7 +289,7 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 		Index := uint32(i) + 1
 		ateIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 1))
 		dutIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 2))
-		configureSubinterfaceDUT(t, d, dutPort, Index, vlanID, dutIPv4)
+		configureSubinterfaceDUT(t, d, dutPort, Index, vlanID, dutIPv4, dut)
 		MAC, err := incrementMAC(atePort1.MAC, i+1)
 		if err != nil {
 			t.Fatalf("Failed to generate mac address; %v", err)
@@ -309,13 +309,13 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 }
 
 // configureSubinterfaceDUT configures a single DUT layer 3 sub-interface.
-func configureSubinterfaceDUT(t *testing.T, d *oc.Root, dutPort *ondatra.Port, index uint32, vlanID uint16, dutIPv4 string) {
+func configureSubinterfaceDUT(t *testing.T, d *oc.Root, dutPort *ondatra.Port, index uint32, vlanID uint16, dutIPv4 string, dut *ondatra.DUTDevice) {
 	t.Helper()
 
 	i := d.GetOrCreateInterface(dutPort.Name())
 	s := i.GetOrCreateSubinterface(index)
 	if vlanID != 0 {
-		if *deviations.DeprecatedVlanID {
+		if deviations.DeprecatedVlanID(dut) {
 			s.GetOrCreateVlan().VlanId = oc.UnionUint16(vlanID)
 		} else {
 			s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
@@ -513,7 +513,7 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 	top := ate.OTG().NewConfig(t)
 	top.Ports().Add().SetName(ap1.ID())
 	// configure DUT port#1 - source port.
-	configureSubinterfaceDUT(t, d, dp1, 0, 0, dutPort1.IPv4)
+	configureSubinterfaceDUT(t, d, dp1, 0, 0, dutPort1.IPv4, dut)
 	configureInterfaceDUT(t, dp1, d, "src")
 	configureATE(t, top, ap1, 0, atePort1.Name, atePort1.MAC, dutPort1.IPv4, atePort1.IPv4)
 	pushConfig(t, dut, dp1, d)

--- a/feature/experimental/gribi/otg_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
+++ b/feature/experimental/gribi/otg_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
@@ -253,7 +253,7 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 		Index := uint32(i)
 		ateIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 1))
 		dutIPv4 := fmt.Sprintf(`198.51.100.%d`, ((4 * i) + 2))
-		configureSubinterfaceDUT(d, dutPort, Index, vlanID, dutIPv4)
+		configureSubinterfaceDUT(d, dutPort, Index, vlanID, dutIPv4, dut)
 		MAC, err := incrementMAC(atePort1.MAC, i+1)
 		if err != nil {
 			t.Fatalf("Failed to increment MAC")
@@ -273,11 +273,11 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 }
 
 // configureSubinterfaceDUT configures a single DUT layer 3 sub-interface.
-func configureSubinterfaceDUT(d *oc.Root, dutPort *ondatra.Port, index uint32, vlanID uint16, dutIPv4 string) {
+func configureSubinterfaceDUT(d *oc.Root, dutPort *ondatra.Port, index uint32, vlanID uint16, dutIPv4 string, dut *ondatra.DUTDevice) {
 	i := d.GetOrCreateInterface(dutPort.Name())
 	s := i.GetOrCreateSubinterface(index)
 	if vlanID != 0 {
-		if *deviations.DeprecatedVlanID {
+		if deviations.DeprecatedVlanID(dut) {
 			s.GetOrCreateVlan().VlanId = oc.UnionUint16(vlanID)
 		} else {
 			s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
@@ -494,7 +494,7 @@ func TestRouteRemovalDuringFailover(t *testing.T) {
 	top := ate.OTG().NewConfig(t)
 	top.Ports().Add().SetName(ap1.ID())
 	// configure DUT port#1 - source port.
-	configureSubinterfaceDUT(d, dp1, 0, 0, dutPort1.IPv4)
+	configureSubinterfaceDUT(d, dp1, 0, 0, dutPort1.IPv4, dut)
 	configureInterfaceDUT(t, dp1, d, "src")
 	configureATE(top, ap1, atePort1.Name, 0, dutPort1.IPv4, atePort1.IPv4, atePort1.MAC)
 	ate.OTG().PushConfig(t, top)

--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/base_vrf_selection/base_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/base_vrf_selection/base_vrf_selection_test.go
@@ -101,12 +101,12 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice, p1 *ondatra.Port, p2 *on
 	// Configure ingress interface
 	t.Logf("*** Configuring interfaces on DUT ...")
 	i1 := &oc.Interface{Name: ygot.String(p1.Name())}
-	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutSrc, 0, 0))
+	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutSrc, 0, 0, dut))
 
 	// Configure egress interface
 	i2 := &oc.Interface{Name: ygot.String(p2.Name())}
-	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutDst, 10, vlan10))
-	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutDst2, 20, vlan20))
+	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutDst, 10, vlan10, dut))
+	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutDst2, 20, vlan20, dut))
 
 	if *deviations.ExplicitPortSpeed {
 		fptest.SetPortSpeed(t, p1)
@@ -134,7 +134,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice, p1 *ondatra.Port, p2 *on
 
 }
 
-func configInterfaceDUT(i *oc.Interface, me *attrs.Attributes, subIntfIndex uint32, vlan uint16) *oc.Interface {
+func configInterfaceDUT(i *oc.Interface, me *attrs.Attributes, subIntfIndex uint32, vlan uint16, dut *ondatra.DUTDevice) *oc.Interface {
 	i.Description = ygot.String(me.Desc)
 	i.Type = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
 	if *deviations.InterfaceEnabled {
@@ -146,7 +146,7 @@ func configInterfaceDUT(i *oc.Interface, me *attrs.Attributes, subIntfIndex uint
 
 	if vlan != 0 {
 		// Add VLANs.
-		if *deviations.DeprecatedVlanID {
+		if deviations.DeprecatedVlanID(dut) {
 			s.GetOrCreateVlan().VlanId = oc.UnionUint16(vlan)
 		} else {
 			singletag := s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged()

--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -194,7 +194,7 @@ func configNetworkInstance(t *testing.T, dut *ondatra.DUTDevice, vrfname string,
 	// create empty subinterface
 	si := &oc.Interface_Subinterface{}
 	si.Index = ygot.Uint32(subint)
-	if *deviations.DeprecatedVlanID {
+	if deviations.DeprecatedVlanID(dut) {
 		si.GetOrCreateVlan().VlanId = oc.UnionUint16(vlanID)
 	} else {
 		si.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
@@ -213,7 +213,7 @@ func configNetworkInstance(t *testing.T, dut *ondatra.DUTDevice, vrfname string,
 }
 
 // getSubInterface returns a subinterface configuration populated with IP addresses and VLAN ID.
-func getSubInterface(dutPort *attrs.Attributes, index uint32, vlanID uint16) *oc.Interface_Subinterface {
+func getSubInterface(dutPort *attrs.Attributes, index uint32, vlanID uint16, dut *ondatra.DUTDevice) *oc.Interface_Subinterface {
 	s := &oc.Interface_Subinterface{}
 	// unshut sub/interface
 	if *deviations.InterfaceEnabled {
@@ -233,7 +233,7 @@ func getSubInterface(dutPort *attrs.Attributes, index uint32, vlanID uint16) *oc
 	a6 := s6.GetOrCreateAddress(dutPort.IPv6)
 	a6.PrefixLength = ygot.Uint8(dutPort.IPv6Len)
 	if index != 0 {
-		if *deviations.DeprecatedVlanID {
+		if deviations.DeprecatedVlanID(dut) {
 			s.GetOrCreateVlan().VlanId = oc.UnionUint16(vlanID)
 		} else {
 			s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
@@ -243,13 +243,13 @@ func getSubInterface(dutPort *attrs.Attributes, index uint32, vlanID uint16) *oc
 }
 
 // configInterfaceDUT configures the interface with the Addrs.
-func configInterfaceDUT(i *oc.Interface, dutPort *attrs.Attributes) *oc.Interface {
+func configInterfaceDUT(i *oc.Interface, dutPort *attrs.Attributes, dut *ondatra.DUTDevice) *oc.Interface {
 	if *deviations.InterfaceEnabled {
 		i.Enabled = ygot.Bool(true)
 	}
 	i.Description = ygot.String(dutPort.Desc)
 	i.Type = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
-	i.AppendSubinterface(getSubInterface(dutPort, 0, 0))
+	i.AppendSubinterface(getSubInterface(dutPort, 0, 0, dut))
 	return i
 }
 
@@ -259,11 +259,11 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 
 	p1 := dut.Port(t, "port1")
 	i1 := &oc.Interface{Name: ygot.String(p1.Name())}
-	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutPort1))
+	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutPort1, dut))
 
 	p2 := dut.Port(t, "port2")
 	i2 := &oc.Interface{Name: ygot.String(p2.Name())}
-	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutPort2))
+	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutPort2, dut))
 	if *deviations.NoMixOfTaggedAndUntaggedSubinterfaces {
 		i3 := &oc.Interface{Name: ygot.String(p2.Name())}
 		s := i3.GetOrCreateSubinterface(0)
@@ -285,13 +285,13 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	configNetworkInstance(t, dut, "VRF10", p2.Name(), uint32(1), 10)
 
 	// configure IP addresses on subinterfaces
-	gnmi.Update(t, dut, outpath.Subinterface(1).Config(), getSubInterface(&dutPort2Vlan10, 1, 10))
+	gnmi.Update(t, dut, outpath.Subinterface(1).Config(), getSubInterface(&dutPort2Vlan10, 1, 10, dut))
 
 	configNetworkInstance(t, dut, "VRF20", p2.Name(), uint32(2), 20)
-	gnmi.Update(t, dut, outpath.Subinterface(2).Config(), getSubInterface(&dutPort2Vlan20, 2, 20))
+	gnmi.Update(t, dut, outpath.Subinterface(2).Config(), getSubInterface(&dutPort2Vlan20, 2, 20, dut))
 
 	configNetworkInstance(t, dut, "VRF30", p2.Name(), uint32(3), 30)
-	gnmi.Update(t, dut, outpath.Subinterface(3).Config(), getSubInterface(&dutPort2Vlan30, 3, 30))
+	gnmi.Update(t, dut, outpath.Subinterface(3).Config(), getSubInterface(&dutPort2Vlan30, 3, 30, dut))
 }
 
 // getIPinIPFlow returns an IPv4inIPv4 *ondatra.Flow with provided DSCP value for a given set of endpoints.

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/base_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/base_vrf_selection_test.go
@@ -106,12 +106,12 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice, p1 *ondatra.Port, p2 *on
 	// Configure ingress interface
 	t.Logf("*** Configuring interfaces on DUT ...")
 	i1 := &oc.Interface{Name: ygot.String(p1.Name())}
-	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutSrc, 0, 0))
+	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutSrc, 0, 0, dut))
 
 	// Configure egress interface
 	i2 := &oc.Interface{Name: ygot.String(p2.Name())}
-	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutDst, 10, vlan10))
-	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutDst2, 20, vlan20))
+	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutDst, 10, vlan10, dut))
+	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutDst2, 20, vlan20, dut))
 
 	if *deviations.ExplicitPortSpeed {
 		fptest.SetPortSpeed(t, p1)
@@ -139,7 +139,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice, p1 *ondatra.Port, p2 *on
 
 }
 
-func configInterfaceDUT(i *oc.Interface, me *attrs.Attributes, subIntfIndex uint32, vlan uint16) *oc.Interface {
+func configInterfaceDUT(i *oc.Interface, me *attrs.Attributes, subIntfIndex uint32, vlan uint16, dut *ondatra.DUTDevice) *oc.Interface {
 	i.Description = ygot.String(me.Desc)
 	i.Type = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
 	if *deviations.InterfaceEnabled {
@@ -151,7 +151,7 @@ func configInterfaceDUT(i *oc.Interface, me *attrs.Attributes, subIntfIndex uint
 
 	if vlan != 0 {
 		// Add VLANs.
-		if *deviations.DeprecatedVlanID {
+		if deviations.DeprecatedVlanID(dut) {
 			s.GetOrCreateVlan().VlanId = oc.UnionUint16(vlan)
 		} else {
 			singletag := s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged()

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -198,7 +198,7 @@ func configNetworkInstance(t *testing.T, dut *ondatra.DUTDevice, vrfname string,
 	// create empty subinterface
 	si := &oc.Interface_Subinterface{}
 	si.Index = ygot.Uint32(subint)
-	if *deviations.DeprecatedVlanID {
+	if deviations.DeprecatedVlanID(dut) {
 		si.GetOrCreateVlan().VlanId = oc.UnionUint16(vlanID)
 	} else {
 		si.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
@@ -217,7 +217,7 @@ func configNetworkInstance(t *testing.T, dut *ondatra.DUTDevice, vrfname string,
 }
 
 // getSubInterface returns a subinterface configuration populated with IP addresses and VLAN ID.
-func getSubInterface(dutPort *attrs.Attributes, index uint32, vlanID uint16) *oc.Interface_Subinterface {
+func getSubInterface(dutPort *attrs.Attributes, index uint32, vlanID uint16, dut *ondatra.DUTDevice) *oc.Interface_Subinterface {
 	s := &oc.Interface_Subinterface{}
 	// unshut sub/interface
 	if *deviations.InterfaceEnabled {
@@ -237,7 +237,7 @@ func getSubInterface(dutPort *attrs.Attributes, index uint32, vlanID uint16) *oc
 	a6 := s6.GetOrCreateAddress(dutPort.IPv6)
 	a6.PrefixLength = ygot.Uint8(dutPort.IPv6Len)
 	if index != 0 {
-		if *deviations.DeprecatedVlanID {
+		if deviations.DeprecatedVlanID(dut) {
 			s.GetOrCreateVlan().VlanId = oc.UnionUint16(vlanID)
 		} else {
 			s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
@@ -247,13 +247,13 @@ func getSubInterface(dutPort *attrs.Attributes, index uint32, vlanID uint16) *oc
 }
 
 // configInterfaceDUT configures the interface with the Addrs.
-func configInterfaceDUT(i *oc.Interface, dutPort *attrs.Attributes) *oc.Interface {
+func configInterfaceDUT(i *oc.Interface, dutPort *attrs.Attributes, dut *ondatra.DUTDevice) *oc.Interface {
 	if *deviations.InterfaceEnabled {
 		i.Enabled = ygot.Bool(true)
 	}
 	i.Description = ygot.String(dutPort.Desc)
 	i.Type = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
-	i.AppendSubinterface(getSubInterface(dutPort, 0, 0))
+	i.AppendSubinterface(getSubInterface(dutPort, 0, 0, dut))
 	return i
 }
 
@@ -263,11 +263,11 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 
 	p1 := dut.Port(t, "port1")
 	i1 := &oc.Interface{Name: ygot.String(p1.Name())}
-	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutPort1))
+	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutPort1, dut))
 
 	p2 := dut.Port(t, "port2")
 	i2 := &oc.Interface{Name: ygot.String(p2.Name())}
-	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutPort2))
+	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutPort2, dut))
 	if *deviations.NoMixOfTaggedAndUntaggedSubinterfaces {
 		i3 := &oc.Interface{Name: ygot.String(p2.Name())}
 		s := i3.GetOrCreateSubinterface(0)
@@ -289,13 +289,13 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	configNetworkInstance(t, dut, "VRF10", p2.Name(), uint32(1), 10)
 
 	// configure IP addresses on subinterfaces
-	gnmi.Update(t, dut, outpath.Subinterface(1).Config(), getSubInterface(&dutPort2Vlan10, 1, 10))
+	gnmi.Update(t, dut, outpath.Subinterface(1).Config(), getSubInterface(&dutPort2Vlan10, 1, 10, dut))
 
 	configNetworkInstance(t, dut, "VRF20", p2.Name(), uint32(2), 20)
-	gnmi.Update(t, dut, outpath.Subinterface(2).Config(), getSubInterface(&dutPort2Vlan20, 2, 20))
+	gnmi.Update(t, dut, outpath.Subinterface(2).Config(), getSubInterface(&dutPort2Vlan20, 2, 20, dut))
 
 	configNetworkInstance(t, dut, "VRF30", p2.Name(), uint32(3), 30)
-	gnmi.Update(t, dut, outpath.Subinterface(3).Config(), getSubInterface(&dutPort2Vlan30, 3, 30))
+	gnmi.Update(t, dut, outpath.Subinterface(3).Config(), getSubInterface(&dutPort2Vlan30, 3, 30, dut))
 }
 
 // getIPinIPFlow returns an IPv4inIPv4 *ondatra.Flow with provided DSCP value for a given set of endpoints.

--- a/feature/gnmi/ate_tests/telemetry_port_speed_test/telemetry_port_speed_test.go
+++ b/feature/gnmi/ate_tests/telemetry_port_speed_test/telemetry_port_speed_test.go
@@ -181,7 +181,7 @@ func (tc *testCase) configureDUT(t *testing.T) {
 
 	d := gnmi.OC()
 
-	if deviations.AggregateAtomicUpdate(tc.dut) {
+	if *deviations.AggregateAtomicUpdate {
 		tc.clearAggregateMembers(t)
 		tc.setupAggregateAtomically(t)
 	}
@@ -225,7 +225,7 @@ func (tc *testCase) configureDUT(t *testing.T) {
 			iPath := d.Interface(iName)
 			gnmi.Replace(t, tc.dut, iPath.Config(), &oc.Interface{Name: ygot.String(iName), Type: ethernetCsmacd})
 		}
-		if deviations.AggregateAtomicUpdate(tc.dut) {
+		if *deviations.AggregateAtomicUpdate {
 			resetBatch := &gnmi.SetBatch{}
 			if *deviations.ExplicitInterfaceInDefaultVRF {
 				gnmi.BatchDelete(resetBatch, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Interface(tc.aggID+".0").Config())

--- a/feature/gnoi/os/tests/osinstall/osinstall_test.go
+++ b/feature/gnoi/os/tests/osinstall/osinstall_test.go
@@ -84,24 +84,23 @@ func TestOSInstall(t *testing.T) {
 		osc:    dut.RawAPIs().GNOI().Default(t).OS(),
 		sc:     dut.RawAPIs().GNOI().Default(t).System(),
 	}
-	noReboot := deviations.OSActivateNoReboot(dut)
 	tc.fetchStandbySupervisorStatus(ctx, t)
 	tc.transferOS(ctx, t, false)
-	tc.activateOS(ctx, t, false, noReboot)
+	tc.activateOS(ctx, t, false)
 
-	if deviations.InstallOSForStandbyRP(dut) && tc.dualSup {
+	if *deviations.InstallOSForStandbyRP && tc.dualSup {
 		tc.transferOS(ctx, t, true)
-		tc.activateOS(ctx, t, true, noReboot)
+		tc.activateOS(ctx, t, true)
 	}
 
-	if noReboot {
+	if *deviations.OSActivateNoReboot {
 		tc.rebootDUT(ctx, t)
 	}
 
 	tc.verifyInstall(ctx, t)
 }
 
-func (tc *testCase) activateOS(ctx context.Context, t *testing.T, standby, noReboot bool) {
+func (tc *testCase) activateOS(ctx context.Context, t *testing.T, standby bool) {
 	t.Helper()
 	if standby {
 		t.Log("OS.Activate is started for standby RP.")
@@ -111,7 +110,7 @@ func (tc *testCase) activateOS(ctx context.Context, t *testing.T, standby, noReb
 	act, err := tc.osc.Activate(ctx, &ospb.ActivateRequest{
 		StandbySupervisor: standby,
 		Version:           *osVersion,
-		NoReboot:          noReboot,
+		NoReboot:          *deviations.OSActivateNoReboot,
 	})
 	if err != nil {
 		t.Fatalf("OS.Activate request failed: %s", err)

--- a/feature/gnoi/system/tests/traceroute_test/traceroute_test.go
+++ b/feature/gnoi/system/tests/traceroute_test/traceroute_test.go
@@ -244,7 +244,7 @@ func TestGNOITraceroute(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			time.Sleep(1 * time.Second) // some devices do not allow back to back traceroute to prevent flooding
-			if deviations.TraceRouteL4ProtocolUDP(dut) {
+			if *deviations.TraceRouteL4ProtocolUDP {
 				if tc.defaultL4Protocol {
 					tc.traceRequest.L4Protocol = spb.TracerouteRequest_UDP
 				}
@@ -252,7 +252,7 @@ func TestGNOITraceroute(t *testing.T) {
 					t.Skip("Test is skiped due to the TraceRouteL4ProtocolUDP deviation")
 				}
 			}
-			if deviations.TraceRouteFragmentation(dut) {
+			if *deviations.TraceRouteFragmentation {
 				if tc.traceRequest.DoNotFragment {
 					t.Skip("Test is skiped due to the TraceRouteFragmentation deviation")
 				}

--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -386,7 +386,7 @@ func createSubifDUT(t *testing.T, d *oc.Root, dut *ondatra.DUTDevice, dutPort *o
 	i := d.GetOrCreateInterface(dutPort.Name())
 	s := i.GetOrCreateSubinterface(index)
 	if vlanID != 0 {
-		if *deviations.DeprecatedVlanID {
+		if deviations.DeprecatedVlanID(dut) {
 			s.GetOrCreateVlan().VlanId = oc.UnionUint16(vlanID)
 		} else {
 			s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)

--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -229,7 +229,7 @@ func awaitTimeout(ctx context.Context, c *fluent.GRIBIClient, t testing.TB, time
 // starting from Sub Interface 1. Each Subinterface is configured with a
 // unique VlanID starting from 1 and an IP address. The starting IP Address
 // for Subinterface(1) = dutPort.ip(1) = dutPort.ip + 4.
-func (a *attributes) configSubinterfaceDUT(t *testing.T, intf *oc.Interface) {
+func (a *attributes) configSubinterfaceDUT(t *testing.T, intf *oc.Interface, dut *ondatra.DUTDevice) {
 	t.Helper()
 
 	for i := uint32(1); i <= a.numSubIntf; i++ {
@@ -239,7 +239,7 @@ func (a *attributes) configSubinterfaceDUT(t *testing.T, intf *oc.Interface) {
 		if *deviations.InterfaceEnabled {
 			s.Enabled = ygot.Bool(true)
 		}
-		if *deviations.DeprecatedVlanID {
+		if deviations.DeprecatedVlanID(dut) {
 			s.GetOrCreateVlan().VlanId = oc.UnionUint16(i)
 		} else {
 			s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(uint16(i))
@@ -275,7 +275,7 @@ func (a *attributes) configInterfaceDUT(t *testing.T, d *ondatra.DUTDevice) {
 		i.GetOrCreateEthernet().PortSpeed = fptest.GetIfSpeed(t, p)
 	}
 
-	a.configSubinterfaceDUT(t, i)
+	a.configSubinterfaceDUT(t, i, d)
 	intfPath := gnmi.OC().Interface(p.Name())
 	gnmi.Replace(t, d, intfPath.Config(), i)
 	fptest.LogQuery(t, "DUT", intfPath.Config(), gnmi.GetConfig(t, d, intfPath.Config()))

--- a/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
@@ -389,7 +389,7 @@ func createSubifDUT(t *testing.T, d *oc.Root, dut *ondatra.DUTDevice, dutPort *o
 	i := d.GetOrCreateInterface(dutPort.Name())
 	s := i.GetOrCreateSubinterface(index)
 	if vlanID != 0 {
-		if *deviations.DeprecatedVlanID {
+		if deviations.DeprecatedVlanID(dut) {
 			s.GetOrCreateVlan().VlanId = oc.UnionUint16(vlanID)
 		} else {
 			s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)

--- a/feature/interface/aggregate/ate_tests/aggregate_forwarding_viable_test/aggregate_forwarding_viable_test.go
+++ b/feature/interface/aggregate/ate_tests/aggregate_forwarding_viable_test/aggregate_forwarding_viable_test.go
@@ -257,7 +257,7 @@ func (tc *testArgs) configureDUT(t *testing.T) {
 
 	d := gnmi.OC()
 
-	if deviations.AggregateAtomicUpdate(tc.dut) {
+	if *deviations.AggregateAtomicUpdate {
 		tc.clearAggregate(t)
 		tc.setupAggregateAtomically(t)
 	}

--- a/feature/interface/aggregate/ate_tests/aggregate_test/aggregate_test.go
+++ b/feature/interface/aggregate/ate_tests/aggregate_test/aggregate_test.go
@@ -197,7 +197,7 @@ func (tc *testCase) configureDUT(t *testing.T) {
 
 	d := gnmi.OC()
 
-	if deviations.AggregateAtomicUpdate(tc.dut) {
+	if *deviations.AggregateAtomicUpdate {
 		tc.clearAggregate(t)
 		tc.setupAggregateAtomically(t)
 	}

--- a/feature/interface/aggregate/ate_tests/balancing_test/balancing_test.go
+++ b/feature/interface/aggregate/ate_tests/balancing_test/balancing_test.go
@@ -213,7 +213,7 @@ func (tc *testCase) configureDUT(t *testing.T) {
 
 	d := gnmi.OC()
 
-	if deviations.AggregateAtomicUpdate(tc.dut) {
+	if *deviations.AggregateAtomicUpdate {
 		tc.clearAggregateMembers(t)
 		tc.setupAggregateAtomically(t)
 	}

--- a/feature/interface/aggregate/otg_tests/aggregate_test/aggregate_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_test/aggregate_test.go
@@ -205,7 +205,7 @@ func (tc *testCase) configureDUT(t *testing.T) {
 
 	d := gnmi.OC()
 
-	if deviations.AggregateAtomicUpdate(tc.dut) {
+	if *deviations.AggregateAtomicUpdate {
 		tc.clearAggregate(t)
 		tc.setupAggregateAtomically(t)
 	}

--- a/feature/interface/aggregate/otg_tests/balancing_test/balancing_test.go
+++ b/feature/interface/aggregate/otg_tests/balancing_test/balancing_test.go
@@ -290,7 +290,7 @@ func (tc *testCase) configureDUT(t *testing.T) {
 
 	d := gnmi.OC()
 
-	if deviations.AggregateAtomicUpdate(tc.dut) {
+	if *deviations.AggregateAtomicUpdate {
 		tc.clearAggregateMembers(t)
 		tc.setupAggregateAtomically(t)
 	}

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -69,13 +69,6 @@ import (
 	"github.com/openconfig/ondatra"
 )
 
-// AggregateAtomicUpdate returns if device requires that aggregate Port-Channel and its members be defined in a single gNMI Update transaction at /interfaces.
-// Otherwise lag-type will be dropped, and no member can be added to the aggregate.
-// Full OpenConfig compliant devices should pass both with and without this deviation.
-func AggregateAtomicUpdate(_ *ondatra.DUTDevice) bool {
-	return *aggregateAtomicUpdate
-}
-
 // P4RTMissingDelete returns whether the device does not support delete mode in P4RT write requests.
 func P4RTMissingDelete(_ *ondatra.DUTDevice) bool {
 	return *p4rtMissingDelete
@@ -219,16 +212,6 @@ func MissingInterfaceHardwarePort(_ *ondatra.DUTDevice) bool {
 	return *missingInterfaceHardwarePort
 }
 
-// TraceRouteL4ProtocolUDP returns if device only support UDP as l4 protocol for traceroute.
-func TraceRouteL4ProtocolUDP(_ *ondatra.DUTDevice) bool {
-	return *traceRouteL4ProtocolUDP
-}
-
-// TraceRouteFragmentation returns if device does not support fragmentation bit for traceroute.
-func TraceRouteFragmentation(_ *ondatra.DUTDevice) bool {
-	return *traceRouteFragmentation
-}
-
 // SubinterfacePacketCountersMissing returns if device is missing subinterface packet counters for IPv4/IPv6,
 // so the test will skip checking them.
 // Full OpenConfig compliant devices should pass both with and without this deviation.
@@ -236,14 +219,9 @@ func SubinterfacePacketCountersMissing(_ *ondatra.DUTDevice) bool {
 	return *subinterfacePacketCountersMissing
 }
 
-// OSActivateNoReboot returns if device requires separate reboot to activate OS.
-func OSActivateNoReboot(_ *ondatra.DUTDevice) bool {
-	return *osActivateNoReboot
-}
-
-// InstallOSForStandbyRP returns if device requires OS installation on standby RP as well as active RP.
-func InstallOSForStandbyRP(_ *ondatra.DUTDevice) bool {
-	return *installOSForStandbyRP
+// DeprecatedVlanID returns if device requires using the deprecated openconfig-vlan:vlan/config/vlan-id or openconfig-vlan:vlan/state/vlan-id leaves.
+func DeprecatedVlanID(_ *ondatra.DUTDevice) bool {
+	return *deprecatedVlanID
 }
 
 // Vendor deviation flags.
@@ -265,7 +243,7 @@ var (
 
 	interfaceCountersFromContainer = flag.Bool("deviation_interface_counters_from_container", false, "Device only supports querying counters from the state container, not from individual counter leaves.")
 
-	aggregateAtomicUpdate = flag.Bool("deviation_aggregate_atomic_update", false,
+	AggregateAtomicUpdate = flag.Bool("deviation_aggregate_atomic_update", false,
 		"Device requires that aggregate Port-Channel and its members be defined in a single gNMI Update transaction at /interfaces; otherwise lag-type will be dropped, and no member can be added to the aggregate.  Full OpenConfig compliant devices should pass both with and without this deviation.")
 
 	DefaultNetworkInstance = flag.String("deviation_default_network_instance", "DEFAULT",
@@ -288,11 +266,11 @@ var (
 
 	GNOIStatusWithEmptySubcomponent = flag.Bool("deviation_gnoi_status_empty_subcomponent", false, "The response of gNOI reboot status is a single value (not a list), so the device requires explict component path to account for a situation when there is more than one active reboot requests.")
 
-	osActivateNoReboot = flag.Bool("deviation_osactivate_noreboot", false, "Device requires separate reboot to activate OS.")
+	OSActivateNoReboot = flag.Bool("deviation_osactivate_noreboot", false, "Device requires seperate reboot to activate OS.")
 
-	installOSForStandbyRP = flag.Bool("deviation_osinstall_for_standby_rp", false, "Device requires OS installation on standby RP as well as active RP.")
+	InstallOSForStandbyRP = flag.Bool("deviation_osinstall_for_standby_rp", false, "Device requires OS installation on standby RP as well as active RP.")
 
-	DeprecatedVlanID = flag.Bool("deviation_deprecated_vlan_id", false, "Device requires using the deprecated openconfig-vlan:vlan/config/vlan-id or openconfig-vlan:vlan/state/vlan-id leaves.")
+	deprecatedVlanID = flag.Bool("deviation_deprecated_vlan_id", false, "Device requires using the deprecated openconfig-vlan:vlan/config/vlan-id or openconfig-vlan:vlan/state/vlan-id leaves.")
 
 	ExplicitInterfaceInDefaultVRF = flag.Bool("deviation_explicit_interface_in_default_vrf", false,
 		"Device requires explicit attachment of an interface or subinterface to the default network instance. OpenConfig expects an unattached interface or subinterface to be implicitly part of the default network instance. Fully-compliant devices should pass with and without this deviation.")
@@ -307,9 +285,9 @@ var (
 
 	RoutePolicyUnderNeighborAfiSafi = flag.Bool("deviation_rpl_under_neighbor_afisafi", false, "Device requires route-policy configuration under bgp neighbor afisafi. Fully-compliant devices should pass with this deviation set to true.")
 
-	traceRouteL4ProtocolUDP = flag.Bool("deviation_traceroute_l4_protocol_udp", false, "Device only support UDP as l4 protocol for traceroute. Use this flag to set default l4 protocol as UDP and skip the tests explictly use TCP or ICMP.")
+	TraceRouteL4ProtocolUDP = flag.Bool("deviation_traceroute_l4_protocol_udp", false, "Device only support UDP as l4 protocol for traceroute. Use this flag to set default l4 protocol as UDP and skip the tests explictly use TCP or ICMP.")
 
-	traceRouteFragmentation = flag.Bool("deviation_traceroute_fragmentation", false, "Device does not support fragmentation bit for traceroute.")
+	TraceRouteFragmentation = flag.Bool("deviation_traceroute_fragmentation", false, "Device does not support fragmentation bit for traceroute.")
 
 	ConnectRetry = flag.Bool("deviation_connect_retry", false, "Connect-retry is not supported /bgp/neighbors/neighbor/timers/config/connect-retry.")
 


### PR DESCRIPTION
PiperOrigin-RevId: 529270653
Move DeprecatedVlanID to accessor method
