### PR TITLE
Move ExplicitGRIBIUnderNetworkInstance to accessor method

### DIFF
--- a/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/backup_nhg_test.go
+++ b/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/backup_nhg_test.go
@@ -307,7 +307,7 @@ func configureNetworkInstance(t *testing.T, dut *ondatra.DUTDevice) {
 	ni1.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrfB).Config(), ni1)
 
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrfA)
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrfB)

--- a/feature/experimental/gribi/ate_tests/backup_nhg_action/backup_nhg_action_test.go
+++ b/feature/experimental/gribi/ate_tests/backup_nhg_action/backup_nhg_action_test.go
@@ -200,7 +200,7 @@ func configureNetworkInstance(t *testing.T, dut *ondatra.DUTDevice) {
 		}
 		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrf).Config(), ni)
 	}
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		for _, vrf := range []string{vrfA, vrfB, vrfC, *deviations.DefaultNetworkInstance} {
 			fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrf)
 		}

--- a/feature/experimental/gribi/ate_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
+++ b/feature/experimental/gribi/ate_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
@@ -507,7 +507,7 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 		fptest.SetPortSpeed(t, dp1)
 		fptest.SetPortSpeed(t, dp2)
 	}
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 	}
 

--- a/feature/experimental/gribi/ate_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
+++ b/feature/experimental/gribi/ate_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
@@ -476,7 +476,7 @@ func TestRouteRemovalDuringFailover(t *testing.T) {
 		fptest.SetPortSpeed(t, dp1)
 		fptest.SetPortSpeed(t, dp2)
 	}
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 	}
 

--- a/feature/experimental/gribi/otg_tests/backup_nhg_action/backup_nhg_action_test.go
+++ b/feature/experimental/gribi/otg_tests/backup_nhg_action/backup_nhg_action_test.go
@@ -202,7 +202,7 @@ func configureNetworkInstance(t *testing.T, dut *ondatra.DUTDevice) {
 		}
 		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrf).Config(), ni)
 	}
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		for _, vrf := range []string{vrfA, vrfB, vrfC, *deviations.DefaultNetworkInstance} {
 			fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrf)
 		}

--- a/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
+++ b/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
@@ -529,7 +529,7 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 		fptest.SetPortSpeed(t, dp1)
 		fptest.SetPortSpeed(t, dp2)
 	}
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 	}
 

--- a/feature/experimental/gribi/otg_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
+++ b/feature/experimental/gribi/otg_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
@@ -511,7 +511,7 @@ func TestRouteRemovalDuringFailover(t *testing.T) {
 		fptest.SetPortSpeed(t, dp1)
 		fptest.SetPortSpeed(t, dp2)
 	}
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 	}
 

--- a/feature/gribi/ate_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
+++ b/feature/gribi/ate_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
@@ -237,7 +237,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
 		fptest.AssignToNetworkInstance(t, dut, p4.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrf1)
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrf2)

--- a/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -375,7 +375,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrfName)
 	}

--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -329,7 +329,7 @@ func createVrf(t *testing.T, dut *ondatra.DUTDevice, vrfs []string) {
 			gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 
 		}
-		if *deviations.ExplicitGRIBIUnderNetworkInstance {
+		if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 			fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrf)
 		}
 	}

--- a/feature/gribi/ate_tests/gribigo_compliance_test/gribigo_compliance_test.go
+++ b/feature/gribi/ate_tests/gribigo_compliance_test/gribigo_compliance_test.go
@@ -194,7 +194,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	ni := d.GetOrCreateNetworkInstance(*nonDefaultNI)
 	ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*nonDefaultNI).Config(), ni)
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *nonDefaultNI)
 	}

--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -316,7 +316,7 @@ func configureNetworkInstance(t *testing.T, d *ondatra.DUTDevice) {
 	gnmi.Replace(t, d, defNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 	gnmi.Replace(t, d, defNIPath.PolicyForwarding().Config(), configurePBF())
 
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(d) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, d, nonDefaultVRF)
 		fptest.EnableGRIBIUnderNetworkInstance(t, d, *deviations.DefaultNetworkInstance)
 	}

--- a/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -323,7 +323,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	if *deviations.ExplicitInterfaceInDefaultVRF {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 	}
 }
@@ -358,7 +358,7 @@ func configureNetworkInstance(t *testing.T, dut *ondatra.DUTDevice) {
 	niIntf.Interface = ygot.String(p1.Name())
 
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(nonDefaultVRF).Config(), nonDefaultNI)
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, nonDefaultVRF)
 	}
 }

--- a/feature/gribi/otg_tests/ack_in_presence_other_routes/route_ack_test.go
+++ b/feature/gribi/otg_tests/ack_in_presence_other_routes/route_ack_test.go
@@ -154,7 +154,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, dut.Port(t, "port3"))
 	}
 
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 	}
 }

--- a/feature/gribi/otg_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
+++ b/feature/gribi/otg_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
@@ -217,7 +217,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
 		fptest.AssignToNetworkInstance(t, dut, p4.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrf1)
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrf2)

--- a/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -380,7 +380,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrfName)
 	}

--- a/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
@@ -332,7 +332,7 @@ func createVrf(t *testing.T, dut *ondatra.DUTDevice, vrfs []string) {
 			dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
 			gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 		}
-		if *deviations.ExplicitGRIBIUnderNetworkInstance {
+		if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 			fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrf)
 		}
 	}

--- a/feature/gribi/otg_tests/gribigo_compliance_test/gribigo_compliance_test.go
+++ b/feature/gribi/otg_tests/gribigo_compliance_test/gribigo_compliance_test.go
@@ -196,7 +196,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	ni := d.GetOrCreateNetworkInstance(*nonDefaultNI)
 	ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*nonDefaultNI).Config(), ni)
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *nonDefaultNI)
 	}

--- a/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -318,7 +318,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	if *deviations.ExplicitInterfaceInDefaultVRF {
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
 	}
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
 	}
 }
@@ -357,7 +357,7 @@ func configureNetworkInstance(t *testing.T, dut *ondatra.DUTDevice) {
 	niIntf.Interface = ygot.String(p1.Name())
 
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(nonDefaultVRF).Config(), nonDefaultNI)
-	if *deviations.ExplicitGRIBIUnderNetworkInstance {
+	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, nonDefaultVRF)
 	}
 }

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -268,6 +268,11 @@ func GNOIStatusWithEmptySubcomponent(_ *ondatra.DUTDevice) bool {
 	return *gNOIStatusWithEmptySubcomponent
 }
 
+// ExplicitGRIBIUnderNetworkInstance returns if device requires gribi-protocol to be enabled under network-instance.
+func ExplicitGRIBIUnderNetworkInstance(_ *ondatra.DUTDevice) bool {
+	return *explicitGRIBIUnderNetworkInstance
+}
+
 // Vendor deviation flags.
 // All new flags should not be exported (define them in lowercase) and accessed
 // from tests through a public accessors like those above.
@@ -373,7 +378,7 @@ var (
 	bgpTrafficTolerance = flag.Int("deviation_bgp_tolerance_value", 0,
 		"Allowed tolerance for BGP traffic flow while comparing for pass or fail condition.")
 
-	ExplicitGRIBIUnderNetworkInstance = flag.Bool("deviation_explicit_gribi_under_network_instance", false,
+	explicitGRIBIUnderNetworkInstance = flag.Bool("deviation_explicit_gribi_under_network_instance", false,
 		"Device requires gribi-protocol to be enabled under network-instance.")
 
 	BGPMD5RequiresReset = flag.Bool("deviation_bgp_md5_requires_reset", false, "Device requires a BGP session reset to utilize a new MD5 key")


### PR DESCRIPTION
PiperOrigin-RevId: 529577328

Move ExplicitGRIBIUnderNetworkInstance to accessor method