### PR TITLE
Move InterfaceConfigVrfBeforeAddress to accessor.

### DIFF
--- a/feature/experimental/gribi/ate_tests/backup_nhg_action/backup_nhg_action_test.go
+++ b/feature/experimental/gribi/ate_tests/backup_nhg_action/backup_nhg_action_test.go
@@ -213,7 +213,7 @@ func TestBackupNHGAction(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
 	// Configure DUT
-	if !*deviations.InterfaceConfigVrfBeforeAddress {
+	if !deviations.InterfaceConfigVrfBeforeAddress(dut) {
 		configureDUT(t, dut)
 	}
 
@@ -222,7 +222,7 @@ func TestBackupNHGAction(t *testing.T) {
 	configureNetworkInstance(t, dut)
 
 	// For interface configuration, Arista prefers config Vrf first then the IP address
-	if *deviations.InterfaceConfigVrfBeforeAddress {
+	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
 		configureDUT(t, dut)
 	}
 

--- a/feature/experimental/gribi/ate_tests/backup_nhg_action/backup_nhg_action_test.go
+++ b/feature/experimental/gribi/ate_tests/backup_nhg_action/backup_nhg_action_test.go
@@ -213,7 +213,7 @@ func TestBackupNHGAction(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
 	// Configure DUT
-	if !deviations.InterfaceConfigVrfBeforeAddress(dut) {
+	if !deviations.InterfaceConfigVRFBeforeAddress(dut) {
 		configureDUT(t, dut)
 	}
 
@@ -222,7 +222,7 @@ func TestBackupNHGAction(t *testing.T) {
 	configureNetworkInstance(t, dut)
 
 	// For interface configuration, Arista prefers config Vrf first then the IP address
-	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
+	if deviations.InterfaceConfigVRFBeforeAddress(dut) {
 		configureDUT(t, dut)
 	}
 

--- a/feature/experimental/gribi/otg_tests/backup_nhg_action/backup_nhg_action_test.go
+++ b/feature/experimental/gribi/otg_tests/backup_nhg_action/backup_nhg_action_test.go
@@ -215,7 +215,7 @@ func TestBackupNHGAction(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
 	// Configure DUT
-	if !deviations.InterfaceConfigVrfBeforeAddress(dut) {
+	if !deviations.InterfaceConfigVRFBeforeAddress(dut) {
 		configureDUT(t, dut)
 	}
 
@@ -224,7 +224,7 @@ func TestBackupNHGAction(t *testing.T) {
 	configureNetworkInstance(t, dut)
 
 	// For interface configuration, Arista prefers config Vrf first then the IP address
-	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
+	if deviations.InterfaceConfigVRFBeforeAddress(dut) {
 		configureDUT(t, dut)
 	}
 

--- a/feature/experimental/gribi/otg_tests/backup_nhg_action/backup_nhg_action_test.go
+++ b/feature/experimental/gribi/otg_tests/backup_nhg_action/backup_nhg_action_test.go
@@ -215,7 +215,7 @@ func TestBackupNHGAction(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
 	// Configure DUT
-	if !*deviations.InterfaceConfigVrfBeforeAddress {
+	if !deviations.InterfaceConfigVrfBeforeAddress(dut) {
 		configureDUT(t, dut)
 	}
 
@@ -224,7 +224,7 @@ func TestBackupNHGAction(t *testing.T) {
 	configureNetworkInstance(t, dut)
 
 	// For interface configuration, Arista prefers config Vrf first then the IP address
-	if *deviations.InterfaceConfigVrfBeforeAddress {
+	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
 		configureDUT(t, dut)
 	}
 

--- a/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -363,13 +363,13 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	p1VRF.Subinterface = ygot.Uint32(0)
 
 	// For interface configuration, Arista prefers config Vrf first then the IP address
-	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
+	if deviations.InterfaceConfigVRFBeforeAddress(dut) {
 		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrfName).Config(), vrf)
 	}
 
 	gnmi.Update(t, dut, d.Interface(p1.Name()).Config(), dutPort1.NewOCInterface(p1.Name()))
 
-	if !deviations.InterfaceConfigVrfBeforeAddress(dut) {
+	if !deviations.InterfaceConfigVRFBeforeAddress(dut) {
 		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrfName).Config(), vrf)
 	}
 

--- a/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -350,13 +350,13 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	p1VRF.Subinterface = ygot.Uint32(0)
 
 	// For interface configuration, Arista prefers config Vrf first then the IP address
-	if *deviations.InterfaceConfigVrfBeforeAddress {
+	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
 		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrfName).Config(), vrf)
 	}
 
 	gnmi.Update(t, dut, d.Interface(p1.Name()).Config(), dutPort1.NewOCInterface(p1.Name()))
 
-	if !*deviations.InterfaceConfigVrfBeforeAddress {
+	if !deviations.InterfaceConfigVrfBeforeAddress(dut) {
 		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrfName).Config(), vrf)
 	}
 

--- a/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -99,7 +99,7 @@ func TestRouteRemovalNonDefaultVRFFlush(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
 	// For interface configuration, Arista prefers config Vrf first then the IP address
-	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
+	if deviations.InterfaceConfigVRFBeforeAddress(dut) {
 		configureNetworkInstance(t, dut)
 	}
 
@@ -108,7 +108,7 @@ func TestRouteRemovalNonDefaultVRFFlush(t *testing.T) {
 	ate := ondatra.ATE(t, "ate")
 	ateTop := configureATE(t, ate)
 
-	if !deviations.InterfaceConfigVrfBeforeAddress(dut) {
+	if !deviations.InterfaceConfigVRFBeforeAddress(dut) {
 		configureNetworkInstance(t, dut)
 	}
 

--- a/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -99,7 +99,7 @@ func TestRouteRemovalNonDefaultVRFFlush(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
 	// For interface configuration, Arista prefers config Vrf first then the IP address
-	if *deviations.InterfaceConfigVrfBeforeAddress {
+	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
 		configureNetworkInstance(t, dut)
 	}
 
@@ -108,7 +108,7 @@ func TestRouteRemovalNonDefaultVRFFlush(t *testing.T) {
 	ate := ondatra.ATE(t, "ate")
 	ateTop := configureATE(t, ate)
 
-	if !*deviations.InterfaceConfigVrfBeforeAddress {
+	if !deviations.InterfaceConfigVrfBeforeAddress(dut) {
 		configureNetworkInstance(t, dut)
 	}
 

--- a/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -366,13 +366,13 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	p1VRF.Subinterface = ygot.Uint32(0)
 
 	// For interface configuration, Arista prefers config Vrf first then the IP address
-	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
+	if deviations.InterfaceConfigVRFBeforeAddress(dut) {
 		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrfName).Config(), vrf)
 	}
 
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), dutPort1.NewOCInterface(p1.Name()))
 
-	if !deviations.InterfaceConfigVrfBeforeAddress(dut) {
+	if !deviations.InterfaceConfigVRFBeforeAddress(dut) {
 		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrfName).Config(), vrf)
 	}
 

--- a/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -353,13 +353,13 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	p1VRF.Subinterface = ygot.Uint32(0)
 
 	// For interface configuration, Arista prefers config Vrf first then the IP address
-	if *deviations.InterfaceConfigVrfBeforeAddress {
+	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
 		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrfName).Config(), vrf)
 	}
 
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), dutPort1.NewOCInterface(p1.Name()))
 
-	if !*deviations.InterfaceConfigVrfBeforeAddress {
+	if !deviations.InterfaceConfigVrfBeforeAddress(dut) {
 		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrfName).Config(), vrf)
 	}
 

--- a/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -101,7 +101,7 @@ func TestRouteRemovalNonDefaultVRFFlush(t *testing.T) {
 
 	dut := ondatra.DUT(t, "dut")
 	// For interface configuration, Arista prefers config Vrf first then the IP address
-	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
+	if deviations.InterfaceConfigVRFBeforeAddress(dut) {
 		configureNetworkInstance(t, dut)
 		configureDUT(t, dut)
 	} else {

--- a/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -101,7 +101,7 @@ func TestRouteRemovalNonDefaultVRFFlush(t *testing.T) {
 
 	dut := ondatra.DUT(t, "dut")
 	// For interface configuration, Arista prefers config Vrf first then the IP address
-	if *deviations.InterfaceConfigVrfBeforeAddress {
+	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
 		configureNetworkInstance(t, dut)
 		configureDUT(t, dut)
 	} else {

--- a/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
@@ -48,7 +48,7 @@ func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attribut
 	// For vendors that require n/w instance definition and interface in
 	// a n/w instance set before the address configuration, set nwInstance +
 	// interface creation in the nwInstance first.
-	if *deviations.InterfaceConfigVrfBeforeAddress {
+	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
 		gnmi.Update(t, dut, gnmi.OC().Config(), d)
 	}
 

--- a/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
@@ -48,7 +48,7 @@ func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attribut
 	// For vendors that require n/w instance definition and interface in
 	// a n/w instance set before the address configuration, set nwInstance +
 	// interface creation in the nwInstance first.
-	if deviations.InterfaceConfigVrfBeforeAddress(dut) {
+	if deviations.InterfaceConfigVRFBeforeAddress(dut) {
 		gnmi.Update(t, dut, gnmi.OC().Config(), d)
 	}
 

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -302,8 +302,8 @@ func GNOIStatusWithEmptySubcomponent(_ *ondatra.DUTDevice) bool {
 }
 
 // InterfaceConfigVrfBeforeAddress returns if vrf should be configured before IP address when configuring interface.
-func InterfaceConfigVrfBeforeAddress(_ *ondatra.DUTDevice) bool {
-	return *interfaceConfigVrfBeforeAddress
+func InterfaceConfigVRFBeforeAddress(_ *ondatra.DUTDevice) bool {
+	return *interfaceConfigVRFBeforeAddress
 }
 
 // ExplicitInterfaceRefDefinition returns if device requires explicit interface ref configuration when applying features to interface.
@@ -448,7 +448,7 @@ var (
 	missingInterfaceHardwarePort = flag.Bool("deviation_missing_interface_hardware_port", false,
 		"Device does not support interface/hardwareport leaf. Set this flag to skip checking the leaf.")
 
-	interfaceConfigVrfBeforeAddress = flag.Bool("deviation_interface_config_vrf_before_address", false, "When configuring interface, config Vrf prior config IP address")
+	interfaceConfigVRFBeforeAddress = flag.Bool("deviation_interface_config_vrf_before_address", false, "When configuring interface, config Vrf prior config IP address")
 
 	bgpTrafficTolerance = flag.Int("deviation_bgp_tolerance_value", 0,
 		"Allowed tolerance for BGP traffic flow while comparing for pass or fail condition.")

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -268,6 +268,11 @@ func GNOIStatusWithEmptySubcomponent(_ *ondatra.DUTDevice) bool {
 	return *gNOIStatusWithEmptySubcomponent
 }
 
+// InterfaceConfigVrfBeforeAddress returns if vrf should be configured before IP address when configuring interface.
+func InterfaceConfigVrfBeforeAddress(_ *ondatra.DUTDevice) bool {
+	return *interfaceConfigVrfBeforeAddress
+}
+
 // Vendor deviation flags.
 // All new flags should not be exported (define them in lowercase) and accessed
 // from tests through a public accessors like those above.
@@ -368,7 +373,7 @@ var (
 	missingInterfaceHardwarePort = flag.Bool("deviation_missing_interface_hardware_port", false,
 		"Device does not support interface/hardwareport leaf. Set this flag to skip checking the leaf.")
 
-	InterfaceConfigVrfBeforeAddress = flag.Bool("deviation_interface_config_vrf_before_address", false, "When configuring interface, config Vrf prior config IP address")
+	interfaceConfigVrfBeforeAddress = flag.Bool("deviation_interface_config_vrf_before_address", false, "When configuring interface, config Vrf prior config IP address")
 
 	bgpTrafficTolerance = flag.Int("deviation_bgp_tolerance_value", 0,
 		"Allowed tolerance for BGP traffic flow while comparing for pass or fail condition.")

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -296,7 +296,7 @@ func GNOIStatusWithEmptySubcomponent(_ *ondatra.DUTDevice) bool {
 	return *gNOIStatusWithEmptySubcomponent
 }
 
-// InterfaceConfigVrfBeforeAddress returns if vrf should be configured before IP address when configuring interface.
+// InterfaceConfigVRFBeforeAddress returns if vrf should be configured before IP address when configuring interface.
 func InterfaceConfigVRFBeforeAddress(_ *ondatra.DUTDevice) bool {
 	return *interfaceConfigVRFBeforeAddress
 }


### PR DESCRIPTION
PiperOrigin-RevId: 529580090
Move InterfaceConfigVrfBeforeAddress to accessor.