### PR TITLE
Move ExplicitInterfaceRefDefinition to accessor method

### DIFF
--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/base_vrf_selection/base_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/base_vrf_selection/base_vrf_selection_test.go
@@ -252,7 +252,7 @@ func applyForwardingPolicy(t *testing.T, ate *ondatra.ATEDevice, ingressPort, ma
 
 	intf := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreatePolicyForwarding().GetOrCreateInterface(ingressPort)
 	intf.ApplyVrfSelectionPolicy = ygot.String(matchType)
-	if *deviations.ExplicitInterfaceRefDefinition {
+	if deviations.ExplicitInterfaceRefDefinition(dut) {
 		intf.GetOrCreateInterfaceRef().Interface = ygot.String(ingressPort)
 		intf.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 	}

--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -524,7 +524,7 @@ func TestPBR(t *testing.T) {
 			pfIntf := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreatePolicyForwarding().GetOrCreateInterface(p1)
 			pfIntfConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Interface(p1)
 
-			if *deviations.ExplicitInterfaceRefDefinition {
+			if deviations.ExplicitInterfaceRefDefinition(dut) {
 				pfIntf.GetOrCreateInterfaceRef().Interface = ygot.String(p1)
 				pfIntf.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 				pfIntf.SetApplyVrfSelectionPolicy(args.policyName)

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/base_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/base_vrf_selection_test.go
@@ -257,7 +257,7 @@ func applyForwardingPolicy(t *testing.T, ate *ondatra.ATEDevice, ingressPort, ma
 
 	intf := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreatePolicyForwarding().GetOrCreateInterface(ingressPort)
 	intf.ApplyVrfSelectionPolicy = ygot.String(matchType)
-	if *deviations.ExplicitInterfaceRefDefinition {
+	if deviations.ExplicitInterfaceRefDefinition(dut) {
 		intf.GetOrCreateInterfaceRef().Interface = ygot.String(ingressPort)
 		intf.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 	}

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -540,7 +540,7 @@ func TestPBR(t *testing.T) {
 			pfIntf := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreatePolicyForwarding().GetOrCreateInterface(p1)
 			pfIntfConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Interface(p1)
 
-			if *deviations.ExplicitInterfaceRefDefinition {
+			if deviations.ExplicitInterfaceRefDefinition(dut) {
 				pfIntf.GetOrCreateInterfaceRef().Interface = ygot.String(p1)
 				pfIntf.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 				pfIntf.SetApplyVrfSelectionPolicy(args.policyName)

--- a/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/ate_tests/gribi_scaling/gribi_scaling_test.go
@@ -357,7 +357,7 @@ func applyForwardingPolicy(t *testing.T, ingressPort string) {
 	pfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Interface(ingressPort)
 	pfCfg := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreatePolicyForwarding().GetOrCreateInterface(ingressPort)
 	pfCfg.ApplyVrfSelectionPolicy = ygot.String(policyName)
-	if *deviations.ExplicitInterfaceRefDefinition {
+	if deviations.ExplicitInterfaceRefDefinition(dut) {
 		pfCfg.GetOrCreateInterfaceRef().Interface = ygot.String(ingressPort)
 		pfCfg.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 	}

--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -356,7 +356,7 @@ func applyForwardingPolicy(t *testing.T, ingressPort string) {
 	pfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Interface(ingressPort)
 	pfCfg := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreatePolicyForwarding().GetOrCreateInterface(ingressPort)
 	pfCfg.ApplyVrfSelectionPolicy = ygot.String(policyName)
-	if *deviations.ExplicitInterfaceRefDefinition {
+	if deviations.ExplicitInterfaceRefDefinition(dut) {
 		pfCfg.GetOrCreateInterfaceRef().Interface = ygot.String(ingressPort)
 		pfCfg.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 	}

--- a/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
@@ -360,7 +360,7 @@ func applyForwardingPolicy(t *testing.T, ingressPort string) {
 	pfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Interface(ingressPort)
 	pfCfg := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreatePolicyForwarding().GetOrCreateInterface(ingressPort)
 	pfCfg.ApplyVrfSelectionPolicy = ygot.String(policyName)
-	if *deviations.ExplicitInterfaceRefDefinition {
+	if deviations.ExplicitInterfaceRefDefinition(dut) {
 		pfCfg.GetOrCreateInterfaceRef().Interface = ygot.String(ingressPort)
 		pfCfg.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 	}

--- a/feature/qos/ate_tests/bursty_traffic_test/bursty_traffic_test.go
+++ b/feature/qos/ate_tests/bursty_traffic_test/bursty_traffic_test.go
@@ -761,7 +761,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range classifierIntfs {
 		i := q.GetOrCreateInterface(tc.intf)
 		i.SetInterfaceId(tc.intf)
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(tc.intf)
 			i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 		}
@@ -900,7 +900,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range schedulerIntfs {
 		i := q.GetOrCreateInterface(dp3.Name())
 		i.SetInterfaceId(dp3.Name())
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp3.Name())
 		}
 		output := i.GetOrCreateOutput()

--- a/feature/qos/ate_tests/mixed_sp_wrr_traffic_test/mixed_sp_wrr_traffic_test.go
+++ b/feature/qos/ate_tests/mixed_sp_wrr_traffic_test/mixed_sp_wrr_traffic_test.go
@@ -931,7 +931,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range classifierIntfs {
 		i := q.GetOrCreateInterface(tc.intf)
 		i.SetInterfaceId(tc.intf)
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(tc.intf)
 			i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 		}
@@ -1070,7 +1070,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range schedulerIntfs {
 		i := q.GetOrCreateInterface(dp3.Name())
 		i.SetInterfaceId(dp3.Name())
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp3.Name())
 		}
 		output := i.GetOrCreateOutput()

--- a/feature/qos/ate_tests/one_sp_queue_traffic_test/one_sp_queue_traffic_test.go
+++ b/feature/qos/ate_tests/one_sp_queue_traffic_test/one_sp_queue_traffic_test.go
@@ -1011,7 +1011,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range classifierIntfs {
 		i := q.GetOrCreateInterface(tc.intf)
 		i.SetInterfaceId(tc.intf)
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(tc.intf)
 			i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 		}
@@ -1150,7 +1150,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range schedulerIntfs {
 		i := q.GetOrCreateInterface(dp3.Name())
 		i.SetInterfaceId(dp3.Name())
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp3.Name())
 		}
 		output := i.GetOrCreateOutput()

--- a/feature/qos/ate_tests/qos_basic_test/qos_basic_test.go
+++ b/feature/qos/ate_tests/qos_basic_test/qos_basic_test.go
@@ -1494,7 +1494,7 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range classifierIntfs {
 		i := q.GetOrCreateInterface(tc.intf)
 		i.SetInterfaceId(tc.intf)
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(tc.intf)
 			i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 		}
@@ -1630,7 +1630,7 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range schedulerIntfs {
 		i := q.GetOrCreateInterface(dp3.Name())
 		i.SetInterfaceId(dp3.Name())
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp3.Name())
 		}
 		output := i.GetOrCreateOutput()

--- a/feature/qos/ate_tests/qos_output_queue_counters_test/qos_output_queue_counters_test.go
+++ b/feature/qos/ate_tests/qos_output_queue_counters_test/qos_output_queue_counters_test.go
@@ -511,7 +511,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range classifierIntfs {
 		i := q.GetOrCreateInterface(tc.intf)
 		i.SetInterfaceId(tc.intf)
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp1.Name())
 			i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 		}
@@ -650,7 +650,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range schedulerIntfs {
 		i := q.GetOrCreateInterface(dp2.Name())
 		i.SetInterfaceId(dp2.Name())
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp2.Name())
 		}
 		output := i.GetOrCreateOutput()

--- a/feature/qos/ate_tests/qos_policy_config_test/qos_policy_config_test.go
+++ b/feature/qos/ate_tests/qos_policy_config_test/qos_policy_config_test.go
@@ -1442,7 +1442,7 @@ func testJuniperClassifierConfig(t *testing.T) {
 	dp := dut.Port(t, "port1")
 	i := q.GetOrCreateInterface(dp.Name())
 	i.SetInterfaceId(dp.Name())
-	if *deviations.ExplicitInterfaceRefDefinition {
+	if deviations.ExplicitInterfaceRefDefinition(dut) {
 		i.GetOrCreateInterfaceRef().Interface = ygot.String(dp.Name())
 		i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 	}
@@ -1486,7 +1486,7 @@ func testJuniperSchedulerPoliciesConfig(t *testing.T) {
 	dp := dut.Port(t, "port2")
 	i := q.GetOrCreateInterface(dp.Name())
 	i.SetInterfaceId(dp.Name())
-	if *deviations.ExplicitInterfaceRefDefinition {
+	if deviations.ExplicitInterfaceRefDefinition(dut) {
 		i.GetOrCreateInterfaceRef().Interface = ygot.String(dp.Name())
 		i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 	}

--- a/feature/qos/ate_tests/two_sp_queue_traffic_test/two_sp_queue_traffic_test.go
+++ b/feature/qos/ate_tests/two_sp_queue_traffic_test/two_sp_queue_traffic_test.go
@@ -1431,7 +1431,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range classifierIntfs {
 		i := q.GetOrCreateInterface(tc.intf)
 		i.SetInterfaceId(tc.intf)
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(tc.intf)
 			i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 		}
@@ -1570,7 +1570,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range schedulerIntfs {
 		i := q.GetOrCreateInterface(dp3.Name())
 		i.SetInterfaceId(dp3.Name())
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp3.Name())
 		}
 		output := i.GetOrCreateOutput()

--- a/feature/qos/ate_tests/wrr_traffic_test/wrr_traffic_test.go
+++ b/feature/qos/ate_tests/wrr_traffic_test/wrr_traffic_test.go
@@ -1197,7 +1197,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range classifierIntfs {
 		i := q.GetOrCreateInterface(tc.intf)
 		i.SetInterfaceId(tc.intf)
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(tc.intf)
 			i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 		}
@@ -1336,7 +1336,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range schedulerIntfs {
 		i := q.GetOrCreateInterface(dp3.Name())
 		i.SetInterfaceId(dp3.Name())
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp3.Name())
 		}
 		output := i.GetOrCreateOutput()

--- a/feature/qos/otg_tests/bursty_traffic_test/bursty_traffic_test.go
+++ b/feature/qos/otg_tests/bursty_traffic_test/bursty_traffic_test.go
@@ -802,7 +802,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range classifierIntfs {
 		i := q.GetOrCreateInterface(tc.intf)
 		i.SetInterfaceId(tc.intf)
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(tc.intf)
 			i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 		}
@@ -941,7 +941,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range schedulerIntfs {
 		i := q.GetOrCreateInterface(dp3.Name())
 		i.SetInterfaceId(dp3.Name())
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp3.Name())
 		}
 		output := i.GetOrCreateOutput()

--- a/feature/qos/otg_tests/qos_basic_test/qos_basic_test.go
+++ b/feature/qos/otg_tests/qos_basic_test/qos_basic_test.go
@@ -1534,7 +1534,7 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range classifierIntfs {
 		i := q.GetOrCreateInterface(tc.intf)
 		i.SetInterfaceId(tc.intf)
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(tc.intf)
 			i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 		}
@@ -1670,7 +1670,7 @@ func ConfigureJuniperQos(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range schedulerIntfs {
 		i := q.GetOrCreateInterface(dp3.Name())
 		i.SetInterfaceId(dp3.Name())
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp3.Name())
 		}
 		output := i.GetOrCreateOutput()

--- a/feature/qos/otg_tests/qos_output_queue_counters_test/qos_output_queue_counters_test.go
+++ b/feature/qos/otg_tests/qos_output_queue_counters_test/qos_output_queue_counters_test.go
@@ -543,7 +543,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range classifierIntfs {
 		i := q.GetOrCreateInterface(tc.intf)
 		i.SetInterfaceId(tc.intf)
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp1.Name())
 			i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 		}
@@ -682,7 +682,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range schedulerIntfs {
 		i := q.GetOrCreateInterface(dp2.Name())
 		i.SetInterfaceId(dp2.Name())
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp2.Name())
 		}
 		output := i.GetOrCreateOutput()

--- a/feature/qos/otg_tests/wrr_traffic_test/wrr_traffic_test.go
+++ b/feature/qos/otg_tests/wrr_traffic_test/wrr_traffic_test.go
@@ -1239,7 +1239,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range classifierIntfs {
 		i := q.GetOrCreateInterface(tc.intf)
 		i.SetInterfaceId(tc.intf)
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(tc.intf)
 			i.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 		}
@@ -1378,7 +1378,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 	for _, tc := range schedulerIntfs {
 		i := q.GetOrCreateInterface(dp3.Name())
 		i.SetInterfaceId(dp3.Name())
-		if *deviations.ExplicitInterfaceRefDefinition {
+		if deviations.ExplicitInterfaceRefDefinition(dut) {
 			i.GetOrCreateInterfaceRef().Interface = ygot.String(dp3.Name())
 		}
 		output := i.GetOrCreateOutput()

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -268,6 +268,11 @@ func GNOIStatusWithEmptySubcomponent(_ *ondatra.DUTDevice) bool {
 	return *gNOIStatusWithEmptySubcomponent
 }
 
+// ExplicitInterfaceRefDefinition returns if device requires explicit interface ref configuration when applying features to interface.
+func ExplicitInterfaceRefDefinition(_ *ondatra.DUTDevice) bool {
+	return *explicitInterfaceRefDefinition
+}
+
 // Vendor deviation flags.
 // All new flags should not be exported (define them in lowercase) and accessed
 // from tests through a public accessors like those above.
@@ -352,7 +357,7 @@ var (
 	ISISInstanceEnabledNotRequired = flag.Bool("deviation_isis_instance_enabled_not_required", false,
 		"Don't set isis instance enable flag on the device if value is true, Default value is false and instance enable flag is set")
 
-	ExplicitInterfaceRefDefinition = flag.Bool("deviation_explicit_interface_ref_definition", false, "Device requires explicit interface ref configuration when applying features to interface")
+	explicitInterfaceRefDefinition = flag.Bool("deviation_explicit_interface_ref_definition", false, "Device requires explicit interface ref configuration when applying features to interface")
 
 	NoMixOfTaggedAndUntaggedSubinterfaces = flag.Bool("deviation_no_mix_of_tagged_and_untagged_subinterfaces", false,
 		"Use this deviation when the device does not support a mix of tagged and untagged subinterfaces")


### PR DESCRIPTION
PiperOrigin-RevId: 529593573
Move ExplicitInterfaceRefDefinition to accessor method