### PR TITLE
Move ISISInterfaceLevel1DisableRequired and MissingIsisInterfaceAfiSafiEnable to accessor methods.

### DIFF
--- a/feature/experimental/isis/ate_tests/base_adjacencies_test/base_adjacencies_test.go
+++ b/feature/experimental/isis/ate_tests/base_adjacencies_test/base_adjacencies_test.go
@@ -91,7 +91,7 @@ func TestBasic(t *testing.T) {
 
 		// if MissingIsisInterfaceAfiSafiEnable is set, ignore enable flag check for AFI, SAFI at global level
 		// and validate enable at interface level
-		if *deviations.MissingIsisInterfaceAfiSafiEnable {
+		if deviations.MissingIsisInterfaceAfiSafiEnable(ts.DUT) {
 			checks = append(checks,
 				check.Equal(port1ISIS.Af(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled().State(), true),
 				check.Equal(port1ISIS.Af(oc.IsisTypes_AFI_TYPE_IPV6, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled().State(), true))
@@ -102,7 +102,7 @@ func TestBasic(t *testing.T) {
 		}
 
 		// if ISISInterfaceLevel1DisableRequired is set, validate Level1 enabled false at interface level else validate Level2 enabled at global level
-		if *deviations.ISISInterfaceLevel1DisableRequired {
+		if deviations.ISISInterfaceLevel1DisableRequired(ts.DUT) {
 			checks = append(checks, check.Equal(port1ISIS.Level(1).Enabled().State(), false))
 		} else {
 			checks = append(checks, check.Equal(isisRoot.Level(2).Enabled().State(), true))

--- a/feature/experimental/isis/ate_tests/internal/session/session.go
+++ b/feature/experimental/isis/ate_tests/internal/session/session.go
@@ -103,7 +103,7 @@ func ProtocolPath() *networkinstance.NetworkInstance_ProtocolPath {
 }
 
 // addISISOC configures basic IS-IS on a device.
-func addISISOC(dev *oc.Root, areaAddress, sysID, ifaceName string) {
+func addISISOC(dev *oc.Root, areaAddress, sysID, ifaceName string, dut *ondatra.DUTDevice) {
 	inst := dev.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
 	prot := inst.GetOrCreateProtocol(PTISIS, ISISName)
 	if !*deviations.ISISprotocolEnabledNotRequired {
@@ -123,14 +123,14 @@ func addISISOC(dev *oc.Root, areaAddress, sysID, ifaceName string) {
 	intf.CircuitType = oc.Isis_CircuitType_POINT_TO_POINT
 	intf.Enabled = ygot.Bool(true)
 	// Configure ISIS level at global mode if true else at interface mode
-	if *deviations.ISISInterfaceLevel1DisableRequired {
+	if deviations.ISISInterfaceLevel1DisableRequired(dut) {
 		intf.GetOrCreateLevel(1).Enabled = ygot.Bool(false)
 	} else {
 		intf.GetOrCreateLevel(2).Enabled = ygot.Bool(true)
 	}
 	glob.LevelCapability = oc.Isis_LevelType_LEVEL_2
 	// Configure ISIS enable flag at interface level
-	if *deviations.MissingIsisInterfaceAfiSafiEnable {
+	if deviations.MissingIsisInterfaceAfiSafiEnable(dut) {
 		intf.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled = ygot.Bool(true)
 		intf.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV6, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled = ygot.Bool(true)
 	}
@@ -208,9 +208,9 @@ func MustNew(t testing.TB) *TestSession {
 // WithISIS adds ISIS to a test session.
 func (s *TestSession) WithISIS() *TestSession {
 	if *deviations.ExplicitInterfaceInDefaultVRF {
-		addISISOC(s.DUTConf, DUTAreaAddress, DUTSysID, s.DUTPort1.Name()+".0")
+		addISISOC(s.DUTConf, DUTAreaAddress, DUTSysID, s.DUTPort1.Name()+".0", s.DUT)
 	} else {
-		addISISOC(s.DUTConf, DUTAreaAddress, DUTSysID, s.DUTPort1.Name())
+		addISISOC(s.DUTConf, DUTAreaAddress, DUTSysID, s.DUTPort1.Name(), s.DUT)
 	}
 	if s.ATE != nil {
 		addISISTopo(s.ATEIntf1, ATEAreaAddress, "*")

--- a/feature/experimental/isis/otg_tests/base_adjacencies_test/base_adjacencies_test.go
+++ b/feature/experimental/isis/otg_tests/base_adjacencies_test/base_adjacencies_test.go
@@ -92,7 +92,7 @@ func TestBasic(t *testing.T) {
 
 		// if MissingIsisInterfaceAfiSafiEnable is set, ignore enable flag check for AFI, SAFI at global level
 		// and validate enable at interface level
-		if *deviations.MissingIsisInterfaceAfiSafiEnable {
+		if deviations.MissingIsisInterfaceAfiSafiEnable(ts.DUT) {
 			checks = append(checks,
 				check.Equal(port1ISIS.Af(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled().State(), true),
 				check.Equal(port1ISIS.Af(oc.IsisTypes_AFI_TYPE_IPV6, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled().State(), true))
@@ -103,7 +103,7 @@ func TestBasic(t *testing.T) {
 		}
 
 		// if ISISInterfaceLevel1DisableRequired is set, validate Level1 enabled false at interface level else validate Level2 enabled at global level
-		if *deviations.ISISInterfaceLevel1DisableRequired {
+		if deviations.ISISInterfaceLevel1DisableRequired(ts.DUT) {
 			checks = append(checks, check.Equal(port1ISIS.Level(1).Enabled().State(), false))
 		} else {
 			checks = append(checks, check.Equal(isisRoot.Level(2).Enabled().State(), true))

--- a/feature/experimental/isis/otg_tests/internal/session/session.go
+++ b/feature/experimental/isis/otg_tests/internal/session/session.go
@@ -108,7 +108,7 @@ func ProtocolPath() *networkinstance.NetworkInstance_ProtocolPath {
 }
 
 // addISISOC configures basic IS-IS on a device.
-func addISISOC(dev *oc.Root, areaAddress, sysID, ifaceName string) {
+func addISISOC(dev *oc.Root, areaAddress, sysID, ifaceName string, dut *ondatra.DUTDevice) {
 	inst := dev.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
 	prot := inst.GetOrCreateProtocol(PTISIS, ISISName)
 	if !*deviations.ISISprotocolEnabledNotRequired {
@@ -128,14 +128,14 @@ func addISISOC(dev *oc.Root, areaAddress, sysID, ifaceName string) {
 	intf.CircuitType = oc.Isis_CircuitType_POINT_TO_POINT
 	intf.Enabled = ygot.Bool(true)
 	// Configure ISIS level at global mode if true else at interface mode
-	if *deviations.ISISInterfaceLevel1DisableRequired {
+	if deviations.ISISInterfaceLevel1DisableRequired(dut) {
 		intf.GetOrCreateLevel(1).Enabled = ygot.Bool(false)
 	} else {
 		intf.GetOrCreateLevel(2).Enabled = ygot.Bool(true)
 	}
 	glob.LevelCapability = oc.Isis_LevelType_LEVEL_2
 	// Configure ISIS enable flag at interface level
-	if *deviations.MissingIsisInterfaceAfiSafiEnable {
+	if deviations.MissingIsisInterfaceAfiSafiEnable(dut) {
 		intf.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled = ygot.Bool(true)
 		intf.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV6, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled = ygot.Bool(true)
 	}
@@ -228,9 +228,9 @@ func MustNew(t testing.TB) *TestSession {
 // WithISIS adds ISIS to a test session.
 func (s *TestSession) WithISIS() *TestSession {
 	if *deviations.ExplicitInterfaceInDefaultVRF {
-		addISISOC(s.DUTConf, DUTAreaAddress, DUTSysID, s.DUTPort1.Name()+".0")
+		addISISOC(s.DUTConf, DUTAreaAddress, DUTSysID, s.DUTPort1.Name()+".0", s.DUT)
 	} else {
-		addISISOC(s.DUTConf, DUTAreaAddress, DUTSysID, s.DUTPort1.Name())
+		addISISOC(s.DUTConf, DUTAreaAddress, DUTSysID, s.DUTPort1.Name(), s.DUT)
 	}
 	if s.ATE != nil {
 		addISISTopo(s.ATEIntf1, ATEAreaAddress, ATESysID)

--- a/feature/experimental/system/gnmi/benchmarking/ate_tests/internal/setup/setup.go
+++ b/feature/experimental/system/gnmi/benchmarking/ate_tests/internal/setup/setup.go
@@ -241,7 +241,7 @@ func BuildBenchmarkingConfig(t *testing.T) *oc.Root {
 		isisIntfLevelAfi.Metric = ygot.Uint32(200)
 
 		// Configure ISIS AfiSafi enable flag at the global level
-		if *deviations.MissingIsisInterfaceAfiSafiEnable {
+		if deviations.MissingIsisInterfaceAfiSafiEnable(dut) {
 			isisIntf.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled = ygot.Bool(true)
 		} else {
 			isisIntfLevelAfi.Enabled = ygot.Bool(true)

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -156,6 +156,17 @@ func ISISLevelAuthenticationNotRequired(_ *ondatra.DUTDevice) bool {
 	return *isisLevelAuthenticationNotRequired
 }
 
+// ISISInterfaceLevel1DisableRequired returns if device should disable isis level1 under interface mode.
+func ISISInterfaceLevel1DisableRequired(_ *ondatra.DUTDevice) bool {
+	return *isisInterfaceLevel1DisableRequired
+}
+
+// MissingIsisInterfaceAfiSafiEnable returns if device should set and validate isis interface address family enable.
+// Default is validate isis address family enable at global mode.
+func MissingIsisInterfaceAfiSafiEnable(_ *ondatra.DUTDevice) bool {
+	return *missingIsisInterfaceAfiSafiEnable
+}
+
 // Ipv6DiscardedPktsUnsupported returns whether the device supports interface ipv6 discarded packet stats.
 func Ipv6DiscardedPktsUnsupported(_ *ondatra.DUTDevice) bool {
 	return *ipv6DiscardedPktsUnsupported
@@ -337,10 +348,10 @@ var (
 
 	ExplicitIPv6EnableForGRIBI = flag.Bool("deviation_ipv6_enable_for_gribi_nh_dmac", false, "Device requires Ipv6 to be enabled on interface for gRIBI NH programmed with destination mac address")
 
-	ISISInterfaceLevel1DisableRequired = flag.Bool("deviation_isis_interface_level1_disable_required", false,
+	isisInterfaceLevel1DisableRequired = flag.Bool("deviation_isis_interface_level1_disable_required", false,
 		"Disable isis level1 under interface mode on the device if value is true, Default value is false and enables isis level2 under interface mode")
 
-	MissingIsisInterfaceAfiSafiEnable = flag.Bool("deviation_missing_isis_interface_afi_safi_enable", false,
+	missingIsisInterfaceAfiSafiEnable = flag.Bool("deviation_missing_isis_interface_afi_safi_enable", false,
 		"Set and validate isis interface address family enable on the device if value is true, Default value is false and validate isis address family enable at global mode")
 
 	IsisSingleTopologyRequired = flag.Bool("deviation_isis_single_topology_required", false,


### PR DESCRIPTION
PiperOrigin-RevId: 529597588
Move ISISInterfaceLevel1DisableRequired and MissingIsisInterfaceAfiSafiEnable to accessor methods.