### PR TITLE
DP-1.3: QoS ECN feature config - parameter adjustment

### DIFF
--- a/feature/qos/ate_tests/qos_ecn_config_test/README.md
+++ b/feature/qos/ate_tests/qos_ecn_config_test/README.md
@@ -10,20 +10,22 @@ Verify QoS ECN feature configuration.
 
 *   ECN config:
 
+    *   This test is verifying DUT ability to accept ECN configuration with vertical buffer utilization cut-off line.\ If buffer is utilized below that cut-off value no packet is ECN CE marked.\ If buffer is utilized at of above that cut-off value all packet are ECN CE marked.
+
     *   ECN profile can be created for different queues. ECN profiles per queue
         can be applied to the output side of interfaces.
 
         min-threshold | max-threshold | enable-ecn | drop  | weight  | max-drop-probability-percent
         ------------- | ------------- | ---------- | ----- | ------- | ----------------------------
-        80000         | 2^64-1        | true       | false | not set | 1
+        8MB           | 8MB           | true       | false | not set | 100
 
-        *   Note: max-threshold is set to max uint64 value 2^64-1
-            or 18446744073709551615.
+    * 8MB max-treshhold is selected as it represents ~640 mico-seconds of Delay bandwidth Buffer on 100GE interfaces. What is O(2%) of buffer depth, hence allows for micro-burst absorbtion without beackpressing senders and at same time leaves enough DBB for accomodate RTT ECN signaling loop delay in global network for longer burst/congestion.
 
     *   Validate that the following values can be configured
 
         *   min-threshold
         *   max-threshold
+        *   min-threshold = max-threshold (vertical cut-off line)
         *   enable-ecn
         *   drop
         *   max-drop-probability-percent

--- a/feature/qos/ate_tests/qos_ecn_config_test/qos_ecn_config_test.go
+++ b/feature/qos/ate_tests/qos_ecn_config_test/qos_ecn_config_test.go
@@ -127,9 +127,9 @@ func testECNConfig(t *testing.T) {
 	}{
 		ecnEnabled:                true,
 		dropEnabled:               false,
-		minThreshold:              uint64(80000),
-		maxThreshold:              math.MaxUint64,
-		maxDropProbabilityPercent: uint8(1),
+		minThreshold:              uint64(10000000),
+		maxThreshold:              uint64(10000000),
+		maxDropProbabilityPercent: uint8(100),
 		weight:                    uint32(0),
 	}
 

--- a/feature/qos/ate_tests/qos_ecn_config_test/qos_ecn_config_test.go
+++ b/feature/qos/ate_tests/qos_ecn_config_test/qos_ecn_config_test.go
@@ -127,8 +127,8 @@ func testECNConfig(t *testing.T) {
 	}{
 		ecnEnabled:                true,
 		dropEnabled:               false,
-		minThreshold:              uint64(10000000),
-		maxThreshold:              uint64(10000000),
+		minThreshold:              uint64(8000000),
+		maxThreshold:              uint64(8000000),
 		maxDropProbabilityPercent: uint8(100),
 		weight:                    uint32(0),
 	}


### PR DESCRIPTION
Changes.
min-treshold 8KB->8MB
max-treshold (2^64)-1 (that is 41h on 100GE) -> 8MB
min-treshold = max-treshold  (same as for B4 today, but for deep buffers)
max-drop-percentage 1% -> 100% (previously only 1 in 100 or less packets wes ECN CE marked, regardless of buffer utilization)