### PR TITLE
Arista_7280 OC component EOS has parent type Chassis

### DIFF
--- a/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -501,10 +501,20 @@ func TestSoftwareVersion(t *testing.T) {
 		parent := gnmi.Lookup(t, dut, gnmi.OC().Component(os).Parent().State())
 		if v, ok := parent.Val(); ok {
 			got := gnmi.Get(t, dut, gnmi.OC().Component(v).Type().State())
-			if got == supervisorType {
-				t.Logf("Got a valid parent %v with a type %v for the component %v", v, got, os)
+
+			// Arista_7280 OC component EOS has parent type Chassis
+			if dut.Model() == "DCS-7280CR3K-32D4" {
+				if got == chassisType {
+					t.Logf("Got a valid parent %v with a type %v for the component %v", v, got, os)
+				} else {
+					t.Errorf("Got a parent %v with a type %v for the component %v, want %v", v, got, os, supervisorType)
+				}
 			} else {
-				t.Errorf("Got a parent %v with a type %v for the component %v, want %v", v, got, os, supervisorType)
+				if got == supervisorType {
+					t.Logf("Got a valid parent %v with a type %v for the component %v", v, got, os)
+				} else {
+					t.Errorf("Got a parent %v with a type %v for the component %v, want %v", v, got, os, supervisorType)
+				}
 			}
 		} else {
 			t.Errorf("Parent for the component %v was not found", os)

--- a/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -507,7 +507,7 @@ func TestSoftwareVersion(t *testing.T) {
 				if got == chassisType {
 					t.Logf("Got a valid parent %v with a type %v for the component %v", v, got, os)
 				} else {
-					t.Errorf("Got a parent %v with a type %v for the component %v, want %v", v, got, os, supervisorType)
+					t.Errorf("Got a parent %v with a type %v for the component %v, want %v", v, got, os, chassisType)
 				}
 			} else {
 				if got == supervisorType {

--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -454,6 +454,11 @@ func TestComponentParent(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
+
+			if len(compList[tc.desc]) == 0 && dut.Model() == "DCS-7280CR3K-32D4" {
+				t.Skipf("Test of %v is skipped due to hardware platform compatibility", tc.componentType)
+			}
+
 			t.Logf("Found component list for type %v : %v", tc.componentType, compList[tc.desc])
 			if len(compList[tc.desc]) == 0 {
 				t.Fatalf("Get component list for %q: got 0, want > 0", dut.Model())
@@ -501,10 +506,20 @@ func TestSoftwareVersion(t *testing.T) {
 		parent := gnmi.Lookup(t, dut, gnmi.OC().Component(os).Parent().State())
 		if v, ok := parent.Val(); ok {
 			got := gnmi.Get(t, dut, gnmi.OC().Component(v).Type().State())
-			if got == supervisorType {
-				t.Logf("Got a valid parent %v with a type %v for the component %v", v, got, os)
+
+			// Arista_7280 OC component EOS has parent type Chassis
+			if dut.Model() == "DCS-7280CR3K-32D4" {
+				if got == chassisType {
+					t.Logf("Got a valid parent %v with a type %v for the component %v", v, got, os)
+				} else {
+					t.Errorf("Got a parent %v with a type %v for the component %v, want %v", v, got, os, chassisType)
+				}
 			} else {
-				t.Errorf("Got a parent %v with a type %v for the component %v, want %v", v, got, os, supervisorType)
+				if got == supervisorType {
+					t.Logf("Got a valid parent %v with a type %v for the component %v", v, got, os)
+				} else {
+					t.Errorf("Got a parent %v with a type %v for the component %v, want %v", v, got, os, supervisorType)
+				}
 			}
 		} else {
 			t.Errorf("Parent for the component %v was not found", os)
@@ -539,6 +554,11 @@ func TestCPU(t *testing.T) {
 
 func TestSupervisorLastRebootInfo(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
+
+	if dut.Model() == "DCS-7280CR3K-32D4" {
+		t.Skipf("Test is skipped due to hardware platform compatibility")
+	}
+
 	cards := components.FindComponentsByType(t, dut, supervisorType)
 	t.Logf("Found card list: %v", cards)
 	if len(cards) == 0 {


### PR DESCRIPTION
for Arista 7280:

"/components/component[name=EOS]/state/parent"
{
  "components": {
    "component": {
      "EOS": {
        "state": {
          "parent": "Chassis"
        }
      }
    }
  }
}

"/components/component[name=Chassis]/state/type"
{
  "components": {
    "component": {
      "Chassis": {
        "state": {
          "type": "openconfig-platform-types:CHASSIS"
        }
      }
    }
  }
}

for Arista 7808:

"/components/component[name=Supervisor1-EOS]/state/parent"
{
  "components": {
    "component": {
      "Supervisor1-EOS": {
        "state": {
          "parent": "Supervisor1"
        }
      }
    }
  }
}

"/components/component[name=Supervisor1]/state/type"
{
  "components": {
    "component": {
      "Supervisor1": {
        "state": {
          "type": "openconfig-platform-types:CONTROLLER_CARD"
        }
      }
    }
  }
}

"/components/component[name=Supervisor1]/state/parent"
{
  "components": {
    "component": {
      "Supervisor1": {
        "state": {
          "parent": "Chassis"
        }
      }
    }
  }
}