### PR TITLE
KNE Textproto Updates

### DIFF
--- a/topologies/kne/arista_ceos.textproto
+++ b/topologies/kne/arista_ceos.textproto
@@ -11,9 +11,9 @@ nodes: {
         config_file: "startup-config"
         cert: {
             self_signed: {
-                cert_name: "gnmiCert.pem",
-                key_name: "gnmiCertKey.pem",
-                key_size: 4096,
+                cert_name: "gnmiCert.pem"
+                key_name: "gnmiCertKey.pem"
+                key_size: 4096
             }
         }
     }

--- a/topologies/kne/arista_ceos_lag.textproto
+++ b/topologies/kne/arista_ceos_lag.textproto
@@ -11,9 +11,9 @@ nodes: {
         config_file: "startup-config"
         cert: {
             self_signed: {
-                cert_name: "gnmiCert.pem",
-                key_name: "gnmiCertKey.pem",
-                key_size: 4096,
+                cert_name: "gnmiCert.pem"
+                key_name: "gnmiCertKey.pem"
+                key_size: 4096
             }
         }
     }

--- a/topologies/kne/juniper_cptx.textproto
+++ b/topologies/kne/juniper_cptx.textproto
@@ -11,9 +11,9 @@ nodes: {
         file: "juniper_cptx.config"
         cert: {
             self_signed: {
-                cert_name: "grpc-server-cert",
-                key_name: "N/A",
-                key_size: 4096,
+                cert_name: "grpc-server-cert"
+                key_name: "N/A"
+                key_size: 4096
             }
         }
     }

--- a/topologies/kne/juniper_cptx_dutdut.textproto
+++ b/topologies/kne/juniper_cptx_dutdut.textproto
@@ -11,9 +11,9 @@ nodes: {
         file: "juniper_cptx.config"
         cert: {
             self_signed: {
-                cert_name: "grpc-server-cert",
-                key_name: "N/A",
-                key_size: 4096,
+                cert_name: "grpc-server-cert"
+                key_name: "N/A"
+                key_size: 4096
             }
         }
     }
@@ -71,9 +71,9 @@ nodes: {
         file: "juniper_cptx.config"
         cert: {
             self_signed: {
-                cert_name: "grpc-server-cert",
-                key_name: "N/A",
-                key_size: 4096,
+                cert_name: "grpc-server-cert"
+                key_name: "N/A"
+                key_size: 4096
             }
         }
     }

--- a/topologies/kne/juniper_cptx_lag.textproto
+++ b/topologies/kne/juniper_cptx_lag.textproto
@@ -5,14 +5,15 @@ nodes: {
     model: "cptx"
     os: "evo"
     config: {
+        image: "cptx:latest"
         config_path: "/home/evo/configdisk"
         config_file: "juniper.conf"
         file: "juniper_cptx.config"
         cert: {
             self_signed: {
-                cert_name: "grpc-server-cert",
-                key_name: "N/A",
-                key_size: 4096,
+                cert_name: "grpc-server-cert"
+                key_name: "N/A"
+                key_size: 4096
             }
         }
     }


### PR DESCRIPTION
Specify the cptx image path in `juniper_cptx_lag.textproto` and remove optional commas from textprotos for consistency.