### PR TITLE
Move `DefaultNetworkInstance` to accessor.

### DIFF
--- a/feature/bgp/addpath/ate_tests/route_propagation_test/route_propagation_test.go
+++ b/feature/bgp/addpath/ate_tests/route_propagation_test/route_propagation_test.go
@@ -135,7 +135,7 @@ func (d *dutData) Configure(t *testing.T, dut *ondatra.DUTDevice) {
 	}
 
 	t.Log("Configure Network Instance")
-	dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut))
 	gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 
 	if deviations.ExplicitPortSpeed(dut) {
@@ -146,11 +146,11 @@ func (d *dutData) Configure(t *testing.T, dut *ondatra.DUTDevice) {
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
 		for _, a := range []attrs.Attributes{dutPort1, dutPort2} {
 			ocName := dut.Port(t, a.Name).Name()
-			fptest.AssignToNetworkInstance(t, dut, ocName, *deviations.DefaultNetworkInstance, 0)
+			fptest.AssignToNetworkInstance(t, dut, ocName, deviations.DefaultNetworkInstance(dut), 0)
 		}
 	}
 
-	dutProto := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).
+	dutProto := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
 	key := oc.NetworkInstance_Protocol_Key{
 		Identifier: oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP,
@@ -158,7 +158,7 @@ func (d *dutData) Configure(t *testing.T, dut *ondatra.DUTDevice) {
 	}
 
 	niOC := &oc.NetworkInstance{
-		Name: deviations.DefaultNetworkInstance,
+		Name: ygot.String(deviations.DefaultNetworkInstance(dut)),
 		Type: oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE,
 		Protocol: map[oc.NetworkInstance_Protocol_Key]*oc.NetworkInstance_Protocol{
 			key: {
@@ -175,7 +175,7 @@ func (d *dutData) Configure(t *testing.T, dut *ondatra.DUTDevice) {
 
 func (d *dutData) AwaitBGPEstablished(t *testing.T, dut *ondatra.DUTDevice) {
 	for neighbor := range d.bgpOC.Neighbor {
-		gnmi.Await(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).
+		gnmi.Await(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
 			Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").
 			Bgp().
 			Neighbor(neighbor).

--- a/feature/bgp/addpath/otg_tests/route_propagation_test/route_propagation_test.go
+++ b/feature/bgp/addpath/otg_tests/route_propagation_test/route_propagation_test.go
@@ -202,17 +202,17 @@ func (d *dutData) Configure(t *testing.T, dut *ondatra.DUTDevice) {
 		ocName := dut.Port(t, a.Name).Name()
 		gnmi.Replace(t, dut, gnmi.OC().Interface(ocName).Config(), a.NewOCInterface(ocName))
 		if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-			fptest.AssignToNetworkInstance(t, dut, ocName, *deviations.DefaultNetworkInstance, 0)
+			fptest.AssignToNetworkInstance(t, dut, ocName, deviations.DefaultNetworkInstance(dut), 0)
 		}
 	}
-	dutProto := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).
+	dutProto := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
 	key := oc.NetworkInstance_Protocol_Key{
 		Identifier: oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP,
 		Name:       "BGP",
 	}
 	niOC := &oc.NetworkInstance{
-		Name: deviations.DefaultNetworkInstance,
+		Name: ygot.String(deviations.DefaultNetworkInstance(dut)),
 		Type: oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE,
 		Protocol: map[oc.NetworkInstance_Protocol_Key]*oc.NetworkInstance_Protocol{
 			key: {
@@ -229,7 +229,7 @@ func (d *dutData) Configure(t *testing.T, dut *ondatra.DUTDevice) {
 
 func (d *dutData) AwaitBGPEstablished(t *testing.T, dut *ondatra.DUTDevice) {
 	for neighbor := range d.bgpOC.Neighbor {
-		gnmi.Await(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).
+		gnmi.Await(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
 			Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").
 			Bgp().
 			Neighbor(neighbor).
@@ -562,7 +562,7 @@ func TestBGP(t *testing.T) {
 
 			dut := ondatra.DUT(t, "dut")
 			t.Log("Configure Network Instance")
-			dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+			dutConfNIPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut))
 			gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 
 			tc.dut.Configure(t, dut)

--- a/feature/bgp/policybase/otg_tests/route_installation_test/route_installation_test.go
+++ b/feature/bgp/policybase/otg_tests/route_installation_test/route_installation_test.go
@@ -142,8 +142,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, dut.Port(t, "port2"))
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, i1.GetName(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, i2.GetName(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, i1.GetName(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, i2.GetName(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 
@@ -160,7 +160,7 @@ func verifyPortsUp(t *testing.T, dev *ondatra.Device) {
 
 // bgpCreateNbr creates a BGP object with neighbors pointing to ateSrc and ateDst, optionally with
 // a peer group policy.
-func bgpCreateNbr(localAs, peerAs uint32, policy string) *oc.NetworkInstance_Protocol {
+func bgpCreateNbr(localAs, peerAs uint32, policy string, dut *ondatra.DUTDevice) *oc.NetworkInstance_Protocol {
 	nbr1v4 := &bgpNeighbor{as: peerAs, neighborip: ateSrc.IPv4, isV4: true}
 	nbr1v6 := &bgpNeighbor{as: peerAs, neighborip: ateSrc.IPv6, isV4: false}
 	nbr2v4 := &bgpNeighbor{as: peerAs, neighborip: ateDst.IPv4, isV4: true}
@@ -168,7 +168,7 @@ func bgpCreateNbr(localAs, peerAs uint32, policy string) *oc.NetworkInstance_Pro
 	nbrs := []*bgpNeighbor{nbr1v4, nbr2v4, nbr1v6, nbr2v6}
 
 	d := &oc.Root{}
-	ni1 := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
+	ni1 := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
 	ni_proto := ni1.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
 	bgp := ni_proto.GetOrCreateBgp()
 	global := bgp.GetOrCreateGlobal()
@@ -254,7 +254,7 @@ func verifyBgpTelemetry(t *testing.T, dut *ondatra.DUTDevice) {
 	ifName := dut.Port(t, "port1").Name()
 	lastFlapTime := gnmi.Get(t, dut, gnmi.OC().Interface(ifName).LastChange().State())
 	t.Logf("Verifying BGP state")
-	statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	nbrPath := statePath.Neighbor(ateSrc.IPv4)
 	nbrPathv6 := statePath.Neighbor(ateSrc.IPv6)
 
@@ -320,7 +320,7 @@ func verifyBgpTelemetry(t *testing.T, dut *ondatra.DUTDevice) {
 // received IPv4 prefixes.
 // TODO: Need to refactor and compare using cmp.diff.
 func verifyPrefixesTelemetry(t *testing.T, dut *ondatra.DUTDevice, wantInstalled, wantRx, wantSent uint32) {
-	statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	prefixesv4 := statePath.Neighbor(ateDst.IPv4).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Prefixes()
 	if gotInstalled := gnmi.Get(t, dut, prefixesv4.Installed().State()); gotInstalled != wantInstalled {
 		t.Errorf("Installed prefixes mismatch: got %v, want %v", gotInstalled, wantInstalled)
@@ -338,7 +338,7 @@ func verifyPrefixesTelemetry(t *testing.T, dut *ondatra.DUTDevice, wantInstalled
 // verifyPrefixesTelemetryV6 confirms that the dut shows the correct numbers of installed, sent and
 // received IPv6 prefixes.
 func verifyPrefixesTelemetryV6(t *testing.T, dut *ondatra.DUTDevice, wantInstalledv6, wantRxv6, wantSentv6 uint32) {
-	statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	prefixesv6 := statePath.Neighbor(ateDst.IPv6).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).Prefixes()
 
 	if gotInstalledv6 := gnmi.Get(t, dut, prefixesv6.Installed().State()); gotInstalledv6 != wantInstalledv6 {
@@ -357,7 +357,7 @@ func verifyPrefixesTelemetryV6(t *testing.T, dut *ondatra.DUTDevice, wantInstall
 // verifyPolicyTelemetry confirms that the dut policy is set as expected.
 func verifyPolicyTelemetry(t *testing.T, dut *ondatra.DUTDevice, policy string) {
 	if !*deviations.RoutePolicyUnderPeerGroup {
-		statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+		statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 		policytel := gnmi.Get(t, dut, statePath.PeerGroup(peerGrpName).ApplyPolicy().ImportPolicy().State())
 		for _, val := range policytel {
 			if val != policy {
@@ -547,17 +547,17 @@ func TestEstablish(t *testing.T) {
 
 	// Configure Network instance type on DUT.
 	t.Log("Configure Network Instance type")
-	dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut))
 	gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 
 	// Configure BGP+Neighbors on the DUT.
 	t.Logf("Start DUT BGP Config")
-	dutConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
+	dutConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
 	gnmi.Delete(t, dut, dutConfPath.Config())
 	d := &oc.Root{}
 	rpl := configureBGPPolicy(d)
 	gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rpl)
-	dutConf := bgpCreateNbr(dutAS, ateAS, defaultPolicy)
+	dutConf := bgpCreateNbr(dutAS, ateAS, defaultPolicy, dut)
 	gnmi.Replace(t, dut, dutConfPath.Config(), dutConf)
 	fptest.LogQuery(t, "DUT BGP Config", dutConfPath.Config(), gnmi.GetConfig(t, dut, dutConfPath.Config()))
 
@@ -587,7 +587,7 @@ func TestEstablish(t *testing.T) {
 	t.Run("RoutesWithdrawn", func(t *testing.T) {
 		t.Log("Breaking BGP config and confirming that forwarding stops working.")
 		// Break config with a mismatching AS number
-		gnmi.Replace(t, dut, dutConfPath.Config(), bgpCreateNbr(dutAS, badAS, defaultPolicy))
+		gnmi.Replace(t, dut, dutConfPath.Config(), bgpCreateNbr(dutAS, badAS, defaultPolicy, dut))
 
 		// Verify the OTG BGP state
 		t.Logf("Verify OTG BGP sessions down")
@@ -610,7 +610,7 @@ func TestBGPPolicy(t *testing.T) {
 
 	// Configure Network instance type on DUT.
 	t.Log("Configure Network Instance type")
-	dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut))
 	gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 
 	cases := []struct {
@@ -653,17 +653,17 @@ func TestBGPPolicy(t *testing.T) {
 			ate := ondatra.ATE(t, "ate")
 
 			// Configure Routing Policy on the DUT.
-			dutConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+			dutConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 			fptest.LogQuery(t, "DUT BGP Config before", dutConfPath.Config(), gnmi.GetConfig(t, dut, dutConfPath.Config()))
 			d := &oc.Root{}
 			t.Log("Configure BGP Policy with BGP actions on the neighbor")
 			rpl := configureBGPPolicy(d)
 			gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rpl)
-			bgp := bgpCreateNbr(dutAS, ateAS, tc.policy)
+			bgp := bgpCreateNbr(dutAS, ateAS, tc.policy, dut)
 			// Configure ATE to setup traffic.
 			otg := ate.OTG()
 			otgConfig := configureATE(t, otg)
-			gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Config(), bgp)
+			gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Config(), bgp)
 
 			// Verify the OTG BGP state
 			t.Logf("Verify OTG BGP sessions up")

--- a/feature/bgp/prefixlimit/ate_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
+++ b/feature/bgp/prefixlimit/ate_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
@@ -119,7 +119,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 
 	// Configure Network instance type on DUT
 	t.Log("Configure/update Network Instance")
-	dutConfNIPath := dc.NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath := dc.NetworkInstance(deviations.DefaultNetworkInstance(dut))
 	gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 
 	if deviations.ExplicitPortSpeed(dut) {
@@ -127,13 +127,13 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, dut.Port(t, "port2"))
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1, *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2, *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1, deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2, deviations.DefaultNetworkInstance(dut), 0)
 	}
 	configureRoutePolicy(t, dut, rplName, rplType)
 
-	dutConfPath := dc.NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
-	dutConf := createBGPNeighbor(dutAS, ateAS, prefixLimit, grRestartTime)
+	dutConfPath := dc.NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
+	dutConf := createBGPNeighbor(dutAS, ateAS, prefixLimit, grRestartTime, dut)
 	gnmi.Replace(t, dut, dutConfPath.Config(), dutConf)
 }
 
@@ -223,7 +223,7 @@ type BGPNeighbor struct {
 	isV4         bool
 }
 
-func createBGPNeighbor(localAs, peerAs, pLimit uint32, restartTime uint16) *oc.NetworkInstance_Protocol {
+func createBGPNeighbor(localAs, peerAs, pLimit uint32, restartTime uint16, dut *ondatra.DUTDevice) *oc.NetworkInstance_Protocol {
 
 	nbrs := []*BGPNeighbor{
 		{as: peerAs, pfxLimit: pLimit, neighborip: ateSrc.IPv4, isV4: true},
@@ -233,7 +233,7 @@ func createBGPNeighbor(localAs, peerAs, pLimit uint32, restartTime uint16) *oc.N
 	}
 
 	d := &oc.Root{}
-	ni1 := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
+	ni1 := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
 	ni_proto := ni1.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
 	bgp := ni_proto.GetOrCreateBgp()
 
@@ -306,7 +306,7 @@ func configureRoutePolicy(t *testing.T, dut *ondatra.DUTDevice, name string, pr 
 }
 
 func waitForBGPSession(t *testing.T, dut *ondatra.DUTDevice, wantEstablished bool) {
-	statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	nbrPath := statePath.Neighbor(ateDst.IPv4)
 	nbrPathv6 := statePath.Neighbor(ateDst.IPv6)
 	compare := func(val *ygnmi.Value[oc.E_Bgp_Neighbor_SessionState]) bool {
@@ -382,7 +382,7 @@ func (tc *testCase) verifyBGPTelemetry(t *testing.T, dut *ondatra.DUTDevice) {
 		return ok && c == installedRoutes
 	}
 	t.Log("Verifying BGP state")
-	statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	prefixes := statePath.Neighbor(ateDst.IPv4).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Prefixes()
 	if got, ok := gnmi.Watch(t, dut, prefixes.Received().State(), 2*time.Minute, compare).Await(t); !ok {
 		t.Errorf("Received prefixes v4 mismatch: got %v, want %v", got, installedRoutes)

--- a/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
+++ b/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
@@ -125,7 +125,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	gnmi.Replace(t, dut, dc.Interface(p2).Config(), i2)
 	// Configure Network instance type on DUT
 	t.Log("Configure/update Network Instance")
-	dutConfNIPath := dc.NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath := dc.NetworkInstance(deviations.DefaultNetworkInstance(dut))
 	gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 
 	if deviations.ExplicitPortSpeed(dut) {
@@ -133,13 +133,13 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, dut.Port(t, "port2"))
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1, *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2, *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1, deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2, deviations.DefaultNetworkInstance(dut), 0)
 	}
 	configureRoutePolicy(t, dut, rplName, rplType)
 
-	dutConfPath := dc.NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
-	dutConf := createBGPNeighbor(dutAS, ateAS, prefixLimit, grRestartTime)
+	dutConfPath := dc.NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
+	dutConf := createBGPNeighbor(dutAS, ateAS, prefixLimit, grRestartTime, dut)
 	gnmi.Replace(t, dut, dutConfPath.Config(), dutConf)
 }
 
@@ -255,7 +255,7 @@ type BGPNeighbor struct {
 	isV4         bool
 }
 
-func createBGPNeighbor(localAs, peerAs, pLimit uint32, restartTime uint16) *oc.NetworkInstance_Protocol {
+func createBGPNeighbor(localAs, peerAs, pLimit uint32, restartTime uint16, dut *ondatra.DUTDevice) *oc.NetworkInstance_Protocol {
 
 	nbrs := []*BGPNeighbor{
 		{as: peerAs, pfxLimit: pLimit, neighborip: ateSrc.IPv4, isV4: true},
@@ -265,7 +265,7 @@ func createBGPNeighbor(localAs, peerAs, pLimit uint32, restartTime uint16) *oc.N
 	}
 
 	d := &oc.Root{}
-	ni1 := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
+	ni1 := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
 	ni_proto := ni1.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
 	bgp := ni_proto.GetOrCreateBgp()
 
@@ -338,7 +338,7 @@ func configureRoutePolicy(t *testing.T, dut *ondatra.DUTDevice, name string, pr 
 }
 
 func waitForBGPSession(t *testing.T, dut *ondatra.DUTDevice, wantEstablished bool) {
-	statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	nbrPath := statePath.Neighbor(ateDst.IPv4)
 	nbrPathv6 := statePath.Neighbor(ateDst.IPv6)
 	compare := func(val *ygnmi.Value[oc.E_Bgp_Neighbor_SessionState]) bool {
@@ -414,7 +414,7 @@ func (tc *testCase) verifyBGPTelemetry(t *testing.T, dut *ondatra.DUTDevice) {
 		return ok && c == installedRoutes
 	}
 	t.Log("Verifying BGP state")
-	statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	prefixes := statePath.Neighbor(ateDst.IPv4).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Prefixes()
 	if got, ok := gnmi.Watch(t, dut, prefixes.Installed().State(), time.Minute, compare).Await(t); !ok {
 		t.Errorf("Installed prefixes v4 mismatch: got %v, want %v", got, installedRoutes)

--- a/feature/bgp/timers/otg_tests/bgp_keepalive_and_holdtimer_configuration_test/bgp_keepalive_and_holdtimer_configuration_test.go
+++ b/feature/bgp/timers/otg_tests/bgp_keepalive_and_holdtimer_configuration_test/bgp_keepalive_and_holdtimer_configuration_test.go
@@ -144,8 +144,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, dut.Port(t, "port2"))
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, i1.GetName(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, i2.GetName(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, i1.GetName(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, i2.GetName(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 
@@ -232,9 +232,9 @@ func ateFlowConfig(t *testing.T, topo gosnappi.Config, srcEth gosnappi.DeviceEth
 
 // bgpCreateNbr creates a BGP object with neighbors pointing to ateSrc and ateDst, optionally with
 // a peer group policy.
-func bgpCreateNbr() *oc.NetworkInstance_Protocol {
+func bgpCreateNbr(dut *ondatra.DUTDevice) *oc.NetworkInstance_Protocol {
 	d := &oc.Root{}
-	ni1 := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
+	ni1 := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
 	niProto := ni1.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
 	bgp := niProto.GetOrCreateBgp()
 	global := bgp.GetOrCreateGlobal()
@@ -284,9 +284,9 @@ func bgpCreateNbr() *oc.NetworkInstance_Protocol {
 }
 
 // bgpTimersConfig sets the right config for BGP timers.
-func (tc *testCase) bgpTimersConfig(t *testing.T) *oc.NetworkInstance_Protocol {
+func (tc *testCase) bgpTimersConfig(t *testing.T, dut *ondatra.DUTDevice) *oc.NetworkInstance_Protocol {
 	d := &oc.Root{}
-	ni1 := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
+	ni1 := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
 	niProto := ni1.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
 	bgp := niProto.GetOrCreateBgp()
 	for _, nbr := range bgpNbrs {
@@ -299,7 +299,7 @@ func (tc *testCase) bgpTimersConfig(t *testing.T) *oc.NetworkInstance_Protocol {
 
 // waitForBGPSession waits for the BGP session state to become established.
 func waitForBGPSession(t *testing.T, dut *ondatra.DUTDevice, wantEstablished bool) {
-	statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	nbrPath := statePath.Neighbor(ateDst.IPv4)
 	nbrPathv6 := statePath.Neighbor(ateDst.IPv6)
 	compare := func(val *ygnmi.Value[oc.E_Bgp_Neighbor_SessionState]) bool {
@@ -371,7 +371,7 @@ func (tc *testCase) verifyPortsUp(t *testing.T, dev *ondatra.Device) {
 // verifyBGPTimers verify BGP timers like keepalive timer and hold timer.
 func (tc *testCase) verifyBGPTimers(t *testing.T, dut *ondatra.DUTDevice) {
 	t.Log("Verifying BGP timers")
-	bgpPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	bgpPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	for _, nbr := range bgpNbrs {
 		timerPath := bgpPath.Neighbor(nbr.neighborip).Timers()
 		gotBgptimers := bgpTimers{
@@ -396,9 +396,9 @@ func (tc *testCase) run(t *testing.T, conf *config, dut *ondatra.DUTDevice, ate 
 	t.Log(tc.desc)
 	configureBGPRoutes(t, conf, tc.numRoutes)
 	// Configure BGP Timers
-	dutConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
+	dutConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
 	t.Logf("Start DUT BGP Config")
-	dutBgpTimerConf := tc.bgpTimersConfig(t)
+	dutBgpTimerConf := tc.bgpTimersConfig(t, dut)
 	gnmi.Update(t, dut, dutConfPath.Config(), dutBgpTimerConf)
 	fptest.LogQuery(t, "Updated DUT BGP Config", dutConfPath.Config(), gnmi.GetConfig(t, dut, dutConfPath.Config()))
 	// Verify Port Status
@@ -453,8 +453,8 @@ func TestBgpKeepAliveHoldTimerConfiguration(t *testing.T) {
 	t.Log("Start DUT interface Config")
 	configureDUT(t, dut)
 	t.Logf("Start DUT BGP Config")
-	dutConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
-	dutConf := bgpCreateNbr()
+	dutConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
+	dutConf := bgpCreateNbr(dut)
 	gnmi.Replace(t, dut, dutConfPath.Config(), dutConf)
 	fptest.LogQuery(t, "DUT BGP Config", dutConfPath.Config(), gnmi.GetConfig(t, dut, dutConfPath.Config()))
 	// ATE Configuration.

--- a/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/backup_nhg_test.go
+++ b/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/backup_nhg_test.go
@@ -195,10 +195,10 @@ func TestDirectBackupNexthopGroup(t *testing.T) {
 		{
 			desc: "Delete nh ipv4 entry",
 			applyImpairmentFn: func() {
-				client.DeleteIPv4(t, nhip+"/"+mask, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+				client.DeleteIPv4(t, nhip+"/"+mask, deviations.DefaultNetworkInstance(dut), fluent.InstalledInFIB)
 			},
 			removeImpairmentFn: func() {
-				client.AddIPv4(t, nhip+"/"+mask, nhg1ID, *deviations.DefaultNetworkInstance, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+				client.AddIPv4(t, nhip+"/"+mask, nhg1ID, deviations.DefaultNetworkInstance(dut), deviations.DefaultNetworkInstance(dut), fluent.InstalledInFIB)
 
 			},
 		},
@@ -206,7 +206,7 @@ func TestDirectBackupNexthopGroup(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Run("Validate Baseline AFT Telemetry", func(t *testing.T) {
-				tcArgs.validateAftTelemetry(t, *deviations.DefaultNetworkInstance, nhip, atePort2.IPv4, atePort2.IPv4)
+				tcArgs.validateAftTelemetry(t, deviations.DefaultNetworkInstance(dut), nhip, atePort2.IPv4, atePort2.IPv4)
 				tcArgs.validateAftTelemetry(t, vrfA, dstPfx, nhip, atePort2.IPv4)
 				tcArgs.validateAftTelemetry(t, vrfB, dstPfx, atePort3.IPv4, atePort3.IPv4)
 			})
@@ -260,8 +260,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p3)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p3.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 }
@@ -271,22 +271,22 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 // entry.
 func (a *testArgs) configureBackupNextHopGroup(t *testing.T, del bool) {
 	t.Logf("Adding NH %d with atePort2 via gRIBI", nh1ID)
-	a.client.AddNH(t, nh1ID, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	a.client.AddNH(t, nh1ID, atePort2.IPv4, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
 	t.Logf("Adding NH %d with atePort3 and NHGs %d, %d via gRIBI", nh2ID, nhg1ID, nhg2ID)
-	a.client.AddNH(t, nh2ID, atePort3.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	a.client.AddNHG(t, nhg1ID, map[uint64]uint64{nh1ID: 100}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	a.client.AddNHG(t, nhg2ID, map[uint64]uint64{nh2ID: 100}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	a.client.AddNH(t, nh2ID, atePort3.IPv4, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
+	a.client.AddNHG(t, nhg1ID, map[uint64]uint64{nh1ID: 100}, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
+	a.client.AddNHG(t, nhg2ID, map[uint64]uint64{nh2ID: 100}, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
 	t.Logf("Adding an IPv4Entry for %s via gRIBI", nhip)
-	a.client.AddIPv4(t, nhip+"/"+mask, nhg1ID, *deviations.DefaultNetworkInstance, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	a.client.AddIPv4(t, nhip+"/"+mask, nhg1ID, deviations.DefaultNetworkInstance(a.dut), deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
 	t.Logf("Adding NH %d in VRF-B via gRIBI", nh100ID)
-	a.client.AddNH(t, nh100ID, "VRFOnly", *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHOptions{VrfName: vrfB})
+	a.client.AddNH(t, nh100ID, "VRFOnly", deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB, &gribi.NHOptions{VrfName: vrfB})
 	t.Logf("Adding NH %d and NHGs %d, %d via gRIBI", nh101ID, nhg100ID, nhg101ID)
-	a.client.AddNH(t, nh101ID, nhip, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	a.client.AddNHG(t, nhg100ID, map[uint64]uint64{nh100ID: 100}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	a.client.AddNHG(t, nhg101ID, map[uint64]uint64{nh101ID: 100}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: nhg100ID})
+	a.client.AddNH(t, nh101ID, nhip, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
+	a.client.AddNHG(t, nhg100ID, map[uint64]uint64{nh100ID: 100}, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
+	a.client.AddNHG(t, nhg101ID, map[uint64]uint64{nh101ID: 100}, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: nhg100ID})
 	t.Logf("Adding IPv4Entries for %s for VRF-A and VRF-B via gRIBI", dstPfx)
-	a.client.AddIPv4(t, dstPfx+"/"+mask, nhg101ID, vrfA, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	a.client.AddIPv4(t, dstPfx+"/"+mask, nhg2ID, vrfB, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	a.client.AddIPv4(t, dstPfx+"/"+mask, nhg101ID, vrfA, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
+	a.client.AddIPv4(t, dstPfx+"/"+mask, nhg2ID, vrfB, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
 
 }
 
@@ -308,7 +308,7 @@ func configureNetworkInstance(t *testing.T, dut *ondatra.DUTDevice) {
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrfB).Config(), ni1)
 
 	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
-		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, deviations.DefaultNetworkInstance(dut))
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrfA)
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrfB)
 	}
@@ -344,13 +344,13 @@ func (a *testArgs) validateAftTelemetry(t *testing.T, vrfName, prefix, ipAddress
 	}
 	nhg, _ := aftPfxNHGVal.Val()
 
-	aftNHG := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().NextHopGroup(nhg).State())
+	aftNHG := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(a.dut)).Afts().NextHopGroup(nhg).State())
 	if got := len(aftNHG.NextHop); got != 1 {
 		t.Fatalf("Prefix %s next-hop entry count: got %d, want 1", prefix+"/"+mask, got)
 	}
 
 	for k := range aftNHG.NextHop {
-		aftnh := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().NextHop(k).State())
+		aftnh := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(a.dut)).Afts().NextHop(k).State())
 		// Handle the cases where the device returns the indirect NH or the recursively resolved NH.
 		// For e.g. in case of a->b->c, device should return either b or c.
 		if got := aftnh.GetIpAddress(); got != ipAddress && got != resolvedNhIpAddress {

--- a/feature/experimental/gribi/ate_tests/backup_nhg_action/backup_nhg_action_test.go
+++ b/feature/experimental/gribi/ate_tests/backup_nhg_action/backup_nhg_action_test.go
@@ -169,7 +169,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 			fptest.SetPortSpeed(t, p1)
 		}
 		if deviations.ExplicitInterfaceInDefaultVRF(dut) && p != "port1" {
-			fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+			fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 		}
 	}
 
@@ -179,10 +179,10 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 func addStaticRoute(t *testing.T, dut *ondatra.DUTDevice) {
 	d := gnmi.OC()
 	s := &oc.Root{}
-	static := s.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
+	static := s.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
 	ipv4Nh := static.GetOrCreateStatic(innerDstIP1 + "/" + mask).GetOrCreateNextHop("0")
 	ipv4Nh.NextHop, _ = ipv4Nh.To_NetworkInstance_Protocol_Static_NextHop_NextHop_Union(atePort4.IPv4)
-	gnmi.Update(t, dut, d.NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName).Config(), static)
+	gnmi.Update(t, dut, d.NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName).Config(), static)
 }
 
 // configureNetworkInstance configures vrfs vrfA,vrfB,vrfC and adds port1 to  vrfA
@@ -201,7 +201,7 @@ func configureNetworkInstance(t *testing.T, dut *ondatra.DUTDevice) {
 		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrf).Config(), ni)
 	}
 	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
-		for _, vrf := range []string{vrfA, vrfB, vrfC, *deviations.DefaultNetworkInstance} {
+		for _, vrf := range []string{vrfA, vrfB, vrfC, deviations.DefaultNetworkInstance(dut)} {
 			fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrf)
 		}
 	}
@@ -217,7 +217,7 @@ func TestBackupNHGAction(t *testing.T) {
 		configureDUT(t, dut)
 	}
 
-	dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut))
 	gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 	configureNetworkInstance(t, dut)
 
@@ -283,20 +283,20 @@ func TestBackupNHGAction(t *testing.T) {
 func testBackupDecap(ctx context.Context, t *testing.T, args *testArgs) {
 
 	t.Logf("Adding VIP %v/32 with NHG %d NH %d and  atePort2 via gRIBI", vip1, nhg1ID, nh1ID)
-	args.client.AddNH(t, nh1ID, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	args.client.AddNHG(t, nhg1ID, map[uint64]uint64{nh1ID: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	args.client.AddIPv4(t, vip1+"/"+mask, nhg1ID, *deviations.DefaultNetworkInstance, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	args.client.AddNH(t, nh1ID, atePort2.IPv4, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
+	args.client.AddNHG(t, nhg1ID, map[uint64]uint64{nh1ID: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
+	args.client.AddIPv4(t, vip1+"/"+mask, nhg1ID, deviations.DefaultNetworkInstance(args.dut), deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
 
 	t.Logf("Adding NHG %d with NH %d as decap and DEFAULT vrf lookup via gRIBI", nhg100ID, nh100ID)
-	args.client.AddNH(t, nh100ID, "Decap", *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHOptions{VrfName: *deviations.DefaultNetworkInstance})
-	args.client.AddNHG(t, nhg100ID, map[uint64]uint64{nh100ID: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	args.client.AddNH(t, nh100ID, "Decap", deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB, &gribi.NHOptions{VrfName: deviations.DefaultNetworkInstance(args.dut)})
+	args.client.AddNHG(t, nhg100ID, map[uint64]uint64{nh100ID: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
 
 	t.Logf("Adding NHG %d NH %d and  NH as %v  and backup NHG %d via gRIBI", nhg101ID, nh101ID, vip1, nhg100ID)
-	args.client.AddNH(t, nh101ID, vip1, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	args.client.AddNHG(t, nhg101ID, map[uint64]uint64{nh101ID: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: nhg100ID})
+	args.client.AddNH(t, nh101ID, vip1, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
+	args.client.AddNHG(t, nhg101ID, map[uint64]uint64{nh101ID: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: nhg100ID})
 
 	t.Logf("Adding an IPv4Entry for %s in VRF %s with primary atePort2, backup as Decap via gRIBI", outerDstIP1, vrfA)
-	args.client.AddIPv4(t, outerDstIP1+"/"+mask, nhg101ID, vrfA, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	args.client.AddIPv4(t, outerDstIP1+"/"+mask, nhg101ID, vrfA, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
 
 	t.Logf("Create flows with dst %s for each path", outerDstIP1)
 	baseFlow := createFlow(t, args.ate, args.top, "BaseFlow", &atePort2)
@@ -327,43 +327,43 @@ func testBackupDecap(ctx context.Context, t *testing.T, args *testArgs) {
 func testDecapEncap(ctx context.Context, t *testing.T, args *testArgs) {
 
 	t.Logf("Adding VIP1 %v/32 with NHG %d NH %d and  atePort2 via gRIBI", vip1, nhg1ID, nh1ID)
-	args.client.AddNH(t, nh1ID, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	args.client.AddNHG(t, nhg1ID, map[uint64]uint64{nh1ID: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	args.client.AddIPv4(t, vip1+"/"+mask, nhg1ID, *deviations.DefaultNetworkInstance, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	args.client.AddNH(t, nh1ID, atePort2.IPv4, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
+	args.client.AddNHG(t, nhg1ID, map[uint64]uint64{nh1ID: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
+	args.client.AddIPv4(t, vip1+"/"+mask, nhg1ID, deviations.DefaultNetworkInstance(args.dut), deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
 
 	t.Logf("Adding VIP2 %v/32 with NHG %d , NH %d and  atePort3 via gRIBI", vip2, nhg2ID, nh2ID)
-	args.client.AddNH(t, nh2ID, atePort3.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	args.client.AddNHG(t, nhg2ID, map[uint64]uint64{nh2ID: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	args.client.AddIPv4(t, vip2+"/"+mask, nhg2ID, *deviations.DefaultNetworkInstance, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	args.client.AddNH(t, nh2ID, atePort3.IPv4, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
+	args.client.AddNHG(t, nhg2ID, map[uint64]uint64{nh2ID: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
+	args.client.AddIPv4(t, vip2+"/"+mask, nhg2ID, deviations.DefaultNetworkInstance(args.dut), deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
 
 	t.Logf("Adding NHG %d with NH %d as redirect to vrfB via gRIBI", nhg100ID, nh100ID)
-	args.client.AddNH(t, nh100ID, "VRFOnly", *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHOptions{VrfName: vrfB})
-	args.client.AddNHG(t, nhg100ID, map[uint64]uint64{nh100ID: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	args.client.AddNH(t, nh100ID, "VRFOnly", deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB, &gribi.NHOptions{VrfName: vrfB})
+	args.client.AddNHG(t, nhg100ID, map[uint64]uint64{nh100ID: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
 
 	t.Logf("Adding NHG %d NH %d with  %v  and backup NHG %d via gRIBI", nhg101ID, nh101ID, vip1, nhg100ID)
-	args.client.AddNH(t, nh101ID, vip1, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	args.client.AddNHG(t, nhg101ID, map[uint64]uint64{nh101ID: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: nhg100ID})
+	args.client.AddNH(t, nh101ID, vip1, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
+	args.client.AddNHG(t, nhg101ID, map[uint64]uint64{nh101ID: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: nhg100ID})
 
 	t.Logf("Adding an IPv4Entry for %s in VRF %s with primary VIP1, backup as VRF %s  via gRIBI", outerDstIP1, vrfA, vrfB)
-	args.client.AddIPv4(t, outerDstIP1+"/"+mask, nhg101ID, vrfA, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	args.client.AddIPv4(t, outerDstIP1+"/"+mask, nhg101ID, vrfA, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
 
 	t.Logf("Adding NHG %d with NH %d as decap and DEFAULT vrf lookup via gRIBI", nhg103ID, nh103ID)
-	args.client.AddNH(t, nh103ID, "Decap", *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHOptions{VrfName: *deviations.DefaultNetworkInstance})
-	args.client.AddNHG(t, nhg103ID, map[uint64]uint64{nh103ID: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	args.client.AddNH(t, nh103ID, "Decap", deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB, &gribi.NHOptions{VrfName: deviations.DefaultNetworkInstance(args.dut)})
+	args.client.AddNHG(t, nhg103ID, map[uint64]uint64{nh103ID: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
 
 	t.Logf("Adding NHG %d NH %d and  NH as %v  and backup NHG %d via gRIBI", nhg104ID, nh104ID, vip2, nhg103ID)
-	args.client.AddNH(t, nh104ID, vip2, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	args.client.AddNHG(t, nhg104ID, map[uint64]uint64{nh104ID: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: nhg103ID})
+	args.client.AddNH(t, nh104ID, vip2, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
+	args.client.AddNHG(t, nhg104ID, map[uint64]uint64{nh104ID: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: nhg103ID})
 
 	t.Logf("Adding an IPv4Entry for %s in vrf %s with NHG %d via gRIBI", outerDstIP2, vrfC, nhg104ID)
-	args.client.AddIPv4(t, outerDstIP2+"/"+mask, nhg104ID, vrfC, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	args.client.AddIPv4(t, outerDstIP2+"/"+mask, nhg104ID, vrfC, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
 
 	t.Logf("Adding NHG %d NH %d and  NH as decap and encap with destination vrf as %v and backup NHG %d via gRIBI", nhg102ID, nh102ID, vrfC, nhg103ID)
-	args.client.AddNH(t, nh102ID, "DecapEncap", *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHOptions{Src: outerSrcIP2, Dest: outerDstIP2, VrfName: vrfC})
-	args.client.AddNHG(t, nhg102ID, map[uint64]uint64{nh102ID: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: nhg103ID})
+	args.client.AddNH(t, nh102ID, "DecapEncap", deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB, &gribi.NHOptions{Src: outerSrcIP2, Dest: outerDstIP2, VrfName: vrfC})
+	args.client.AddNHG(t, nhg102ID, map[uint64]uint64{nh102ID: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: nhg103ID})
 
 	t.Logf("Adding an IPv4Entry for %s in vrf %s with decap and encap destiantion  in  %s via gRIBI", outerDstIP1, vrfB, vrfC)
-	args.client.AddIPv4(t, outerDstIP1+"/"+mask, nhg102ID, vrfB, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	args.client.AddIPv4(t, outerDstIP1+"/"+mask, nhg102ID, vrfB, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInFIB)
 
 	p2 := args.dut.Port(t, "port2")
 	t.Log("Capture port2 status if Up")

--- a/feature/experimental/gribi/ate_tests/dut_daemon_failure/dut_daemon_failure_test.go
+++ b/feature/experimental/gribi/ate_tests/dut_daemon_failure/dut_daemon_failure_test.go
@@ -125,8 +125,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 
@@ -198,15 +198,15 @@ type testArgs struct {
 // after programming the necessary nexthop and nexthop-group.
 func addRoute(ctx context.Context, t *testing.T, args *testArgs, clientA *gribi.Client) {
 	t.Logf("Add an IPv4Entry for %s pointing to ATE port-2 via clientA", ateDstNetCIDR)
-	clientA.AddNH(t, nhIndex, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	clientA.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex, *deviations.DefaultNetworkInstance, "", fluent.InstalledInRIB)
+	clientA.AddNH(t, nhIndex, atePort2.IPv4, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	clientA.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex, deviations.DefaultNetworkInstance(args.dut), "", fluent.InstalledInRIB)
 }
 
 // verifyAFT verifies through AFT Telemetry if a route is present on the DUT.
 func verifyAFT(ctx context.Context, t *testing.T, args *testArgs) {
 	t.Logf("Verify through AFT Telemetry that %s is active", ateDstNetCIDR)
-	ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
 		prefix, present := val.Val()
 		return present && prefix == ateDstNetCIDR
@@ -229,9 +229,9 @@ func verifyTraffic(ctx context.Context, t *testing.T, args *testArgs) {
 }
 
 // verifyGRIBIGet verifies through gRIBI Get RPC if a route is present on the DUT.
-func verifyGRIBIGet(ctx context.Context, t *testing.T, clientA *gribi.Client) {
+func verifyGRIBIGet(ctx context.Context, t *testing.T, clientA *gribi.Client, dut *ondatra.DUTDevice) {
 	t.Logf("Verify through gRIBI Get RPC that %s is present", ateDstNetCIDR)
-	getResponse, err := clientA.Fluent(t).Get().WithNetworkInstance(*deviations.DefaultNetworkInstance).WithAFT(fluent.IPv4).Send()
+	getResponse, err := clientA.Fluent(t).Get().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).WithAFT(fluent.IPv4).Send()
 	if err != nil {
 		t.Errorf("Cannot Get: %v", err)
 	}
@@ -410,7 +410,7 @@ func TestDUTDaemonFailure(t *testing.T) {
 		}
 
 		t.Run("VerifyGRIBIGet", func(t *testing.T) {
-			verifyGRIBIGet(ctx, t, clientA)
+			verifyGRIBIGet(ctx, t, clientA, dut)
 		})
 	})
 

--- a/feature/experimental/gribi/ate_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
+++ b/feature/experimental/gribi/ate_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
@@ -184,14 +184,14 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops, virtualVIPs []st
 
 	if configNhg {
 		fluentNhgVar := fluent.NextHopGroupEntry()
-		fluentNhgVar.WithNetworkInstance(*deviations.DefaultNetworkInstance).WithID(uint64(nhgID)).
+		fluentNhgVar.WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).WithID(uint64(nhgID)).
 			WithElectionID(args.electionID.Low, args.electionID.High)
 
 		for i := range nextHops {
 			index := uint64(i + 1)
 			args.client.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(*deviations.DefaultNetworkInstance).
+					WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 					WithIndex(index).
 					WithIPAddress(nextHops[i]).
 					WithElectionID(args.electionID.Low, args.electionID.High))
@@ -205,7 +205,7 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops, virtualVIPs []st
 		args.client.Modify().AddEntry(t,
 			fluent.IPv4Entry().
 				WithPrefix(virtualVIPs[ip]+"/32").
-				WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 				WithNextHopGroup(uint64(nhgID)).
 				WithElectionID(args.electionID.Low, args.electionID.High))
 	}
@@ -233,7 +233,7 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops, virtualVIPs []st
 		}
 
 		gr, err := args.client.Get().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithAFT(fluent.IPv4).
 			Send()
 		if err != nil {
@@ -243,7 +243,7 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops, virtualVIPs []st
 		for ip := range virtualVIPs {
 			chk.GetResponseHasEntries(t, gr,
 				fluent.IPv4Entry().
-					WithNetworkInstance(*deviations.DefaultNetworkInstance).
+					WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 					WithNextHopGroup(uint64(nhgID)).
 					WithPrefix(virtualVIPs[ip]+"/32"),
 			)
@@ -295,7 +295,7 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
 		intf := d.GetOrCreateInterface(dutPort.Name())
 		for i := 1; i <= nextHopCount+1; i++ {
-			fptest.AssignToNetworkInstance(t, dut, intf.GetName(), *deviations.DefaultNetworkInstance, uint32(i))
+			fptest.AssignToNetworkInstance(t, dut, intf.GetName(), deviations.DefaultNetworkInstance(dut), uint32(i))
 		}
 	}
 	return nextHops
@@ -501,14 +501,14 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 	subIntfIPs := generateSubIntfPair(t, dut, dp2, ate, ap2, top, d)
 
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, dp1)
 		fptest.SetPortSpeed(t, dp2)
 	}
 	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
-		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, deviations.DefaultNetworkInstance(dut))
 	}
 
 	top.Push(t).StartProtocols(t)
@@ -556,7 +556,7 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 	pushDefaultEntries(t, args, subIntfIPs, virtualIPs, configNhg, !switchover)
 
 	gr, err := args.client.Get().
-		WithNetworkInstance(*deviations.DefaultNetworkInstance).
+		WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithAFT(fluent.IPv4).
 		Send()
 	if err != nil {
@@ -663,7 +663,7 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 	t.Log("Validate if partially ACKed entries of IPBlock2 are present as FIB_PROGRAMMED using a get RPC.")
 
 	gr, err = args.client.Get().
-		WithNetworkInstance(*deviations.DefaultNetworkInstance).
+		WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithAFT(fluent.IPv4).
 		Send()
 	if err != nil {

--- a/feature/experimental/gribi/ate_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
+++ b/feature/experimental/gribi/ate_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
@@ -151,14 +151,14 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops, virtualVIPs []st
 	t.Helper()
 
 	fluentNhgVar := fluent.NextHopGroupEntry()
-	fluentNhgVar.WithNetworkInstance(*deviations.DefaultNetworkInstance).WithID(uint64(nhgID)).
+	fluentNhgVar.WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).WithID(uint64(nhgID)).
 		WithElectionID(args.electionID.Low, args.electionID.High)
 
 	for i := range nextHops {
 		index := uint64(i + 1)
 		args.client.Modify().AddEntry(t,
 			fluent.NextHopEntry().
-				WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 				WithIndex(index).
 				WithIPAddress(nextHops[i]).
 				WithElectionID(args.electionID.Low, args.electionID.High))
@@ -172,7 +172,7 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops, virtualVIPs []st
 		args.client.Modify().AddEntry(t,
 			fluent.IPv4Entry().
 				WithPrefix(virtualVIPs[ip]+"/32").
-				WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 				WithNextHopGroup(uint64(nhgID)).
 				WithElectionID(args.electionID.Low, args.electionID.High))
 	}
@@ -193,7 +193,7 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops, virtualVIPs []st
 	}
 
 	gr, err := args.client.Get().
-		WithNetworkInstance(*deviations.DefaultNetworkInstance).
+		WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 		WithAFT(fluent.IPv4).
 		Send()
 	if err != nil {
@@ -203,7 +203,7 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops, virtualVIPs []st
 	for ip := range virtualVIPs {
 		chk.GetResponseHasEntries(t, gr,
 			fluent.IPv4Entry().
-				WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 				WithNextHopGroup(uint64(nhgID)).
 				WithPrefix(virtualVIPs[ip]+"/32"),
 		)
@@ -257,7 +257,7 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
 		intf := d.GetOrCreateInterface(dutPort.Name())
 		for i := 0; i <= nextHopCount; i++ {
-			fptest.AssignToNetworkInstance(t, dut, intf.GetName(), *deviations.DefaultNetworkInstance, uint32(i))
+			fptest.AssignToNetworkInstance(t, dut, intf.GetName(), deviations.DefaultNetworkInstance(dut), uint32(i))
 		}
 	}
 	return nextHops
@@ -470,14 +470,14 @@ func TestRouteRemovalDuringFailover(t *testing.T) {
 	subIntfIPs := generateSubIntfPair(t, dut, dp2, ate, ap2, top, d)
 
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, dp1)
 		fptest.SetPortSpeed(t, dp2)
 	}
 	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
-		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, deviations.DefaultNetworkInstance(dut))
 	}
 
 	top.Push(t).StartProtocols(t)
@@ -526,7 +526,7 @@ func TestRouteRemovalDuringFailover(t *testing.T) {
 	pushDefaultEntries(t, args, subIntfIPs, virtualIPs)
 
 	gr, err := args.client.Get().
-		WithNetworkInstance(*deviations.DefaultNetworkInstance).
+		WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithAFT(fluent.IPv4).
 		Send()
 	if err != nil {
@@ -563,13 +563,13 @@ func TestRouteRemovalDuringFailover(t *testing.T) {
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 
-	entriesBefore := checkNIHasNEntries(ctx, client, *deviations.DefaultNetworkInstance, t)
+	entriesBefore := checkNIHasNEntries(ctx, client, deviations.DefaultNetworkInstance(dut), t)
 
 	// Concurrently run switchover and gribi route flush.
 	var flushRes, wantFlushRes *gpb.FlushResponse
 	t.Log("Execute gRIBi flush and master switchover concurrently.")
 	go func(msg string) {
-		flushRes, err := gribi.Flush(client, eID, *deviations.DefaultNetworkInstance)
+		flushRes, err := gribi.Flush(client, eID, deviations.DefaultNetworkInstance(dut))
 		if err != nil {
 			t.Logf("Unexpected error from flush, got: %v, %v", err, flushRes)
 		}
@@ -632,7 +632,7 @@ func TestRouteRemovalDuringFailover(t *testing.T) {
 	t.Log("Compare route entries after switchover based on flush response.")
 
 	gr, err = args.client.Get().
-		WithNetworkInstance(*deviations.DefaultNetworkInstance).
+		WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithAFT(fluent.IPv4).
 		Send()
 	if err != nil {

--- a/feature/experimental/gribi/otg_tests/dut_daemon_failure/dut_daemon_failure_test.go
+++ b/feature/experimental/gribi/otg_tests/dut_daemon_failure/dut_daemon_failure_test.go
@@ -132,8 +132,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 
@@ -192,15 +192,15 @@ type testArgs struct {
 // after programming the necessary nexthop and nexthop-group.
 func addRoute(ctx context.Context, t *testing.T, args *testArgs, clientA *gribi.Client) {
 	t.Logf("Add an IPv4Entry for %s pointing to ATE port-2 via clientA", ateDstNetCIDR)
-	clientA.AddNH(t, nhIndex, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	clientA.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex, *deviations.DefaultNetworkInstance, "", fluent.InstalledInRIB)
+	clientA.AddNH(t, nhIndex, atePort2.IPv4, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	clientA.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex, deviations.DefaultNetworkInstance(args.dut), "", fluent.InstalledInRIB)
 }
 
 // verifyAFT verifies through AFT Telemetry if a route is present on the DUT.
 func verifyAFT(ctx context.Context, t *testing.T, args *testArgs) {
 	t.Logf("Verify through AFT Telemetry that %s is active", ateDstNetCIDR)
-	ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
 		prefix, present := val.Val()
 		return present && prefix == ateDstNetCIDR
@@ -221,9 +221,9 @@ func verifyTraffic(ctx context.Context, t *testing.T, args *testArgs) {
 }
 
 // verifyGRIBIGet verifies through gRIBI Get RPC if a route is present on the DUT.
-func verifyGRIBIGet(ctx context.Context, t *testing.T, clientA *gribi.Client) {
+func verifyGRIBIGet(ctx context.Context, t *testing.T, clientA *gribi.Client, dut *ondatra.DUTDevice) {
 	t.Logf("Verify through gRIBI Get RPC that %s is present", ateDstNetCIDR)
-	getResponse, err := clientA.Fluent(t).Get().WithNetworkInstance(*deviations.DefaultNetworkInstance).WithAFT(fluent.IPv4).Send()
+	getResponse, err := clientA.Fluent(t).Get().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).WithAFT(fluent.IPv4).Send()
 	if err != nil {
 		t.Errorf("Cannot Get: %v", err)
 	}
@@ -399,7 +399,7 @@ func TestDUTDaemonFailure(t *testing.T) {
 		}
 
 		t.Run("VerifyGRIBIGet", func(t *testing.T) {
-			verifyGRIBIGet(ctx, t, clientA)
+			verifyGRIBIGet(ctx, t, clientA, dut)
 		})
 	})
 

--- a/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
+++ b/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
@@ -186,14 +186,14 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops, virtualVIPs []st
 
 	if configNhg {
 		fluentNhgVar := fluent.NextHopGroupEntry()
-		fluentNhgVar.WithNetworkInstance(*deviations.DefaultNetworkInstance).WithID(uint64(nhgID)).
+		fluentNhgVar.WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).WithID(uint64(nhgID)).
 			WithElectionID(args.electionID.Low, args.electionID.High)
 
 		for i := range nextHops {
 			index := uint64(i + 1)
 			args.client.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(*deviations.DefaultNetworkInstance).
+					WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 					WithIndex(index).
 					WithIPAddress(nextHops[i]).
 					WithElectionID(args.electionID.Low, args.electionID.High))
@@ -207,7 +207,7 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops, virtualVIPs []st
 		args.client.Modify().AddEntry(t,
 			fluent.IPv4Entry().
 				WithPrefix(virtualVIPs[ip]+"/32").
-				WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 				WithNextHopGroup(uint64(nhgID)).
 				WithElectionID(args.electionID.Low, args.electionID.High))
 	}
@@ -235,7 +235,7 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops, virtualVIPs []st
 		}
 
 		gr, err := args.client.Get().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithAFT(fluent.IPv4).
 			Send()
 		if err != nil {
@@ -245,7 +245,7 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops, virtualVIPs []st
 		for ip := range virtualVIPs {
 			chk.GetResponseHasEntries(t, gr,
 				fluent.IPv4Entry().
-					WithNetworkInstance(*deviations.DefaultNetworkInstance).
+					WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 					WithNextHopGroup(uint64(nhgID)).
 					WithPrefix(virtualVIPs[ip]+"/32"),
 			)
@@ -302,7 +302,7 @@ func generateSubIntfPair(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
 		intf := d.GetOrCreateInterface(dutPort.Name())
 		for i := 1; i <= nextHopCount+1; i++ {
-			fptest.AssignToNetworkInstance(t, dut, intf.GetName(), *deviations.DefaultNetworkInstance, uint32(i))
+			fptest.AssignToNetworkInstance(t, dut, intf.GetName(), deviations.DefaultNetworkInstance(dut), uint32(i))
 		}
 	}
 	return nextHops
@@ -523,14 +523,14 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 	subIntfIPs := generateSubIntfPair(t, dut, dp2, ate, ap2, top, d)
 
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, dp1)
 		fptest.SetPortSpeed(t, dp2)
 	}
 	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
-		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, deviations.DefaultNetworkInstance(dut))
 	}
 
 	ate.OTG().PushConfig(t, top)
@@ -579,7 +579,7 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 	pushDefaultEntries(t, args, subIntfIPs, virtualIPs, configNhg, !switchover)
 
 	gr, err := args.client.Get().
-		WithNetworkInstance(*deviations.DefaultNetworkInstance).
+		WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithAFT(fluent.IPv4).
 		Send()
 	if err != nil {
@@ -691,7 +691,7 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 	t.Log("Validate if partially ACKed entries of IPBlock2 are present as FIB_PROGRAMMED using a get RPC.")
 
 	gr, err = args.client.Get().
-		WithNetworkInstance(*deviations.DefaultNetworkInstance).
+		WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithAFT(fluent.IPv4).
 		Send()
 	if err != nil {

--- a/feature/experimental/interface/my_station_mac/ate_tests/my_station_mac_test/my_station_mac_test.go
+++ b/feature/experimental/interface/my_station_mac/ate_tests/my_station_mac_test/my_station_mac_test.go
@@ -124,8 +124,8 @@ func configureDUT(t *testing.T) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/experimental/interface/my_station_mac/otg_tests/my_station_mac_test/my_station_mac_test.go
+++ b/feature/experimental/interface/my_station_mac/otg_tests/my_station_mac_test/my_station_mac_test.go
@@ -128,8 +128,8 @@ func configureDUT(t *testing.T) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/experimental/isis/ate_tests/base_adjacencies_test/base_adjacencies_test.go
+++ b/feature/experimental/isis/ate_tests/base_adjacencies_test/base_adjacencies_test.go
@@ -70,7 +70,7 @@ func TestBasic(t *testing.T) {
 	if err := ts.PushDUT(context.Background(), t); err != nil {
 		t.Fatalf("Unable to push initial DUT config: %v", err)
 	}
-	isisRoot := session.ISISPath()
+	isisRoot := session.ISISPath(ts.DUT)
 	port1ISIS := isisRoot.Interface(ts.DUTPort1.Name())
 	if deviations.ExplicitInterfaceInDefaultVRF(ts.DUT) {
 		port1ISIS = isisRoot.Interface(ts.DUTPort1.Name() + ".0")
@@ -413,7 +413,7 @@ func TestHelloPadding(t *testing.T) {
 			if err != nil {
 				t.Fatalf("No IS-IS adjacency formed: %v", err)
 			}
-			telemPth := session.ISISPath().Global()
+			telemPth := session.ISISPath(ts.DUT).Global()
 			var vd check.Validator
 			if tc.mode == oc.Isis_HelloPaddingType_STRICT {
 				vd = EqualToDefault(telemPth.HelloPadding().State(), oc.Isis_HelloPaddingType_STRICT)

--- a/feature/experimental/isis/ate_tests/internal/session/session.go
+++ b/feature/experimental/isis/ate_tests/internal/session/session.go
@@ -92,19 +92,19 @@ var (
 )
 
 // ISISPath is shorthand for ProtocolPath().Isis().
-func ISISPath() *networkinstance.NetworkInstance_Protocol_IsisPath {
-	return ProtocolPath().Isis()
+func ISISPath(dut *ondatra.DUTDevice) *networkinstance.NetworkInstance_Protocol_IsisPath {
+	return ProtocolPath(dut).Isis()
 }
 
 // ProtocolPath returns the path to the IS-IS protocol named ISISName on the
 // default network instance.
-func ProtocolPath() *networkinstance.NetworkInstance_ProtocolPath {
-	return ocpath.Root().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(PTISIS, ISISName)
+func ProtocolPath(dut *ondatra.DUTDevice) *networkinstance.NetworkInstance_ProtocolPath {
+	return ocpath.Root().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(PTISIS, ISISName)
 }
 
 // addISISOC configures basic IS-IS on a device.
 func addISISOC(dev *oc.Root, areaAddress, sysID, ifaceName string, dut *ondatra.DUTDevice) {
-	inst := dev.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
+	inst := dev.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
 	prot := inst.GetOrCreateProtocol(PTISIS, ISISName)
 	if !deviations.ISISprotocolEnabledNotRequired(dut) {
 		prot.Enabled = ygot.Bool(true)
@@ -223,7 +223,7 @@ func (s *TestSession) WithISIS() *TestSession {
 // to the IS-IS block of ts.DUTConfig, and the second will be applied to the
 // IS-IS configuration of ts.ATETop
 func (s *TestSession) ConfigISIS(ocFn func(*oc.NetworkInstance_Protocol_Isis), ateFn func(*ixnet.ISIS)) {
-	ocFn(s.DUTConf.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreateProtocol(PTISIS, ISISName).GetOrCreateIsis())
+	ocFn(s.DUTConf.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(s.DUT)).GetOrCreateProtocol(PTISIS, ISISName).GetOrCreateIsis())
 	if s.ATE != nil {
 		ateFn(s.ATEIntf1.ISIS())
 	}
@@ -251,8 +251,8 @@ func (s *TestSession) PushDUT(ctx context.Context, t testing.TB) error {
 		}
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(s.DUT) {
-		fptest.AssignToNetworkInstance(t, s.DUT, s.DUTPort1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, s.DUT, s.DUTPort2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, s.DUT, s.DUTPort1.Name(), deviations.DefaultNetworkInstance(s.DUT), 0)
+		fptest.AssignToNetworkInstance(t, s.DUT, s.DUTPort2.Name(), deviations.DefaultNetworkInstance(s.DUT), 0)
 	}
 	if deviations.ExplicitPortSpeed(s.DUT) {
 		fptest.SetPortSpeed(t, s.DUTPort1)
@@ -260,11 +260,11 @@ func (s *TestSession) PushDUT(ctx context.Context, t testing.TB) error {
 	}
 
 	// Push the ISIS protocol
-	if _, err := ygnmi.Replace(ctx, s.DUTClient, ocpath.Root().NetworkInstance(*deviations.DefaultNetworkInstance).Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE); err != nil {
+	if _, err := ygnmi.Replace(ctx, s.DUTClient, ocpath.Root().NetworkInstance(deviations.DefaultNetworkInstance(s.DUT)).Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE); err != nil {
 		return fmt.Errorf("configuring network instance: %w", err)
 	}
-	dutConf := s.DUTConf.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreateProtocol(PTISIS, ISISName)
-	_, err := ygnmi.Replace(ctx, s.DUTClient, ProtocolPath().Config(), dutConf)
+	dutConf := s.DUTConf.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(s.DUT)).GetOrCreateProtocol(PTISIS, ISISName)
+	_, err := ygnmi.Replace(ctx, s.DUTClient, ProtocolPath(s.DUT).Config(), dutConf)
 	if err != nil {
 		return fmt.Errorf("configuring ISIS: %w", err)
 	}
@@ -284,9 +284,9 @@ func (s *TestSession) PushAndStartATE(t testing.TB) {
 // link has formed any IS-IS adjacency, returning the adjacency ID or an error
 // if one doesn't form.
 func (s *TestSession) AwaitAdjacency() (string, error) {
-	intf := ISISPath().Interface(s.DUTPort1.Name())
+	intf := ISISPath(s.DUT).Interface(s.DUTPort1.Name())
 	if deviations.ExplicitInterfaceInDefaultVRF(s.DUT) {
-		intf = ISISPath().Interface(s.DUTPort1.Name() + ".0")
+		intf = ISISPath(s.DUT).Interface(s.DUTPort1.Name() + ".0")
 	}
 	query := intf.LevelAny().AdjacencyAny().AdjacencyState().State()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)

--- a/feature/experimental/isis/ate_tests/lsp_updates_test/lsp_updates_test.go
+++ b/feature/experimental/isis/ate_tests/lsp_updates_test/lsp_updates_test.go
@@ -39,7 +39,7 @@ func TestOverloadBit(t *testing.T) {
 	if err := ts.PushDUT(context.Background(), t); err != nil {
 		t.Fatalf("Unable to push initial DUT config: %v", err)
 	}
-	isisPath := session.ISISPath()
+	isisPath := session.ISISPath(ts.DUT)
 	overloads := isisPath.Level(2).SystemLevelCounters().DatabaseOverloads()
 	//Lookup the initial value for 'database-overloads' leaf counter after config is pushed to DUT & before adjacency is formed
 	getDbOlInitCount := gnmi.Lookup(t, ts.DUT, overloads.State())
@@ -65,7 +65,7 @@ func TestOverloadBit(t *testing.T) {
 		}
 	}
 	ts.DUTConf.
-		GetNetworkInstance(*deviations.DefaultNetworkInstance).
+		GetNetworkInstance(deviations.DefaultNetworkInstance(ts.DUT)).
 		GetProtocol(session.PTISIS, session.ISISName).
 		GetIsis().
 		GetGlobal().
@@ -93,7 +93,7 @@ func TestMetric(t *testing.T) {
 	if deviations.ExplicitInterfaceInDefaultVRF(ts.DUT) {
 		isisIntfName = ts.DUT.Port(t, "port1").Name() + ".0"
 	}
-	ts.DUTConf.GetNetworkInstance(*deviations.DefaultNetworkInstance).GetProtocol(session.PTISIS, session.ISISName).GetIsis().
+	ts.DUTConf.GetNetworkInstance(deviations.DefaultNetworkInstance(ts.DUT)).GetProtocol(session.PTISIS, session.ISISName).GetIsis().
 		GetInterface(isisIntfName).
 		GetOrCreateLevel(2).
 		GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).
@@ -101,7 +101,7 @@ func TestMetric(t *testing.T) {
 	ts.PushAndStart(t)
 	ts.MustAdjacency(t)
 
-	metric := session.ISISPath().Interface(isisIntfName).Level(2).
+	metric := session.ISISPath(ts.DUT).Interface(isisIntfName).Level(2).
 		Af(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).Metric()
 	if err := check.Equal(metric.State(), uint32(100)).AwaitFor(time.Second*3, ts.DUTClient); err != nil {
 		t.Error(err)

--- a/feature/experimental/isis/otg_tests/base_adjacencies_test/base_adjacencies_test.go
+++ b/feature/experimental/isis/otg_tests/base_adjacencies_test/base_adjacencies_test.go
@@ -70,7 +70,7 @@ func TestBasic(t *testing.T) {
 	if err := ts.PushDUT(context.Background(), t); err != nil {
 		t.Fatalf("Unable to push initial DUT config: %v", err)
 	}
-	isisRoot := session.ISISPath()
+	isisRoot := session.ISISPath(ts.DUT)
 	port1ISIS := isisRoot.Interface(ts.DUTPort1.Name())
 	if deviations.ExplicitInterfaceInDefaultVRF(ts.DUT) {
 		port1ISIS = isisRoot.Interface(ts.DUTPort1.Name() + ".0")
@@ -413,7 +413,7 @@ func TestHelloPadding(t *testing.T) {
 			if err != nil {
 				t.Fatalf("No IS-IS adjacency formed: %v", err)
 			}
-			telemPth := session.ISISPath().Global()
+			telemPth := session.ISISPath(ts.DUT).Global()
 			var vd check.Validator
 			if tc.mode == oc.Isis_HelloPaddingType_STRICT {
 				vd = EqualToDefault(telemPth.HelloPadding().State(), oc.Isis_HelloPaddingType_STRICT)

--- a/feature/experimental/isis/otg_tests/lsp_updates_test/lsp_updates_test.go
+++ b/feature/experimental/isis/otg_tests/lsp_updates_test/lsp_updates_test.go
@@ -42,7 +42,7 @@ func TestOverloadBit(t *testing.T) {
 	otg := ts.ATE.OTG()
 	ts.PushAndStart(t)
 	ts.MustAdjacency(t)
-	isisPath := session.ISISPath()
+	isisPath := session.ISISPath(ts.DUT)
 	overloads := isisPath.Level(2).SystemLevelCounters().DatabaseOverloads()
 	setBit := isisPath.Global().LspBit().OverloadBit().SetBit()
 	deadline := time.Now().Add(time.Second * 3)
@@ -60,7 +60,7 @@ func TestOverloadBit(t *testing.T) {
 		}
 	}
 	ts.DUTConf.
-		GetNetworkInstance(*deviations.DefaultNetworkInstance).
+		GetNetworkInstance(deviations.DefaultNetworkInstance(ts.DUT)).
 		GetProtocol(session.PTISIS, session.ISISName).
 		GetIsis().
 		GetGlobal().
@@ -101,18 +101,18 @@ func TestMetric(t *testing.T) {
 	if deviations.ExplicitInterfaceInDefaultVRF(ts.DUT) {
 		isisIntfName = ts.DUT.Port(t, "port1").Name() + ".0"
 	}
-	ts.DUTConf.GetNetworkInstance(*deviations.DefaultNetworkInstance).GetProtocol(session.PTISIS, session.ISISName).GetIsis().
+	ts.DUTConf.GetNetworkInstance(deviations.DefaultNetworkInstance(ts.DUT)).GetProtocol(session.PTISIS, session.ISISName).GetIsis().
 		GetInterface(isisIntfName).
 		GetOrCreateLevel(2).
 		GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).
 		Metric = ygot.Uint32(configuredMetric)
-	ts.DUTConf.GetNetworkInstance(*deviations.DefaultNetworkInstance).GetProtocol(session.PTISIS, session.ISISName).GetIsis().GetOrCreateLevel(2).
+	ts.DUTConf.GetNetworkInstance(deviations.DefaultNetworkInstance(ts.DUT)).GetProtocol(session.PTISIS, session.ISISName).GetIsis().GetOrCreateLevel(2).
 		MetricStyle = oc.E_Isis_MetricStyle(2)
 
 	ts.PushAndStart(t)
 	ts.MustAdjacency(t)
 
-	metric := session.ISISPath().Interface(isisIntfName).Level(2).
+	metric := session.ISISPath(ts.DUT).Interface(isisIntfName).Level(2).
 		Af(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).Metric()
 	if err := check.Equal(metric.State(), uint32(100)).AwaitFor(time.Second*3, ts.DUTClient); err != nil {
 		t.Error(err)

--- a/feature/experimental/p4rt/ate_tests/base_p4rt/base_p4rt_test.go
+++ b/feature/experimental/p4rt/ate_tests/base_p4rt/base_p4rt_test.go
@@ -142,8 +142,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice, ports []string) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetin_test/google_discovery_protocol_packetin_test.go
+++ b/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetin_test/google_discovery_protocol_packetin_test.go
@@ -265,14 +265,14 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	i1 := &oc.Interface{Name: ygot.String(p1.Name()), Id: ygot.Uint32(portID)}
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutPort1))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	p2 := dut.Port(t, "port2")
 	i2 := &oc.Interface{Name: ygot.String(p2.Name()), Id: ygot.Uint32(portID + 1)}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutPort2))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, p1)

--- a/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetout_test/google_discovery_protocol_packetout_test.go
+++ b/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetout_test/google_discovery_protocol_packetout_test.go
@@ -234,14 +234,14 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	i1 := &oc.Interface{Name: ygot.String(p1.Name()), Id: ygot.Uint32(portID)}
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutPort1))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	p2 := dut.Port(t, "port2")
 	i2 := &oc.Interface{Name: ygot.String(p2.Name()), Id: ygot.Uint32(portID + 1)}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutPort2))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, p1)

--- a/feature/experimental/p4rt/ate_tests/lldp_packetin_test/lldp_packetin_test.go
+++ b/feature/experimental/p4rt/ate_tests/lldp_packetin_test/lldp_packetin_test.go
@@ -253,8 +253,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	}
 
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/experimental/p4rt/ate_tests/lldp_packetout_test/lldp_packetout_test.go
+++ b/feature/experimental/p4rt/ate_tests/lldp_packetout_test/lldp_packetout_test.go
@@ -235,8 +235,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	}
 
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/experimental/p4rt/ate_tests/p4rt_daemon_failure_test/p4rt_daemon_failure_test.go
+++ b/feature/experimental/p4rt/ate_tests/p4rt_daemon_failure_test/p4rt_daemon_failure_test.go
@@ -142,8 +142,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 
@@ -221,12 +221,12 @@ func installRoutes(t *testing.T, dut *ondatra.DUTDevice) error {
 	defer c.Close(t)
 
 	t.Logf("Add an IPv4Entry for %s pointing to ATE port-2 via clientA", ateDstNetCIDR)
-	c.AddNH(t, nhIndex, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	c.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	c.AddIPv4(t, ateDstNetCIDR, nhgIndex, *deviations.DefaultNetworkInstance, "", fluent.InstalledInRIB)
+	c.AddNH(t, nhIndex, atePort2.IPv4, deviations.DefaultNetworkInstance(dut), fluent.InstalledInRIB)
+	c.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, deviations.DefaultNetworkInstance(dut), fluent.InstalledInRIB)
+	c.AddIPv4(t, ateDstNetCIDR, nhgIndex, deviations.DefaultNetworkInstance(dut), "", fluent.InstalledInRIB)
 
 	t.Logf("Verify through AFT Telemetry that %s is active", ateDstNetCIDR)
-	ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	if got, ok := gnmi.Watch(t, dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
 		prefix, present := val.Val()
 		return present && prefix == ateDstNetCIDR

--- a/feature/experimental/p4rt/ate_tests/traceroute_packetin_test/traceroute_packetin_test.go
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetin_test/traceroute_packetin_test.go
@@ -132,8 +132,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/traceroute_packetout_test.go
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/traceroute_packetout_test.go
@@ -123,8 +123,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, dut.Port(t, "port2"))
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1, *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2, *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1, deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2, deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/experimental/p4rt/otg_tests/base_p4rt/base_p4rt_test.go
+++ b/feature/experimental/p4rt/otg_tests/base_p4rt/base_p4rt_test.go
@@ -148,8 +148,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice, ports []string) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/experimental/p4rt/otg_tests/google_discovery_protocol_packetin_test/google_discovery_protocol_packetin_test.go
+++ b/feature/experimental/p4rt/otg_tests/google_discovery_protocol_packetin_test/google_discovery_protocol_packetin_test.go
@@ -274,14 +274,14 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	i1 := &oc.Interface{Name: ygot.String(p1.Name()), Id: ygot.Uint32(portID)}
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutPort1))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	p2 := dut.Port(t, "port2")
 	i2 := &oc.Interface{Name: ygot.String(p2.Name()), Id: ygot.Uint32(portID + 1)}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutPort2))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, p1)

--- a/feature/experimental/p4rt/otg_tests/google_discovery_protocol_packetout_test/google_discovery_protocol_packetout_test.go
+++ b/feature/experimental/p4rt/otg_tests/google_discovery_protocol_packetout_test/google_discovery_protocol_packetout_test.go
@@ -237,14 +237,14 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	i1 := &oc.Interface{Name: ygot.String(p1.Name()), Id: ygot.Uint32(portID)}
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutPort1))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	p2 := dut.Port(t, "port2")
 	i2 := &oc.Interface{Name: ygot.String(p2.Name()), Id: ygot.Uint32(portID + 1)}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutPort2))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, p1)

--- a/feature/experimental/p4rt/otg_tests/lldp_packetin_test/lldp_packetin_test.go
+++ b/feature/experimental/p4rt/otg_tests/lldp_packetin_test/lldp_packetin_test.go
@@ -262,8 +262,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	}
 
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/experimental/p4rt/otg_tests/lldp_packetout_test/lldp_packetout_test.go
+++ b/feature/experimental/p4rt/otg_tests/lldp_packetout_test/lldp_packetout_test.go
@@ -238,8 +238,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	}
 
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/experimental/p4rt/otg_tests/traceroute_packetin_test/traceroute_packetin_test.go
+++ b/feature/experimental/p4rt/otg_tests/traceroute_packetin_test/traceroute_packetin_test.go
@@ -135,8 +135,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/experimental/p4rt/otg_tests/traceroute_packetout_test/traceroute_packetout_test.go
+++ b/feature/experimental/p4rt/otg_tests/traceroute_packetout_test/traceroute_packetout_test.go
@@ -134,8 +134,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, dut.Port(t, "port2"))
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1, *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2, *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1, deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2, deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -276,8 +276,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	outpath := d.Interface(p2.Name())
@@ -501,13 +501,13 @@ func TestPBR(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Log(tc.desc)
-			pfpath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding()
+			pfpath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding()
 
 			//configure pbr policy-forwarding
-			dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+			dutConfNIPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut))
 			gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 			errMsg := testt.CaptureFatal(t, func(t testing.TB) {
-				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
+				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Config(), tc.policy)
 			})
 			if errMsg != nil {
 				if tc.rejectable {
@@ -521,8 +521,8 @@ func TestPBR(t *testing.T) {
 			// apply pbr policy on ingress interface
 			p1 := port1.Name()
 			d := &oc.Root{}
-			pfIntf := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreatePolicyForwarding().GetOrCreateInterface(p1)
-			pfIntfConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Interface(p1)
+			pfIntf := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreatePolicyForwarding().GetOrCreateInterface(p1)
+			pfIntfConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Interface(p1)
 
 			if deviations.ExplicitInterfaceRefDefinition(dut) {
 				pfIntf.GetOrCreateInterfaceRef().Interface = ygot.String(p1)

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/base_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/base_vrf_selection_test.go
@@ -126,15 +126,15 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice, p1 *ondatra.Port, p2 *on
 
 	// Configure default NI and forwarding policy
 	t.Logf("*** Configuring default instance forwarding policy on DUT ...")
-	dutConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut))
 	gnmi.Replace(t, dut, dutConfPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, i1.GetName(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, i2.GetName(), *deviations.DefaultNetworkInstance, 20)
+		fptest.AssignToNetworkInstance(t, dut, i1.GetName(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, i2.GetName(), deviations.DefaultNetworkInstance(dut), 20)
 	}
 
-	policyDutConf := configForwardingPolicy()
+	policyDutConf := configForwardingPolicy(dut)
 	gnmi.Replace(t, dut, dutConfPath.PolicyForwarding().Config(), policyDutConf)
 
 }
@@ -192,16 +192,16 @@ func configNetworkInstance(name string, intf *oc.Interface, id uint32) *oc.Netwo
 // configDefaultRoute configures a static route in DEFAULT network-instance.
 func configDefaultRoute(t *testing.T, dut *ondatra.DUTDevice, v4Prefix, v4NextHop, v6Prefix, v6NextHop string) {
 	t.Logf("*** Configuring static route in DEFAULT network-instance ...")
-	ni := oc.NetworkInstance{Name: deviations.DefaultNetworkInstance}
+	ni := oc.NetworkInstance{Name: ygot.String(deviations.DefaultNetworkInstance(dut))}
 	static := ni.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
 	sr := static.GetOrCreateStatic(v4Prefix)
 	nh := sr.GetOrCreateNextHop("0")
 	nh.NextHop = oc.UnionString(v4NextHop)
-	gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName).Config(), static)
+	gnmi.Update(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName).Config(), static)
 	sr = static.GetOrCreateStatic(v6Prefix)
 	nh = sr.GetOrCreateNextHop("0")
 	nh.NextHop = oc.UnionString(v6NextHop)
-	gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName).Config(), static)
+	gnmi.Update(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName).Config(), static)
 }
 
 // configVRFRoute configures a static route in VRF.
@@ -215,9 +215,9 @@ func configVRFRoute(t *testing.T, dut *ondatra.DUTDevice, v4Prefix, v4NextHop st
 	gnmi.Update(t, dut, gnmi.OC().NetworkInstance("VRF-10").Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName).Config(), static)
 }
 
-func configForwardingPolicy() *oc.NetworkInstance_PolicyForwarding {
+func configForwardingPolicy(dut *ondatra.DUTDevice) *oc.NetworkInstance_PolicyForwarding {
 	d := &oc.Root{}
-	ni := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
+	ni := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
 	// Match policy.
 	policyFwding := ni.GetOrCreatePolicyForwarding()
 
@@ -252,17 +252,17 @@ func applyForwardingPolicy(t *testing.T, ate *ondatra.ATEDevice, ingressPort, ma
 
 	d := &oc.Root{}
 	dut := ondatra.DUT(t, "dut")
-	pfpath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Interface(ingressPort)
+	pfpath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Interface(ingressPort)
 	gnmi.Delete(t, dut, pfpath.Config())
 
-	intf := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreatePolicyForwarding().GetOrCreateInterface(ingressPort)
+	intf := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreatePolicyForwarding().GetOrCreateInterface(ingressPort)
 	intf.ApplyVrfSelectionPolicy = ygot.String(matchType)
 	if deviations.ExplicitInterfaceRefDefinition(dut) {
 		intf.GetOrCreateInterfaceRef().Interface = ygot.String(ingressPort)
 		intf.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 	}
 	// Configure default NI and forwarding policy.
-	intfConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Interface(ingressPort)
+	intfConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Interface(ingressPort)
 	gnmi.Replace(t, dut, intfConfPath.Config(), intf)
 
 	// Restart Protocols after policy change

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -280,8 +280,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	outpath := d.Interface(p2.Name())
@@ -517,13 +517,13 @@ func TestPBR(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Log(tc.desc)
-			pfpath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding()
+			pfpath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding()
 
 			//configure pbr policy-forwarding
-			dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+			dutConfNIPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut))
 			gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 			errMsg := testt.CaptureFatal(t, func(t testing.TB) {
-				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), tc.policy)
+				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Config(), tc.policy)
 			})
 			if errMsg != nil {
 				if tc.rejectable {
@@ -537,8 +537,8 @@ func TestPBR(t *testing.T) {
 			// apply pbr policy on ingress interface
 			p1 := port1.Name()
 			d := &oc.Root{}
-			pfIntf := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreatePolicyForwarding().GetOrCreateInterface(p1)
-			pfIntfConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Interface(p1)
+			pfIntf := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreatePolicyForwarding().GetOrCreateInterface(p1)
+			pfIntfConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Interface(p1)
 
 			if deviations.ExplicitInterfaceRefDefinition(dut) {
 				pfIntf.GetOrCreateInterfaceRef().Interface = ygot.String(p1)

--- a/feature/experimental/system/gnmi/benchmarking/ate_tests/drained_configuration_convergence_time/drained_configuration_convergence_time_bgp_test.go
+++ b/feature/experimental/system/gnmi/benchmarking/ate_tests/drained_configuration_convergence_time/drained_configuration_convergence_time_bgp_test.go
@@ -89,19 +89,19 @@ func setASPath(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root) {
 	pdef.GetOrCreateStatement("id-1").GetOrCreateActions().PolicyResult = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
 	gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
 
-	netInstance := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
+	netInstance := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
 	bgp := netInstance.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
 	pg := bgp.GetOrCreatePeerGroup(setup.PeerGrpName)
 	rpl := pg.GetOrCreateApplyPolicy()
 	rpl.SetImportPolicy([]string{setALLOWPolicy})
 
-	gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).Config(), pg)
+	gnmi.Update(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).Config(), pg)
 
 }
 
 func setPolicyPeerGroup(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root, policy []string) {
 
-	netInstance := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
+	netInstance := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
 	bgp := netInstance.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
 	pg := bgp.GetOrCreatePeerGroup(setup.PeerGrpEgressName)
 	pg.PeerAs = ygot.Uint32(setup.ATEAs)
@@ -110,7 +110,7 @@ func setPolicyPeerGroup(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root, policy
 	afipg.Enabled = ygot.Bool(true)
 	pgpolicy := afipg.GetOrCreateApplyPolicy()
 	pgpolicy.ExportPolicy = policy
-	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpEgressName).Config(), pg)
+	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpEgressName).Config(), pg)
 
 	pg1 := bgp.GetOrCreatePeerGroup(setup.PeerGrpName)
 	pg1.PeerAs = ygot.Uint32(setup.ATEAs)
@@ -119,14 +119,14 @@ func setPolicyPeerGroup(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root, policy
 	afipg1.Enabled = ygot.Bool(true)
 	pgpolicy1 := afipg1.GetOrCreateApplyPolicy()
 	pgpolicy1.ImportPolicy = []string{setALLOWPolicy}
-	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).Config(), pg1)
+	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).Config(), pg1)
 
 }
 
 func deletePolicyPeerGroup(t *testing.T, dut *ondatra.DUTDevice) {
 
-	dutExportPolicyPathDest := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpEgressName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ExportPolicy()
-	dutImportPolicyPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ImportPolicy()
+	dutExportPolicyPathDest := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpEgressName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ExportPolicy()
+	dutImportPolicyPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ImportPolicy()
 	gnmi.Delete(t, dut, dutImportPolicyPath.Config())
 	gnmi.Delete(t, dut, dutExportPolicyPathDest.Config())
 }
@@ -135,7 +135,7 @@ func deletePolicyPeerGroup(t *testing.T, dut *ondatra.DUTDevice) {
 func isConverged(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice, ap *ondatra.Port) {
 
 	// Check if all prefixes are learned at ATE.
-	statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).
+	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 prefixLoop:
 	for repeat := 4; repeat > 0; repeat-- {
@@ -159,7 +159,7 @@ prefixLoop:
 // verifyBGPAsPath is to Validate AS Path attribute using bgp rib telemetry on ATE.
 func verifyBGPAsPath(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
 
-	dutPolicyConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).
+	dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
 		PeerGroup(setup.PeerGrpName).ApplyPolicy().ExportPolicy()
 
@@ -205,7 +205,7 @@ func verifyBGPAsPath(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevic
 // verifyBGPSetMED is to Validate MED attribute using bgp rib telemetry on ATE.
 func verifyBGPSetMED(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
 
-	dutPolicyConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).
+	dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
 		PeerGroup(setup.PeerGrpName).ApplyPolicy().ExportPolicy()
 
@@ -259,7 +259,7 @@ func TestEstablish(t *testing.T) {
 	dutConfigPath := gnmi.OC()
 
 	t.Log("Configure Network Instance type to DEFAULT on DUT.")
-	dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut))
 	gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 
 	t.Log("Build Benchmarking BGP and ISIS test configs.")
@@ -290,7 +290,7 @@ func TestBGPBenchmarking(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	ate := ondatra.ATE(t, "ate")
 	// Cleanup existing policy details.
-	dutPolicyConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).ApplyPolicy()
+	dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).ApplyPolicy()
 	gnmi.Delete(t, dut, dutPolicyConfPath.ExportPolicy().Config())
 	gnmi.Delete(t, dut, dutPolicyConfPath.ImportPolicy().Config())
 	gnmi.Delete(t, dut, gnmi.OC().RoutingPolicy().Config())

--- a/feature/experimental/system/gnmi/benchmarking/ate_tests/drained_configuration_convergence_time/drained_configuration_convergence_time_isis_test.go
+++ b/feature/experimental/system/gnmi/benchmarking/ate_tests/drained_configuration_convergence_time/drained_configuration_convergence_time_isis_test.go
@@ -32,7 +32,7 @@ import (
 func setISISOverloadBit(t *testing.T, dut *ondatra.DUTDevice) {
 
 	// ISIS Configs to set Overload Bit to true.
-	dutISISPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, setup.ISISInstance).Isis()
+	dutISISPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, setup.ISISInstance).Isis()
 	lspBit := dutISISPath.Global().LspBit().OverloadBit()
 	gnmi.Replace(t, dut, lspBit.SetBit().Config(), true)
 }
@@ -40,7 +40,7 @@ func setISISOverloadBit(t *testing.T, dut *ondatra.DUTDevice) {
 // setISISMetric is used to configure metric on isis interfaces.
 func setISISMetric(t *testing.T, dut *ondatra.DUTDevice) {
 
-	dutISISPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, setup.ISISInstance).Isis()
+	dutISISPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, setup.ISISInstance).Isis()
 	t.Logf("Configure ISIS metric to %v", setup.ISISMetric)
 	for _, dp := range dut.Ports() {
 		intfName := dp.Name()

--- a/feature/experimental/system/gnmi/benchmarking/ate_tests/full_configuration_replace_test/full_configuration_replace_test.go
+++ b/feature/experimental/system/gnmi/benchmarking/ate_tests/full_configuration_replace_test/full_configuration_replace_test.go
@@ -61,13 +61,13 @@ func TestGnmiFullConfigReplace(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
 	t.Log("Configure network instance on DUT")
-	dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut))
 	gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 
 	t.Log("Cleanup exisitng BGP and ISIS configs on DUT before configuring test configs")
-	dutBGPPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	dutBGPPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	gnmi.Delete(t, dut, dutBGPPath.Config())
-	dutISISPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, setup.ISISInstance).Isis()
+	dutISISPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, setup.ISISInstance).Isis()
 	gnmi.Delete(t, dut, dutISISPath.Config())
 
 	confP := gnmi.OC()

--- a/feature/experimental/system/gnmi/benchmarking/ate_tests/internal/setup/setup.go
+++ b/feature/experimental/system/gnmi/benchmarking/ate_tests/internal/setup/setup.go
@@ -116,7 +116,7 @@ func BuildBenchmarkingConfig(t *testing.T) *oc.Root {
 	buildPortIPs(dut)
 
 	// Network instance and BGP configs.
-	netInstance := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
+	netInstance := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
 
 	bgp := netInstance.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
 	global := bgp.GetOrCreateGlobal()
@@ -252,7 +252,7 @@ func BuildBenchmarkingConfig(t *testing.T) *oc.Root {
 
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
 		for _, dp := range dut.Ports() {
-			ni := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
+			ni := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
 			niIntf, _ := ni.NewInterface(dp.Name())
 			niIntf.Interface = ygot.String(dp.Name())
 			niIntf.Subinterface = ygot.Uint32(0)
@@ -321,7 +321,7 @@ func ConfigureATE(t *testing.T, ate *ondatra.ATEDevice) {
 // VerifyISISTelemetry function to used verify ISIS telemetry on DUT
 // using OC isis telemetry path.
 func VerifyISISTelemetry(t *testing.T, dut *ondatra.DUTDevice) {
-	statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, ISISInstance).Isis()
+	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, ISISInstance).Isis()
 	for _, dp := range dut.Ports() {
 		intfName := dp.Name()
 		if deviations.ExplicitInterfaceInDefaultVRF(dut) {
@@ -343,7 +343,7 @@ func VerifyISISTelemetry(t *testing.T, dut *ondatra.DUTDevice) {
 // VerifyBgpTelemetry function is to verify BGP telemetry on DUT using
 // BGP OC telemetry path.
 func VerifyBgpTelemetry(t *testing.T, dut *ondatra.DUTDevice) {
-	statePath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	for _, peerAddr := range ATEIPList {
 		nbrIP := peerAddr.String()
 		nbrPath := statePath.Neighbor(nbrIP)

--- a/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -899,8 +899,8 @@ func ConfigureDUTIntf(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, dp2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, dp2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, dp2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -368,8 +368,8 @@ func ConfigureDUTIntf(t *testing.T, dut *ondatra.DUTDevice) {
 		}
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, dp2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, dp2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, dp1)

--- a/feature/gnmi/ate_tests/telemetry_port_speed_test/telemetry_port_speed_test.go
+++ b/feature/gnmi/ate_tests/telemetry_port_speed_test/telemetry_port_speed_test.go
@@ -216,7 +216,7 @@ func (tc *testCase) configureDUT(t *testing.T) {
 	fptest.LogQuery(t, tc.aggID, aggPath.Config(), agg)
 	gnmi.Replace(t, tc.dut, aggPath.Config(), agg)
 	if deviations.ExplicitInterfaceInDefaultVRF(tc.dut) {
-		fptest.AssignToNetworkInstance(t, tc.dut, tc.aggID, *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, tc.aggID, deviations.DefaultNetworkInstance(tc.dut), 0)
 	}
 	t.Cleanup(func() {
 		gnmi.Delete(t, tc.dut, gnmi.OC().Interface(tc.aggID).Aggregation().MinLinks().Config())
@@ -228,7 +228,7 @@ func (tc *testCase) configureDUT(t *testing.T) {
 		if deviations.AggregateAtomicUpdate(tc.dut) {
 			resetBatch := &gnmi.SetBatch{}
 			if deviations.ExplicitInterfaceInDefaultVRF(tc.dut) {
-				gnmi.BatchDelete(resetBatch, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Interface(tc.aggID+".0").Config())
+				gnmi.BatchDelete(resetBatch, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(tc.dut)).Interface(tc.aggID+".0").Config())
 			}
 			gnmi.BatchDelete(resetBatch, aggPath.Config())
 			gnmi.BatchDelete(resetBatch, d.Lacp().Interface(tc.aggID).Config())

--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -914,8 +914,8 @@ func ConfigureDUTIntf(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, dp2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, dp2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, dp2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -405,8 +405,8 @@ func ConfigureDUTIntf(t *testing.T, dut *ondatra.DUTDevice) {
 		}
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, dp2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, dp2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, dp1)

--- a/feature/gnoi/system/tests/ping_test/ping_test.go
+++ b/feature/gnoi/system/tests/ping_test/ping_test.go
@@ -112,7 +112,7 @@ func TestGNOIPing(t *testing.T) {
 		t.Fatalf("Failed to get a valid IPv6 loopback address: %+v", ipv6Addrs)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, lbIntf, *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, lbIntf, deviations.DefaultNetworkInstance(dut), 0)
 	}
 	commonExpectedIPv4Reply := &spb.PingResponse{
 		Source:   ipv4Addrs[0].GetIp(),

--- a/feature/gnoi/system/tests/traceroute_test/traceroute_test.go
+++ b/feature/gnoi/system/tests/traceroute_test/traceroute_test.go
@@ -97,7 +97,7 @@ func TestGNOITraceroute(t *testing.T) {
 		t.Fatalf("Failed to get a valid IPv6 loopback address: %+v", ipv6Addrs)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, lbIntf, *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, lbIntf, deviations.DefaultNetworkInstance(dut), 0)
 	}
 	cases := []struct {
 		desc              string

--- a/feature/gribi/ate_tests/ack_in_presence_other_routes/route_ack_test.go
+++ b/feature/gribi/ate_tests/ack_in_presence_other_routes/route_ack_test.go
@@ -120,21 +120,21 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	i1 := &oc.Interface{Name: ygot.String(p1.Name())}
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutPort1))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	p2 := dut.Port(t, "port2")
 	i2 := &oc.Interface{Name: ygot.String(p2.Name())}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutPort2))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	p3 := dut.Port(t, "port3")
 	i3 := &oc.Interface{Name: ygot.String(p3.Name())}
 	gnmi.Replace(t, dut, d.Interface(p3.Name()).Config(), configInterfaceDUT(i3, &dutPort3))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p3.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	if deviations.ExplicitPortSpeed(dut) {
@@ -208,18 +208,18 @@ type testArgs struct {
 func configureNetworkInstance(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
-	dutConfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut))
 	gnmi.Replace(t, dut, dutConfPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 }
 
 // configStaticRoute configures a static route.
 func configStaticRoute(t *testing.T, dut *ondatra.DUTDevice, prefix string, nexthop string) {
-	ni := oc.NetworkInstance{Name: deviations.DefaultNetworkInstance}
+	ni := oc.NetworkInstance{Name: ygot.String(deviations.DefaultNetworkInstance(dut))}
 	static := ni.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
 	sr := static.GetOrCreateStatic(prefix)
 	nh := sr.GetOrCreateNextHop("0")
 	nh.NextHop = oc.UnionString(nexthop)
-	gnmi.Update(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName).Config(), static)
+	gnmi.Update(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName).Config(), static)
 }
 
 // routeAck configures a IPv4 entry through clientA. Ensure that the entry via ClientA
@@ -228,12 +228,12 @@ func routeAck(ctx context.Context, t *testing.T, args *testArgs) {
 	// Add an IPv4Entry for 203.0.113.0/24 pointing to ATE port-3 via gRIBI-A,
 	// ensure that the entry is active through AFT telemetry
 	t.Logf("Add an IPv4Entry for %s pointing to ATE port-3 via gRIBI-A", ateDstNetCIDR)
-	args.clientA.AddNH(t, nhIndex, atePort3.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	args.clientA.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex, *deviations.DefaultNetworkInstance, "", fluent.InstalledInRIB)
+	args.clientA.AddNH(t, nhIndex, atePort3.IPv4, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	args.clientA.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex, deviations.DefaultNetworkInstance(args.dut), "", fluent.InstalledInRIB)
 
 	// Verify the entry for 203.0.113.0/24 is active through AFT Telemetry.
-	ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
 		pre, present := val.Val()
 		return present && pre == ateDstNetCIDR
@@ -264,7 +264,7 @@ func TestRouteAck(t *testing.T) {
 	t.Logf("Configure the DUT with static route 203.0.113.0/24...")
 	configStaticRoute(t, dut, ateDstNetCIDR, staticNH)
 	// Verify the entry for 203.0.113.0/24 is active through AFT Telemetry.
-	ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	if got, ok := gnmi.Watch(t, dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
 		pre, present := val.Val()
 		return present && pre == ateDstNetCIDR

--- a/feature/gribi/ate_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
+++ b/feature/gribi/ate_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
@@ -233,12 +233,12 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p4)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p4.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p3.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p4.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
-		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, deviations.DefaultNetworkInstance(dut))
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrf1)
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrf2)
 	}
@@ -328,19 +328,19 @@ func (a *testArgs) testIPv4BackUpSwitch(t *testing.T) {
 	)
 
 	t.Logf("Program a backup pointing to vrfB via gRIBI")
-	a.client.AddNH(t, nhid3, "VRFOnly", *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHOptions{VrfName: vrf2})
-	a.client.AddNHG(t, backupnhgid, map[uint64]uint64{nhid3: 10}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	a.client.AddNH(t, nhid3, "VRFOnly", deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB, &gribi.NHOptions{VrfName: vrf2})
+	a.client.AddNHG(t, backupnhgid, map[uint64]uint64{nhid3: 10}, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
 
 	t.Logf("an IPv4Entry for %s in %s pointing to ATE port-2 and port-3 via gRIBI", dstPfx, vrf1)
-	a.client.AddNH(t, nhid1, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	a.client.AddNH(t, nhid2, atePort3.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	a.client.AddNHG(t, nhgid1, map[uint64]uint64{nhid1: 80, nhid2: 20}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: backupnhgid})
-	a.client.AddIPv4(t, dstPfx, nhgid1, vrf1, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	a.client.AddNH(t, nhid1, atePort2.IPv4, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
+	a.client.AddNH(t, nhid2, atePort3.IPv4, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
+	a.client.AddNHG(t, nhgid1, map[uint64]uint64{nhid1: 80, nhid2: 20}, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: backupnhgid})
+	a.client.AddIPv4(t, dstPfx, nhgid1, vrf1, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
 
 	t.Logf("an IPv4Entry for %s in %s pointing to ATE port-4 via gRIBI", dstPfx, vrf2)
-	a.client.AddNH(t, nhid4, atePort4.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	a.client.AddNHG(t, nhgid2, map[uint64]uint64{nhid4: 100}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	a.client.AddIPv4(t, dstPfx, nhgid2, vrf2, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	a.client.AddNH(t, nhid4, atePort4.IPv4, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
+	a.client.AddNHG(t, nhgid2, map[uint64]uint64{nhid4: 100}, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
+	a.client.AddIPv4(t, dstPfx, nhgid2, vrf2, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
 
 	// validate programming using AFT
 	// TODO: add checks for NHs when AFT OC schema concludes how viability should be indicated.
@@ -452,7 +452,7 @@ func (a *testArgs) aftCheck(t testing.TB, prefix string, instance string) {
 	nhg, _ := aftPfxNHGVal.Val()
 
 	// using NHG ID validate NH
-	aftNHG := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().NextHopGroup(nhg).State())
+	aftNHG := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(a.dut)).Afts().NextHopGroup(nhg).State())
 	if len(aftNHG.NextHop) == 0 && aftNHG.BackupNextHopGroup == nil {
 		t.Fatalf("Prefix %s references a NHG that has neither NH or backup NHG", prefix)
 	}

--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/base_hierarchical_route_installation_test.go
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/base_hierarchical_route_installation_test.go
@@ -118,8 +118,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 
@@ -200,20 +200,20 @@ func setupRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 	// Add an IPv4Entry for 198.51.100.0/24 pointing to 203.0.113.1/32.
 	args.c.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithIndex(nhIndex).
 			WithIPAddress(ateIndirectNH))
 
 	args.c.Modify().AddEntry(t,
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithID(nhgIndex).
 			AddNextHop(nhIndex, 1))
 
 	args.c.Modify().AddEntry(t,
 		fluent.IPv4Entry().
 			WithPrefix(ateDstNetCIDR).
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithNextHopGroup(nhgIndex))
 
 	if err := awaitTimeout(args.ctx, args.c, t, time.Minute); err != nil {
@@ -223,20 +223,20 @@ func setupRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 	// Add an IPv4Entry for 203.0.113.1/32 pointing to 192.0.2.6.
 	args.c.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithIndex(nhIndex2).
 			WithIPAddress(atePort2.IPv4))
 
 	args.c.Modify().AddEntry(t,
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithID(nhgIndex2).
 			AddNextHop(nhIndex2, 1))
 
 	args.c.Modify().AddEntry(t,
 		fluent.IPv4Entry().
 			WithPrefix(ateIndirectNHCIDR).
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithNextHopGroup(nhgIndex2))
 
 	if err := awaitTimeout(args.ctx, args.c, t, time.Minute); err != nil {
@@ -268,7 +268,7 @@ func deleteRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 	args.c.Modify().DeleteEntry(t,
 		fluent.IPv4Entry().
 			WithPrefix(ateIndirectNHCIDR).
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithNextHopGroup(nhgIndex2))
 
 	if err := awaitTimeout(args.ctx, args.c, t, time.Minute); err != nil {
@@ -291,25 +291,25 @@ func deleteRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 func testRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 	setupRecursiveIPv4Entry(t, args)
 
-	aftsPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts()
+	aftsPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts()
 	fptest.LogQuery(t, "AFTs", aftsPath.State(), gnmi.Get(t, args.dut, aftsPath.State()))
 
 	// Verify that the entry for 198.51.100.0/24 (a) is installed through AFT Telemetry. a->c or a->b are the expected results.
-	ipv4Entry := gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR).State())
+	ipv4Entry := gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR).State())
 	if got, want := ipv4Entry.GetPrefix(), ateDstNetCIDR; got != want {
 		t.Errorf("TestRecursiveIPv4Entry: ipv4-entry/state/prefix = %v, want %v", got, want)
 	}
 	if got, want := ipv4Entry.GetOriginProtocol(), oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_GRIBI; got != want {
 		t.Errorf("TestRecursiveIPv4Entry: ipv4-entry/state/origin-protocol = %v, want %v", got, want)
 	}
-	if got, want := ipv4Entry.GetNextHopGroupNetworkInstance(), *deviations.DefaultNetworkInstance; got != want {
+	if got, want := ipv4Entry.GetNextHopGroupNetworkInstance(), deviations.DefaultNetworkInstance(args.dut); got != want {
 		t.Errorf("TestRecursiveIPv4Entry: ipv4-entry/state/next-hop-group-network-instance = %v, want %v", got, want)
 	}
 	nhgIndexInst := ipv4Entry.GetNextHopGroup()
 	if nhgIndexInst == 0 {
 		t.Errorf("TestRecursiveIPv4Entry: ipv4-entry/state/next-hop-group is not present")
 	}
-	nhg := gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().NextHopGroup(nhgIndexInst).State())
+	nhg := gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().NextHopGroup(nhgIndexInst).State())
 	if got, want := nhg.GetProgrammedId(), uint64(nhgIndex); got != want {
 		t.Errorf("TestRecursiveIPv4Entry: next-hop-group/state/programmed-id = %v, want %v", got, want)
 	}
@@ -318,7 +318,7 @@ func testRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 		if got, want := nhgNH.GetIndex(), uint64(nhIndexInst); got != want {
 			t.Errorf("next-hop index is incorrect: got %v, want %v", got, want)
 		}
-		nh := gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().NextHop(nhIndexInst).State())
+		nh := gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().NextHop(nhIndexInst).State())
 		// for devices that return  the nexthop with resolving it recursively. For a->b->c the device returns c
 		if got := nh.GetIpAddress(); got != atePort2.IPv4 && got != ateIndirectNH {
 			t.Errorf("next-hop is incorrect: got %v, want %v or %v ", got, ateIndirectNH, atePort2.IPv4)
@@ -326,21 +326,21 @@ func testRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 	}
 
 	// Verify that the entry for 203.0.113.1/32 (b) is installed through AFT Telemetry. b->c is the expected result.
-	ipv4Entry = gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateIndirectNHCIDR).State())
+	ipv4Entry = gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateIndirectNHCIDR).State())
 	if got, want := ipv4Entry.GetPrefix(), ateIndirectNHCIDR; got != want {
 		t.Errorf("TestRecursiveIPv4Entry = %v: ipv4-entry/state/prefix, want %v", got, want)
 	}
 	if got, want := ipv4Entry.GetOriginProtocol(), oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_GRIBI; got != want {
 		t.Errorf("TestRecursiveIPv4Entry: ipv4-entry/state/origin-protocol = %v, want %v", got, want)
 	}
-	if got, want := ipv4Entry.GetNextHopGroupNetworkInstance(), *deviations.DefaultNetworkInstance; got != want {
+	if got, want := ipv4Entry.GetNextHopGroupNetworkInstance(), deviations.DefaultNetworkInstance(args.dut); got != want {
 		t.Errorf("TestRecursiveIPv4Entry: ipv4-entry/state/next-hop-group-network-instance = %v, want %v", got, want)
 	}
 	nhgIndexInst = ipv4Entry.GetNextHopGroup()
 	if nhgIndexInst == 0 {
 		t.Errorf("TestRecursiveIPv4Entry: ipv4-entry/state/next-hop-group is not present")
 	}
-	nhg = gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().NextHopGroup(nhgIndexInst).State())
+	nhg = gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().NextHopGroup(nhgIndexInst).State())
 	if got, want := nhg.GetProgrammedId(), uint64(nhgIndex2); got != want {
 		t.Errorf("TestRecursiveIPv4Entry: next-hop-group/state/programmed-id = %v, want %v", got, want)
 	}
@@ -349,7 +349,7 @@ func testRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 		if got, want := nhgNH.GetIndex(), uint64(nhIndexInst); got != want {
 			t.Errorf("next-hop index is incorrect: got %v, want %v", got, want)
 		}
-		nh := gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().NextHop(nhIndexInst).State())
+		nh := gnmi.Get(t, args.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().NextHop(nhIndexInst).State())
 		if got, want := nh.GetIpAddress(), atePort2.IPv4; got != want {
 			t.Errorf("next-hop is incorrect: got %v, want %v", got, want)
 		}
@@ -374,7 +374,7 @@ func testRecursiveIPv4Entry(t *testing.T, args *testArgs) {
 	time.Sleep(30 * time.Second)
 
 	// Verify that the entry for 198.51.100.0/24 is not installed through AFT Telemetry.
-	ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateIndirectNHCIDR)
+	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateIndirectNHCIDR)
 	if gnmi.Lookup(t, args.dut, ipv4Path.State()).IsPresent() {
 		t.Errorf("TestRecursiveIPv4Entry: ipv4-entry/state/prefix: Found route %s that should not exist", ateIndirectNHCIDR)
 	}

--- a/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
+++ b/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
@@ -118,21 +118,21 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	i1 := &oc.Interface{Name: ygot.String(p1.Name())}
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutPort1))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	p2 := dut.Port(t, "port2")
 	i2 := &oc.Interface{Name: ygot.String(p2.Name())}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutPort2))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	p3 := dut.Port(t, "port3")
 	i3 := &oc.Interface{Name: ygot.String(p3.Name())}
 	gnmi.Replace(t, dut, d.Interface(p3.Name()).Config(), configInterfaceDUT(i3, &dutPort3))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p3.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, p1)
@@ -215,13 +215,13 @@ func testIPv4LeaderActiveChange(ctx context.Context, t *testing.T, args *testArg
 	// ensure that the entry is active through AFT telemetry and traffic.
 	t.Logf("an IPv4Entry for %s pointing to ATE port-3 via gRIBI-B", ateDstNetCIDR)
 	args.clientB.BecomeLeader(t)
-	args.clientB.AddNH(t, nhIndex, atePort3.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	args.clientB.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	args.clientB.AddIPv4(t, ateDstNetCIDR, nhgIndex, *deviations.DefaultNetworkInstance, "", fluent.InstalledInRIB)
+	args.clientB.AddNH(t, nhIndex, atePort3.IPv4, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	args.clientB.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	args.clientB.AddIPv4(t, ateDstNetCIDR, nhgIndex, deviations.DefaultNetworkInstance(args.dut), "", fluent.InstalledInRIB)
 
 	// Verify the entry for 198.51.100.0/24 is active through AFT Telemetry.
 	t.Logf("Verify the entry for %s is active through AFT Telemetry.", ateDstNetCIDR)
-	ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	gnmi.Await(t, args.dut, ipv4Path.Prefix().State(), time.Minute, ateDstNetCIDR)
 
 	// Verify the entry for 198.51.100.0/24 is active through Traffic.
@@ -232,22 +232,22 @@ func testIPv4LeaderActiveChange(ctx context.Context, t *testing.T, args *testArg
 	// Add an IPv4Entry for 198.51.100.0/24 pointing to ATE port-2 via gRIBI-A,
 	// ensure that the entry is ignored by the DUT.
 	t.Logf("Adding an IPv4Entry for %s pointing to ATE port-2 via gRIBI-A", ateDstNetCIDR)
-	args.clientA.AddNH(t, nhIndex+1, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.ProgrammingFailed)
-	args.clientA.AddNHG(t, nhgIndex+1, map[uint64]uint64{nhIndex + 1: 1}, *deviations.DefaultNetworkInstance, fluent.ProgrammingFailed)
-	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex+1, *deviations.DefaultNetworkInstance, "", fluent.ProgrammingFailed)
+	args.clientA.AddNH(t, nhIndex+1, atePort2.IPv4, deviations.DefaultNetworkInstance(args.dut), fluent.ProgrammingFailed)
+	args.clientA.AddNHG(t, nhgIndex+1, map[uint64]uint64{nhIndex + 1: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.ProgrammingFailed)
+	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex+1, deviations.DefaultNetworkInstance(args.dut), "", fluent.ProgrammingFailed)
 
 	// Send a ModifyRequest from gRIBI-A updating its election_id to make it leader,
 	// followed by a ModifyRequest updating 198.51.100.0/24 pointing to ATE port-2,
 	// ensure that routing is updated to receive packets for 198.51.100.0/24 at ATE port-2.
 	args.clientA.BecomeLeader(t)
 	t.Logf("Adding an IPv4Entry for %s pointing to ATE port-2 via client gRIBI-A", ateDstNetCIDR)
-	args.clientA.AddNH(t, nhIndex+2, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	args.clientA.AddNHG(t, nhgIndex+2, map[uint64]uint64{nhIndex + 2: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex+2, *deviations.DefaultNetworkInstance, "", fluent.InstalledInRIB)
+	args.clientA.AddNH(t, nhIndex+2, atePort2.IPv4, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	args.clientA.AddNHG(t, nhgIndex+2, map[uint64]uint64{nhIndex + 2: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex+2, deviations.DefaultNetworkInstance(args.dut), "", fluent.InstalledInRIB)
 
 	// Verify the entry for 198.51.100.0/24 is active through AFT Telemetry.
 	t.Logf("Verify the entry for %s is active through AFT Telemetry.", ateDstNetCIDR)
-	ipv4Path = gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+	ipv4Path = gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	gnmi.Await(t, args.dut, ipv4Path.Prefix().State(), time.Minute, ateDstNetCIDR)
 
 	// Verify with traffic that the entry for 198.51.100.0/24 is installed through the ATE port-2.

--- a/feature/gribi/ate_tests/get_rpc_test/get_rpc_test.go
+++ b/feature/gribi/ate_tests/get_rpc_test/get_rpc_test.go
@@ -128,8 +128,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 
@@ -170,19 +170,19 @@ type testArgs struct {
 }
 
 // helperAddEntry configures a sequence of adding the NH, NHG and IPv4Entry by a client.
-func helperAddEntry(ctx context.Context, t *testing.T, client *fluent.GRIBIClient, nextHop string, ipPrefix string) {
+func helperAddEntry(ctx context.Context, t *testing.T, client *fluent.GRIBIClient, nextHop string, ipPrefix string, dut *ondatra.DUTDevice) {
 	t.Helper()
 	client.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 			WithIndex(nhIndex).
 			WithIPAddress(nextHop),
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 			WithID(nhgIndex).
 			AddNextHop(nhIndex, 1),
 		fluent.IPv4Entry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 			WithPrefix(ipPrefix).
 			WithNextHopGroup(nhgIndex),
 	)
@@ -199,7 +199,7 @@ func helperAddEntry(ctx context.Context, t *testing.T, client *fluent.GRIBIClien
 func configureIPv4ViaClientB(t *testing.T, args *testArgs) {
 	for _, cidr := range ateDstNetCIDR {
 		t.Logf("Adding an IPv4Entry for %s pointing to ATE port-2 via clientB.", cidr)
-		helperAddEntry(args.ctx, t, args.clientB, atePort2.IPv4, cidr)
+		helperAddEntry(args.ctx, t, args.clientB, atePort2.IPv4, cidr, args.dut)
 
 		// Verify the entry is not installed due to client B having lower election ID.
 		chk.HasResult(t, args.clientB.Results(t),
@@ -222,13 +222,13 @@ func configureIPv4ViaClientAInstalled(t *testing.T, args *testArgs) {
 	// once gribi/gribigo in google3 is updated.
 	args.clientA.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithIndex(nhIndex).
 			WithIPAddress(atePort2.IPv4))
 
 	args.clientA.Modify().AddEntry(t,
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithID(nhgIndex).
 			AddNextHop(nhIndex, 1))
 
@@ -236,7 +236,7 @@ func configureIPv4ViaClientAInstalled(t *testing.T, args *testArgs) {
 		args.clientA.Modify().AddEntry(t,
 			fluent.IPv4Entry().
 				WithPrefix(ateDstNetCIDR[ip]).
-				WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 				WithNextHopGroup(nhgIndex))
 	}
 
@@ -307,7 +307,7 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 
 	// Verify the above entries are active through AFT Telemetry.
 	for ip := range ateDstNetCIDR {
-		ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR[ip])
+		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR[ip])
 		if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR[ip]; got != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
@@ -324,13 +324,13 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	// and ensure that only entries for 198.51.100.0/26, 198.51.100.64/26, 198.51.100.128/26
 	// are returned, with no entry returned for 198.51.100.192/64.
 	dc := gnmi.OC()
-	niProto := dc.NetworkInstance(*deviations.DefaultNetworkInstance).
+	niProto := dc.NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 		Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
 
-	dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut))
 	gnmi.Replace(t, args.dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 
-	ni := &oc.NetworkInstance{Name: deviations.DefaultNetworkInstance}
+	ni := &oc.NetworkInstance{Name: ygot.String(deviations.DefaultNetworkInstance(args.dut))}
 	static := ni.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
 	staticRoute := static.GetOrCreateStatic(staticCIDR)
 	nextHop := staticRoute.GetOrCreateNextHop("0")
@@ -338,7 +338,7 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	gnmi.Update(t, args.dut, niProto.Config(), static)
 	validateGetRPC(ctx, t, args.clientA)
 	for ip := range ateDstNetCIDR {
-		ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR[ip])
+		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR[ip])
 		if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR[ip]; got != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
@@ -349,15 +349,15 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	// that the entry for 203.0.113.0/24 is not returned.
 	args.clientA.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithIndex(1000+nhIndex).
 			WithIPAddress(unresolvedNextHop),
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithID(1000+nhgIndex).
 			AddNextHop(1000+nhIndex, 1),
 		fluent.IPv4Entry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithPrefix(ipv4Prefix).
 			WithNextHopGroup(1000+nhgIndex),
 	)

--- a/feature/gribi/ate_tests/gribigo_compliance_test/gribigo_compliance_test.go
+++ b/feature/gribi/ate_tests/gribigo_compliance_test/gribigo_compliance_test.go
@@ -133,7 +133,7 @@ func TestCompliance(t *testing.T) {
 			if reason := shouldSkip(tt); reason != "" {
 				t.Skip(reason)
 			}
-			compliance.SetDefaultNetworkInstanceName(*deviations.DefaultNetworkInstance)
+			compliance.SetDefaultNetworkInstanceName(deviations.DefaultNetworkInstance(dut))
 			compliance.SetNonDefaultVRFName(*nonDefaultNI)
 
 			c := fluent.NewClient()
@@ -186,16 +186,16 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p3)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p3.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	d := &oc.Root{}
 	ni := d.GetOrCreateNetworkInstance(*nonDefaultNI)
 	ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*nonDefaultNI).Config(), ni)
 	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
-		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, deviations.DefaultNetworkInstance(dut))
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *nonDefaultNI)
 	}
 	nip := gnmi.OC().NetworkInstance(*nonDefaultNI)

--- a/feature/gribi/ate_tests/ipv4_entry_test/ipv4_entry_test.go
+++ b/feature/gribi/ate_tests/ipv4_entry_test/ipv4_entry_test.go
@@ -134,11 +134,11 @@ func TestIPv4Entry(t *testing.T) {
 		{
 			desc: "Single next-hop",
 			entries: []fluent.GRIBIEntry{
-				fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithIndex(nh1ID).WithIPAddress(atePort2.IPv4),
-				fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithID(nhgID).AddNextHop(nh1ID, 1),
-				fluent.IPv4Entry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithPrefix(dstPfx).WithNextHopGroup(nhgID),
 			},
 			wantGoodFlows: []*ondatra.Flow{port2Flow},
@@ -164,13 +164,13 @@ func TestIPv4Entry(t *testing.T) {
 		{
 			desc: "Multiple next-hops",
 			entries: []fluent.GRIBIEntry{
-				fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithIndex(nh1ID).WithIPAddress(atePort2.IPv4),
-				fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithIndex(nh2ID).WithIPAddress(atePort3.IPv4),
-				fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithID(nhgID).AddNextHop(nh1ID, 1).AddNextHop(nh2ID, 1),
-				fluent.IPv4Entry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithPrefix(dstPfx).WithNextHopGroup(nhgID),
 			},
 			wantGoodFlows: []*ondatra.Flow{ecmpFlow},
@@ -200,13 +200,13 @@ func TestIPv4Entry(t *testing.T) {
 		{
 			desc: "Multiple next-hops with MAC override",
 			entries: []fluent.GRIBIEntry{
-				fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithIndex(nh1ID).WithInterfaceRef(dut.Port(t, "port2").Name()).WithMacAddress(staticDstMAC),
-				fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithIndex(nh2ID).WithInterfaceRef(dut.Port(t, "port3").Name()).WithMacAddress(staticDstMAC),
-				fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithID(nhgID).AddNextHop(nh1ID, 1).AddNextHop(nh2ID, 1),
-				fluent.IPv4Entry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithPrefix(dstPfx).WithNextHopGroup(nhgID),
 			},
 			wantGoodFlows: []*ondatra.Flow{ecmpFlow},
@@ -237,9 +237,9 @@ func TestIPv4Entry(t *testing.T) {
 		{
 			desc: "Nonexistant next-hop",
 			entries: []fluent.GRIBIEntry{
-				fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithID(nhgID).AddNextHop(badNH, 1),
-				fluent.IPv4Entry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithPrefix(dstPfx).WithNextHopGroup(nhgID),
 			},
 			wantBadFlows: []*ondatra.Flow{port2Flow, port3Flow},
@@ -260,12 +260,12 @@ func TestIPv4Entry(t *testing.T) {
 			desc:     "Downed next-hop interface",
 			downPort: ate.Port(t, "port2"),
 			entries: []fluent.GRIBIEntry{
-				fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithIndex(nh1ID).WithIPAddress(atePort2.IPv4).
 					WithInterfaceRef(dut.Port(t, "port2").Name()).WithMacAddress(staticDstMAC),
-				fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithID(nhgID).AddNextHop(nh1ID, 1),
-				fluent.IPv4Entry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithPrefix(dstPfx).WithNextHopGroup(nhgID),
 			},
 			wantBadFlows: []*ondatra.Flow{port2Flow, port3Flow},
@@ -310,13 +310,13 @@ func TestIPv4Entry(t *testing.T) {
 						gnmi.Update(t, dut, d.Interface(p3.Name()).Config(), configStaticArp(t, p3, "192.0.2.42", staticDstMAC))
 						//Programming a gRIBI flow with above IP/mac-address as the next-hop entry
 						tc.entries = []fluent.GRIBIEntry{
-							fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+							fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 								WithIndex(nh1ID).WithInterfaceRef(dut.Port(t, "port2").Name()).WithIPAddress("192.0.2.22").WithMacAddress(staticDstMAC),
-							fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+							fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 								WithIndex(nh2ID).WithInterfaceRef(dut.Port(t, "port3").Name()).WithIPAddress("192.0.2.42").WithMacAddress(staticDstMAC),
-							fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+							fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 								WithID(nhgID).AddNextHop(nh1ID, 1).AddNextHop(nh2ID, 1),
-							fluent.IPv4Entry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+							fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 								WithPrefix(dstPfx).WithNextHopGroup(nhgID),
 						}
 
@@ -409,9 +409,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p3)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p3.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/gribi/ate_tests/ordering_ack_test/ordering_ack_test.go
+++ b/feature/gribi/ate_tests/ordering_ack_test/ordering_ack_test.go
@@ -132,8 +132,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 
@@ -210,11 +210,11 @@ type testCaseFunc func(t *testing.T, args *testArgs)
 func testModifyNHG(t *testing.T, args *testArgs) {
 	args.c.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithIndex(nhIndex).
 			WithIPAddress(ateDst.IPv4),
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithID(nhgIndex).
 			AddNextHop(nhIndex, nhWeight),
 	)
@@ -241,7 +241,7 @@ func testModifyNHG(t *testing.T, args *testArgs) {
 	)
 
 	t.Run("Telemetry", func(t *testing.T) {
-		got, err := aftNextHopWeights(t, args.dut, nhgIndex, *deviations.DefaultNetworkInstance)
+		got, err := aftNextHopWeights(t, args.dut, nhgIndex, deviations.DefaultNetworkInstance(args.dut))
 		if err != nil {
 			t.Errorf("Error getting weights for nhg %d : %v", nhIndex, err)
 		} else {
@@ -263,15 +263,15 @@ func testModifyNHG(t *testing.T, args *testArgs) {
 func testModifyIPv4NHG(t *testing.T, args *testArgs) {
 	args.c.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithIndex(nhIndex).
 			WithIPAddress(ateDst.IPv4),
 		fluent.IPv4Entry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithPrefix(ateDstNetCIDR).
 			WithNextHopGroup(nhgIndex),
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithID(nhgIndex).
 			AddNextHop(nhIndex, nhWeight),
 	)
@@ -294,15 +294,15 @@ func testModifyIPv4NHG(t *testing.T, args *testArgs) {
 func testModifyNHGIPv4(t *testing.T, args *testArgs) {
 	args.c.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithIndex(nhIndex).
 			WithIPAddress(ateDst.IPv4),
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithID(nhgIndex).
 			AddNextHop(nhIndex, nhWeight),
 		fluent.IPv4Entry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithPrefix(ateDstNetCIDR).
 			WithNextHopGroup(nhgIndex),
 	)
@@ -337,7 +337,7 @@ func testModifyNHGIPv4(t *testing.T, args *testArgs) {
 	)
 
 	t.Run("Telemetry", func(t *testing.T) {
-		got, err := aftNextHopWeights(t, args.dut, nhgIndex, *deviations.DefaultNetworkInstance)
+		got, err := aftNextHopWeights(t, args.dut, nhgIndex, deviations.DefaultNetworkInstance(args.dut))
 		if err != nil {
 			t.Errorf("Error getting weights for nhg %d : %v", nhIndex, err)
 		} else {
@@ -350,7 +350,7 @@ func testModifyNHGIPv4(t *testing.T, args *testArgs) {
 					t.Errorf("next-hop-group/next-hop/state/weight got %v, want %v", got, want)
 				}
 			}
-			ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+			ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 			if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR; got != want {
 				t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 			}
@@ -391,7 +391,7 @@ func testModifyIPv4AddDelAdd(t *testing.T, args *testArgs) {
 	testModifyNHG(t, args) // Uses operation IDs 1 and 2.
 
 	ent := fluent.IPv4Entry().
-		WithNetworkInstance(*deviations.DefaultNetworkInstance).
+		WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 		WithPrefix(ateDstNetCIDR).
 		WithNextHopGroup(nhgIndex)
 
@@ -430,7 +430,7 @@ func testModifyIPv4AddDelAdd(t *testing.T, args *testArgs) {
 	)
 
 	t.Run("Telemetry", func(t *testing.T) {
-		ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 		if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR; got != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}

--- a/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -179,7 +179,7 @@ func TestRouteRemovalNonDefaultVRFFlush(t *testing.T) {
 	injectIPEntry(ctx, t, dut, clientB, nonDefaultVRF, ateDstNetEntryNonDefault)
 
 	t.Log("Inject entry for 203.0.113.0/24 in default VRF from gRIBI-B. This function also verifies entry via telemetry.")
-	injectIPEntry(ctx, t, dut, clientB, *deviations.DefaultNetworkInstance, ateDstNetEntryDefault)
+	injectIPEntry(ctx, t, dut, clientB, deviations.DefaultNetworkInstance(dut), ateDstNetEntryDefault)
 
 	t.Run("flushNonZeroReference", func(t *testing.T) {
 		t.Log("After re-injecting entries, flush RPC from gRIBI-B for default VRF expected to return NON_ZERO_REFERENCE_REMAIN result.")
@@ -270,7 +270,7 @@ func flushNonZeroReference(ctx context.Context, t *testing.T, dut *ondatra.DUTDe
 	}
 
 	t.Log("Issue Flush RPC from gRIBI-B for default VRF. It expected to return NON_ZERO_REFERENCE_REMAIN result.")
-	flushRes, _ := gribi.Flush(clientB.Fluent(t), clientB.ElectionID(), *deviations.DefaultNetworkInstance)
+	flushRes, _ := gribi.Flush(clientB.Fluent(t), clientB.ElectionID(), deviations.DefaultNetworkInstance(dut))
 
 	wantRes := &gpb.FlushResponse{
 		Result: gpb.FlushResponse_NON_ZERO_REFERENCE_REMAIN,
@@ -297,11 +297,11 @@ func flushNonZeroReference(ctx context.Context, t *testing.T, dut *ondatra.DUTDe
 	}
 
 	t.Log("Ensure that 203.0.113.0/24 (ateDstNetEntryDefault) has been removed by validating telemetry.")
-	entry = verifyEntry(t, dut, *deviations.DefaultNetworkInstance, ateDstNetEntryDefault)
+	entry = verifyEntry(t, dut, deviations.DefaultNetworkInstance(dut), ateDstNetEntryDefault)
 	if entry {
 		t.Errorf("ipv4-entry/state/prefix contains entry %s, expected no entry", ateDstNetEntryDefault)
 	} else {
-		t.Logf("IP Entry for %s has been successfully removed from network instance: %s as confirmed from telemetry.", ateDstNetEntryDefault, *deviations.DefaultNetworkInstance)
+		t.Logf("IP Entry for %s has been successfully removed from network instance: %s as confirmed from telemetry.", ateDstNetEntryDefault, deviations.DefaultNetworkInstance(dut))
 	}
 }
 
@@ -321,10 +321,10 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
-		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, deviations.DefaultNetworkInstance(dut))
 	}
 }
 
@@ -407,15 +407,15 @@ func verifyEntry(t *testing.T, dut *ondatra.DUTDevice, networkInstanceName strin
 // injectEntries adds a fully referenced IP Entry, NH and NHG.
 func injectEntries(ctx context.Context, t *testing.T, dut *ondatra.DUTDevice, client *gribi.Client, networkInstanceName string, ateDstNetCIDR string) {
 	t.Logf("Add an IPv4Entry for %s pointing to ATE port-2 via gRIBI client", ateDstNetCIDR)
-	client.AddNH(t, nhIndex, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	client.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	client.AddIPv4(t, ateDstNetCIDR, nhgIndex, networkInstanceName, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
+	client.AddNH(t, nhIndex, atePort2.IPv4, deviations.DefaultNetworkInstance(dut), fluent.InstalledInRIB)
+	client.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, deviations.DefaultNetworkInstance(dut), fluent.InstalledInRIB)
+	client.AddIPv4(t, ateDstNetCIDR, nhgIndex, networkInstanceName, deviations.DefaultNetworkInstance(dut), fluent.InstalledInRIB)
 }
 
 // injectIPEntry adds only IPv4 entry to the specified network instance referencing to the nhgid, to the VRF.
 func injectIPEntry(ctx context.Context, t *testing.T, dut *ondatra.DUTDevice, client *gribi.Client, networkInstanceName string, ateDstNetCIDR string) {
 	t.Logf("Add an IPv4Entry for %s via gRIBI client's %s network instance", ateDstNetCIDR, networkInstanceName)
-	client.AddIPv4(t, ateDstNetCIDR, nhgIndex, networkInstanceName, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
+	client.AddIPv4(t, ateDstNetCIDR, nhgIndex, networkInstanceName, deviations.DefaultNetworkInstance(dut), fluent.InstalledInRIB)
 
 	// After adding the entry, verify the entry is active through AFT Telemetry.
 	ipv4Path := gnmi.OC().NetworkInstance(networkInstanceName).Afts().Ipv4Entry(ateDstNetCIDR)

--- a/feature/gribi/ate_tests/route_removal_via_flush_test/route_removal_via_flush_test.go
+++ b/feature/gribi/ate_tests/route_removal_via_flush_test/route_removal_via_flush_test.go
@@ -158,7 +158,7 @@ func TestRouteRemovelViaFlush(t *testing.T) {
 func testFlushWithDefaultNetworkInstance(ctx context.Context, t *testing.T, args *testArgs) {
 	// Inject an entry into the default network instance pointing to ATE port-2.
 	// clientA is primary client
-	injectEntry(ctx, t, args.clientA, *deviations.DefaultNetworkInstance)
+	injectEntry(ctx, t, args.clientA, deviations.DefaultNetworkInstance(args.dut))
 	srcEndPoint := args.ateTop.Interfaces()[atePort1.Name]
 	dstEndPoint := args.ateTop.Interfaces()[atePort2.Name]
 	// Test traffic between ATE port-1 and ATE port-2.
@@ -169,7 +169,7 @@ func testFlushWithDefaultNetworkInstance(ctx context.Context, t *testing.T, args
 		t.Log("Traffic can be forwarded between ATE port-1 and ATE port-2")
 	}
 	// Flush should delete all entries
-	if _, err := gribi.Flush(args.clientA, args.electionID, *deviations.DefaultNetworkInstance); err != nil {
+	if _, err := gribi.Flush(args.clientA, args.electionID, deviations.DefaultNetworkInstance(args.dut)); err != nil {
 		t.Errorf("Unexpected error from flush, got: %v", err)
 	}
 	// After flush, left entry should be 0, and packets can no longer be forwarded.
@@ -179,19 +179,19 @@ func testFlushWithDefaultNetworkInstance(ctx context.Context, t *testing.T, args
 	} else {
 		t.Log("Traffic can not be forwarded between ATE port-1 and ATE port-2")
 	}
-	if got, want := checkNIHasNEntries(ctx, args.clientA, *deviations.DefaultNetworkInstance, t), 0; got != want {
+	if got, want := checkNIHasNEntries(ctx, args.clientA, deviations.DefaultNetworkInstance(args.dut), t), 0; got != want {
 		t.Errorf("Network instance has %d entry/entries, wanted: %d", got, want)
 	}
 
 	// clientA is primary client
-	injectEntry(ctx, t, args.clientA, *deviations.DefaultNetworkInstance)
+	injectEntry(ctx, t, args.clientA, deviations.DefaultNetworkInstance(args.dut))
 
 	// flush should fail, and preserve 3 entries.
-	if res, err := gribi.Flush(args.clientB, args.electionID.Decrement(), *deviations.DefaultNetworkInstance); err == nil {
+	if res, err := gribi.Flush(args.clientB, args.electionID.Decrement(), deviations.DefaultNetworkInstance(args.dut)); err == nil {
 		t.Errorf("Flush should return an error, got response: %v", res)
 	}
 
-	if got, want := checkNIHasNEntries(ctx, args.clientB, *deviations.DefaultNetworkInstance, t), 3; got != want {
+	if got, want := checkNIHasNEntries(ctx, args.clientB, deviations.DefaultNetworkInstance(args.dut), t), 3; got != want {
 		t.Errorf("Network instance has %d entry/entries, wanted: %d", got, want)
 	}
 
@@ -199,10 +199,10 @@ func testFlushWithDefaultNetworkInstance(ctx context.Context, t *testing.T, args
 	eID := gribi.BecomeLeader(t, args.clientB)
 
 	// Flush should be succeed and 0 entry left.
-	if _, err := gribi.Flush(args.clientB, eID, *deviations.DefaultNetworkInstance); err != nil {
+	if _, err := gribi.Flush(args.clientB, eID, deviations.DefaultNetworkInstance(args.dut)); err != nil {
 		t.Fatalf("Unexpected error from flush, got: %v", err)
 	}
-	if got, want := checkNIHasNEntries(ctx, args.clientB, *deviations.DefaultNetworkInstance, t), 0; got != want {
+	if got, want := checkNIHasNEntries(ctx, args.clientB, deviations.DefaultNetworkInstance(args.dut), t), 0; got != want {
 		t.Errorf("Network instance has %d entry/entries, wanted: %d", got, want)
 	}
 }
@@ -217,11 +217,11 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), dutPort1.NewOCInterface(p1.Name()))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), dutPort2.NewOCInterface(p2.Name()))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, p1)

--- a/feature/gribi/ate_tests/supervisor_failure_test/supervisor_failure_test.go
+++ b/feature/gribi/ate_tests/supervisor_failure_test/supervisor_failure_test.go
@@ -123,8 +123,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 
@@ -204,7 +204,7 @@ func routeInstall(ctx context.Context, t *testing.T, args *testArgs) {
 	// Add an IPv4Entry for 203.0.113.0/24 pointing to ATE port-2 via gRIBI-A,
 	// ensure that the entry is active through AFT telemetry
 	t.Logf("Add an IPv4Entry for %s pointing to ATE port-2 via gRIBI-A", ateDstNetCIDR)
-	vrf := *deviations.DefaultNetworkInstance
+	vrf := deviations.DefaultNetworkInstance(args.dut)
 	args.clientA.AddNH(t, nhIndex, atePort2.IPv4, vrf, fluent.InstalledInRIB)
 	args.clientA.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, vrf, fluent.InstalledInRIB)
 	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex, vrf, "", fluent.InstalledInRIB)
@@ -384,7 +384,7 @@ func TestSupFailure(t *testing.T) {
 
 	// Verify the entry for 203.0.113.0/24 is active through AFT Telemetry.
 	t.Logf("Verify the entry for %s is active through AFT Telemetry.", ateDstNetCIDR)
-	ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	gnmi.Await(t, args.dut, ipv4Path.Prefix().State(), 2*time.Minute, ateDstNetCIDR)
 	t.Logf("ipv4-entry found for %s after controller switchover..", ateDstNetCIDR)
 

--- a/feature/gribi/ate_tests/weighted_balancing_test/port_flap_rebalanced_test.go
+++ b/feature/gribi/ate_tests/weighted_balancing_test/port_flap_rebalanced_test.go
@@ -128,7 +128,7 @@ func TestPortFlap(t *testing.T) {
 		t.Errorf("Cannot flush: %v", err)
 	}
 
-	ents, wants := buildNextHops(t, nexthops, 1)
+	ents, wants := buildNextHops(t, nexthops, 1, dut)
 
 	c.Modify().AddEntry(t, ents...)
 	if err := awaitTimeout(ctx, c, t, time.Minute); err != nil {

--- a/feature/gribi/ate_tests/weighted_balancing_test/setup_test.go
+++ b/feature/gribi/ate_tests/weighted_balancing_test/setup_test.go
@@ -178,7 +178,7 @@ func configureDUT(t testing.TB, dut *ondatra.DUTDevice) {
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
 		for _, dp := range dut.Ports() {
-			fptest.AssignToNetworkInstance(t, dut, dp.Name(), *deviations.DefaultNetworkInstance, 0)
+			fptest.AssignToNetworkInstance(t, dut, dp.Name(), deviations.DefaultNetworkInstance(dut), 0)
 		}
 	}
 	if deviations.ExplicitPortSpeed(dut) {
@@ -222,8 +222,8 @@ func awaitTimeout(ctx context.Context, c *fluent.GRIBIClient, t testing.TB, time
 // buildNextHops converts the nextHop specification to gRIBI entries
 // and wanted OpResult.  The entries are part of the Modify request,
 // and the Modify response is verified against the wants.
-func buildNextHops(t testing.TB, nexthops []nextHop, scale uint64) (ents []fluent.GRIBIEntry, wants []*client.OpResult) {
-	nhgent := fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+func buildNextHops(t testing.TB, nexthops []nextHop, scale uint64, dut *ondatra.DUTDevice) (ents []fluent.GRIBIEntry, wants []*client.OpResult) {
+	nhgent := fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithID(nhgIndex)
 	nhgwant := fluent.OperationResult().
 		WithOperationID(uint64(len(nexthops) + 1)).
@@ -238,7 +238,7 @@ func buildNextHops(t testing.TB, nexthops []nextHop, scale uint64) (ents []fluen
 		t.Logf("Installing gRIBI next hop entry %d to %s (%s) of weight %d",
 			index, nhip, nh.Port, nh.Weight*scale)
 
-		ent := fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+		ent := fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 			WithIndex(index).WithIPAddress(nhip)
 		ents = append(ents, ent)
 
@@ -253,7 +253,7 @@ func buildNextHops(t testing.TB, nexthops []nextHop, scale uint64) (ents []fluen
 		wants = append(wants, want)
 	}
 
-	ipv4ent := fluent.IPv4Entry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+	ipv4ent := fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithPrefix(ateDstNetCIDR).WithNextHopGroup(42)
 	ipv4want := fluent.OperationResult().
 		WithOperationID(uint64(len(nexthops) + 2)).
@@ -377,7 +377,7 @@ func portWants(nexthops []nextHop, atePorts []*ondatra.Port) []float64 {
 
 func debugGRIBI(t testing.TB, dut *ondatra.DUTDevice) {
 	// Debugging through OpenConfig.
-	aftsPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts()
+	aftsPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Afts()
 	if q, present := gnmi.Lookup(t, dut, aftsPath.State()).Val(); present {
 		fptest.LogQuery(t, "Afts", aftsPath.State(), q)
 	} else {

--- a/feature/gribi/ate_tests/weighted_balancing_test/weighted_balancing_test.go
+++ b/feature/gribi/ate_tests/weighted_balancing_test/weighted_balancing_test.go
@@ -114,6 +114,7 @@ func testNextHop(
 	gribic spb.GRIBIClient,
 	ate *ondatra.ATEDevice,
 	top *ondatra.ATETopology,
+	dut *ondatra.DUTDevice,
 ) {
 	// Configure the gRIBI client.
 	c := fluent.NewClient()
@@ -143,7 +144,7 @@ func testNextHop(
 		t.Errorf("Cannot flush: %v", err)
 	}
 
-	ents, wants := buildNextHops(t, nexthops, scale)
+	ents, wants := buildNextHops(t, nexthops, scale, dut)
 
 	c.Modify().AddEntry(t, ents...)
 	if err := awaitTimeout(ctx, c, t, time.Minute); err != nil {
@@ -214,7 +215,7 @@ func TestWeightedBalancing(t *testing.T) {
 					if got, want := len(dutPorts), len(c.NextHops)+1; got < want {
 						t.Skipf("Testbed provides only %d ports, but test case needs %d.", got, want)
 					}
-					testNextHop(ctx, t, c.NextHops, s.Scale, gribic, ate, top)
+					testNextHop(ctx, t, c.NextHops, s.Scale, gribic, ate, top, dut)
 					debugGRIBI(t, dut)
 				})
 			}

--- a/feature/gribi/otg_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
+++ b/feature/gribi/otg_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
@@ -213,12 +213,12 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p4)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p4.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p3.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p4.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
-		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, deviations.DefaultNetworkInstance(dut))
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrf1)
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrf2)
 	}
@@ -309,19 +309,19 @@ func (a *testArgs) testIPv4BackUpSwitch(t *testing.T) {
 	)
 
 	t.Logf("Program a backup pointing to vrfB via gRIBI")
-	a.client.AddNH(t, nhid3, "VRFOnly", *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHOptions{VrfName: vrf2})
-	a.client.AddNHG(t, backupnhgid, map[uint64]uint64{nhid3: 10}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	a.client.AddNH(t, nhid3, "VRFOnly", deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB, &gribi.NHOptions{VrfName: vrf2})
+	a.client.AddNHG(t, backupnhgid, map[uint64]uint64{nhid3: 10}, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
 
 	t.Logf("an IPv4Entry for %s in %s pointing to ATE port-2 and port-3 via gRIBI", dstPfx, vrf1)
-	a.client.AddNH(t, nhid1, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	a.client.AddNH(t, nhid2, atePort3.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	a.client.AddNHG(t, nhgid1, map[uint64]uint64{nhid1: 80, nhid2: 20}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: backupnhgid})
-	a.client.AddIPv4(t, dstPfx, nhgid1, vrf1, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	a.client.AddNH(t, nhid1, atePort2.IPv4, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
+	a.client.AddNH(t, nhid2, atePort3.IPv4, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
+	a.client.AddNHG(t, nhgid1, map[uint64]uint64{nhid1: 80, nhid2: 20}, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB, &gribi.NHGOptions{BackupNHG: backupnhgid})
+	a.client.AddIPv4(t, dstPfx, nhgid1, vrf1, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
 
 	t.Logf("an IPv4Entry for %s in %s pointing to ATE port-4 via gRIBI", dstPfx, vrf2)
-	a.client.AddNH(t, nhid4, atePort4.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	a.client.AddNHG(t, nhgid2, map[uint64]uint64{nhid4: 100}, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
-	a.client.AddIPv4(t, dstPfx, nhgid2, vrf2, *deviations.DefaultNetworkInstance, fluent.InstalledInFIB)
+	a.client.AddNH(t, nhid4, atePort4.IPv4, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
+	a.client.AddNHG(t, nhgid2, map[uint64]uint64{nhid4: 100}, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
+	a.client.AddIPv4(t, dstPfx, nhgid2, vrf2, deviations.DefaultNetworkInstance(a.dut), fluent.InstalledInFIB)
 
 	// validate programming using AFT
 	// TODO: add checks for NHs when AFT OC schema concludes how viability should be indicated.
@@ -443,7 +443,7 @@ func (a *testArgs) aftCheck(t testing.TB, prefix string, instance string) {
 	nhg, _ := aftPfxNHGVal.Val()
 
 	// using NHG ID validate NH
-	aftNHG := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().NextHopGroup(nhg).State())
+	aftNHG := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(a.dut)).Afts().NextHopGroup(nhg).State())
 	if len(aftNHG.NextHop) == 0 && aftNHG.BackupNextHopGroup == nil {
 		t.Fatalf("Prefix %s references a NHG that has neither NH or backup NHG", prefix)
 	}

--- a/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
+++ b/feature/gribi/otg_tests/base_hierarchical_nhg_update/base_hierarchical_nhg_update_test.go
@@ -160,7 +160,7 @@ func TestBaseHierarchicalNHGUpdate(t *testing.T) {
 			t.Error(err)
 		}
 		if deviations.GRIBIMACOverrideStaticARPStaticRoute(dut) {
-			sp := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
+			sp := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
 			gnmi.Delete(t, dut, sp.Static(atePort2DummyIP.IPv4CIDR()).Config())
 			gnmi.Delete(t, dut, sp.Static(atePort3DummyIP.IPv4CIDR()).Config())
 		}
@@ -172,11 +172,11 @@ func TestBaseHierarchicalNHGUpdate(t *testing.T) {
 
 	t.Logf("Adding gribi routes and validating traffic forwarding via port %v and NH ID %v", dutP2, p2NHID)
 	if deviations.GRIBIMACOverrideWithStaticARP(dut) || deviations.GRIBIMACOverrideStaticARPStaticRoute(dut) {
-		addVIPRoute(ctx, t, gribic, p2NHID, dutP2, atePort2DummyIP.IPv4)
+		addVIPRoute(ctx, dut, t, gribic, p2NHID, dutP2, atePort2DummyIP.IPv4)
 	} else {
-		addVIPRoute(ctx, t, gribic, p2NHID, dutP2)
+		addVIPRoute(ctx, dut, t, gribic, p2NHID, dutP2)
 	}
-	addDestinationRoute(ctx, t, gribic)
+	addDestinationRoute(ctx, dut, t, gribic)
 	waitOTGARPEntry(t)
 	validateTrafficFlows(t, p2flow, p3flow)
 
@@ -188,21 +188,21 @@ func TestBaseHierarchicalNHGUpdate(t *testing.T) {
 	}
 
 	t.Logf("Performing implicit in-place replace with two next-hops (NH IDs: %v and %v)", p2NHID, p3NHID)
-	addNHG(ctx, t, gribic, virtualIPNHGID, []uint64{p2NHID, p3NHID})
+	addNHG(ctx, dut, t, gribic, virtualIPNHGID, []uint64{p2NHID, p3NHID})
 	validateTrafficFlows(t, lbFlow, "")
 
 	t.Logf("Performing implicit in-place replace using the next-hop with ID %v", p3NHID)
-	addNHG(ctx, t, gribic, virtualIPNHGID, []uint64{p3NHID})
+	addNHG(ctx, dut, t, gribic, virtualIPNHGID, []uint64{p3NHID})
 	validateTrafficFlows(t, p3flow, p2flow)
 
 	t.Logf("Performing implicit in-place replace using the next-hop with ID %v", p2NHID)
-	addNHG(ctx, t, gribic, virtualIPNHGID, []uint64{p2NHID})
+	addNHG(ctx, dut, t, gribic, virtualIPNHGID, []uint64{p2NHID})
 	validateTrafficFlows(t, p2flow, p3flow)
 }
 
 // addNH adds a GRIBI NH with a FIB ACK confirmation via Modify RPC
 func addNH(ctx context.Context, t *testing.T, dut *ondatra.DUTDevice, gribic *fluent.GRIBIClient, id uint64, intf, mac string, nhip ...string) {
-	nh := fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+	nh := fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithIndex(id).WithInterfaceRef(intf).WithMacAddress(mac)
 	if len(nhip) > 0 {
 		nh = nh.WithIPAddress(nhip[0])
@@ -229,8 +229,8 @@ func addNH(ctx context.Context, t *testing.T, dut *ondatra.DUTDevice, gribic *fl
 }
 
 // addNHG adds a GRIBI NHG with a FIB ACK confirmation via Modify RPC
-func addNHG(ctx context.Context, t *testing.T, gribic *fluent.GRIBIClient, id uint64, nhs []uint64) {
-	nhg := fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+func addNHG(ctx context.Context, dut *ondatra.DUTDevice, t *testing.T, gribic *fluent.GRIBIClient, id uint64, nhs []uint64) {
+	nhg := fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithID(id)
 	for _, nh := range nhs {
 		nhg.AddNextHop(nh, 1)
@@ -252,12 +252,12 @@ func addNHG(ctx context.Context, t *testing.T, gribic *fluent.GRIBIClient, id ui
 }
 
 // addDestinationRoute adds a GRIBI route to dstPfx via the VirtualIP GRIBI nexthop.
-func addDestinationRoute(ctx context.Context, t *testing.T, gribic *fluent.GRIBIClient) {
-	dnh := fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+func addDestinationRoute(ctx context.Context, dut *ondatra.DUTDevice, t *testing.T, gribic *fluent.GRIBIClient) {
+	dnh := fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithIndex(dstNHID).WithIPAddress(virtualIP)
-	dnhg := fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+	dnhg := fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithID(dstNHGID).AddNextHop(dstNHID, 1)
-	dpfx := fluent.IPv4Entry().WithNetworkInstance(vrfName).WithPrefix(dstPfx).WithNextHopGroup(dstNHGID).WithNextHopGroupNetworkInstance(*deviations.DefaultNetworkInstance)
+	dpfx := fluent.IPv4Entry().WithNetworkInstance(vrfName).WithPrefix(dstPfx).WithNextHopGroup(dstNHGID).WithNextHopGroupNetworkInstance(deviations.DefaultNetworkInstance(dut))
 
 	gribic.Modify().AddEntry(t, dnh, dnhg, dpfx)
 	if err := awaitTimeout(ctx, gribic, t, time.Minute); err != nil {
@@ -289,12 +289,12 @@ func addDestinationRoute(ctx context.Context, t *testing.T, gribic *fluent.GRIBI
 
 // addVIPRoute creates a GRIBI route that points to the egress interface defined by id,
 // port, and nhip.
-func addVIPRoute(ctx context.Context, t *testing.T, gribic *fluent.GRIBIClient, id uint64, port string, nhip ...string) {
-	inh := fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+func addVIPRoute(ctx context.Context, dut *ondatra.DUTDevice, t *testing.T, gribic *fluent.GRIBIClient, id uint64, port string, nhip ...string) {
+	inh := fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithIndex(id).WithInterfaceRef(port).WithMacAddress(pMAC)
-	inhg := fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+	inhg := fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithID(virtualIPNHGID).AddNextHop(id, 1)
-	ipfx := fluent.IPv4Entry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+	ipfx := fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 		WithPrefix(virtualPfx).WithNextHopGroup(virtualIPNHGID)
 	if len(nhip) > 0 {
 		inh = inh.WithIPAddress(nhip[0])
@@ -390,11 +390,11 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p3)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p3.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
-		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, deviations.DefaultNetworkInstance(dut))
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, vrfName)
 	}
 
@@ -442,7 +442,7 @@ func staticARPWithMagicUniversalIP(t *testing.T, dut *ondatra.DUTDevice) {
 			},
 		},
 	}
-	sp := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
+	sp := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
 	gnmi.Replace(t, dut, sp.Static(atePort2DummyIP.IPv4CIDR()).Config(), s2)
 	gnmi.Replace(t, dut, sp.Static(atePort3DummyIP.IPv4CIDR()).Config(), s3)
 	gnmi.Update(t, dut, gnmi.OC().Interface(p2.Name()).Config(), configStaticArp(p2, atePort2DummyIP.IPv4, pMAC))

--- a/feature/gribi/otg_tests/base_leader_election_test/base_leader_election_test.go
+++ b/feature/gribi/otg_tests/base_leader_election_test/base_leader_election_test.go
@@ -132,21 +132,21 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	i1 := &oc.Interface{Name: ygot.String(p1.Name())}
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutPort1))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	p2 := dut.Port(t, "port2")
 	i2 := &oc.Interface{Name: ygot.String(p2.Name())}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutPort2))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	p3 := dut.Port(t, "port3")
 	i3 := &oc.Interface{Name: ygot.String(p3.Name())}
 	gnmi.Replace(t, dut, d.Interface(p3.Name()).Config(), configInterfaceDUT(i3, &dutPort3))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p3.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, p1)
@@ -263,13 +263,13 @@ func testIPv4LeaderActiveChange(ctx context.Context, t *testing.T, args *testArg
 	// ensure that the entry is active through AFT telemetry and traffic.
 	t.Logf("an IPv4Entry for %s pointing to ATE port-3 via gRIBI-B", ateDstNetCIDR)
 	args.clientB.BecomeLeader(t)
-	args.clientB.AddNH(t, nhIndex, atePort3.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	args.clientB.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	args.clientB.AddIPv4(t, ateDstNetCIDR, nhgIndex, *deviations.DefaultNetworkInstance, "", fluent.InstalledInRIB)
+	args.clientB.AddNH(t, nhIndex, atePort3.IPv4, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	args.clientB.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	args.clientB.AddIPv4(t, ateDstNetCIDR, nhgIndex, deviations.DefaultNetworkInstance(args.dut), "", fluent.InstalledInRIB)
 
 	// Verify the entry for 198.51.100.0/24 is active through AFT Telemetry.
 	t.Logf("Verify the entry for %s is active through AFT Telemetry.", ateDstNetCIDR)
-	ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	gnmi.Await(t, args.dut, ipv4Path.Prefix().State(), time.Minute, ateDstNetCIDR)
 
 	// Verify the entry for 198.51.100.0/24 is active through Traffic.
@@ -278,22 +278,22 @@ func testIPv4LeaderActiveChange(ctx context.Context, t *testing.T, args *testArg
 	// Add an IPv4Entry for 198.51.100.0/24 pointing to ATE port-2 via gRIBI-A,
 	// ensure that the entry is ignored by the DUT.
 	t.Logf("Adding an IPv4Entry for %s pointing to ATE port-2 via gRIBI-A", ateDstNetCIDR)
-	args.clientA.AddNH(t, nhIndex+1, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.ProgrammingFailed)
-	args.clientA.AddNHG(t, nhgIndex+1, map[uint64]uint64{nhIndex + 1: 1}, *deviations.DefaultNetworkInstance, fluent.ProgrammingFailed)
-	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex+1, *deviations.DefaultNetworkInstance, "", fluent.ProgrammingFailed)
+	args.clientA.AddNH(t, nhIndex+1, atePort2.IPv4, deviations.DefaultNetworkInstance(args.dut), fluent.ProgrammingFailed)
+	args.clientA.AddNHG(t, nhgIndex+1, map[uint64]uint64{nhIndex + 1: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.ProgrammingFailed)
+	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex+1, deviations.DefaultNetworkInstance(args.dut), "", fluent.ProgrammingFailed)
 
 	// Send a ModifyRequest from gRIBI-A updating its election_id to make it leader,
 	// followed by a ModifyRequest updating 198.51.100.0/24 pointing to ATE port-2,
 	// ensure that routing is updated to receive packets for 198.51.100.0/24 at ATE port-2.
 	args.clientA.BecomeLeader(t)
 	t.Logf("Adding an IPv4Entry for %s pointing to ATE port-2 via client gRIBI-A", ateDstNetCIDR)
-	args.clientA.AddNH(t, nhIndex+2, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	args.clientA.AddNHG(t, nhgIndex+2, map[uint64]uint64{nhIndex + 2: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex+2, *deviations.DefaultNetworkInstance, "", fluent.InstalledInRIB)
+	args.clientA.AddNH(t, nhIndex+2, atePort2.IPv4, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	args.clientA.AddNHG(t, nhgIndex+2, map[uint64]uint64{nhIndex + 2: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex+2, deviations.DefaultNetworkInstance(args.dut), "", fluent.InstalledInRIB)
 
 	// Verify the entry for 198.51.100.0/24 is active through AFT Telemetry.
 	t.Logf("Verify the entry for %s is active through AFT Telemetry.", ateDstNetCIDR)
-	ipv4Path = gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+	ipv4Path = gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	gnmi.Await(t, args.dut, ipv4Path.Prefix().State(), time.Minute, ateDstNetCIDR)
 
 	// Verify with traffic that the entry for 198.51.100.0/24 is installed through the ATE port-2.

--- a/feature/gribi/otg_tests/get_rpc_test/get_rpc_test.go
+++ b/feature/gribi/otg_tests/get_rpc_test/get_rpc_test.go
@@ -131,8 +131,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 }
@@ -179,19 +179,19 @@ type testArgs struct {
 }
 
 // helperAddEntry configures a sequence of adding the NH, NHG and IPv4Entry by a client.
-func helperAddEntry(ctx context.Context, t *testing.T, client *fluent.GRIBIClient, nextHop string, ipPrefix string) {
+func helperAddEntry(ctx context.Context, dut *ondatra.DUTDevice, t *testing.T, client *fluent.GRIBIClient, nextHop string, ipPrefix string) {
 	t.Helper()
 	client.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 			WithIndex(nhIndex).
 			WithIPAddress(nextHop),
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 			WithID(nhgIndex).
 			AddNextHop(nhIndex, 1),
 		fluent.IPv4Entry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 			WithPrefix(ipPrefix).
 			WithNextHopGroup(nhgIndex),
 	)
@@ -208,7 +208,7 @@ func helperAddEntry(ctx context.Context, t *testing.T, client *fluent.GRIBIClien
 func configureIPv4ViaClientB(t *testing.T, args *testArgs) {
 	for _, cidr := range ateDstNetCIDR {
 		t.Logf("Adding an IPv4Entry for %s pointing to ATE port-2 via clientB.", cidr)
-		helperAddEntry(args.ctx, t, args.clientB, atePort2.IPv4, cidr)
+		helperAddEntry(args.ctx, args.dut, t, args.clientB, atePort2.IPv4, cidr)
 
 		// Verify the entry is not installed due to client B having lower election ID.
 		chk.HasResult(t, args.clientB.Results(t),
@@ -231,13 +231,13 @@ func configureIPv4ViaClientAInstalled(t *testing.T, args *testArgs) {
 	// once gribi/gribigo in google3 is updated.
 	args.clientA.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithIndex(nhIndex).
 			WithIPAddress(atePort2.IPv4))
 
 	args.clientA.Modify().AddEntry(t,
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithID(nhgIndex).
 			AddNextHop(nhIndex, 1))
 
@@ -245,7 +245,7 @@ func configureIPv4ViaClientAInstalled(t *testing.T, args *testArgs) {
 		args.clientA.Modify().AddEntry(t,
 			fluent.IPv4Entry().
 				WithPrefix(ateDstNetCIDR[ip]).
-				WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 				WithNextHopGroup(nhgIndex))
 	}
 
@@ -316,7 +316,7 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 
 	// Verify the above entries are active through AFT Telemetry.
 	for ip := range ateDstNetCIDR {
-		ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR[ip])
+		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR[ip])
 		if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR[ip]; got != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
@@ -333,11 +333,11 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	// and ensure that only entries for 198.51.100.0/26, 198.51.100.64/26, 198.51.100.128/26
 	// are returned, with no entry returned for 198.51.100.192/64.
 	dc := gnmi.OC()
-	niProto := dc.NetworkInstance(*deviations.DefaultNetworkInstance).
+	niProto := dc.NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 		Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
-	dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+	dutConfNIPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut))
 	gnmi.Replace(t, args.dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
-	ni := &oc.NetworkInstance{Name: deviations.DefaultNetworkInstance}
+	ni := &oc.NetworkInstance{Name: ygot.String(deviations.DefaultNetworkInstance(args.dut))}
 	static := ni.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, *deviations.StaticProtocolName)
 	staticRoute := static.GetOrCreateStatic(staticCIDR)
 	nextHop := staticRoute.GetOrCreateNextHop("0")
@@ -345,7 +345,7 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	gnmi.Update(t, args.dut, niProto.Config(), static)
 	validateGetRPC(ctx, t, args.clientA)
 	for ip := range ateDstNetCIDR {
-		ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR[ip])
+		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR[ip])
 		if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR[ip]; got != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
@@ -356,15 +356,15 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	// that the entry for 203.0.113.0/24 is not returned.
 	args.clientA.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithIndex(1000+nhIndex).
 			WithIPAddress(unresolvedNextHop),
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithID(1000+nhgIndex).
 			AddNextHop(1000+nhIndex, 1),
 		fluent.IPv4Entry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithPrefix(ipv4Prefix).
 			WithNextHopGroup(1000+nhgIndex),
 	)

--- a/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
@@ -169,7 +169,7 @@ func installEntries(t *testing.T, ips []string, nexthops []string, index routesP
 		ind := uint64(index.nhID + i)
 		if index.vrf == "vrf3" {
 			nh := fluent.NextHopEntry().
-				WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 				WithIndex(ind).
 				WithIPinIP(tunnelSrcIP, ateAddr).
 				WithDecapsulateHeader(fluent.IPinIP).
@@ -179,7 +179,7 @@ func installEntries(t *testing.T, ips []string, nexthops []string, index routesP
 			args.client.Modify().AddEntry(t, nh)
 		} else {
 			nh := fluent.NextHopEntry().
-				WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 				WithIndex(ind).
 				WithIPAddress(ateAddr).
 				WithElectionID(args.electionID.Low, args.electionID.High)
@@ -187,7 +187,7 @@ func installEntries(t *testing.T, ips []string, nexthops []string, index routesP
 		}
 
 		nhg := fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithID(uint64(localIndex)).
 			AddNextHop(ind, uint64(index.maxNhCount)).
 			WithElectionID(args.electionID.Low, args.electionID.High)
@@ -213,7 +213,7 @@ func installEntries(t *testing.T, ips []string, nexthops []string, index routesP
 				WithPrefix(ips[ip]+"/32").
 				WithNetworkInstance(index.vrf).
 				WithNextHopGroup(uint64(localIndex)).
-				WithNextHopGroupNetworkInstance(*deviations.DefaultNetworkInstance))
+				WithNextHopGroupNetworkInstance(deviations.DefaultNetworkInstance(args.dut)))
 		nextCount = nextCount + 1
 		if nextCount == index.maxIPCount {
 			localIndex = localIndex + 1
@@ -254,14 +254,14 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops []string) []strin
 		index := uint64(i + 1)
 		args.client.Modify().AddEntry(t,
 			fluent.NextHopEntry().
-				WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 				WithIndex(index).
 				WithIPAddress(nextHops[i]).
 				WithElectionID(args.electionID.Low, args.electionID.High))
 
 		args.client.Modify().AddEntry(t,
 			fluent.NextHopGroupEntry().
-				WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 				WithID(uint64(2)).
 				AddNextHop(index, 64).
 				WithElectionID(args.electionID.Low, args.electionID.High))
@@ -273,7 +273,7 @@ func pushDefaultEntries(t *testing.T, args *testArgs, nextHops []string) []strin
 		args.client.Modify().AddEntry(t,
 			fluent.IPv4Entry().
 				WithPrefix(virtualVIPs[ip]+"/32").
-				WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 				WithNextHopGroup(uint64(2)).
 				WithElectionID(args.electionID.Low, args.electionID.High))
 	}
@@ -299,7 +299,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	dp2 := dut.Port(t, "port2")
 	d := &oc.Root{}
 
-	vrfs := []string{*deviations.DefaultNetworkInstance, vrf1, vrf2, vrf3}
+	vrfs := []string{deviations.DefaultNetworkInstance(dut), vrf1, vrf2, vrf3}
 	createVrf(t, dut, vrfs)
 
 	// configure Ethernet interfaces first
@@ -309,7 +309,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	// configure an L3 subinterface without vlan tagging under DUT port#1
 	createSubifDUT(t, d, dut, dp1, 0, 0, dutPort1.IPv4)
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, dp1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	applyForwardingPolicy(t, dp1.Name())
@@ -321,7 +321,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 // createVrf takes in a list of VRF names and creates them on the target devices.
 func createVrf(t *testing.T, dut *ondatra.DUTDevice, vrfs []string) {
 	for _, vrf := range vrfs {
-		if vrf != *deviations.DefaultNetworkInstance {
+		if vrf != deviations.DefaultNetworkInstance(dut) {
 			// configure non-default VRFs
 			d := &oc.Root{}
 			i := d.GetOrCreateNetworkInstance(vrf)
@@ -329,7 +329,7 @@ func createVrf(t *testing.T, dut *ondatra.DUTDevice, vrfs []string) {
 			gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(vrf).Config(), i)
 		} else {
 			// configure DEFAULT vrf
-			dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+			dutConfNIPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut))
 			gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 		}
 		if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
@@ -337,13 +337,13 @@ func createVrf(t *testing.T, dut *ondatra.DUTDevice, vrfs []string) {
 		}
 	}
 	// configure PBF
-	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Config(), configurePBF())
+	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Config(), configurePBF(dut))
 }
 
 // configurePBF returns a fully configured network-instance PF struct
-func configurePBF() *oc.NetworkInstance_PolicyForwarding {
+func configurePBF(dut *ondatra.DUTDevice) *oc.NetworkInstance_PolicyForwarding {
 	d := &oc.Root{}
-	ni := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance)
+	ni := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
 	pf := ni.GetOrCreatePolicyForwarding()
 	vrfPolicy := pf.GetOrCreatePolicy(policyName)
 	vrfPolicy.SetType(oc.Policy_Type_VRF_SELECTION_POLICY)
@@ -357,8 +357,8 @@ func applyForwardingPolicy(t *testing.T, ingressPort string) {
 	t.Logf("Applying forwarding policy on interface %v ... ", ingressPort)
 	d := &oc.Root{}
 	dut := ondatra.DUT(t, "dut")
-	pfPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).PolicyForwarding().Interface(ingressPort)
-	pfCfg := d.GetOrCreateNetworkInstance(*deviations.DefaultNetworkInstance).GetOrCreatePolicyForwarding().GetOrCreateInterface(ingressPort)
+	pfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Interface(ingressPort)
+	pfCfg := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreatePolicyForwarding().GetOrCreateInterface(ingressPort)
 	pfCfg.ApplyVrfSelectionPolicy = ygot.String(policyName)
 	if deviations.ExplicitInterfaceRefDefinition(dut) {
 		pfCfg.GetOrCreateInterfaceRef().Interface = ygot.String(ingressPort)
@@ -415,7 +415,7 @@ func configureDUTSubIfs(t *testing.T, d *oc.Root, dut *ondatra.DUTDevice, dutPor
 		dutIPv4 := fmt.Sprintf(`198.51.100.%d`, (4*i)+2)
 		createSubifDUT(t, d, dut, dutPort, index, vlanID, dutIPv4)
 		if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-			fptest.AssignToNetworkInstance(t, dut, dutPort.Name(), *deviations.DefaultNetworkInstance, index)
+			fptest.AssignToNetworkInstance(t, dut, dutPort.Name(), deviations.DefaultNetworkInstance(dut), index)
 		}
 	}
 }

--- a/feature/gribi/otg_tests/gribigo_compliance_test/gribigo_compliance_test.go
+++ b/feature/gribi/otg_tests/gribigo_compliance_test/gribigo_compliance_test.go
@@ -135,7 +135,7 @@ func TestCompliance(t *testing.T) {
 				t.Skip(reason)
 			}
 
-			compliance.SetDefaultNetworkInstanceName(*deviations.DefaultNetworkInstance)
+			compliance.SetDefaultNetworkInstanceName(deviations.DefaultNetworkInstance(dut))
 			compliance.SetNonDefaultVRFName(*nonDefaultNI)
 
 			c := fluent.NewClient()
@@ -188,16 +188,16 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p3)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p3.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	d := &oc.Root{}
 	ni := d.GetOrCreateNetworkInstance(*nonDefaultNI)
 	ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(*nonDefaultNI).Config(), ni)
 	if deviations.ExplicitGRIBIUnderNetworkInstance(dut) {
-		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *deviations.DefaultNetworkInstance)
+		fptest.EnableGRIBIUnderNetworkInstance(t, dut, deviations.DefaultNetworkInstance(dut))
 		fptest.EnableGRIBIUnderNetworkInstance(t, dut, *nonDefaultNI)
 	}
 

--- a/feature/gribi/otg_tests/ipv4_entry_test/ipv4_entry_test.go
+++ b/feature/gribi/otg_tests/ipv4_entry_test/ipv4_entry_test.go
@@ -127,11 +127,11 @@ func TestIPv4Entry(t *testing.T) {
 		{
 			desc: "Single next-hop",
 			entries: []fluent.GRIBIEntry{
-				fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithIndex(nh1ID).WithIPAddress(atePort2.IPv4),
-				fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithID(nhgID).AddNextHop(nh1ID, 1),
-				fluent.IPv4Entry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithPrefix(dstPfx).WithNextHopGroup(nhgID),
 			},
 			wantGoodFlows: []string{"port2Flow"},
@@ -157,13 +157,13 @@ func TestIPv4Entry(t *testing.T) {
 		{
 			desc: "Multiple next-hops",
 			entries: []fluent.GRIBIEntry{
-				fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithIndex(nh1ID).WithIPAddress(atePort2.IPv4),
-				fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithIndex(nh2ID).WithIPAddress(atePort3.IPv4),
-				fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithID(nhgID).AddNextHop(nh1ID, 1).AddNextHop(nh2ID, 1),
-				fluent.IPv4Entry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithPrefix(dstPfx).WithNextHopGroup(nhgID),
 			},
 			wantGoodFlows: []string{"ecmpFlow"},
@@ -193,13 +193,13 @@ func TestIPv4Entry(t *testing.T) {
 		{
 			desc: "Multiple next-hops with MAC override",
 			entries: []fluent.GRIBIEntry{
-				fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithIndex(nh1ID).WithInterfaceRef(dut.Port(t, "port2").Name()).WithMacAddress(staticDstMAC),
-				fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithIndex(nh2ID).WithInterfaceRef(dut.Port(t, "port3").Name()).WithMacAddress(staticDstMAC),
-				fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithID(nhgID).AddNextHop(nh1ID, 1).AddNextHop(nh2ID, 1),
-				fluent.IPv4Entry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithPrefix(dstPfx).WithNextHopGroup(nhgID),
 			},
 			wantGoodFlows: []string{"ecmpFlow"},
@@ -229,9 +229,9 @@ func TestIPv4Entry(t *testing.T) {
 		{
 			desc: "Nonexistant next-hop",
 			entries: []fluent.GRIBIEntry{
-				fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithID(nhgID).AddNextHop(badNH, 1),
-				fluent.IPv4Entry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithPrefix(dstPfx).WithNextHopGroup(nhgID),
 			},
 			wantBadFlows: []string{"port2Flow", "port3Flow"},
@@ -253,12 +253,12 @@ func TestIPv4Entry(t *testing.T) {
 			desc:     "Downed next-hop interface",
 			downPort: dut.Port(t, "port2"),
 			entries: []fluent.GRIBIEntry{
-				fluent.NextHopEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithIndex(nh1ID).WithIPAddress(atePort2.IPv4).
 					WithInterfaceRef(dut.Port(t, "port2").Name()).WithMacAddress(staticDstMAC),
-				fluent.NextHopGroupEntry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithID(nhgID).AddNextHop(nh1ID, 1),
-				fluent.IPv4Entry().WithNetworkInstance(*deviations.DefaultNetworkInstance).
+				fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 					WithPrefix(dstPfx).WithNextHopGroup(nhgID),
 			},
 			wantBadFlows: []string{"port2Flow", "port3Flow"},
@@ -383,9 +383,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p3)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p3.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p3.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
+++ b/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
@@ -145,8 +145,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 
@@ -249,11 +249,11 @@ type testCaseFunc func(t *testing.T, args *testArgs)
 func testModifyNHG(t *testing.T, args *testArgs) {
 	args.c.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithIndex(nhIndex).
 			WithIPAddress(ateDst.IPv4),
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithID(nhgIndex).
 			AddNextHop(nhIndex, nhWeight),
 	)
@@ -283,7 +283,7 @@ func testModifyNHG(t *testing.T, args *testArgs) {
 		if !*checkTelemetry {
 			t.Skip()
 		}
-		nhgNhPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().NextHopGroup(nhgIndex).NextHop(nhIndex)
+		nhgNhPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().NextHopGroup(nhgIndex).NextHop(nhIndex)
 		if got, want := gnmi.Get(t, args.dut, nhgNhPath.Index().State()), uint64(nhIndex); got != want {
 			t.Errorf("next-hop-group/next-hop/state/index got %d, want %d", got, want)
 		}
@@ -298,15 +298,15 @@ func testModifyNHG(t *testing.T, args *testArgs) {
 func testModifyIPv4NHG(t *testing.T, args *testArgs) {
 	args.c.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithIndex(nhIndex).
 			WithIPAddress(ateDst.IPv4),
 		fluent.IPv4Entry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithPrefix(ateDstNetCIDR).
 			WithNextHopGroup(nhgIndex),
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithID(nhgIndex).
 			AddNextHop(nhIndex, nhWeight),
 	)
@@ -329,15 +329,15 @@ func testModifyIPv4NHG(t *testing.T, args *testArgs) {
 func testModifyNHGIPv4(t *testing.T, args *testArgs) {
 	args.c.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithIndex(nhIndex).
 			WithIPAddress(ateDst.IPv4),
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithID(nhgIndex).
 			AddNextHop(nhIndex, nhWeight),
 		fluent.IPv4Entry().
-			WithNetworkInstance(*deviations.DefaultNetworkInstance).
+			WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 			WithPrefix(ateDstNetCIDR).
 			WithNextHopGroup(nhgIndex),
 	)
@@ -375,7 +375,7 @@ func testModifyNHGIPv4(t *testing.T, args *testArgs) {
 		if !*checkTelemetry {
 			t.Skip()
 		}
-		nhgNhPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().NextHopGroup(nhgIndex).NextHop(nhIndex)
+		nhgNhPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().NextHopGroup(nhgIndex).NextHop(nhIndex)
 		if got, want := gnmi.Get(t, args.dut, nhgNhPath.Index().State()), uint64(nhIndex); got != want {
 			t.Errorf("next-hop-group/next-hop/state/index got %d, want %d", got, want)
 		}
@@ -383,7 +383,7 @@ func testModifyNHGIPv4(t *testing.T, args *testArgs) {
 			t.Errorf("next-hop-group/next-hop/state/weight got %d, want %d", got, want)
 		}
 
-		ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 		if got, want := gnmi.Get(t, args.dut, ipv4Path.NextHopGroup().State()), uint64(nhgIndex); got != want {
 			t.Errorf("ipv4-entry/state/next-hop-group got %d, want %d", got, want)
 		}
@@ -403,7 +403,7 @@ func testModifyIPv4AddDelAdd(t *testing.T, args *testArgs) {
 	testModifyNHG(t, args) // Uses operation IDs 1 and 2.
 
 	ent := fluent.IPv4Entry().
-		WithNetworkInstance(*deviations.DefaultNetworkInstance).
+		WithNetworkInstance(deviations.DefaultNetworkInstance(args.dut)).
 		WithPrefix(ateDstNetCIDR).
 		WithNextHopGroup(nhgIndex)
 
@@ -445,7 +445,7 @@ func testModifyIPv4AddDelAdd(t *testing.T, args *testArgs) {
 		if !*checkTelemetry {
 			t.Skip()
 		}
-		ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 		if got, want := gnmi.Get(t, args.dut, ipv4Path.NextHopGroup().State()), uint64(nhgIndex); got != want {
 			t.Errorf("ipv4-entry/state/next-hop-group got %d, want %d", got, want)
 		}

--- a/feature/gribi/otg_tests/persistence_mode_test/persistence_mode_test.go
+++ b/feature/gribi/otg_tests/persistence_mode_test/persistence_mode_test.go
@@ -120,8 +120,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 
@@ -220,15 +220,15 @@ type testArgs struct {
 // after programming the necessary nexthop and nexthop-group.
 func addRoute(ctx context.Context, t *testing.T, args *testArgs, clientA *gribi.Client) {
 	t.Logf("Add an IPv4Entry for %s pointing to ATE port-2 via clientA", ateDstNetCIDR)
-	clientA.AddNH(t, nhIndex, atePort2.IPv4, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	clientA.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
-	clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex, *deviations.DefaultNetworkInstance, "", fluent.InstalledInRIB)
+	clientA.AddNH(t, nhIndex, atePort2.IPv4, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	clientA.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, deviations.DefaultNetworkInstance(args.dut), fluent.InstalledInRIB)
+	clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex, deviations.DefaultNetworkInstance(args.dut), "", fluent.InstalledInRIB)
 }
 
 // verifyAFT verifies through AFT Telemetry if a route is present on the DUT.
 func verifyAFT(ctx context.Context, t *testing.T, args *testArgs) {
 	t.Logf("Verify through AFT Telemetry that %s is active", ateDstNetCIDR)
-	ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
 		prefix, present := val.Val()
 		return present && prefix == ateDstNetCIDR
@@ -240,7 +240,7 @@ func verifyAFT(ctx context.Context, t *testing.T, args *testArgs) {
 // verifyNoAFT verifies through AFT Telemetry that a route is NOT present on the DUT.
 func verifyNoAFT(ctx context.Context, t *testing.T, args *testArgs) {
 	t.Logf("Verify through Telemetry that the route to %s is not present", ateDstNetCIDR)
-	ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
 		prefix, present := val.Val()
 		return !present || (present && prefix == "")
@@ -358,7 +358,7 @@ func TestLeaderFailover(t *testing.T) {
 
 		t.Run("DeleteRoute", func(t *testing.T) {
 			t.Logf("Delete route to %s and verify through Telemetry and Traffic", ateDstNetCIDR)
-			clientA.DeleteIPv4(t, ateDstNetCIDR, *deviations.DefaultNetworkInstance, fluent.InstalledInRIB)
+			clientA.DeleteIPv4(t, ateDstNetCIDR, deviations.DefaultNetworkInstance(dut), fluent.InstalledInRIB)
 
 			t.Run("VerifyNoAFT", func(t *testing.T) {
 				verifyNoAFT(ctx, t, args)

--- a/feature/gribi/otg_tests/route_removal_via_flush_test/route_removal_via_flush_test.go
+++ b/feature/gribi/otg_tests/route_removal_via_flush_test/route_removal_via_flush_test.go
@@ -163,7 +163,7 @@ func TestRouteRemovelViaFlush(t *testing.T) {
 func testFlushWithDefaultNetworkInstance(ctx context.Context, t *testing.T, args *testArgs) {
 	// Inject an entry into the default network instance pointing to ATE port-2.
 	// clientA is primary client
-	injectEntry(ctx, t, args.clientA, *deviations.DefaultNetworkInstance)
+	injectEntry(ctx, t, args.clientA, deviations.DefaultNetworkInstance(args.dut))
 	// Test traffic between ATE port-1 and ATE port-2.
 	lossPct := testTraffic(t, args.ate, args.ateTop)
 	if got := lossPct; got > 0 {
@@ -173,7 +173,7 @@ func testFlushWithDefaultNetworkInstance(ctx context.Context, t *testing.T, args
 	}
 
 	// Flush should delete the entries
-	if _, err := gribi.Flush(args.clientA, args.electionID, *deviations.DefaultNetworkInstance); err != nil {
+	if _, err := gribi.Flush(args.clientA, args.electionID, deviations.DefaultNetworkInstance(args.dut)); err != nil {
 		t.Errorf("Unexpected error from flush, got: %v", err)
 	}
 	// After flush, left entry should be 0, and packets can no longer be forwarded.
@@ -183,19 +183,19 @@ func testFlushWithDefaultNetworkInstance(ctx context.Context, t *testing.T, args
 	} else {
 		t.Log("Traffic can not be forwarded between ATE port-1 and ATE port-2")
 	}
-	if got, want := checkNIHasNEntries(ctx, args.clientA, *deviations.DefaultNetworkInstance, t), 0; got != want {
+	if got, want := checkNIHasNEntries(ctx, args.clientA, deviations.DefaultNetworkInstance(args.dut), t), 0; got != want {
 		t.Errorf("Network instance has %d entry/entries, wanted: %d", got, want)
 	}
 
 	// clientA is primary client
-	injectEntry(ctx, t, args.clientA, *deviations.DefaultNetworkInstance)
+	injectEntry(ctx, t, args.clientA, deviations.DefaultNetworkInstance(args.dut))
 
 	// flush should fail, and preserve 3 entries.
-	if res, err := gribi.Flush(args.clientB, args.electionID.Decrement(), *deviations.DefaultNetworkInstance); err == nil {
+	if res, err := gribi.Flush(args.clientB, args.electionID.Decrement(), deviations.DefaultNetworkInstance(args.dut)); err == nil {
 		t.Errorf("Flush should return an error, got response: %v", res)
 	}
 
-	if got, want := checkNIHasNEntries(ctx, args.clientB, *deviations.DefaultNetworkInstance, t), 3; got != want {
+	if got, want := checkNIHasNEntries(ctx, args.clientB, deviations.DefaultNetworkInstance(args.dut), t), 3; got != want {
 		t.Errorf("Network instance has %d entry/entries, wanted: %d", got, want)
 	}
 
@@ -203,11 +203,11 @@ func testFlushWithDefaultNetworkInstance(ctx context.Context, t *testing.T, args
 	eID := gribi.BecomeLeader(t, args.clientB)
 
 	// Flush should be succeed and 0 entry left.
-	if _, err := gribi.Flush(args.clientB, eID, *deviations.DefaultNetworkInstance); err != nil {
+	if _, err := gribi.Flush(args.clientB, eID, deviations.DefaultNetworkInstance(args.dut)); err != nil {
 		t.Fatalf("Unexpected error from flush, got: %v", err)
 	}
 
-	if got, want := checkNIHasNEntries(ctx, args.clientB, *deviations.DefaultNetworkInstance, t), 0; got != want {
+	if got, want := checkNIHasNEntries(ctx, args.clientB, deviations.DefaultNetworkInstance(args.dut), t), 0; got != want {
 		t.Errorf("Network instance has %d entry/entries, wanted: %d", got, want)
 	}
 }
@@ -222,11 +222,11 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), dutPort1.NewOCInterface(p1.Name()))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), dutPort2.NewOCInterface(p2.Name()))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, p1)

--- a/feature/gribi/otg_tests/supervisor_failure_test/supervisor_failure_test.go
+++ b/feature/gribi/otg_tests/supervisor_failure_test/supervisor_failure_test.go
@@ -130,8 +130,8 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, p2)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 
@@ -190,7 +190,7 @@ func routeInstall(ctx context.Context, t *testing.T, args *testArgs) {
 	// Add an IPv4Entry for 203.0.113.0/24 pointing to ATE port-2 via gRIBI-A,
 	// ensure that the entry is active through AFT telemetry
 	t.Logf("Add an IPv4Entry for %s pointing to ATE port-2 via gRIBI-A", ateDstNetCIDR)
-	vrf := *deviations.DefaultNetworkInstance
+	vrf := deviations.DefaultNetworkInstance(args.dut)
 	args.clientA.AddNH(t, nhIndex, atePort2.IPv4, vrf, fluent.InstalledInRIB)
 	args.clientA.AddNHG(t, nhgIndex, map[uint64]uint64{nhIndex: 1}, vrf, fluent.InstalledInRIB)
 	args.clientA.AddIPv4(t, ateDstNetCIDR, nhgIndex, vrf, "", fluent.InstalledInRIB)
@@ -371,7 +371,7 @@ func TestSupFailure(t *testing.T) {
 
 	// Verify the entry for 203.0.113.0/24 is active through AFT Telemetry.
 	t.Logf("Verify the entry for %s is active through AFT Telemetry.", ateDstNetCIDR)
-	ipv4Path := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance).Afts().Ipv4Entry(ateDstNetCIDR)
+	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	gnmi.Await(t, args.dut, ipv4Path.Prefix().State(), 2*time.Minute, ateDstNetCIDR)
 	t.Logf("ipv4-entry found for %s after controller switchover..", ateDstNetCIDR)
 

--- a/feature/gribi/otg_tests/weighted_balancing_test/port_flap_rebalanced_test.go
+++ b/feature/gribi/otg_tests/weighted_balancing_test/port_flap_rebalanced_test.go
@@ -129,7 +129,7 @@ func TestPortFlap(t *testing.T) {
 		t.Errorf("Cannot flush: %v", err)
 	}
 
-	ents, wants := buildNextHops(t, nexthops, 1)
+	ents, wants := buildNextHops(t, dut, nexthops, 1)
 
 	c.Modify().AddEntry(t, ents...)
 	if err := awaitTimeout(ctx, c, t, time.Minute); err != nil {

--- a/feature/gribi/otg_tests/weighted_balancing_test/weighted_balancing_test.go
+++ b/feature/gribi/otg_tests/weighted_balancing_test/weighted_balancing_test.go
@@ -114,6 +114,7 @@ func testNextHop(
 	scale uint64, // multiplies the weights in nexthops by this.
 	gribic spb.GRIBIClient,
 	ate *ondatra.ATEDevice,
+	dut *ondatra.DUTDevice,
 	top gosnappi.Config,
 ) {
 	// Configure the gRIBI client.
@@ -144,7 +145,7 @@ func testNextHop(
 		t.Errorf("Cannot flush: %v", err)
 	}
 
-	ents, wants := buildNextHops(t, nexthops, scale)
+	ents, wants := buildNextHops(t, dut, nexthops, scale)
 
 	c.Modify().AddEntry(t, ents...)
 	if err := awaitTimeout(ctx, c, t, time.Minute); err != nil {
@@ -215,7 +216,7 @@ func TestWeightedBalancing(t *testing.T) {
 					if got, want := len(dutPorts), len(c.NextHops)+1; got < want {
 						t.Skipf("Testbed provides only %d ports, but test case needs %d.", got, want)
 					}
-					testNextHop(ctx, t, c.NextHops, s.Scale, gribic, ate, top)
+					testNextHop(ctx, t, c.NextHops, s.Scale, gribic, ate, dut, top)
 					debugGRIBI(t, dut)
 				})
 			}

--- a/feature/interface/aggregate/ate_tests/aggregate_forwarding_viable_test/aggregate_forwarding_viable_test.go
+++ b/feature/interface/aggregate/ate_tests/aggregate_forwarding_viable_test/aggregate_forwarding_viable_test.go
@@ -278,7 +278,7 @@ func (tc *testArgs) configureDUT(t *testing.T) {
 	fptest.LogQuery(t, tc.aggID, aggPath.Config(), agg)
 	gnmi.Replace(t, tc.dut, aggPath.Config(), agg)
 	if deviations.ExplicitInterfaceInDefaultVRF(tc.dut) {
-		fptest.AssignToNetworkInstance(t, tc.dut, tc.aggID, *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, tc.aggID, deviations.DefaultNetworkInstance(tc.dut), 0)
 	}
 
 	srcp := tc.dutPorts[0]
@@ -292,7 +292,7 @@ func (tc *testArgs) configureDUT(t *testing.T) {
 	fptest.LogQuery(t, srcp.String(), srciPath.Config(), srci)
 	gnmi.Replace(t, tc.dut, srciPath.Config(), srci)
 	if deviations.ExplicitInterfaceInDefaultVRF(tc.dut) {
-		fptest.AssignToNetworkInstance(t, tc.dut, srcp.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, srcp.Name(), deviations.DefaultNetworkInstance(tc.dut), 0)
 	}
 
 	for _, port := range tc.dutPorts[1:] {

--- a/feature/interface/aggregate/ate_tests/aggregate_test/aggregate_test.go
+++ b/feature/interface/aggregate/ate_tests/aggregate_test/aggregate_test.go
@@ -227,8 +227,8 @@ func (tc *testCase) configureDUT(t *testing.T) {
 	gnmi.Replace(t, tc.dut, srciPath.Config(), srci)
 
 	if deviations.ExplicitInterfaceInDefaultVRF(tc.dut) {
-		fptest.AssignToNetworkInstance(t, tc.dut, tc.aggID, *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, tc.dut, srcp.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, tc.aggID, deviations.DefaultNetworkInstance(tc.dut), 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, srcp.Name(), deviations.DefaultNetworkInstance(tc.dut), 0)
 	}
 
 	for _, port := range tc.dutPorts[1:] {

--- a/feature/interface/aggregate/ate_tests/balancing_test/balancing_test.go
+++ b/feature/interface/aggregate/ate_tests/balancing_test/balancing_test.go
@@ -242,8 +242,8 @@ func (tc *testCase) configureDUT(t *testing.T) {
 	gnmi.Replace(t, tc.dut, aggPath.Config(), agg)
 
 	if deviations.ExplicitInterfaceInDefaultVRF(tc.dut) {
-		fptest.AssignToNetworkInstance(t, tc.dut, tc.aggID, *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, tc.dut, srcp.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, tc.aggID, deviations.DefaultNetworkInstance(tc.dut), 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, srcp.Name(), deviations.DefaultNetworkInstance(tc.dut), 0)
 	}
 
 	for n, port := range tc.dutPorts {

--- a/feature/interface/aggregate/otg_tests/aggregate_forwarding_viable_test/aggregate_forwarding_viable_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_forwarding_viable_test/aggregate_forwarding_viable_test.go
@@ -287,7 +287,7 @@ func (tc *testArgs) configureDUT(t *testing.T) {
 	fptest.LogQuery(t, tc.aggID, aggPath.Config(), agg)
 	gnmi.Replace(t, tc.dut, aggPath.Config(), agg)
 	if deviations.ExplicitInterfaceInDefaultVRF(tc.dut) {
-		fptest.AssignToNetworkInstance(t, tc.dut, tc.aggID, *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, tc.aggID, deviations.DefaultNetworkInstance(tc.dut), 0)
 	}
 
 	srcp := tc.dutPorts[0]
@@ -301,7 +301,7 @@ func (tc *testArgs) configureDUT(t *testing.T) {
 	fptest.LogQuery(t, srcp.String(), srciPath.Config(), srci)
 	gnmi.Replace(t, tc.dut, srciPath.Config(), srci)
 	if deviations.ExplicitInterfaceInDefaultVRF(tc.dut) {
-		fptest.AssignToNetworkInstance(t, tc.dut, srcp.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, srcp.Name(), deviations.DefaultNetworkInstance(tc.dut), 0)
 	}
 
 	for _, port := range tc.dutPorts[1:] {

--- a/feature/interface/singleton/ate_tests/singleton_test/singleton_test.go
+++ b/feature/interface/singleton/ate_tests/singleton_test/singleton_test.go
@@ -165,8 +165,8 @@ func (tc *testCase) configureDUT(t *testing.T) {
 	gnmi.Replace(t, tc.dut, di2.Config(), tc.duti2)
 
 	if deviations.ExplicitInterfaceInDefaultVRF(tc.dut) {
-		fptest.AssignToNetworkInstance(t, tc.dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, tc.dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, p1.Name(), deviations.DefaultNetworkInstance(tc.dut), 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, p2.Name(), deviations.DefaultNetworkInstance(tc.dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(tc.dut) {
 		fptest.SetPortSpeed(t, p1)

--- a/feature/interface/singleton/otg_tests/singleton_test/singleton_test.go
+++ b/feature/interface/singleton/otg_tests/singleton_test/singleton_test.go
@@ -147,8 +147,8 @@ func (tc *testCase) configureDUT(t *testing.T) {
 	gnmi.Replace(t, tc.dut, di2.Config(), tc.duti2)
 
 	if deviations.ExplicitInterfaceInDefaultVRF(tc.dut) {
-		fptest.AssignToNetworkInstance(t, tc.dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
-		fptest.AssignToNetworkInstance(t, tc.dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, p1.Name(), deviations.DefaultNetworkInstance(tc.dut), 0)
+		fptest.AssignToNetworkInstance(t, tc.dut, p2.Name(), deviations.DefaultNetworkInstance(tc.dut), 0)
 	}
 	if deviations.ExplicitPortSpeed(tc.dut) {
 		fptest.SetPortSpeed(t, p1)

--- a/feature/interface/staticarp/ate_tests/static_arp_test/static_arp_test.go
+++ b/feature/interface/staticarp/ate_tests/static_arp_test/static_arp_test.go
@@ -159,13 +159,13 @@ func configureDUT(t *testing.T, peermac string) {
 	p1 := dut.Port(t, "port1")
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(t, p1, &dutSrc, &ateSrc, peermac, dut))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 
 	p2 := dut.Port(t, "port2")
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(t, p2, &dutDst, &ateDst, peermac, dut))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/interface/staticarp/otg_tests/static_arp_test/static_arp_test.go
+++ b/feature/interface/staticarp/otg_tests/static_arp_test/static_arp_test.go
@@ -164,13 +164,13 @@ func configureDUT(t *testing.T, peermac string) {
 	if peermac == "" {
 		gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(t, p1, &dutSrc, &ateSrc, peermac, dut))
 		if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-			fptest.AssignToNetworkInstance(t, dut, p1.Name(), *deviations.DefaultNetworkInstance, 0)
+			fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 		}
 	}
 	p2 := dut.Port(t, "port2")
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(t, p2, &dutDst, &ateDst, peermac, dut))
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p2.Name(), *deviations.DefaultNetworkInstance, 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
 	}
 }
 

--- a/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/ate_tests/defaults_test/defaults_test.go
@@ -36,10 +36,10 @@ func TestMain(m *testing.M) {
 func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attributes, dut *ondatra.DUTDevice) {
 	t.Helper()
 	ni := d.GetOrCreateNetworkInstance(niName)
-	if niName != *deviations.DefaultNetworkInstance {
+	if niName != deviations.DefaultNetworkInstance(dut) {
 		ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 	}
-	if niName != *deviations.DefaultNetworkInstance || deviations.ExplicitInterfaceInDefaultVRF(dut) {
+	if niName != deviations.DefaultNetworkInstance(dut) || deviations.ExplicitInterfaceInDefaultVRF(dut) {
 		niIntf := ni.GetOrCreateInterface(intf)
 		niIntf.Interface = ygot.String(intf)
 		niIntf.Subinterface = ygot.Uint32(0)
@@ -63,7 +63,7 @@ func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attribut
 func unassignPort(t *testing.T, dut *ondatra.DUTDevice, intf, niName string) {
 	t.Helper()
 	// perform unassignment only for non-default VRFs unless ExplicitInterfaceInDefaultVRF deviation is enabled
-	if niName == *deviations.DefaultNetworkInstance && !deviations.ExplicitInterfaceInDefaultVRF(dut) {
+	if niName == deviations.DefaultNetworkInstance(dut) && !deviations.ExplicitInterfaceInDefaultVRF(dut) {
 		return
 	}
 
@@ -106,6 +106,7 @@ var (
 // configuration within a network instance. It does so by validating that simple IPv4 and IPv6 flows do not experience
 // loss.
 func TestDefaultAddressFamilies(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
 	ate := ondatra.ATE(t, "ate")
 	top := ate.Topology().New()
 
@@ -141,14 +142,13 @@ func TestDefaultAddressFamilies(t *testing.T) {
 	}{
 		{
 			desc:   "Default network instance",
-			niName: *deviations.DefaultNetworkInstance,
+			niName: deviations.DefaultNetworkInstance(dut),
 		},
 		{
 			desc:   "Non default network instance",
 			niName: "xyz",
 		},
 	}
-	dut := ondatra.DUT(t, "dut")
 	dutP1 := dut.Port(t, "port1")
 	dutP2 := dut.Port(t, "port2")
 	for _, tc := range cases {
@@ -157,8 +157,8 @@ func TestDefaultAddressFamilies(t *testing.T) {
 				fptest.SetPortSpeed(t, dutP1)
 				fptest.SetPortSpeed(t, dutP2)
 			}
-			if tc.niName == *deviations.DefaultNetworkInstance {
-				dutConfNIPath := gnmi.OC().NetworkInstance(*deviations.DefaultNetworkInstance)
+			if tc.niName == deviations.DefaultNetworkInstance(dut) {
+				dutConfNIPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut))
 				gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
 			}
 

--- a/feature/networkinstance/otg_tests/defaults_test/defaults_test.go
+++ b/feature/networkinstance/otg_tests/defaults_test/defaults_test.go
@@ -39,10 +39,10 @@ func TestMain(m *testing.M) {
 func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attributes, dut *ondatra.DUTDevice) {
 	t.Helper()
 	ni := d.GetOrCreateNetworkInstance(niName)
-	if niName != *deviations.DefaultNetworkInstance {
+	if niName != deviations.DefaultNetworkInstance(dut) {
 		ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
 	}
-	if niName != *deviations.DefaultNetworkInstance || deviations.ExplicitInterfaceInDefaultVRF(dut) {
+	if niName != deviations.DefaultNetworkInstance(dut) || deviations.ExplicitInterfaceInDefaultVRF(dut) {
 		niIntf := ni.GetOrCreateInterface(intf)
 		niIntf.Interface = ygot.String(intf)
 		niIntf.Subinterface = ygot.Uint32(0)
@@ -59,7 +59,7 @@ func assignPort(t *testing.T, d *oc.Root, intf, niName string, a *attrs.Attribut
 func unassignPort(t *testing.T, dut *ondatra.DUTDevice, intf, niName string) {
 	t.Helper()
 	// perform unassignment only for non-default VRFs unless ExplicitInterfaceInDefaultVRF deviation is enabled
-	if niName == *deviations.DefaultNetworkInstance && !deviations.ExplicitInterfaceInDefaultVRF(dut) {
+	if niName == deviations.DefaultNetworkInstance(dut) && !deviations.ExplicitInterfaceInDefaultVRF(dut) {
 		return
 	}
 
@@ -102,6 +102,7 @@ var (
 // configuration within a network instance. It does so by validating that simple IPv4 and IPv6 flows do not experience
 // loss.
 func TestDefaultAddressFamilies(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
 	ate := ondatra.ATE(t, "ate")
 	top := ate.OTG().NewConfig(t)
 
@@ -138,14 +139,13 @@ func TestDefaultAddressFamilies(t *testing.T) {
 	}{
 		{
 			desc:   "Default network instance",
-			niName: *deviations.DefaultNetworkInstance,
+			niName: deviations.DefaultNetworkInstance(dut),
 		},
 		{
 			desc:   "Non default network instance",
 			niName: "xyz",
 		},
 	}
-	dut := ondatra.DUT(t, "dut")
 	dutP1 := dut.Port(t, "port1")
 	dutP2 := dut.Port(t, "port2")
 	for _, tc := range cases {

--- a/feature/system/gnmi/set/tests/gnmi_set_test/gnmi_set_test.go
+++ b/feature/system/gnmi/set/tests/gnmi_set_test/gnmi_set_test.go
@@ -312,18 +312,18 @@ func TestDeleteNonDefaultVRF(t *testing.T) {
 }
 
 func TestMoveInterface(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
 	t.Run("DefaultToNonDefaultVRF", func(t *testing.T) {
-		testMoveInterfaceBetweenVRF(t, *deviations.DefaultNetworkInstance, "BLUE")
+		testMoveInterfaceBetweenVRF(t, dut, deviations.DefaultNetworkInstance(dut), "BLUE")
 	})
 	t.Run("NonDefaultToNonDefaultVRF", func(t *testing.T) {
-		testMoveInterfaceBetweenVRF(t, "RED", "BLUE")
+		testMoveInterfaceBetweenVRF(t, dut, "RED", "BLUE")
 	})
 }
 
-func testMoveInterfaceBetweenVRF(t *testing.T, firstVRF, secondVRF string) {
-	defaultVRF := *deviations.DefaultNetworkInstance
+func testMoveInterfaceBetweenVRF(t *testing.T, dut *ondatra.DUTDevice, firstVRF, secondVRF string) {
+	defaultVRF := deviations.DefaultNetworkInstance(dut)
 
-	dut := ondatra.DUT(t, "dut")
 	p1 := dut.Port(t, "port1")
 	p2 := dut.Port(t, "port2")
 
@@ -403,7 +403,8 @@ func testMoveInterfaceBetweenVRF(t *testing.T, firstVRF, secondVRF string) {
 }
 
 func TestStaticProtocol(t *testing.T) {
-	defaultVRF := *deviations.DefaultNetworkInstance
+	dut := ondatra.DUT(t, "dut")
+	defaultVRF := deviations.DefaultNetworkInstance(dut)
 	staticName := *deviations.StaticProtocolName
 
 	const (
@@ -415,7 +416,6 @@ func TestStaticProtocol(t *testing.T) {
 		nhip2     = "192.0.2.6"
 	)
 
-	dut := ondatra.DUT(t, "dut")
 	p1 := dut.Port(t, "port1")
 	p2 := dut.Port(t, "port2")
 
@@ -644,7 +644,7 @@ func defaultPushScope(dut *ondatra.DUTDevice) *pushScope {
 
 	return &pushScope{
 		interfaces:       interfaces,
-		networkInstances: []string{*deviations.DefaultNetworkInstance},
+		networkInstances: []string{deviations.DefaultNetworkInstance(dut)},
 	}
 }
 

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -81,6 +81,11 @@ func AggregateAtomicUpdate(_ *ondatra.DUTDevice) bool {
 	return *aggregateAtomicUpdate
 }
 
+// DefaultNetworkInstance returns the name used for the default network instance for VRF.
+func DefaultNetworkInstance(_ *ondatra.DUTDevice) string {
+	return *defaultNetworkInstance
+}
+
 // P4RTMissingDelete returns whether the device does not support delete mode in P4RT write requests.
 func P4RTMissingDelete(_ *ondatra.DUTDevice) bool {
 	return *p4rtMissingDelete
@@ -383,7 +388,7 @@ var (
 	aggregateAtomicUpdate = flag.Bool("deviation_aggregate_atomic_update", false,
 		"Device requires that aggregate Port-Channel and its members be defined in a single gNMI Update transaction at /interfaces; otherwise lag-type will be dropped, and no member can be added to the aggregate.  Full OpenConfig compliant devices should pass both with and without this deviation.")
 
-	DefaultNetworkInstance = flag.String("deviation_default_network_instance", "DEFAULT",
+	defaultNetworkInstance = flag.String("deviation_default_network_instance", "DEFAULT",
 		"The name used for the default network instance for VRF.  The default name in OpenConfig is \"DEFAULT\" but some legacy devices still use \"default\".  Full OpenConfig compliant devices should be able to use any operator-assigned value.")
 
 	subinterfacePacketCountersMissing = flag.Bool("deviation_subinterface_packet_counters_missing", false,


### PR DESCRIPTION
PiperOrigin-RevId: 530404668

Move `DefaultNetworkInstance` to accessor.