### PR TITLE
NTP server: place the new server into the same network-instance as these already exist in the device if any

### DIFF
--- a/feature/system/ntp/tests/system_ntp_test/server_test.go
+++ b/feature/system/ntp/tests/system_ntp_test/server_test.go
@@ -44,16 +44,12 @@ func TestNtpServerConfigurability(t *testing.T) {
 				Address: &testCase.address,
 			}
 
-			// Arista restricts the new server to be in the same network-instance as these already exist
-			// in the device
-			if dut.Vendor() == ondatra.ARISTA {
-				stateGot := gnmi.Get(t, dut, state.Server("*").State())
-				if NetworkInstanceGot := stateGot.GetNetworkInstance(); NetworkInstanceGot != "" {
-					t.Logf("The DUT has NTP server in network-instance: %s", NetworkInstanceGot)
-					ntpServer = oc.System_Ntp_Server{
-						Address:         &testCase.address,
-						NetworkInstance: &NetworkInstanceGot,
-					}
+			stateGot := gnmi.Get(t, dut, state.Server("*").State())
+			if NetworkInstanceGot := stateGot.GetNetworkInstance(); NetworkInstanceGot != "" {
+				t.Logf("The DUT has NTP server in network-instance: %s", NetworkInstanceGot)
+				ntpServer = oc.System_Ntp_Server{
+					Address:         &testCase.address,
+					NetworkInstance: &NetworkInstanceGot,
 				}
 			}
 

--- a/feature/system/ntp/tests/system_ntp_test/server_test.go
+++ b/feature/system/ntp/tests/system_ntp_test/server_test.go
@@ -47,7 +47,7 @@ func TestNtpServerConfigurability(t *testing.T) {
 			// Arista restricts the new server to be in the same network-instance as these already exist
 			// in the device
 			if dut.Vendor() == ondatra.ARISTA {
-				stateGot := gnmi.Get(t, dut, state.Server("216.239.35.0").State())
+				stateGot := gnmi.Get(t, dut, state.Server("*").State())
 				if NetworkInstanceGot := stateGot.GetNetworkInstance(); NetworkInstanceGot != "" {
 					t.Logf("The DUT has NTP server in network-instance: %s", NetworkInstanceGot)
 					ntpServer = oc.System_Ntp_Server{

--- a/feature/system/ntp/tests/system_ntp_test/server_test.go
+++ b/feature/system/ntp/tests/system_ntp_test/server_test.go
@@ -44,6 +44,19 @@ func TestNtpServerConfigurability(t *testing.T) {
 				Address: &testCase.address,
 			}
 
+			// Arista restricts the new server to be in the same network-instance as these already exist
+			// in the device
+			if dut.Vendor() == ondatra.ARISTA {
+				stateGot := gnmi.Get(t, dut, state.Server("216.239.35.0").State())
+				if NetworkInstanceGot := stateGot.GetNetworkInstance(); NetworkInstanceGot != "" {
+					t.Logf("The DUT has NTP server in network-instance: %s", NetworkInstanceGot)
+					ntpServer = oc.System_Ntp_Server{
+						Address:         &testCase.address,
+						NetworkInstance: &NetworkInstanceGot,
+					}
+				}
+			}
+
 			gnmi.Replace(t, dut, config.Server(testCase.address).Config(), &ntpServer)
 
 			t.Run("Get NTP Server Config", func(t *testing.T) {


### PR DESCRIPTION

Some vendors restricts the new server to be in the same network-instance as these already exist in the device

Currently the feature/system/ntp/tests/system_ntp_test/server_test is failing with on those vendors since the mgmt_vrf been enabled;

When mgmt vrf is enabled, the new adding NTP server(s) has to be in the same network-instance as these already configured in the device which are in the management vrf, regardless of IPv4 or IPv6 server address;
If no network-instance been specified, DUT will reject the Replace call.
