### PR TITLE
Move GetSubcomponentPath to accessor method.

### DIFF
--- a/feature/experimental/gribi/ate_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
+++ b/feature/experimental/gribi/ate_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
@@ -592,8 +592,9 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 	t.Logf("Controller %q is ready for switchover before test.", primaryBeforeSwitch)
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
+	useNameOnly := deviations.GNOISubcomponentPath(dut)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, dut),
+		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, useNameOnly),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 

--- a/feature/experimental/gribi/ate_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
+++ b/feature/experimental/gribi/ate_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
@@ -593,7 +593,7 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch),
+		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, dut),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 

--- a/feature/experimental/gribi/ate_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
+++ b/feature/experimental/gribi/ate_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
@@ -559,7 +559,7 @@ func TestRouteRemovalDuringFailover(t *testing.T) {
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch),
+		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, dut),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 

--- a/feature/experimental/gribi/ate_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
+++ b/feature/experimental/gribi/ate_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
@@ -558,8 +558,9 @@ func TestRouteRemovalDuringFailover(t *testing.T) {
 	t.Logf("Controller %q is ready for switchover before test.", primaryBeforeSwitch)
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
+	useNameOnly := deviations.GNOISubcomponentPath(dut)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, dut),
+		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, useNameOnly),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 

--- a/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
+++ b/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
@@ -620,8 +620,9 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 	t.Logf("Controller %q is ready for switchover before test.", primaryBeforeSwitch)
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
+	useNameOnly := deviations.GNOISubcomponentPath(dut)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, dut),
+		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, useNameOnly),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 

--- a/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
+++ b/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/route_addition_during_failover_test.go
@@ -621,7 +621,7 @@ func TestRouteAdditionDuringFailover(t *testing.T) {
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch),
+		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, dut),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 

--- a/feature/experimental/gribi/otg_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
+++ b/feature/experimental/gribi/otg_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
@@ -599,8 +599,9 @@ func TestRouteRemovalDuringFailover(t *testing.T) {
 	t.Logf("Controller %q is ready for switchover before test.", primaryBeforeSwitch)
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
+	useNameOnly := deviations.GNOISubcomponentPath(dut)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, dut),
+		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, useNameOnly),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 

--- a/feature/experimental/gribi/otg_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
+++ b/feature/experimental/gribi/otg_tests/route_removal_during_failover_test/route_removal_during_failover_test.go
@@ -600,7 +600,7 @@ func TestRouteRemovalDuringFailover(t *testing.T) {
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch),
+		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, dut),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 

--- a/feature/gnoi/system/tests/chassis_reboot_status_and_cancel_test/chassis_reboot_status_and_cancel_test.go
+++ b/feature/gnoi/system/tests/chassis_reboot_status_and_cancel_test/chassis_reboot_status_and_cancel_test.go
@@ -199,5 +199,5 @@ func getSubCompPath(t *testing.T, dut *ondatra.DUTDevice) *tpb.Path {
 	if len(controllerCards) == 2 {
 		_, activeRP = components.FindStandbyRP(t, dut, controllerCards)
 	}
-	return components.GetSubcomponentPath(activeRP)
+	return components.GetSubcomponentPath(activeRP, dut)
 }

--- a/feature/gnoi/system/tests/chassis_reboot_status_and_cancel_test/chassis_reboot_status_and_cancel_test.go
+++ b/feature/gnoi/system/tests/chassis_reboot_status_and_cancel_test/chassis_reboot_status_and_cancel_test.go
@@ -199,5 +199,6 @@ func getSubCompPath(t *testing.T, dut *ondatra.DUTDevice) *tpb.Path {
 	if len(controllerCards) == 2 {
 		_, activeRP = components.FindStandbyRP(t, dut, controllerCards)
 	}
-	return components.GetSubcomponentPath(activeRP, dut)
+	useNameOnly := deviations.GNOISubcomponentPath(dut)
+	return components.GetSubcomponentPath(activeRP, useNameOnly)
 }

--- a/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
+++ b/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/openconfig/featureprofiles/internal/args"
 	"github.com/openconfig/featureprofiles/internal/components"
+	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/featureprofiles/internal/helpers"
 	"github.com/openconfig/ondatra"
@@ -97,10 +98,11 @@ func TestStandbyControllerCardReboot(t *testing.T) {
 	t.Logf("Detected rpStandby: %v, rpActive: %v", rpStandby, rpActive)
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
+	useNameOnly := deviations.GNOISubcomponentPath(dut)
 	rebootSubComponentRequest := &spb.RebootRequest{
 		Method: spb.RebootMethod_COLD,
 		Subcomponents: []*tpb.Path{
-			components.GetSubcomponentPath(rpStandby, dut),
+			components.GetSubcomponentPath(rpStandby, useNameOnly),
 		},
 	}
 
@@ -168,10 +170,11 @@ func TestLinecardReboot(t *testing.T) {
 	}
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
+	useNameOnly := deviations.GNOISubcomponentPath(dut)
 	rebootSubComponentRequest := &spb.RebootRequest{
 		Method: spb.RebootMethod_COLD,
 		Subcomponents: []*tpb.Path{
-			components.GetSubcomponentPath(removableLinecard, dut),
+			components.GetSubcomponentPath(removableLinecard, useNameOnly),
 		},
 	}
 

--- a/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
+++ b/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
@@ -100,7 +100,7 @@ func TestStandbyControllerCardReboot(t *testing.T) {
 	rebootSubComponentRequest := &spb.RebootRequest{
 		Method: spb.RebootMethod_COLD,
 		Subcomponents: []*tpb.Path{
-			components.GetSubcomponentPath(rpStandby),
+			components.GetSubcomponentPath(rpStandby, dut),
 		},
 	}
 
@@ -171,7 +171,7 @@ func TestLinecardReboot(t *testing.T) {
 	rebootSubComponentRequest := &spb.RebootRequest{
 		Method: spb.RebootMethod_COLD,
 		Subcomponents: []*tpb.Path{
-			components.GetSubcomponentPath(removableLinecard),
+			components.GetSubcomponentPath(removableLinecard, dut),
 		},
 	}
 

--- a/feature/gnoi/system/tests/supervisor_switchover_test/supervisor_switchover_test.go
+++ b/feature/gnoi/system/tests/supervisor_switchover_test/supervisor_switchover_test.go
@@ -102,8 +102,9 @@ func TestSupervisorSwitchover(t *testing.T) {
 	}
 
 	gnoiClient := dut.RawAPIs().GNOI().New(t)
+	useNameOnly := deviations.GNOISubcomponentPath(dut)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: components.GetSubcomponentPath(rpStandbyBeforeSwitch, dut),
+		ControlProcessor: components.GetSubcomponentPath(rpStandbyBeforeSwitch, useNameOnly),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 	switchoverResponse, err := gnoiClient.System().SwitchControlProcessor(context.Background(), switchoverRequest)

--- a/feature/gnoi/system/tests/supervisor_switchover_test/supervisor_switchover_test.go
+++ b/feature/gnoi/system/tests/supervisor_switchover_test/supervisor_switchover_test.go
@@ -103,7 +103,7 @@ func TestSupervisorSwitchover(t *testing.T) {
 
 	gnoiClient := dut.RawAPIs().GNOI().New(t)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: components.GetSubcomponentPath(rpStandbyBeforeSwitch),
+		ControlProcessor: components.GetSubcomponentPath(rpStandbyBeforeSwitch, dut),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 	switchoverResponse, err := gnoiClient.System().SwitchControlProcessor(context.Background(), switchoverRequest)
@@ -114,7 +114,7 @@ func TestSupervisorSwitchover(t *testing.T) {
 
 	want := rpStandbyBeforeSwitch
 	got := ""
-	if *deviations.GNOISubcomponentPath {
+	if deviations.GNOISubcomponentPath(dut) {
 		got = switchoverResponse.GetControlProcessor().GetElem()[0].GetName()
 	} else {
 		got = switchoverResponse.GetControlProcessor().GetElem()[1].GetKey()["name"]

--- a/feature/gribi/ate_tests/supervisor_failure_test/supervisor_failure_test.go
+++ b/feature/gribi/ate_tests/supervisor_failure_test/supervisor_failure_test.go
@@ -338,8 +338,9 @@ func TestSupFailure(t *testing.T) {
 	}
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
+	useNameOnly := deviations.GNOISubcomponentPath(dut)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, dut),
+		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, useNameOnly),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 	switchoverResponse, err := gnoiClient.System().SwitchControlProcessor(context.Background(), switchoverRequest)

--- a/feature/gribi/ate_tests/supervisor_failure_test/supervisor_failure_test.go
+++ b/feature/gribi/ate_tests/supervisor_failure_test/supervisor_failure_test.go
@@ -339,7 +339,7 @@ func TestSupFailure(t *testing.T) {
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch),
+		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, dut),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 	switchoverResponse, err := gnoiClient.System().SwitchControlProcessor(context.Background(), switchoverRequest)

--- a/feature/gribi/otg_tests/supervisor_failure_test/supervisor_failure_test.go
+++ b/feature/gribi/otg_tests/supervisor_failure_test/supervisor_failure_test.go
@@ -325,8 +325,9 @@ func TestSupFailure(t *testing.T) {
 	}
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
+	useNameOnly := deviations.GNOISubcomponentPath(dut)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, dut),
+		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, useNameOnly),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 	switchoverResponse, err := gnoiClient.System().SwitchControlProcessor(context.Background(), switchoverRequest)

--- a/feature/gribi/otg_tests/supervisor_failure_test/supervisor_failure_test.go
+++ b/feature/gribi/otg_tests/supervisor_failure_test/supervisor_failure_test.go
@@ -326,7 +326,7 @@ func TestSupFailure(t *testing.T) {
 
 	gnoiClient := dut.RawAPIs().GNOI().Default(t)
 	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch),
+		ControlProcessor: cmp.GetSubcomponentPath(secondaryBeforeSwitch, dut),
 	}
 	t.Logf("switchoverRequest: %v", switchoverRequest)
 	switchoverResponse, err := gnoiClient.System().SwitchControlProcessor(context.Background(), switchoverRequest)

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -91,8 +91,8 @@ func FindMatchingStrings(components []string, r *regexp.Regexp) []string {
 }
 
 // GetSubcomponentPath creates a gNMI path based on the componnent name.
-func GetSubcomponentPath(name string) *tpb.Path {
-	if *deviations.GNOISubcomponentPath {
+func GetSubcomponentPath(name string, dut *ondatra.DUTDevice) *tpb.Path {
+	if deviations.GNOISubcomponentPath(dut) {
 		return &tpb.Path{
 			Elem: []*tpb.PathElem{{Name: name}},
 		}

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openconfig/featureprofiles/internal/deviations"
 	tpb "github.com/openconfig/gnoi/types"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -90,9 +90,10 @@ func FindMatchingStrings(components []string, r *regexp.Regexp) []string {
 	return s
 }
 
-// GetSubcomponentPath creates a gNMI path based on the componnent name.
-func GetSubcomponentPath(name string, dut *ondatra.DUTDevice) *tpb.Path {
-	if deviations.GNOISubcomponentPath(dut) {
+// GetSubcomponentPath creates a gNMI path based on the component name.
+// If useNameOnly is true, returns a path to the specified name instead of a full subcomponent path.
+func GetSubcomponentPath(name string, useNameOnly bool) *tpb.Path {
+	if useNameOnly {
 		return &tpb.Path{
 			Elem: []*tpb.PathElem{{Name: name}},
 		}

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -316,11 +316,6 @@ func GNOIStatusWithEmptySubcomponent(_ *ondatra.DUTDevice) bool {
 	return *gNOIStatusWithEmptySubcomponent
 }
 
-// GNOISubcomponentPath returns if device currently uses component name instead of a full openconfig path.
-func GNOISubcomponentPath(_ *ondatra.DUTDevice) bool {
-	return *gNOISubcomponentPath
-}
-
 // NetworkInstanceTableDeletionRequired returns if device requires explicit deletion of network-instance table.
 func NetworkInstanceTableDeletionRequired(_ *ondatra.DUTDevice) bool {
 	return *networkInstanceTableDeletionRequired

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -316,6 +316,11 @@ func GNOIStatusWithEmptySubcomponent(_ *ondatra.DUTDevice) bool {
 	return *gNOIStatusWithEmptySubcomponent
 }
 
+// GNOISubcomponentPath returns if device currently uses component name instead of a full openconfig path.
+func GNOISubcomponentPath(_ *ondatra.DUTDevice) bool {
+	return *gNOISubcomponentPath
+}
+
 // NetworkInstanceTableDeletionRequired returns if device requires explicit deletion of network-instance table.
 func NetworkInstanceTableDeletionRequired(_ *ondatra.DUTDevice) bool {
 	return *networkInstanceTableDeletionRequired
@@ -379,6 +384,11 @@ func ISISInstanceEnabledNotRequired(_ *ondatra.DUTDevice) bool {
 	return *isisInstanceEnabledNotRequired
 }
 
+// GNOISubcomponentPath returns if device currently uses component name instead of a full openconfig path.
+func GNOISubcomponentPath(_ *ondatra.DUTDevice) bool {
+	return *gNOISubcomponentPath
+}
+
 // NoMixOfTaggedAndUntaggedSubinterfaces returns if device does not support a mix of tagged and untagged subinterfaces
 func NoMixOfTaggedAndUntaggedSubinterfaces(_ *ondatra.DUTDevice) bool {
 	return *noMixOfTaggedAndUntaggedSubinterfaces
@@ -424,7 +434,7 @@ var (
 
 	staticProtocolName = flag.String("deviation_static_protocol_name", "DEFAULT", "The name used for the static routing protocol.  The default name in OpenConfig is \"DEFAULT\" but some devices use other names.")
 
-	GNOISubcomponentPath = flag.Bool("deviation_gnoi_subcomponent_path", false, "Device currently uses component name instead of a full openconfig path, so suppress creating a full oc compliant path for subcomponent.")
+	gNOISubcomponentPath = flag.Bool("deviation_gnoi_subcomponent_path", false, "Device currently uses component name instead of a full openconfig path, so suppress creating a full oc compliant path for subcomponent.")
 
 	gNOIStatusWithEmptySubcomponent = flag.Bool("deviation_gnoi_status_empty_subcomponent", false, "The response of gNOI reboot status is a single value (not a list), so the device requires explict component path to account for a situation when there is more than one active reboot requests.")
 


### PR DESCRIPTION
PiperOrigin-RevId: 529713463
Move GetSubcomponentPath to accessor method.