### PR TITLE
Move `ExplicitP4RTNodeComponent` to accessor.

### DIFF
--- a/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
+++ b/feature/experimental/p4rt/internal/p4rtutils/p4rtutils.go
@@ -233,7 +233,7 @@ func inferP4RTNodesNokia(t testing.TB, dut *ondatra.DUTDevice) map[string]string
 // ports using the component and the interface OC tree.
 func P4RTNodesByPort(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
 	t.Helper()
-	if *deviations.ExplicitP4RTNodeComponent {
+	if deviations.ExplicitP4RTNodeComponent(dut) {
 		switch dut.Vendor() {
 		case ondatra.NOKIA:
 			return inferP4RTNodesNokia(t, dut)

--- a/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/ate_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -947,7 +947,7 @@ func inferP4RTNodesNokia(t testing.TB, dut *ondatra.DUTDevice) map[string]string
 // ports using the component and the interface OC tree.
 func P4RTNodesByPort(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
 	t.Helper()
-	if *deviations.ExplicitP4RTNodeComponent {
+	if deviations.ExplicitP4RTNodeComponent(dut) {
 		switch dut.Vendor() {
 		case ondatra.NOKIA:
 			return inferP4RTNodesNokia(t, dut)

--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -965,7 +965,7 @@ func inferP4RTNodesNokia(t testing.TB, dut *ondatra.DUTDevice) map[string]string
 // ports using the component and the interface OC tree.
 func P4RTNodesByPort(t testing.TB, dut *ondatra.DUTDevice) map[string]string {
 	t.Helper()
-	if *deviations.ExplicitP4RTNodeComponent {
+	if deviations.ExplicitP4RTNodeComponent(dut) {
 		switch dut.Vendor() {
 		case ondatra.NOKIA:
 			return inferP4RTNodesNokia(t, dut)

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -101,6 +101,12 @@ func P4RTUnsetElectionIDUnsupported(_ *ondatra.DUTDevice) bool {
 	return *p4rtUnsetElectionIDUnsupported
 }
 
+// ExplicitP4RTNodeComponent returns if device does not report P4RT node names in the component hierarchy.
+// Fully compliant devices should report the PORT hardware components with the INTEGRATED_CIRCUIT components as their parents, as the P4RT node names.
+func ExplicitP4RTNodeComponent(_ *ondatra.DUTDevice) bool {
+	return *explicitP4RTNodeComponent
+}
+
 // ISISRestartSuppressUnsupported returns whether the device should skip isis restart-suppress check.
 func ISISRestartSuppressUnsupported(_ *ondatra.DUTDevice) bool {
 	return *isisRestartSuppressUnsupported
@@ -439,7 +445,7 @@ var (
 
 	explicitPortSpeed = flag.Bool("deviation_explicit_port_speed", false, "Device requires port-speed to be set because its default value may not be usable. Fully compliant devices should select the highest speed available based on negotiation.")
 
-	ExplicitP4RTNodeComponent = flag.Bool("deviation_explicit_p4rt_node_component", false, "Device does not report P4RT node names in the component hierarchy, so use hard coded P4RT node names by passing them through internal/args flags. Fully compliant devices should report the PORT hardware components with the INTEGRATED_CIRCUIT components as their parents, as the P4RT node names.")
+	explicitP4RTNodeComponent = flag.Bool("deviation_explicit_p4rt_node_component", false, "Device does not report P4RT node names in the component hierarchy, so use hard coded P4RT node names by passing them through internal/args flags. Fully compliant devices should report the PORT hardware components with the INTEGRATED_CIRCUIT components as their parents, as the P4RT node names.")
 
 	RoutePolicyUnderPeerGroup = flag.Bool("deviation_rpl_under_peergroup", false, "Device requires route-policy configuration under bgp peer-group. Fully-compliant devices should pass with and without this deviation.")
 


### PR DESCRIPTION
PiperOrigin-RevId: 532155770
Move `ExplicitP4RTNodeComponent` to accessor.