### PR TITLE
Adding deviations.MissingValueForDefaults for SUP power-admin-state which the default value is not streamed in telemetry

### DIFF
--- a/feature/platform/tests/power_admin_down_up_test/power_admin_down_up_test.go
+++ b/feature/platform/tests/power_admin_down_up_test/power_admin_down_up_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/openconfig/featureprofiles/internal/components"
+	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
@@ -117,11 +118,13 @@ func powerDownUp(t *testing.T, dut *ondatra.DUTDevice, name string, cType oc.E_P
 	t.Logf("Starting %s POWER_ENABLE", name)
 	gnmi.Replace(t, dut, config, oc.Platform_ComponentPowerType_POWER_ENABLED)
 
-	power, ok = gnmi.Await(t, dut, state, timeout, oc.Platform_ComponentPowerType_POWER_ENABLED).Val()
-	if !ok {
-		t.Errorf("Component %s, power-admin-state got: %v, want: %v", name, power, oc.Platform_ComponentPowerType_POWER_ENABLED)
+	if !deviations.MissingValueForDefaults(dut) {
+		power, ok = gnmi.Await(t, dut, state, timeout, oc.Platform_ComponentPowerType_POWER_ENABLED).Val()
+		if !ok {
+			t.Errorf("Component %s, power-admin-state got: %v, want: %v", name, power, oc.Platform_ComponentPowerType_POWER_ENABLED)
+		}
+		t.Logf("Component %s, power-admin-state after %f minutes: %v", name, time.Since(start).Minutes(), power)
 	}
-	t.Logf("Component %s, power-admin-state after %f minutes: %v", name, time.Since(start).Minutes(), power)
 
 	oper, ok = gnmi.Await(t, dut, c.OperStatus().State(), timeout, oc.PlatformTypes_COMPONENT_OPER_STATUS_ACTIVE).Val()
 	if !ok {


### PR DESCRIPTION
Adding deviations.MissingValueForDefaults for SUP power-admin-state which the default value is not streamed in telemetry to make the test the deviation aware!

gNMI GET "/components/component[name=Supervisor1]/controller-card/state/power-admin-state"
{

}
