### PR TITLE
DP-1.8: Two strict priority queue traffic test - Updating vendor specific queue numbers and scheduler weights

### DIFF
--- a/feature/qos/ate_tests/two_sp_queue_traffic_test/two_sp_queue_traffic_test.go
+++ b/feature/qos/ate_tests/two_sp_queue_traffic_test/two_sp_queue_traffic_test.go
@@ -156,13 +156,13 @@ func TestTwoSPQueueTraffic(t *testing.T) {
 			"BE1": "g_BE1",
 		},
 		ondatra.JUNIPER: {
-			"NC1": "3",
-			"AF4": "2",
-			"AF3": "5",
-			"AF2": "1",
-			"AF1": "4",
+			"NC1": "7",
+			"AF4": "6",
+			"AF3": "4",
+			"AF2": "3",
+			"AF1": "2",
 			"BE1": "0",
-			"BE0": "6",
+			"BE0": "1",
 		},
 		ondatra.NOKIA: {
 			"NC1": "7",
@@ -1214,13 +1214,13 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 
 	if dut.Vendor() == ondatra.JUNIPER {
 		qos = qosVals{
-			be0: "6",
+			be0: "1",
 			be1: "0",
-			af1: "4",
-			af2: "1",
-			af3: "5",
-			af4: "2",
-			nc1: "3",
+			af1: "2",
+			af2: "3",
+			af3: "4",
+			af4: "6",
+			nc1: "7",
 		}
 	}
 
@@ -1502,7 +1502,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		priority:    oc.Scheduler_Priority_STRICT,
 		inputID:     "AF4",
 		inputType:   oc.Input_InputType_QUEUE,
-		weight:      uint64(100),
+		weight:      uint64(99),
 		queueName:   qos.af4,
 		targetGroup: "target-group-AF4",
 	}, {
@@ -1511,7 +1511,7 @@ func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		priority:    oc.Scheduler_Priority_STRICT,
 		inputID:     "NC1",
 		inputType:   oc.Input_InputType_QUEUE,
-		weight:      uint64(200),
+		weight:      uint64(100),
 		queueName:   qos.nc1,
 		targetGroup: "target-group-NC1",
 	}}


### PR DESCRIPTION
DP-1.8: Two strict priority queue traffic test - Updating vendor specific queue numbers and scheduler weights
1.   Update Queue number changes
2.  Update Scheduler weight as there is a weight limit of 100
