### PR TITLE
Update KNE CI Trigger

### DIFF
--- a/cloudbuild/virtual.sh
+++ b/cloudbuild/virtual.sh
@@ -71,7 +71,7 @@ done
 
 kne deploy kne-internal/deploy/kne/kind-bridge.yaml
 
-pushd /tmp/workspace
+pushd /tmp/featureprofiles
 
 cp -r "${PWD}"/topologies/kne /tmp
 

--- a/cloudbuild/virtual.yaml
+++ b/cloudbuild/virtual.yaml
@@ -8,8 +8,8 @@ steps:
       - INSTANCE_NAME=fp-presubmit-${BUILD_ID}
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type ${_MACHINE_TYPE} ${_MACHINE_ARGS} --boot-disk-size 100GB --preemptible
       - ZONE=us-west1-a
-      - REMOTE_WORKSPACE=/tmp/workspace
-      - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/workspace/cloudbuild/virtual.sh "${_DUT_PLATFORM}" "${_DUT_TESTS}"
+      - REMOTE_WORKSPACE=/tmp/featureprofiles
+      - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/featureprofiles/cloudbuild/virtual.sh "${_DUT_PLATFORM}" "${_DUT_TESTS}"
 timeout: 2700s
 substitutions:
     _DUT_PLATFORM: unknown

--- a/tools/ci-trigger/README.md
+++ b/tools/ci-trigger/README.md
@@ -84,7 +84,7 @@ docker push us-west1-docker.pkg.dev/disco-idea-817/featureprofiles-ci/featurepro
 To deploy the container into the project:
 
 ```
-gcloud run deploy featureprofiles-ci-trigger --region us-west1 --image us-west1-docker.pkg.dev/disco-idea-817/featureprofiles-ci/featureprofiles-ci-trigger:latest
+gcloud run deploy featureprofiles-ci-trigger --memory 1G --region us-west1 --image us-west1-docker.pkg.dev/disco-idea-817/featureprofiles-ci/featureprofiles-ci-trigger:latest
 ```
 
 Allow for background CPU and a minimum instance count for pubsub pull to continue processing.

--- a/tools/ci-trigger/config.go
+++ b/tools/ci-trigger/config.go
@@ -120,4 +120,5 @@ var commentTpl = template.Must(template.New("commentTpl").Funcs(template.FuncMap
 
 {{ end }}{{ if and (not .Virtual) (not .Physical) }}
 No tests identified for validation.
-{{ end }}`))
+{{ end }}
+[Help](https://gist.github.com/OpenConfigBot/7dadd09b7c3133c9d8bc0d08fcb19b46)`))


### PR DESCRIPTION
* Update docs to recommend 1GB memory for CI Trigger.
* Update Cloud Build to use `/tmp/featureprofiles` for working directory: metadata file detection requires a root directory with this name.
* Add a 'Help' link to docs to PR comments.