### PR TITLE
gnmi-1.4: disable mfg-name validation for cpu component type

### DIFF
--- a/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
+++ b/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
@@ -251,7 +251,7 @@ func TestHardwareCards(t *testing.T) {
 				nameValidation:        true,
 				partNoValidation:      true,
 				serialNoValidation:    true,
-				mfgNameValidation:     true,
+				mfgNameValidation:     false,
 				mfgDateValidation:     false,
 				swVerValidation:       false,
 				hwVerValidation:       false,


### PR DESCRIPTION
Manufacturer name is not required for CPU per conversation in b/283934938

---
<sup>
This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.</sup>