### PR TITLE
ci-trigger: Allow unknown fields when decoding metadata.

### DIFF
--- a/tools/ci-trigger/pr.go
+++ b/tools/ci-trigger/pr.go
@@ -226,7 +226,7 @@ func (p *pullRequest) populateTestDetail(functionalTests []string) error {
 			return err
 		}
 		md := &mpb.Metadata{}
-		if err := prototext.Unmarshal(in, md); err != nil {
+		if err := (prototext.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(in, md); err != nil {
 			return err
 		}
 		for _, d := range virtualDeviceTypes {

--- a/tools/ci-trigger/pr_test.go
+++ b/tools/ci-trigger/pr_test.go
@@ -105,9 +105,9 @@ func TestPopulateTestDetail(t *testing.T) {
 		ID:      100,
 		HeadSHA: "1a2b3",
 		localFS: fstest.MapFS{
-			"feature/a/a/metadata.textproto":                                {Data: []byte("uuid: \"uuid-A\"\nplan_id: \"plan_id-A\"\ndescription: \"description-A\"\n")},
-			"feature/bgp/addpath/otg_tests/example_test/metadata.textproto": {Data: []byte("uuid: \"uuid-B\"\nplan_id: \"plan_id-B\"\ndescription: \"description-B\"\n")},
-			"feature/bgp/addpath/ate_tests/example_test/metadata.textproto": {Data: []byte("uuid: \"uuid-C\"\nplan_id: \"plan_id-C\"\ndescription: \"description-C\"\n")},
+			"feature/a/a/metadata.textproto":                                {Data: []byte("uuid: \"uuid-A\"\nplan_id: \"plan_id-A\"\ndescription: \"description-A\"\nunknown_field: true\n")},
+			"feature/bgp/addpath/otg_tests/example_test/metadata.textproto": {Data: []byte("uuid: \"uuid-B\"\nplan_id: \"plan_id-B\"\ndescription: \"description-B\"\nunknown_field: true\n")},
+			"feature/bgp/addpath/ate_tests/example_test/metadata.textproto": {Data: []byte("uuid: \"uuid-C\"\nplan_id: \"plan_id-C\"\ndescription: \"description-C\"\nunknown_field: true\n")},
 		},
 	}
 	modifiedTests := []string{"feature/bgp/addpath/otg_tests/example_test", "feature/bgp/addpath/ate_tests/example_test"}


### PR DESCRIPTION
The metadata protobuf is regularly changing as deviations evolve in pull requests.  Currently, ci-trigger will fail to parse the metadata.textproto if any new fields are introduced.  This PR allows for the unknown fields to be ignored, as it only needs to be aware of the PlanID and Description fields.