### PR TITLE
adding additional adjacency state telemetry to isis/feature.textproto

### DIFF
--- a/feature/isis/feature.textproto
+++ b/feature/isis/feature.textproto
@@ -121,6 +121,9 @@ config_path {
 telemetry_path {
   path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/state/circuit-type"
 }
+telemetry_path {
+  path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/circuit-counters/state/adj-changes"
+}
 
 # Interfaces csnp interval
 config_path {
@@ -302,6 +305,9 @@ telemetry_path {
 }
 telemetry_path {
     path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/adjacencies/adjacency/state/system-id"
+}
+telemetry_path {
+    path: "/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/adjacencies/adjacency/state/up-timestamp"
 }
 
 # AFI-SAFI


### PR DESCRIPTION
Adding additional adjacency state telemetry paths to isis/feature.textproto:

- .../circuit-counters/state/adj-changes
- .../levels/level/adjacencies/adjacency/state/up-timestamp

