### PR TITLE
Move deviations to metadata.textproto

### DIFF
--- a/feature/bgp/addpath/ate_tests/route_propagation_test/metadata.textproto
+++ b/feature/bgp/addpath/ate_tests/route_propagation_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/bgp/addpath/otg_tests/route_propagation_test/metadata.textproto
+++ b/feature/bgp/addpath/otg_tests/route_propagation_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/bgp/gracefulrestart/ate_tests/bgp_graceful_restart_test/metadata.textproto
+++ b/feature/bgp/gracefulrestart/ate_tests/bgp_graceful_restart_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     use_vendor_native_acl_config: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/bgp/policybase/ate_tests/route_installation_test/metadata.textproto
+++ b/feature/bgp/policybase/ate_tests/route_installation_test/metadata.textproto
@@ -18,3 +18,14 @@ platform_exceptions: {
     prepolicy_received_routes: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/bgp/policybase/otg_tests/route_installation_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/route_installation_test/metadata.textproto
@@ -18,3 +18,14 @@ platform_exceptions: {
     prepolicy_received_routes: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/bgp/prefixlimit/ate_tests/bgp_prefix_limit_test/metadata.textproto
+++ b/feature/bgp/prefixlimit/ate_tests/bgp_prefix_limit_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/metadata.textproto
+++ b/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/bgp/tests/local_bgp_test/metadata.textproto
+++ b/feature/bgp/tests/local_bgp_test/metadata.textproto
@@ -18,3 +18,14 @@ platform_exceptions: {
     missing_bgp_last_notification_error_code: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/bgp/timers/otg_tests/bgp_keepalive_and_holdtimer_configuration_test/metadata.textproto
+++ b/feature/bgp/timers/otg_tests/bgp_keepalive_and_holdtimer_configuration_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/metadata.textproto
+++ b/feature/experimental/backup_nhg/ate_tests/backup_nhg_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/backup_nhg/otg_tests/backup_nhg_test/metadata.textproto
+++ b/feature/experimental/backup_nhg/otg_tests/backup_nhg_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/bgp/ate_tests/base_bgp_session_parameters/metadata.textproto
+++ b/feature/experimental/bgp/ate_tests/base_bgp_session_parameters/metadata.textproto
@@ -18,3 +18,14 @@ platform_exceptions: {
     skip_bgp_test_password_mismatch: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/experimental/gribi/ate_tests/backup_nhg_action/metadata.textproto
+++ b/feature/experimental/gribi/ate_tests/backup_nhg_action/metadata.textproto
@@ -36,5 +36,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/gribi/ate_tests/dut_daemon_failure/metadata.textproto
+++ b/feature/experimental/gribi/ate_tests/dut_daemon_failure/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/experimental/gribi/ate_tests/route_addition_during_failover_test/metadata.textproto
+++ b/feature/experimental/gribi/ate_tests/route_addition_during_failover_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/gribi/ate_tests/route_removal_during_failover_test/metadata.textproto
+++ b/feature/experimental/gribi/ate_tests/route_removal_during_failover_test/metadata.textproto
@@ -26,6 +26,8 @@ platform_exceptions: {
   deviations: {
     no_mix_of_tagged_and_untagged_subinterfaces: true
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/experimental/gribi/otg_tests/backup_nhg_action/metadata.textproto
+++ b/feature/experimental/gribi/otg_tests/backup_nhg_action/metadata.textproto
@@ -36,5 +36,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/gribi/otg_tests/dut_daemon_failure/metadata.textproto
+++ b/feature/experimental/gribi/otg_tests/dut_daemon_failure/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/metadata.textproto
+++ b/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/gribi/otg_tests/route_removal_during_failover_test/metadata.textproto
+++ b/feature/experimental/gribi/otg_tests/route_removal_during_failover_test/metadata.textproto
@@ -26,6 +26,8 @@ platform_exceptions: {
   deviations: {
     no_mix_of_tagged_and_untagged_subinterfaces: true
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/experimental/interface/my_station_mac/ate_tests/my_station_mac_test/metadata.textproto
+++ b/feature/experimental/interface/my_station_mac/ate_tests/my_station_mac_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/experimental/interface/my_station_mac/otg_tests/my_station_mac_test/metadata.textproto
+++ b/feature/experimental/interface/my_station_mac/otg_tests/my_station_mac_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/experimental/isis/ate_tests/base_adjacencies_test/metadata.textproto
+++ b/feature/experimental/isis/ate_tests/base_adjacencies_test/metadata.textproto
@@ -17,6 +17,8 @@ platform_exceptions: {
     isis_instance_enabled_not_required: true
     missing_isis_interface_afi_safi_enable: true
     isis_restart_suppress_unsupported: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/experimental/isis/ate_tests/lsp_updates_test/metadata.textproto
+++ b/feature/experimental/isis/ate_tests/lsp_updates_test/metadata.textproto
@@ -15,6 +15,8 @@ platform_exceptions: {
     isis_interface_level1_disable_required: true
     isis_instance_enabled_not_required: true
     missing_isis_interface_afi_safi_enable: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/experimental/isis/otg_tests/base_adjacencies_test/metadata.textproto
+++ b/feature/experimental/isis/otg_tests/base_adjacencies_test/metadata.textproto
@@ -17,6 +17,8 @@ platform_exceptions: {
     isis_instance_enabled_not_required: true
     missing_isis_interface_afi_safi_enable: true
     isis_restart_suppress_unsupported: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/experimental/isis/otg_tests/lsp_updates_test/metadata.textproto
+++ b/feature/experimental/isis/otg_tests/lsp_updates_test/metadata.textproto
@@ -15,6 +15,8 @@ platform_exceptions: {
     isis_interface_level1_disable_required: true
     isis_instance_enabled_not_required: true
     missing_isis_interface_afi_safi_enable: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/experimental/p4rt/ate_tests/base_p4rt/metadata.textproto
+++ b/feature/experimental/p4rt/ate_tests/base_p4rt/metadata.textproto
@@ -13,5 +13,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetin_test/metadata.textproto
+++ b/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetin_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetout_test/metadata.textproto
+++ b/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetout_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/ate_tests/lldp_packetin_test/metadata.textproto
+++ b/feature/experimental/p4rt/ate_tests/lldp_packetin_test/metadata.textproto
@@ -13,5 +13,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/ate_tests/lldp_packetout_test/metadata.textproto
+++ b/feature/experimental/p4rt/ate_tests/lldp_packetout_test/metadata.textproto
@@ -13,5 +13,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/ate_tests/p4rt_daemon_failure_test/metadata.textproto
+++ b/feature/experimental/p4rt/ate_tests/p4rt_daemon_failure_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/ate_tests/performance_test/metadata.textproto
+++ b/feature/experimental/p4rt/ate_tests/performance_test/metadata.textproto
@@ -13,5 +13,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/ate_tests/traceroute_packetin_test/metadata.textproto
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetin_test/metadata.textproto
@@ -13,5 +13,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/metadata.textproto
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/otg_tests/base_p4rt/metadata.textproto
+++ b/feature/experimental/p4rt/otg_tests/base_p4rt/metadata.textproto
@@ -13,5 +13,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/otg_tests/google_discovery_protocol_packetin_test/metadata.textproto
+++ b/feature/experimental/p4rt/otg_tests/google_discovery_protocol_packetin_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/otg_tests/google_discovery_protocol_packetout_test/metadata.textproto
+++ b/feature/experimental/p4rt/otg_tests/google_discovery_protocol_packetout_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/otg_tests/lldp_packetin_test/metadata.textproto
+++ b/feature/experimental/p4rt/otg_tests/lldp_packetin_test/metadata.textproto
@@ -13,5 +13,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/otg_tests/lldp_packetout_test/metadata.textproto
+++ b/feature/experimental/p4rt/otg_tests/lldp_packetout_test/metadata.textproto
@@ -13,5 +13,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/otg_tests/traceroute_packetin_test/metadata.textproto
+++ b/feature/experimental/p4rt/otg_tests/traceroute_packetin_test/metadata.textproto
@@ -13,5 +13,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/p4rt/otg_tests/traceroute_packetout_test/metadata.textproto
+++ b/feature/experimental/p4rt/otg_tests/traceroute_packetout_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/base_vrf_selection/metadata.textproto
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/base_vrf_selection/metadata.textproto
@@ -18,3 +18,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/metadata.textproto
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/metadata.textproto
@@ -26,6 +26,8 @@ platform_exceptions: {
   }
   deviations: {
     no_mix_of_tagged_and_untagged_subinterfaces: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/metadata.textproto
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/metadata.textproto
@@ -18,3 +18,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/metadata.textproto
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/metadata.textproto
@@ -26,6 +26,8 @@ platform_exceptions: {
   }
   deviations: {
     no_mix_of_tagged_and_untagged_subinterfaces: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/experimental/system/gnmi/benchmarking/ate_tests/drained_configuration_convergence_time/metadata.textproto
+++ b/feature/experimental/system/gnmi/benchmarking/ate_tests/drained_configuration_convergence_time/metadata.textproto
@@ -28,5 +28,7 @@ platform_exceptions: {
     isis_global_authentication_not_required: true
     isis_explicit_level_authentication_config: true
     missing_isis_interface_afi_safi_enable: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/experimental/system/gnmi/benchmarking/ate_tests/full_configuration_replace_test/metadata.textproto
+++ b/feature/experimental/system/gnmi/benchmarking/ate_tests/full_configuration_replace_test/metadata.textproto
@@ -28,5 +28,7 @@ platform_exceptions: {
     isis_global_authentication_not_required: true
     isis_explicit_level_authentication_config: true
     missing_isis_interface_afi_safi_enable: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/gnmi/ate_tests/telemetry_basic_check_test/metadata.textproto
+++ b/feature/gnmi/ate_tests/telemetry_basic_check_test/metadata.textproto
@@ -29,6 +29,8 @@ platform_exceptions: {
   deviations: {
     interface_counters_from_container: true
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/metadata.textproto
+++ b/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/metadata.textproto
@@ -36,6 +36,8 @@ platform_exceptions: {
   }
   deviations: {
     interface_counters_from_container: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/gnmi/ate_tests/telemetry_port_speed_test/metadata.textproto
+++ b/feature/gnmi/ate_tests/telemetry_port_speed_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/metadata.textproto
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/metadata.textproto
@@ -29,6 +29,8 @@ platform_exceptions: {
   deviations: {
     interface_counters_from_container: true
     explicit_p4rt_node_component: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/metadata.textproto
+++ b/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/metadata.textproto
@@ -36,6 +36,8 @@ platform_exceptions: {
   }
   deviations: {
     interface_counters_from_container: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/gnoi/system/tests/ping_test/metadata.textproto
+++ b/feature/gnoi/system/tests/ping_test/metadata.textproto
@@ -5,3 +5,13 @@ uuid: "24dc9bcf-f76c-4ac4-a268-35d417d01a3d"
 plan_id: "gNOI-5.1"
 description: "Ping Test"
 testbed: TESTBED_DUT_ATE_2LINKS
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gnoi/system/tests/traceroute_test/metadata.textproto
+++ b/feature/gnoi/system/tests/traceroute_test/metadata.textproto
@@ -18,3 +18,13 @@ platform_exceptions: {
     traceroute_l4_protocol_udp: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/ate_tests/ack_in_presence_other_routes/metadata.textproto
+++ b/feature/gribi/ate_tests/ack_in_presence_other_routes/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/ate_tests/backup_nhg_multiple_nh_test/metadata.textproto
+++ b/feature/gribi/ate_tests/backup_nhg_multiple_nh_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/gribi/ate_tests/base_hierarchical_nhg_update/metadata.textproto
+++ b/feature/gribi/ate_tests/base_hierarchical_nhg_update/metadata.textproto
@@ -36,5 +36,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/metadata.textproto
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/ate_tests/base_leader_election_test/metadata.textproto
+++ b/feature/gribi/ate_tests/base_leader_election_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/ate_tests/get_rpc_test/metadata.textproto
+++ b/feature/gribi/ate_tests/get_rpc_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/ate_tests/gribi_scaling/metadata.textproto
+++ b/feature/gribi/ate_tests/gribi_scaling/metadata.textproto
@@ -27,6 +27,8 @@ platform_exceptions: {
     no_mix_of_tagged_and_untagged_subinterfaces: true
     explicit_interface_ref_definition: true
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/gribi/ate_tests/gribigo_compliance_test/metadata.textproto
+++ b/feature/gribi/ate_tests/gribigo_compliance_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/metadata.textproto
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/metadata.textproto
@@ -39,5 +39,7 @@ platform_exceptions: {
   deviations: {
     explicit_interface_ref_definition: true
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/gribi/ate_tests/ipv4_entry_test/metadata.textproto
+++ b/feature/gribi/ate_tests/ipv4_entry_test/metadata.textproto
@@ -28,3 +28,14 @@ platform_exceptions: {
     ipv6_enable_for_gribi_nh_dmac: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/ate_tests/ordering_ack_test/metadata.textproto
+++ b/feature/gribi/ate_tests/ordering_ack_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/ate_tests/persistence_mode_test/metadata.textproto
+++ b/feature/gribi/ate_tests/persistence_mode_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/ate_tests/route_removal_non_default_vrf_test/metadata.textproto
+++ b/feature/gribi/ate_tests/route_removal_non_default_vrf_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/gribi/ate_tests/route_removal_via_flush_test/metadata.textproto
+++ b/feature/gribi/ate_tests/route_removal_via_flush_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/ate_tests/supervisor_failure_test/metadata.textproto
+++ b/feature/gribi/ate_tests/supervisor_failure_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/ate_tests/weighted_balancing_test/metadata.textproto
+++ b/feature/gribi/ate_tests/weighted_balancing_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/otg_tests/ack_in_presence_other_routes/metadata.textproto
+++ b/feature/gribi/otg_tests/ack_in_presence_other_routes/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/gribi/otg_tests/backup_nhg_multiple_nh_test/metadata.textproto
+++ b/feature/gribi/otg_tests/backup_nhg_multiple_nh_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/gribi/otg_tests/base_hierarchical_nhg_update/metadata.textproto
+++ b/feature/gribi/otg_tests/base_hierarchical_nhg_update/metadata.textproto
@@ -36,5 +36,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/gribi/otg_tests/base_hierarchical_route_installation_test/metadata.textproto
+++ b/feature/gribi/otg_tests/base_hierarchical_route_installation_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/otg_tests/base_leader_election_test/metadata.textproto
+++ b/feature/gribi/otg_tests/base_leader_election_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/otg_tests/get_rpc_test/metadata.textproto
+++ b/feature/gribi/otg_tests/get_rpc_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/otg_tests/gribi_scaling/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_scaling/metadata.textproto
@@ -27,6 +27,8 @@ platform_exceptions: {
     no_mix_of_tagged_and_untagged_subinterfaces: true
     explicit_interface_ref_definition: true
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }
 platform_exceptions: {

--- a/feature/gribi/otg_tests/gribigo_compliance_test/metadata.textproto
+++ b/feature/gribi/otg_tests/gribigo_compliance_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/gribi/otg_tests/ipv4_entry_test/metadata.textproto
+++ b/feature/gribi/otg_tests/ipv4_entry_test/metadata.textproto
@@ -28,3 +28,14 @@ platform_exceptions: {
     ipv6_enable_for_gribi_nh_dmac: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/otg_tests/ordering_ack_test/metadata.textproto
+++ b/feature/gribi/otg_tests/ordering_ack_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/otg_tests/persistence_mode_test/metadata.textproto
+++ b/feature/gribi/otg_tests/persistence_mode_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/otg_tests/route_removal_non_default_vrf_test/metadata.textproto
+++ b/feature/gribi/otg_tests/route_removal_non_default_vrf_test/metadata.textproto
@@ -25,5 +25,7 @@ platform_exceptions: {
   }
   deviations: {
     explicit_gribi_under_network_instance: true
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
   }
 }

--- a/feature/gribi/otg_tests/route_removal_via_flush_test/metadata.textproto
+++ b/feature/gribi/otg_tests/route_removal_via_flush_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/otg_tests/supervisor_failure_test/metadata.textproto
+++ b/feature/gribi/otg_tests/supervisor_failure_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/gribi/otg_tests/weighted_balancing_test/metadata.textproto
+++ b/feature/gribi/otg_tests/weighted_balancing_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/interface/aggregate/ate_tests/aggregate_forwarding_viable_test/metadata.textproto
+++ b/feature/interface/aggregate/ate_tests/aggregate_forwarding_viable_test/metadata.textproto
@@ -5,3 +5,14 @@ uuid: "7a38f75a-0ff8-4a86-9398-e28c32de1862"
 plan_id: "RT-5.4"
 description: "Aggregate Forwarding Viable"
 testbed: TESTBED_DUT_ATE_9LINKS
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/interface/aggregate/ate_tests/aggregate_test/metadata.textproto
+++ b/feature/interface/aggregate/ate_tests/aggregate_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/interface/aggregate/ate_tests/balancing_test/metadata.textproto
+++ b/feature/interface/aggregate/ate_tests/balancing_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/interface/aggregate/otg_tests/aggregate_forwarding_viable_test/metadata.textproto
+++ b/feature/interface/aggregate/otg_tests/aggregate_forwarding_viable_test/metadata.textproto
@@ -5,3 +5,14 @@ uuid: "7a38f75a-0ff8-4a86-9398-e28c32de1862"
 plan_id: "RT-5.4"
 description: "Aggregate Forwarding Viable"
 testbed: TESTBED_DUT_ATE_9LINKS
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/interface/aggregate/otg_tests/aggregate_test/metadata.textproto
+++ b/feature/interface/aggregate/otg_tests/aggregate_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/interface/aggregate/otg_tests/balancing_test/metadata.textproto
+++ b/feature/interface/aggregate/otg_tests/balancing_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/interface/singleton/ate_tests/singleton_test/metadata.textproto
+++ b/feature/interface/singleton/ate_tests/singleton_test/metadata.textproto
@@ -18,3 +18,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/interface/singleton/otg_tests/singleton_test/metadata.textproto
+++ b/feature/interface/singleton/otg_tests/singleton_test/metadata.textproto
@@ -18,3 +18,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/interface/staticarp/ate_tests/static_arp_test/metadata.textproto
+++ b/feature/interface/staticarp/ate_tests/static_arp_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/interface/staticarp/otg_tests/static_arp_test/metadata.textproto
+++ b/feature/interface/staticarp/otg_tests/static_arp_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/networkinstance/ate_tests/defaults_test/metadata.textproto
+++ b/feature/networkinstance/ate_tests/defaults_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/networkinstance/otg_tests/defaults_test/metadata.textproto
+++ b/feature/networkinstance/otg_tests/defaults_test/metadata.textproto
@@ -17,3 +17,14 @@ platform_exceptions: {
     ipv4_missing_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+    explicit_interface_in_default_vrf: true
+  }
+}

--- a/feature/platform/tests/optics_power_and_bias_current_test/metadata.textproto
+++ b/feature/platform/tests/optics_power_and_bias_current_test/metadata.textproto
@@ -5,3 +5,13 @@ uuid: "fd964d62-068c-486d-8b17-912dfd48f388"
 plan_id: "gNMI-1.13"
 description: "Telemetry: Optics Power and Bias Current"
 testbed: TESTBED_DUT_ATE_2LINKS
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    explicit_port_speed: true
+  }
+}

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -415,15 +415,17 @@ func NetworkInstanceTableDeletionRequired(_ *ondatra.DUTDevice) bool {
 
 // ExplicitPortSpeed returns if device requires port-speed to be set because its default value may not be usable.
 // Fully compliant devices selects the highest speed available based on negotiation.
-func ExplicitPortSpeed(_ *ondatra.DUTDevice) bool {
-	return *explicitPortSpeed
+func ExplicitPortSpeed(dut *ondatra.DUTDevice) bool {
+	logErrorIfFlagSet("deviation_explicit_port_speed")
+	return lookupDUTDeviations(dut).GetExplicitPortSpeed()
 }
 
 // ExplicitInterfaceInDefaultVRF returns if device requires explicit attachment of an interface or subinterface to the default network instance.
 // OpenConfig expects an unattached interface or subinterface to be implicitly part of the default network instance.
 // Fully-compliant devices should pass with and without this deviation.
-func ExplicitInterfaceInDefaultVRF(_ *ondatra.DUTDevice) bool {
-	return *explicitInterfaceInDefaultVRF
+func ExplicitInterfaceInDefaultVRF(dut *ondatra.DUTDevice) bool {
+	logErrorIfFlagSet("deviation_explicit_interface_in_default_vrf")
+	return lookupDUTDeviations(dut).GetExplicitInterfaceInDefaultVrf()
 }
 
 // InterfaceConfigVRFBeforeAddress returns if vrf should be configured before IP address when configuring interface.
@@ -562,10 +564,10 @@ var (
 
 	deprecatedVlanID = flag.Bool("deviation_deprecated_vlan_id", false, "Device requires using the deprecated openconfig-vlan:vlan/config/vlan-id or openconfig-vlan:vlan/state/vlan-id leaves.")
 
-	explicitInterfaceInDefaultVRF = flag.Bool("deviation_explicit_interface_in_default_vrf", false,
+	_ = flag.Bool("deviation_explicit_interface_in_default_vrf", false,
 		"Device requires explicit attachment of an interface or subinterface to the default network instance. OpenConfig expects an unattached interface or subinterface to be implicitly part of the default network instance. Fully-compliant devices should pass with and without this deviation.")
 
-	explicitPortSpeed = flag.Bool("deviation_explicit_port_speed", false, "Device requires port-speed to be set because its default value may not be usable. Fully compliant devices should select the highest speed available based on negotiation.")
+	_ = flag.Bool("deviation_explicit_port_speed", false, "Device requires port-speed to be set because its default value may not be usable. Fully compliant devices should select the highest speed available based on negotiation.")
 
 	_ = flag.Bool("deviation_explicit_p4rt_node_component", false, "Device does not report P4RT node names in the component hierarchy, so use hard coded P4RT node names by passing them through internal/args flags. Fully compliant devices should report the PORT hardware components with the INTEGRATED_CIRCUIT components as their parents, as the P4RT node names.")
 

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -162,6 +162,13 @@ message Metadata {
     bool storage_component_unsupported = 39;
     // Device requires gribi-protocol to be enabled under network-instance.
     bool explicit_gribi_under_network_instance = 40;
+    // Device requires port-speed to be set because its default value may not be
+    // usable.
+    bool explicit_port_speed = 41;
+    // Device requires explicit attachment of an interface or subinterface to
+    // the default network instance.
+    // Nokia: partnerissuetracker.corp.google.com/260928639
+    bool explicit_interface_in_default_vrf = 42;
   }
 
   message PlatformExceptions {

--- a/proto/metadata_go_proto/metadata.pb.go
+++ b/proto/metadata_go_proto/metadata.pb.go
@@ -24,9 +24,10 @@ import (
 	reflect "reflect"
 	sync "sync"
 
-	proto "github.com/openconfig/ondatra/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
+	proto "github.com/openconfig/ondatra/proto"
 )
 
 const (

--- a/tools/ci-trigger/main.go
+++ b/tools/ci-trigger/main.go
@@ -20,7 +20,6 @@
 package main
 
 import (
-	"flag"
 	"net/http"
 	"os"
 


### PR DESCRIPTION
PiperOrigin-RevId: 538578102
Moving the following protos:
 - explicit_port_speed
 - explicit_interface_in_default_vrf