### PR TITLE
TE-3.1: Updating metadata.textproto with missing deviation

### DIFF
--- a/feature/gribi/ate_tests/base_hierarchical_route_installation_test/metadata.textproto
+++ b/feature/gribi/ate_tests/base_hierarchical_route_installation_test/metadata.textproto
@@ -26,5 +26,7 @@ platform_exceptions: {
   deviations: {
     explicit_port_speed: true
     explicit_interface_in_default_vrf: true
+    explicit_gribi_under_network_instance: true
+    explicit_interface_ref_definition: true
   }
 }

--- a/feature/gribi/otg_tests/base_hierarchical_route_installation_test/metadata.textproto
+++ b/feature/gribi/otg_tests/base_hierarchical_route_installation_test/metadata.textproto
@@ -26,5 +26,7 @@ platform_exceptions: {
   deviations: {
     explicit_port_speed: true
     explicit_interface_in_default_vrf: true
+    explicit_gribi_under_network_instance: true
+    explicit_interface_ref_definition: true
   }
 }


### PR DESCRIPTION
Adding following 2 missing deviations to `metadata.textproto` -

      explicit_gribi_under_network_instance: true
      explicit_interface_ref_definition: true

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."