### PR TITLE
restore mac+interface-ref addNH() code in gribi.go helper

### DIFF
--- a/internal/gribi/gribi.go
+++ b/internal/gribi/gribi.go
@@ -229,7 +229,7 @@ func (c *Client) AddNH(t testing.TB, nhIndex uint64, address, instance string, e
 				nh = nh.WithSubinterfaceRef(opt.Interface, opt.SubInterface).
 					WithMacAddress(opt.Mac)
 			} else {
-				nh = nh.WithIPAddress(opt.Dest).WithMacAddress(opt.Mac)
+				nh = nh.WithInterfaceRef(opt.Interface).WithMacAddress(opt.Mac)
 			}
 		}
 	default:


### PR DESCRIPTION
In #1740, code for gribi addNH() helper was modified to remove interface-ref from intf+MAC NH case statement, that doesn't seem to be correct
restoring the previous version

---
<sup>
This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.
</sup>