### PR TITLE
Increase await timeouts for slower systems

### DIFF
--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -262,7 +262,7 @@ func TestAwait(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc+"/AwaitFor", func(t *testing.T) {
 			fakeGNMI.stubChildTwo(tc.updates...)
-			gotErr := tc.validator.AwaitFor(time.Millisecond*50, c)
+			gotErr := tc.validator.AwaitFor(time.Millisecond*500, c)
 			if len(tc.errIncludes) > 0 {
 				if err := errContainsAll(gotErr, tc.errIncludes); err != nil {
 					t.Error(err)
@@ -273,7 +273,7 @@ func TestAwait(t *testing.T) {
 		})
 		t.Run(tc.desc+"/AwaitUntil", func(t *testing.T) {
 			fakeGNMI.stubChildTwo(tc.updates...)
-			gotErr := tc.validator.AwaitUntil(time.Now().Add(time.Millisecond*50), c)
+			gotErr := tc.validator.AwaitUntil(time.Now().Add(time.Millisecond*500), c)
 			if len(tc.errIncludes) > 0 {
 				if err := errContainsAll(gotErr, tc.errIncludes); err != nil {
 					t.Error(err)


### PR DESCRIPTION
We occasionally see an error such as `check_test.go:279: Error [/parent/child/state/two: got no value, want "correct" (deadline exceeded)]: Missing substring "EOF"` in `go test` output in GitHub Actions CI. This change raises the deadline from 50ms to 500ms. I have not been able to reproduce this flake on my machine except when significantly lowering the deadline (i.e. 10ms). These flakes might be explained if the CPU is being preempted on the GitHub runner side.

Fixes #1759.