### PR TITLE
adding 7280 and cEOS to the fabric_component_reboot_unsupported exception list 

### DIFF
--- a/feature/gnoi/system/tests/per_component_reboot_test/metadata.textproto
+++ b/feature/gnoi/system/tests/per_component_reboot_test/metadata.textproto
@@ -16,3 +16,13 @@ platform_exceptions: {
     gnoi_fabric_component_reboot_unsupported: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: ARISTA
+    hardware_model: "DCS-7280CR3K-32D4"
+    hardware_model: "ceos"
+  }
+  deviations: {
+    gnoi_fabric_component_reboot_unsupported: true
+  }
+}


### PR DESCRIPTION
the non-modular 7280 doesn't support dedicated fabric chip for OC query nor reboot operation., same to the cEOS instance. 