### PR TITLE
ci-trigger: Add support for raw log buckets

### DIFF
--- a/tools/ci-trigger/cloudbuild.go
+++ b/tools/ci-trigger/cloudbuild.go
@@ -75,6 +75,7 @@ func (c *cloudBuild) submitBuild(ctx context.Context) (string, string, error) {
 		return "", "", err
 	}
 
+	build.LogsBucket = "gs://featureprofiles-ci-logs-" + vendor
 	build.Source = &cloudbuild.Source{
 		StorageSource: &cloudbuild.StorageSource{
 			Bucket: gcpCloudBuildBucketName,

--- a/tools/ci-trigger/config.go
+++ b/tools/ci-trigger/config.go
@@ -113,9 +113,9 @@ var commentTpl = template.Must(template.New("commentTpl").Funcs(template.FuncMap
 {{ if .Virtual }}
 ### Virtual Devices
 
-| Device | Test | Test Documentation | Job |
-| --- | --- | --- | --- |
-{{ range .Virtual }}| {{ .Type.Vendor.String | titleCase }} {{ .Type.HardwareModel }} | {{ range .Tests }}[![status]({{ .BadgeURL }})]({{ .TestURL }})<br />{{ end }} | {{ range .Tests }}[{{ .Name }}: {{ .Description }}]({{ .DocURL }})<br />{{ end }} | {{ if and .CloudBuildLogURL .CloudBuildID }}[{{ printf "%.8s" .CloudBuildID }}]({{ .CloudBuildLogURL }}){{ end }} |
+| Device | Test | Test Documentation | Job | Raw Log |
+| --- | --- | --- | --- | --- |
+{{ range .Virtual }}| {{ .Type.Vendor.String | titleCase }} {{ .Type.HardwareModel }} | {{ range .Tests }}[![status]({{ .BadgeURL }})]({{ .TestURL }})<br />{{ end }} | {{ range .Tests }}[{{ .Name }}: {{ .Description }}]({{ .DocURL }})<br />{{ end }} | {{ if and .CloudBuildLogURL .CloudBuildID }}[{{ printf "%.8s" .CloudBuildID }}]({{ .CloudBuildLogURL }}){{ end }} | {{ if .CloudBuildRawLogURL }}[Log]({{ .CloudBuildRawLogURL }}){{ end }} |
 {{ end }}{{ end }}{{ if .Physical }}
 ### Hardware Devices
 

--- a/tools/ci-trigger/pr.go
+++ b/tools/ci-trigger/pr.go
@@ -50,10 +50,11 @@ type pullRequest struct {
 }
 
 type device struct {
-	Type             deviceType
-	CloudBuildID     string
-	CloudBuildLogURL string
-	Tests            []functionalTest
+	Type                deviceType
+	CloudBuildID        string
+	CloudBuildLogURL    string
+	CloudBuildRawLogURL string
+	Tests               []functionalTest
 }
 
 type deviceType struct {
@@ -102,6 +103,9 @@ func (p *pullRequest) createBuild(ctx context.Context, buildClient *cloudbuild.S
 				}
 				p.Virtual[i].CloudBuildID = jobID
 				p.Virtual[i].CloudBuildLogURL = logURL
+				vendor := strings.ToLower(virtualDevice.Type.Vendor.String())
+				vendor = strings.ReplaceAll(vendor, " ", "")
+				p.Virtual[i].CloudBuildRawLogURL = fmt.Sprintf("https://storage.cloud.google.com/featureprofiles-ci-logs-%s/log-%s.txt", vendor, jobID)
 				for j := range virtualDevice.Tests {
 					p.Virtual[i].Tests[j].Status = "setup"
 				}
@@ -154,6 +158,9 @@ func (p *pullRequest) populateObjectMetadata(ctx context.Context, storClient *st
 			if cloudBuildLogURL, ok := objAttrs.Metadata["cloudBuildLogURL"]; ok {
 				p.Virtual[i].CloudBuildLogURL = cloudBuildLogURL
 			}
+			if cloudBuildRawLogURL, ok := objAttrs.Metadata["CloudBuildRawLogURL"]; ok {
+				p.Virtual[i].CloudBuildRawLogURL = cloudBuildRawLogURL
+			}
 		}
 	}
 }
@@ -174,10 +181,11 @@ func (p *pullRequest) updateBadges(ctx context.Context, storClient *storage.Clie
 			obj.ContentType = "image/svg+xml"
 			obj.CacheControl = "no-cache,max-age=0"
 			obj.Metadata = map[string]string{
-				"status":           test.Status,
-				"label":            test.Name,
-				"cloudBuild":       device.CloudBuildID,
-				"cloudBuildLogURL": device.CloudBuildLogURL,
+				"status":              test.Status,
+				"label":               test.Name,
+				"cloudBuild":          device.CloudBuildID,
+				"cloudBuildLogURL":    device.CloudBuildLogURL,
+				"cloudBuildRawLogURL": device.CloudBuildRawLogURL,
 			}
 			if _, err := buf.WriteTo(obj); err != nil {
 				return err


### PR DESCRIPTION
This PR adds support for raw logs to be exported to buckets by Cloud Build.  The existing link to the GCP Cloud Build log/console has some issues with how logs are rendered and we do not want to broadly expose access to this anyway.  With this change, log text files are exported to buckets by vendor.  This will allow for giving more fine-grained access to these logs in the future.