### PR TITLE
Support for self-deletion of CI VM instances.

### DIFF
--- a/cloudbuild/cleanup.sh
+++ b/cloudbuild/cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 sleep 2h
-echo "Execution timeout reached; deleting self"
-NAME=$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/name -H 'Metadata-Flavor: Google')
-ZONE=$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/zone -H 'Metadata-Flavor: Google')
-gcloud --quiet compute instances delete $NAME --zone=$ZONE
+echo 'Execution timeout reached; deleting self'
+NAME="$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/name -H 'Metadata-Flavor: Google')"
+ZONE="$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/zone -H 'Metadata-Flavor: Google')"
+gcloud --quiet compute instances delete "${NAME}" --zone="${ZONE}"

--- a/cloudbuild/cleanup.sh
+++ b/cloudbuild/cleanup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+sleep 2h
+echo "Execution timeout reached; deleting self"
+NAME=$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/name -H 'Metadata-Flavor: Google')
+ZONE=$(curl -X GET http://metadata.google.internal/computeMetadata/v1/instance/zone -H 'Metadata-Flavor: Google')
+gcloud --quiet compute instances delete $NAME --zone=$ZONE

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
     env:
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-arista-ceos-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-8 --boot-disk-size 200GB --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-8 --boot-disk-size 200GB --preemptible --scopes=default,compute-rw
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/featureprofiles
       - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/featureprofiles/cloudbuild/test.sh arista_ceos 2>&1
@@ -15,7 +15,7 @@ steps:
     env:
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-juniper-cptx-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-16 --boot-disk-size 200GB --enable-nested-virtualization --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-16 --boot-disk-size 200GB --enable-nested-virtualization --preemptible --scopes=default,compute-rw
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/featureprofiles
       - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/featureprofiles/cloudbuild/test.sh juniper_cptx 2>&1
@@ -25,7 +25,7 @@ steps:
     env:
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-cisco-8000e-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-8 --boot-disk-size 200GB --enable-nested-virtualization --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type n2-standard-8 --boot-disk-size 200GB --enable-nested-virtualization --preemptible --scopes=default,compute-rw
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/featureprofiles
       - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/featureprofiles/cloudbuild/test.sh cisco_8000e 2>&1
@@ -35,7 +35,7 @@ steps:
     env:
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-cisco-xrd-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-8 --boot-disk-size 200GB --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-8 --boot-disk-size 200GB --preemptible --scopes=default,compute-rw
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/featureprofiles
       - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/featureprofiles/cloudbuild/test.sh cisco_xrd 2>&1
@@ -46,7 +46,7 @@ steps:
       - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-nokia-srlinux-$BUILD_ID
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-8 --boot-disk-size 200GB --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type e2-standard-8 --boot-disk-size 200GB --preemptible --scopes=default,compute-rw
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/featureprofiles
       - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/featureprofiles/cloudbuild/test.sh nokia_srlinux 2>&1

--- a/cloudbuild/test.sh
+++ b/cloudbuild/test.sh
@@ -15,6 +15,8 @@
 
 set -xe
 
+nohup /tmp/featureprofiles/cloudbuild/cleanup.sh 2>/dev/null &
+
 case $1 in
   arista_ceos)
     topology=arista/ceos/dutate.textproto

--- a/cloudbuild/virtual.sh
+++ b/cloudbuild/virtual.sh
@@ -15,6 +15,8 @@
 
 set -x
 
+nohup /tmp/featureprofiles/cloudbuild/cleanup.sh 2>/dev/null &
+
 readonly platform="${1}"
 readonly dut_tests="${2}"
 

--- a/cloudbuild/virtual.yaml
+++ b/cloudbuild/virtual.yaml
@@ -6,7 +6,7 @@ steps:
       - USERNAME=user
       - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
       - INSTANCE_NAME=fp-presubmit-${BUILD_ID}
-      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type ${_MACHINE_TYPE} ${_MACHINE_ARGS} --boot-disk-size 200GB --preemptible
+      - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type ${_MACHINE_TYPE} ${_MACHINE_ARGS} --boot-disk-size 200GB --preemptible --scopes=default,compute-rw
       - ZONE=us-west1-a
       - REMOTE_WORKSPACE=/tmp/featureprofiles
       - COMMAND=sudo su -c "echo 'user ALL=(ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo"; sudo -iu user /tmp/featureprofiles/cloudbuild/virtual.sh "${_DUT_PLATFORM}" "${_DUT_TESTS}"


### PR DESCRIPTION
In some cases, it is possible for Cloud Build to terminate a job immediately without cleanup.  This can leave VM instances orphaned because Cloud Build is the only task that can clean up an instance.  With this change, VMs will delete themselves after 2 hours.  This is greater than the 2700s (45min) limit currently set, so it should only be possible to trigger this event if something has gone wrong.