### PR TITLE
RT-1.12: adding route-policy import for ebgp sessions

### DIFF
--- a/feature/experimental/bgp/ate_tests/bgp_always_compare_med/bgp_always_compare_med_test.go
+++ b/feature/experimental/bgp/ate_tests/bgp_always_compare_med/bgp_always_compare_med_test.go
@@ -124,8 +124,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 // verifyPortsUp asserts that each port on the device is operating.
 func verifyPortsUp(t *testing.T, dev *ondatra.Device) {
 	t.Helper()
-	//for _, p := range dev.Ports() {
-	for _, p := range []*ondatra.Port{dev.Port(t, "port1"), dev.Port(t, "port2"), dev.Port(t, "port3")} {
+	for _, p := range dev.Ports() {
 		status := gnmi.Get(t, dev, gnmi.OC().Interface(p.Name()).OperStatus().State())
 		if want := oc.Interface_OperStatus_UP; status != want {
 			t.Errorf("%s Status: got %v, want %v", p, status, want)
@@ -507,15 +506,9 @@ func TestAlwaysCompareMED(t *testing.T) {
 		t.Log("Disable MED settings on DUT.")
 		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 		if deviations.RoutePolicyUnderAFIUnsupported(dut) {
-			gnmi.Delete(t, dut, dutPolicyConfPath.PeerGroup(peerGrpName2).ApplyPolicy().ImportPolicy().Config())
-			gnmi.Delete(t, dut, dutPolicyConfPath.PeerGroup(peerGrpName3).ApplyPolicy().ImportPolicy().Config())
-
 			gnmi.Replace(t, dut, dutPolicyConfPath.PeerGroup(peerGrpName2).ApplyPolicy().ImportPolicy().Config(), []string{rplAllowPolicy})
 			gnmi.Replace(t, dut, dutPolicyConfPath.PeerGroup(peerGrpName3).ApplyPolicy().ImportPolicy().Config(), []string{rplAllowPolicy})
 		} else {
-			gnmi.Delete(t, dut, dutPolicyConfPath.PeerGroup(peerGrpName2).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ImportPolicy().Config())
-			gnmi.Delete(t, dut, dutPolicyConfPath.PeerGroup(peerGrpName3).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ImportPolicy().Config())
-
 			gnmi.Replace(t, dut, dutPolicyConfPath.PeerGroup(peerGrpName2).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ImportPolicy().Config(), []string{rplAllowPolicy})
 			gnmi.Replace(t, dut, dutPolicyConfPath.PeerGroup(peerGrpName3).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ImportPolicy().Config(), []string{rplAllowPolicy})
 		}

--- a/feature/experimental/bgp/ate_tests/bgp_always_compare_med/bgp_always_compare_med_test.go
+++ b/feature/experimental/bgp/ate_tests/bgp_always_compare_med/bgp_always_compare_med_test.go
@@ -164,11 +164,9 @@ func bgpCreateNbr(localAs, peerAs uint32, dut *ondatra.DUTDevice) *oc.NetworkIns
 
 	if deviations.RoutePolicyUnderAFIUnsupported(dut) {
 		rp2 := pg2.GetOrCreateApplyPolicy()
-		rp2.SetExportPolicy([]string{rplAllowPolicy})
 		rp2.SetImportPolicy([]string{rplAllowPolicy})
 
 		rp3 := pg3.GetOrCreateApplyPolicy()
-		rp3.SetExportPolicy([]string{rplAllowPolicy})
 		rp3.SetImportPolicy([]string{rplAllowPolicy})
 
 	} else {
@@ -177,14 +175,12 @@ func bgpCreateNbr(localAs, peerAs uint32, dut *ondatra.DUTDevice) *oc.NetworkIns
 		pg2af4.Enabled = ygot.Bool(true)
 
 		pg2rpl4 := pg2af4.GetOrCreateApplyPolicy()
-		pg2rpl4.SetExportPolicy([]string{rplAllowPolicy})
 		pg2rpl4.SetImportPolicy([]string{rplAllowPolicy})
 
 		pg3af4 := pg3.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
 		pg3af4.Enabled = ygot.Bool(true)
 
 		pg3rpl4 := pg3af4.GetOrCreateApplyPolicy()
-		pg3rpl4.SetExportPolicy([]string{rplAllowPolicy})
 		pg3rpl4.SetImportPolicy([]string{rplAllowPolicy})
 	}
 

--- a/feature/experimental/bgp/ate_tests/bgp_always_compare_med/metadata.textproto
+++ b/feature/experimental/bgp/ate_tests/bgp_always_compare_med/metadata.textproto
@@ -5,3 +5,36 @@ uuid: "4e512503-5fec-4dcf-87f4-f510dede1cd0"
 plan_id: "RT-1.12"
 description: "BGP always compare MED"
 testbed: TESTBED_DUT_ATE_4LINKS
+
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    route_policy_under_afi_unsupported: true
+  }
+}
+platform_exceptions: {
+  platform: {
+    vendor: JUNIPER
+    hardware_model: "PTX10001-36MR"
+    hardware_model: "cptx"
+  }
+  deviations: {
+    route_policy_under_afi_unsupported: true
+  }
+}
+platform_exceptions: {
+  platform: {
+    vendor: ARISTA
+    hardware_model: "DCS-7280CR3K-32D4"
+    hardware_model: "DCS-7808"
+    hardware_model: "DCS-7804-CH"
+    hardware_model: "ceos"
+  }
+  deviations: {
+    route_policy_under_afi_unsupported: true
+  }
+}


### PR DESCRIPTION
Added route-policy to import routes on ebgp sessions under peer-group under deviation and peer-group/afisafi/
