### PR TITLE
Fix base_vrf_selection_test failure for ARISTA

### DIFF
--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/base_vrf_selection/base_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/base_vrf_selection/base_vrf_selection_test.go
@@ -118,6 +118,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice, p1 *ondatra.Port, p2 *on
 	niConfPath := gnmi.OC().NetworkInstance("VRF-10")
 	niConf := configNetworkInstance("VRF-10", i2, 10)
 	gnmi.Replace(t, dut, niConfPath.Config(), niConf)
+	if deviations.InterfaceConfigVRFBeforeAddress(dut) {
+		gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), i2)
+	}
 
 	// Configure default NI and forwarding policy
 	t.Logf("*** Configuring default instance forwarding policy on DUT ...")
@@ -139,6 +142,10 @@ func configInterfaceDUT(i *oc.Interface, me *attrs.Attributes, subIntfIndex uint
 	i.Type = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
 	if deviations.InterfaceEnabled(dut) {
 		i.Enabled = ygot.Bool(true)
+	}
+	if deviations.RequireRoutedSubinterface0(dut) {
+		s0 := i.GetOrCreateSubinterface(0).GetOrCreateIpv4()
+		s0.Enabled = ygot.Bool(true)
 	}
 
 	// Create subinterface.
@@ -252,9 +259,10 @@ func applyForwardingPolicy(t *testing.T, ate *ondatra.ATEDevice, ingressPort, ma
 
 	intf := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreatePolicyForwarding().GetOrCreateInterface(ingressPort)
 	intf.ApplyVrfSelectionPolicy = ygot.String(matchType)
-	if !deviations.InterfaceRefConfigUnsupported(dut) {
-		intf.GetOrCreateInterfaceRef().Interface = ygot.String(ingressPort)
-		intf.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
+	intf.GetOrCreateInterfaceRef().Interface = ygot.String(ingressPort)
+	intf.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
+	if deviations.InterfaceRefConfigUnsupported(dut) || deviations.IntfRefConfigUnsupported(dut) {
+		intf.InterfaceRef = nil
 	}
 	// Configure default NI and forwarding policy.
 	intfConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Interface(ingressPort)

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/base_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/base_vrf_selection_test.go
@@ -267,7 +267,7 @@ func applyForwardingPolicy(t *testing.T, ate *ondatra.ATEDevice, ingressPort, ma
 	intf.ApplyVrfSelectionPolicy = ygot.String(matchType)
 	intf.GetOrCreateInterfaceRef().Interface = ygot.String(ingressPort)
 	intf.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
-	if !deviations.InterfaceRefConfigUnsupported(dut) || !deviations.IntfRefConfigUnsupported(dut) {
+	if deviations.InterfaceRefConfigUnsupported(dut) || deviations.IntfRefConfigUnsupported(dut) {
 		intf.InterfaceRef = nil
 	}
 

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/base_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/base_vrf_selection_test.go
@@ -44,7 +44,6 @@ const (
 	ipipProtocol      = 4
 	ipv6ipProtocol    = 41
 	ipv4Address       = "198.18.0.1/32"
-	flowSrcIp         = "198.18.0.1"
 	ateDestIPv4VLAN10 = "203.0.113.0/30"
 	ateDestIPv4VLAN20 = "203.0.113.4/30"
 	ateDestIPv6       = "2001:DB8:2::/64"
@@ -348,7 +347,7 @@ func createFlow(name string, top gosnappi.Config, dst attrs.Attributes, innerIpT
 	e1 := flow.Packet().Add().Ethernet()
 	e1.Src().SetValue(ateSrc.MAC)
 	v4 := flow.Packet().Add().Ipv4()
-	v4.Src().SetValue(flowSrcIp)
+	v4.Src().SetValue(ateSrc.IPv4)
 	v4.Dst().SetValue(dst.IPv4)
 	if innerIpType == "IPv4" {
 		flow.Packet().Add().Ipv4()


### PR DESCRIPTION
The test was failing for the following reasons:
- parent interface was not routed causing the subinterfaces to not be routed as well.
- DUT egress interface ip address was getting configured before the VRF assignment. So when the interface was moved to VRF-10, the interface ipv4 address got reset.
- Unsupported interface ref leaf was set in the interface OC configuration
- The match source ip in the vrf selection policy rule was incorrectly set and hence the incoming traffic flows expected to pass through VRF-10 were not getting forwarded correctly

After fixing the above issues the test is passing correctly