### PR TITLE
Fix for protocol_dscp_rules_for_vrf_selection_test failure in EOS

### DIFF
--- a/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/experimental/policy/policy_vrf_selection/ate_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -199,6 +199,10 @@ func configNetworkInstance(t *testing.T, dut *ondatra.DUTDevice, vrfname string,
 	} else {
 		si.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(vlanID)
 	}
+	s4 := si.GetOrCreateIpv4()
+	if deviations.InterfaceEnabled(dut) {
+		s4.Enabled = ygot.Bool(true)
+	}
 	gnmi.Replace(t, dut, gnmi.OC().Interface(intfname).Subinterface(subint).Config(), si)
 
 	// create vrf and apply on subinterface
@@ -523,15 +527,13 @@ func TestPBR(t *testing.T) {
 			d := &oc.Root{}
 			pfIntf := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreatePolicyForwarding().GetOrCreateInterface(p1)
 			pfIntfConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Interface(p1)
-
-			if !deviations.InterfaceRefConfigUnsupported(dut) {
-				pfIntf.GetOrCreateInterfaceRef().Interface = ygot.String(p1)
-				pfIntf.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
-				pfIntf.SetApplyVrfSelectionPolicy(args.policyName)
-				gnmi.Update(t, dut, pfIntfConfPath.Config(), pfIntf)
-			} else {
-				gnmi.Replace(t, args.dut, pfpath.Interface(p1).ApplyVrfSelectionPolicy().Config(), args.policyName)
+			pfIntf.GetOrCreateInterfaceRef().Interface = ygot.String(p1)
+			pfIntf.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
+			if deviations.InterfaceRefConfigUnsupported(dut) || deviations.IntfRefConfigUnsupported(dut) {
+				pfIntf.InterfaceRef = nil
 			}
+			pfIntf.SetApplyVrfSelectionPolicy(args.policyName)
+			gnmi.Update(t, dut, pfIntfConfPath.Config(), pfIntf)
 
 			// defer deletion of policy from interface
 			defer gnmi.Delete(t, args.dut, pfIntfConfPath.Config())


### PR DESCRIPTION
The test was failing for the following reasons
- The subinterface was not a routed port which is not supported in EOS when the parent is routed
- OC configuration for applying vrf selection policy in the ingress interface was incorrect and erroring out. After fixing the above 2, the test is passing fine