### PR TITLE
ci-trigger: Launch virtual tests if PR author is authorized

### DIFF
--- a/tools/ci-trigger/pr.go
+++ b/tools/ci-trigger/pr.go
@@ -82,6 +82,9 @@ func (p *pullRequest) createBuild(ctx context.Context, buildClient *cloudbuild.S
 	for _, d := range devices {
 		for i, virtualDevice := range p.Virtual {
 			if virtualDevice.Type == d {
+				if len(virtualDevice.Tests) == 0 {
+					continue
+				}
 				skip := false
 				for _, v := range virtualDevice.Tests {
 					if v.Status != "pending authorization" {

--- a/tools/ci-trigger/trigger.go
+++ b/tools/ci-trigger/trigger.go
@@ -136,6 +136,16 @@ func (t *trigger) processPullRequest(ctx context.Context, e *github.PullRequestE
 		return fmt.Errorf("identify modified tests: %w", err)
 	}
 
+	auth, err := t.authorizedUser(ctx, e.GetPullRequest().GetUser().GetLogin())
+	if err != nil {
+		return fmt.Errorf("validating user auth: %w", err)
+	}
+	if auth {
+		if err := pr.createBuild(ctx, t.buildClient, t.storClient, virtualDeviceTypes); err != nil {
+			return fmt.Errorf("create build: %w", err)
+		}
+	}
+
 	if err := pr.updateBadges(ctx, t.storClient); err != nil {
 		return fmt.Errorf("update GCS badges: %w", err)
 	}


### PR DESCRIPTION
If a pull request was created by an authorized user, launch tests for all virtual device types instead of waiting for the user to post `/fptest virtual` in a comment.  This mimics the previous Cloud Build native behavior where tests would automatically run when the PR was submitted by a contributor.