### PR TITLE
Update go-p4 library

### DIFF
--- a/feature/experimental/p4rt/ate_tests/base_p4rt/base_p4rt_test.go
+++ b/feature/experimental/p4rt/ate_tests/base_p4rt/base_p4rt_test.go
@@ -248,7 +248,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 			ElectionId: &p4_v1.Uint128{High: uint64(0), Low: electionId},
 			Action:     p4_v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 			Config: &p4_v1.ForwardingPipelineConfig{
-				P4Info: &p4Info,
+				P4Info: p4Info,
 				Cookie: &p4_v1.ForwardingPipelineConfig_Cookie{
 					Cookie: 159,
 				},
@@ -268,7 +268,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 			return errors.New("Errors seen when sending SetForwardingPipelineConfig.")
 		}
 		// Compare P4Info from GetForwardingPipelineConfig and SetForwardingPipelineConfig
-		if diff := cmp.Diff(&p4Info, resp.Config.P4Info, protocmp.Transform()); diff != "" {
+		if diff := cmp.Diff(p4Info, resp.Config.P4Info, protocmp.Transform()); diff != "" {
 			return fmt.Errorf("P4info diff (-want +got): \n%s", diff)
 		}
 	}

--- a/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetin_test/google_discovery_protocol_packetin_test.go
+++ b/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetin_test/google_discovery_protocol_packetin_test.go
@@ -373,7 +373,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 		ElectionId: &p4_v1.Uint128{High: uint64(0), Low: electionID},
 		Action:     p4_v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4_v1.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4_v1.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetout_test/google_discovery_protocol_packetout_test.go
+++ b/feature/experimental/p4rt/ate_tests/google_discovery_protocol_packetout_test/google_discovery_protocol_packetout_test.go
@@ -334,7 +334,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 		ElectionId: &p4_v1.Uint128{High: uint64(0), Low: electionID},
 		Action:     p4_v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4_v1.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4_v1.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/ate_tests/lldp_packetin_test/lldp_packetin_test.go
+++ b/feature/experimental/p4rt/ate_tests/lldp_packetin_test/lldp_packetin_test.go
@@ -351,7 +351,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 		ElectionId: &p4pb.Uint128{High: uint64(0), Low: electionID},
 		Action:     p4pb.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4pb.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4pb.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/ate_tests/lldp_packetout_test/lldp_packetout_test.go
+++ b/feature/experimental/p4rt/ate_tests/lldp_packetout_test/lldp_packetout_test.go
@@ -325,7 +325,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 		ElectionId: &p4pb.Uint128{High: uint64(0), Low: electionID},
 		Action:     p4pb.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4pb.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4pb.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/ate_tests/performance_test/performance_test.go
+++ b/feature/experimental/p4rt/ate_tests/performance_test/performance_test.go
@@ -562,7 +562,7 @@ func setupP4RTClient(args *testArgs) error {
 		ElectionId: &p4v1pb.Uint128{High: uint64(0), Low: electionID},
 		Action:     p4v1pb.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4v1pb.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4v1pb.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/ate_tests/traceroute_packetin_test/traceroute_packetin_test.go
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetin_test/traceroute_packetin_test.go
@@ -230,7 +230,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 		ElectionId: &p4_v1.Uint128{High: uint64(0), Low: electionId},
 		Action:     p4_v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4_v1.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4_v1.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/traceroute_packetout_test.go
+++ b/feature/experimental/p4rt/ate_tests/traceroute_packetout_test/traceroute_packetout_test.go
@@ -203,7 +203,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 		ElectionId: &p4v1.Uint128{High: uint64(0), Low: electionId},
 		Action:     p4v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4v1.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4v1.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/otg_tests/base_p4rt/base_p4rt_test.go
+++ b/feature/experimental/p4rt/otg_tests/base_p4rt/base_p4rt_test.go
@@ -250,7 +250,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 			ElectionId: &p4_v1.Uint128{High: uint64(0), Low: electionId},
 			Action:     p4_v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 			Config: &p4_v1.ForwardingPipelineConfig{
-				P4Info: &p4Info,
+				P4Info: p4Info,
 				Cookie: &p4_v1.ForwardingPipelineConfig_Cookie{
 					Cookie: 159,
 				},
@@ -270,7 +270,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 			return errors.New("Errors seen when sending SetForwardingPipelineConfig.")
 		}
 		// Compare P4Info from GetForwardingPipelineConfig and SetForwardingPipelineConfig
-		if diff := cmp.Diff(&p4Info, resp.Config.P4Info, protocmp.Transform()); diff != "" {
+		if diff := cmp.Diff(p4Info, resp.Config.P4Info, protocmp.Transform()); diff != "" {
 			return fmt.Errorf("P4info diff (-want +got): \n%s", diff)
 		}
 	}

--- a/feature/experimental/p4rt/otg_tests/google_discovery_protocol_packetin_test/google_discovery_protocol_packetin_test.go
+++ b/feature/experimental/p4rt/otg_tests/google_discovery_protocol_packetin_test/google_discovery_protocol_packetin_test.go
@@ -378,7 +378,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 		ElectionId: &p4_v1.Uint128{High: uint64(0), Low: electionID},
 		Action:     p4_v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4_v1.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4_v1.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/otg_tests/google_discovery_protocol_packetout_test/google_discovery_protocol_packetout_test.go
+++ b/feature/experimental/p4rt/otg_tests/google_discovery_protocol_packetout_test/google_discovery_protocol_packetout_test.go
@@ -332,7 +332,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 		ElectionId: &p4_v1.Uint128{High: uint64(0), Low: electionID},
 		Action:     p4_v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4_v1.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4_v1.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/otg_tests/lldp_packetin_test/lldp_packetin_test.go
+++ b/feature/experimental/p4rt/otg_tests/lldp_packetin_test/lldp_packetin_test.go
@@ -355,7 +355,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 		ElectionId: &p4pb.Uint128{High: uint64(0), Low: electionID},
 		Action:     p4pb.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4pb.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4pb.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/otg_tests/lldp_packetout_test/lldp_packetout_test.go
+++ b/feature/experimental/p4rt/otg_tests/lldp_packetout_test/lldp_packetout_test.go
@@ -323,7 +323,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 		ElectionId: &p4pb.Uint128{High: uint64(0), Low: electionID},
 		Action:     p4pb.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4pb.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4pb.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/otg_tests/performance_test/performance_test.go
+++ b/feature/experimental/p4rt/otg_tests/performance_test/performance_test.go
@@ -568,7 +568,7 @@ func setupP4RTClient(args *testArgs) error {
 		ElectionId: &p4v1pb.Uint128{High: uint64(0), Low: electionID},
 		Action:     p4v1pb.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4v1pb.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4v1pb.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/otg_tests/traceroute_packetin_test/traceroute_packetin_test.go
+++ b/feature/experimental/p4rt/otg_tests/traceroute_packetin_test/traceroute_packetin_test.go
@@ -221,7 +221,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 		ElectionId: &p4_v1.Uint128{High: uint64(0), Low: electionId},
 		Action:     p4_v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4_v1.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4_v1.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/otg_tests/traceroute_packetout_test/traceroute_packetout_test.go
+++ b/feature/experimental/p4rt/otg_tests/traceroute_packetout_test/traceroute_packetout_test.go
@@ -215,7 +215,7 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 		ElectionId: &p4v1.Uint128{High: uint64(0), Low: electionId},
 		Action:     p4v1.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4v1.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4v1.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},

--- a/feature/experimental/p4rt/tests/p4rt_election/p4rt_election_test.go
+++ b/feature/experimental/p4rt/tests/p4rt_election/p4rt_election_test.go
@@ -249,7 +249,7 @@ func canRead(t *testing.T, args *testArgs) (bool, error) {
 		ElectionId: &p4v1pb.Uint128{High: args.highID, Low: args.lowID},
 		Action:     p4v1pb.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 		Config: &p4v1pb.ForwardingPipelineConfig{
-			P4Info: &p4Info,
+			P4Info: p4Info,
 			Cookie: &p4v1pb.ForwardingPipelineConfig_Cookie{
 				Cookie: 159,
 			},
@@ -412,7 +412,7 @@ func TestUnsetElectionid(t *testing.T) {
 				DeviceId: deviceID,
 				Action:   p4v1pb.SetForwardingPipelineConfigRequest_VERIFY_AND_COMMIT,
 				Config: &p4v1pb.ForwardingPipelineConfig{
-					P4Info: &p4Info,
+					P4Info: p4Info,
 					Cookie: &p4v1pb.ForwardingPipelineConfig_Cookie{
 						Cookie: 159,
 					},

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	cloud.google.com/go/pubsub v1.30.0
 	cloud.google.com/go/storage v1.28.1
-	github.com/cisco-open/go-p4 v0.1.1-0.20230301194618-caa766ba7dd4
+	github.com/cisco-open/go-p4 v0.1.1
 	github.com/go-git/go-billy/v5 v5.4.1
 	github.com/go-git/go-git/v5 v5.7.0
 	github.com/golang/glog v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -568,8 +568,8 @@ github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cisco-open/go-p4 v0.1.1-0.20230301194618-caa766ba7dd4 h1:RGO/anzq6Nu5M0a0YY2ZQ3TRAOly6MSR5jbBtGaTT0A=
-github.com/cisco-open/go-p4 v0.1.1-0.20230301194618-caa766ba7dd4/go.mod h1:iZTF7o84nki1abNEhzdEAExVnjEC3Y/+8V9h7czjE2Q=
+github.com/cisco-open/go-p4 v0.1.1 h1:HkgALtPr8nCp8TlRVfN002AzmG/tHo+qHkCv8OnVig4=
+github.com/cisco-open/go-p4 v0.1.1/go.mod h1:iZTF7o84nki1abNEhzdEAExVnjEC3Y/+8V9h7czjE2Q=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=


### PR DESCRIPTION
This PR updates go-p4 library and p4rt tests to address https://github.com/cisco-open/go-p4/issues/16