### PR TITLE
add RequireRoutedSubinterface0 deviation

### DIFF
--- a/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/ate_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -231,7 +231,10 @@ func awaitTimeout(ctx context.Context, c *fluent.GRIBIClient, t testing.TB, time
 // for Subinterface(1) = dutPort.ip(1) = dutPort.ip + 4.
 func (a *attributes) configSubinterfaceDUT(t *testing.T, intf *oc.Interface, dut *ondatra.DUTDevice) {
 	t.Helper()
-
+	if deviations.RequireRoutedSubinterface0(dut) {
+		s0 := intf.GetOrCreateSubinterface(0).GetOrCreateIpv4()
+		s0.Enabled = ygot.Bool(true)
+	}
 	for i := uint32(1); i <= a.numSubIntf; i++ {
 		ip := a.ip(uint8(i))
 


### PR DESCRIPTION
Some devices require a Routed SubInterface 0 for other SubInterfaces to be active.

Adding the relevant deviation for the same.