### PR TITLE
Update Wiki to parse test metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/openconfig/ygot v0.28.3
 	github.com/p4lang/p4runtime v1.4.0-rc.5
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20220608084003-fc78c767cd6a
-	github.com/yuin/goldmark v1.4.13
 	golang.org/x/crypto v0.10.0
 	golang.org/x/text v0.10.0
 	google.golang.org/api v0.122.0

--- a/go.sum
+++ b/go.sum
@@ -1027,7 +1027,6 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=

--- a/tools/wikidoc/wikidoc.go
+++ b/tools/wikidoc/wikidoc.go
@@ -17,25 +17,27 @@
 package main
 
 import (
-	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"text/template"
 
 	"flag"
 
 	log "github.com/golang/glog"
-	"github.com/yuin/goldmark"
-	"github.com/yuin/goldmark/text"
+	"google.golang.org/protobuf/encoding/prototext"
+
+	mpb "github.com/openconfig/featureprofiles/proto/metadata_go_proto"
 )
 
 // testDoc stores test plan metadata.
 type testDoc struct {
-	Name  string
+	// Test directory name, e.g. "example_test"
+	Name string
+	// Full test title, e.g. "XX-01: Example Test"
 	Title string
-	Path  string
+	// Path is the file location of the test documentation, typically named README.md.
+	Path string
 }
 
 // path relative from outputRoot containing all test plan documents.
@@ -118,7 +120,7 @@ func writeTestDocs(docs []testDoc, rootPath string) error {
 
 // fetchTestDocs gathers all valid test plan documents in rootPath
 func fetchTestDocs(rootPath string) ([]testDoc, error) {
-	docs := []testDoc{}
+	docMap := make(map[string]testDoc)
 
 	err := filepath.WalkDir(rootPath,
 		func(path string, e fs.DirEntry, err error) error {
@@ -126,56 +128,30 @@ func fetchTestDocs(rootPath string) ([]testDoc, error) {
 				return err
 			}
 
-			if !validDoc(path) {
+			if filepath.Base(path) != "metadata.textproto" {
 				return nil
 			}
 
-			title, err := docTitle(path)
+			bytes, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}
-
-			doc := testDoc{
-				Name:  filepath.Base(filepath.Dir(path)),
-				Title: title,
-				Path:  path,
+			md := new(mpb.Metadata)
+			if err := prototext.Unmarshal(bytes, md); err != nil {
+				return err
 			}
-			docs = append(docs, doc)
+			docMap[md.GetUuid()] = testDoc{
+				Name:  filepath.Base(filepath.Dir(path)),
+				Path:  filepath.Dir(path) + "/README.md",
+				Title: md.GetPlanId() + ": " + md.GetDescription(),
+			}
 
 			return nil
 		})
 
+	docs := make([]testDoc, 0, len(docMap))
+	for _, v := range docMap {
+		docs = append(docs, v)
+	}
 	return docs, err
-}
-
-// validDoc checks if a given file path is eligible to contain a testplan doc.
-func validDoc(path string) bool {
-	if filepath.Base(path) != "README.md" {
-		return false
-	}
-
-	validPaths := []string{"/ate_tests/", "/tests/"}
-	for _, validPath := range validPaths {
-		if strings.Contains(path, validPath) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// docTitle fetches the first header string from a markdown file
-func docTitle(path string) (string, error) {
-	b, err := os.ReadFile(path)
-	if err != nil {
-		return "", err
-	}
-
-	markdown := goldmark.New()
-	doc := markdown.Parser().Parse(text.NewReader(b))
-	if doc.ChildCount() == 0 {
-		return "", errors.New("no children")
-	}
-
-	return string(doc.FirstChild().Text(b)), nil
 }


### PR DESCRIPTION
The [wiki](https://github.com/openconfig/featureprofiles/wiki) has a list of all test plans auto generated into a single reference.  With the introduction of metadata.textproto in test directories, we can now identify tests more reliably. The logic previously only considered "ate_tests" or "tests" as valid directories. Now, OTG tests can be considered.  Tests are deduplicated by UUIDs.