### PR TITLE
Improve feature.textproto path checking

### DIFF
--- a/.github/workflows/protobufs.yml
+++ b/.github/workflows/protobufs.yml
@@ -101,5 +101,14 @@ jobs:
     - name: Fetch Openconfig Models
       run: make openconfig_public
     - name: Validate Paths
-      run: make validate_paths
+      run: |
+        if [ ! -z "${GITHUB_BASE_REF}" ]; then
+          # If it is a pull request, then only check added/modified
+          # feature.textprotos.
+          #
+          # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+          export FEATURE_FILES=changed-feature-textprotos.githubactions.txt
+          git diff --diff-filter=d --name-only "${GITHUB_BASE_REF}" | grep -E 'feature.textproto$' > "${FEATURE_FILES}"
+        fi
+        make validate_paths
 

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,11 @@ openconfig_public:
 .PHONY: validate_paths
 validate_paths: openconfig_public proto/feature_go_proto/feature.pb.go
 	go run -v tools/validate_paths.go \
+		-alsologtostderr \
 		--feature_root=$(CURDIR)/feature/ \
 		--yang_roots=$(CURDIR)/openconfig_public/release/models/,$(CURDIR)/openconfig_public/third_party/ \
-		--yang_skip_roots=$(CURDIR)/openconfig_public/release/models/wifi
+		--yang_skip_roots=$(CURDIR)/openconfig_public/release/models/wifi \
+		--feature_files=${FEATURE_FILES}
 
 proto/feature_go_proto/feature.pb.go: proto/feature.proto
 	mkdir -p proto/feature_go_proto

--- a/tools/clone_oc_public.sh
+++ b/tools/clone_oc_public.sh
@@ -3,7 +3,5 @@
 set -e
 git clone https://github.com/openconfig/public.git "$1"
 cd "$1"
-# presence of "-" indicates prelease https://semver.org/#spec-item-9
-branch="$(git tag -l | grep -v "-" | sort -V | tail -1)"
-git checkout "$branch"
+# Use latest commit of OpenConfig public repo.
 echo "Using github.com/openconfig/public branch: $branch"


### PR DESCRIPTION
* Always validating against HEAD of OC models to improve development velocity.
* Checks are only done for added/modified feature.textproto files in PRs.
* Scheduled runs on the main branch will still check all affected feature.textproto files.

Tested manually.

The check now outputs logging messages when validating each file.