### PR TITLE
RT-1.1: Updating check for last-notification-error-code from gnmi.get to gnmi.watch

### DIFF
--- a/feature/experimental/bgp/ate_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
+++ b/feature/experimental/bgp/ate_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
@@ -326,9 +326,13 @@ func TestEstablishAndDisconnect(t *testing.T) {
 
 	// Verify if Cease notification is received on DUT.
 	t.Log("Verify Error code received on DUT: BgpTypes_BGP_ERROR_CODE_CEASE")
-	code := gnmi.Get(t, dut, nbrPath.Messages().Received().LastNotificationErrorCode().State())
-	if code != oc.BgpTypes_BGP_ERROR_CODE_CEASE {
-		t.Errorf("On disconnect: expected error code %v, got %v", oc.BgpTypes_BGP_ERROR_CODE_CEASE, code)
+	_, codeok := gnmi.Watch(t, dut, nbrPath.Messages().Received().LastNotificationErrorCode().State(), time.Second*2, func(val *ygnmi.Value[oc.E_BgpTypes_BGP_ERROR_CODE]) bool {
+		code, present := val.Val()
+		t.Logf("On disconnect, received code status %v", present)
+		return present && code == oc.BgpTypes_BGP_ERROR_CODE_CEASE
+	}).Await(t)
+	if !codeok {
+		t.Errorf("On disconnect: expected error code %v", oc.BgpTypes_BGP_ERROR_CODE_CEASE)
 	}
 
 	// Clear config on DUT and ATE


### PR DESCRIPTION

After bgp session goes down due to cease notification, `last-notification-error-code` is not updated intermittently at the same time, as discussed in issue b/290298138.

Updating the `last-notification-error-code` check from `gnmi.get` to `gnmi.watch.await` to achieve consistency.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."