### PR TITLE
fix core llp tlv test for Arista

### DIFF
--- a/feature/lldp/ate_tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
+++ b/feature/lldp/ate_tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
@@ -64,16 +64,23 @@ func TestCoreLLDPTLVPopulation(t *testing.T) {
 			dutPort := dut.Port(t, portName)
 			atePort := ate.Port(t, portName)
 
-			verifyNodeConfig(t, dut, dutPort, dutConf, test.lldpEnabled)
 			verifyNodeConfig(t, ate, atePort, ateConf, true)
+			verifyNodeConfig(t, dut, dutPort, dutConf, test.lldpEnabled)
 			if test.lldpEnabled {
-				verifyNodeTelemetry(t, dut, ate, dutPort, atePort, test.lldpEnabled, dut)
-				verifyNodeTelemetry(t, ate, dut, atePort, dutPort, test.lldpEnabled, dut)
+				verifyNodeTelemetry(t, dut, ate, dutPort, atePort, test.lldpEnabled)
+				verifyNodeTelemetry(t, ate, dut, atePort, dutPort, test.lldpEnabled)
 			} else {
-				verifyNodeTelemetry(t, dut, ate, dutPort, atePort, test.lldpEnabled, dut)
+				verifyNodeTelemetry(t, dut, ate, dutPort, atePort, test.lldpEnabled)
 			}
 		})
 	}
+
+	// disable LLDP before releasing the devices.
+	dut := ondatra.DUT(t, "dut1")
+	ate := ondatra.DUT(t, "dut2")
+
+	gnmi.Replace(t, dut, gnmi.OC().Lldp().Enabled().Config(), false)
+	gnmi.Replace(t, ate, gnmi.OC().Lldp().Enabled().Config(), false)
 }
 
 // configureNode configures LLDP on a single node.
@@ -86,6 +93,10 @@ func configureNode(t *testing.T, name string, lldpEnabled bool) (*ondatra.DUTDev
 
 	if lldpEnabled {
 		gnmi.Replace(t, node, lldp.Interface(p.Name()).Enabled().Config(), lldpEnabled)
+	}
+
+	if deviations.InterfaceEnabled(node) {
+		gnmi.Replace(t, node, gnmi.OC().Interface(p.Name()).Enabled().Config(), true)
 	}
 
 	return node, gnmi.GetConfig(t, node, lldp.Config())
@@ -124,11 +135,11 @@ func verifyNodeConfig(t *testing.T, node gnmi.DeviceOrOpts, port *ondatra.Port, 
 }
 
 // verifyNodeTelemetry verifies the telemetry values from the node such as port LLDP neighbor info.
-func verifyNodeTelemetry(t *testing.T, node, peer gnmi.DeviceOrOpts, nodePort, peerPort *ondatra.Port, lldpEnabled bool, dut *ondatra.DUTDevice) {
+func verifyNodeTelemetry(t *testing.T, node, peer *ondatra.DUTDevice, nodePort, peerPort *ondatra.Port, lldpEnabled bool) {
 	interfacePath := gnmi.OC().Lldp().Interface(nodePort.Name())
 
 	// LLDP Disabled
-	if !deviations.MissingValueForDefaults(dut) {
+	if !deviations.MissingValueForDefaults(node) {
 		lldpTelemetry := gnmi.Get(t, node, gnmi.OC().Lldp().Enabled().State())
 		if lldpEnabled != lldpTelemetry {
 			t.Errorf("LLDP enabled telemetry got: %t, want: %t.", lldpTelemetry, lldpEnabled)
@@ -146,12 +157,12 @@ func verifyNodeTelemetry(t *testing.T, node, peer gnmi.DeviceOrOpts, nodePort, p
 				return true
 			}
 			gotLen = len(intf.Neighbor)
-			if deviations.LLDPInterfaceConfigOverrideGlobal(dut) {
+			if deviations.LLDPInterfaceConfigOverrideGlobal(node) {
 				return gotLen > 0
 			}
 			return gotLen == 0
 		}).Await(t); !ok {
-			if deviations.LLDPInterfaceConfigOverrideGlobal(dut) {
+			if deviations.LLDPInterfaceConfigOverrideGlobal(node) {
 				t.Errorf("Number of neighbors got: %d, want: non-zero.", gotLen)
 			} else {
 				t.Errorf("Number of neighbors got: %d, want: 0.", gotLen)

--- a/feature/lldp/otg_tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
+++ b/feature/lldp/otg_tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/openconfig/featureprofiles/internal/attrs"
 	"github.com/openconfig/featureprofiles/internal/confirm"
+	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/featureprofiles/internal/otgutils"
 	"github.com/openconfig/ondatra"
@@ -104,6 +105,9 @@ func TestLLDPEnabled(t *testing.T) {
 		chassisIdType: otgtelemetry.E_LldpNeighbor_ChassisIdType(dutConf.GetChassisIdType()),
 	}
 	checkOTGLLDPNeighbor(t, otg, otgConfig, expOtgLLDPNeighbor)
+
+	// disable LLDP before releasing the devices.
+	gnmi.Replace(t, dut, gnmi.OC().Lldp().Enabled().Config(), false)
 }
 
 // TestLLDPDisabled tests LLDP advertisement turned off.
@@ -135,6 +139,9 @@ func configureDUT(t *testing.T, name string, lldpEnabled bool) (*ondatra.DUTDevi
 
 	if lldpEnabled {
 		gnmi.Replace(t, node, lldp.Interface(p.Name()).Enabled().Config(), lldpEnabled)
+	}
+	if deviations.InterfaceEnabled(node) {
+		gnmi.Replace(t, node, gnmi.OC().Interface(p.Name()).Enabled().Config(), true)
 	}
 
 	return node, gnmi.GetConfig(t, node, lldp.Config())


### PR DESCRIPTION
Include `InterfaceEnabled` deviation.

Configure ATE before DUT to get Neighbour data on DUT faster.