### PR TITLE
OC-26.1: enable deviation for Nokia

### DIFF
--- a/feature/system/ntp/tests/system_ntp_test/metadata.textproto
+++ b/feature/system/ntp/tests/system_ntp_test/metadata.textproto
@@ -37,3 +37,4 @@ platform_exceptions: {
     ntp_non_default_vrf_unsupported: true
   }
 }
+

--- a/feature/system/ntp/tests/system_ntp_test/metadata.textproto
+++ b/feature/system/ntp/tests/system_ntp_test/metadata.textproto
@@ -27,4 +27,13 @@ platform_exceptions: {
     ntp_non_default_vrf_unsupported: true
   }
 }
-
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+    hardware_model: "7250-ixr10e"
+    hardware_model: "ixr10"
+  }
+  deviations: {
+    ntp_non_default_vrf_unsupported: true
+  }
+}


### PR DESCRIPTION
This PR enables ntp_non_default_vrf_unsupported deviation for Nokia

---
<sup>
This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.
</sup>