### PR TITLE
Clarify bootz-3.1 wanted behavior.

### DIFF
--- a/feature/system/bootz/tests/README.md
+++ b/feature/system/bootz/tests/README.md
@@ -95,7 +95,7 @@ be sent to the device and properly handled.
 
 | ID        |Case  | Result |
 | --------- | ------------- | --- |
-| bootz-3.1 | No ownership voucher  | Device boots without OV present  |
+| bootz-3.1 | No ownership voucher  | Device fails with status invalid parameter |
 | bootz-3.2 | Invalid OV  | Device fails with status invalid parameter  |
 | bootz-3.3 | OV fails | Device fails with status invalid parameter |
 | bootz-3.4 | OV valid | Device boots with OV installed |


### PR DESCRIPTION
Bootz should check for OV.

It would be useful for Bootz to also support an "insecure" mode where OV check is skipped (e.g. in some lab environment). That will require an update to https://github.com/openconfig/bootz first, and then update this test case later to cover the "insecure" mode.