### PR TITLE
Fix P4Runtime performance test in EOS

### DIFF
--- a/feature/experimental/p4rt/ate_tests/performance_test/performance_test.go
+++ b/feature/experimental/p4rt/ate_tests/performance_test/performance_test.go
@@ -300,6 +300,9 @@ func testPktInPktOut(t *testing.T, args *testArgs) {
 
 		wg.Wait() // Wait for all four goroutines to finish before exiting.
 
+		// Wait for the packetOut requests to be completed on the server side
+		time.Sleep(30 * time.Second)
+
 		// Check packet counters after packet out
 		counter1 := gnmi.Get(t, args.ate, gnmi.OC().Interface(port).Counters().InPkts().State())
 

--- a/feature/experimental/p4rt/otg_tests/performance_test/performance_test.go
+++ b/feature/experimental/p4rt/otg_tests/performance_test/performance_test.go
@@ -317,6 +317,9 @@ func testPktInPktOut(t *testing.T, args *testArgs) {
 
 		wg.Wait() // Wait for all four goroutines to finish before exiting.
 
+		// Wait for the packetOut requests to be completed on the server side
+		time.Sleep(30 * time.Second)
+
 		// Check packet counters after packet out
 		counter1 := gnmi.Get(t, args.ate.OTG(), gnmi.OTG().Port(port).Counters().InFrames().State())
 


### PR DESCRIPTION
The test was failing intermittently in EOS because the ATE ingress counters check for verifying the expected packetOut counters was done right after injecting the traceroute/LLDP/GDP packets with no delay.

There is no guarantee that all the packetOut requests have been guaranteed by that time. Added a 30s delay, to account for any trailing inflight packets.