### PR TITLE
Fix ci-trigger Cloud Build service name

### DIFF
--- a/tools/ci-trigger/cloudbuild.yaml
+++ b/tools/ci-trigger/cloudbuild.yaml
@@ -8,6 +8,6 @@ steps:
     args: ['push', 'us-west1-docker.pkg.dev/$PROJECT_ID/featureprofiles-ci/featureprofiles-ci-trigger:$COMMIT_SHA']
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: gcloud
-    args: ['run', 'deploy', 'ci-trigger', '--image', 'us-west1-docker.pkg.dev/$PROJECT_ID/featureprofiles-ci/featureprofiles-ci-trigger:$COMMIT_SHA', '--region', 'us-west1']
+    args: ['run', 'deploy', 'featureprofiles-ci-trigger', '--image', 'us-west1-docker.pkg.dev/$PROJECT_ID/featureprofiles-ci/featureprofiles-ci-trigger:$COMMIT_SHA', '--region', 'us-west1']
 images:
   - us-west1-docker.pkg.dev/$PROJECT_ID/featureprofiles-ci/featureprofiles-ci-trigger


### PR DESCRIPTION
The build https://github.com/openconfig/featureprofiles/runs/15034045050 failed to deploy. This was the first time a change was made that triggered a rebuild of the service.  It failed because the service name is actually `featureprofiles-ci-trigger` not `ci-trigger`.