### PR TITLE
Use latest version of Ondatra and enable atomic-aware ygnmi API

### DIFF
--- a/feature/experimental/backup_nhg/otg_tests/backup_nhg_test/backup_nhg_test.go
+++ b/feature/experimental/backup_nhg/otg_tests/backup_nhg_test/backup_nhg_test.go
@@ -342,22 +342,17 @@ func (a *testArgs) createFlow(name string, ateTop gosnappi.Config, dst *attrs.At
 
 // validateAftTelmetry verifies aft telemetry entries.
 func (a *testArgs) validateAftTelemetry(t *testing.T, vrfName, prefix, ipAddress, resolvedNhIpAddress string) {
-	aftPfxNHG := gnmi.OC().NetworkInstance(vrfName).Afts().Ipv4Entry(prefix + "/" + mask).NextHopGroup()
-	aftPfxNHGVal, found := gnmi.Watch(t, a.dut, aftPfxNHG.State(), 2*time.Minute, func(val *ygnmi.Value[uint64]) bool {
-		if val.IsPresent() {
-			value, _ := val.Val()
-			if value != 0 {
-				return true
-			}
-		}
-		return false
+	aftPfxPath := gnmi.OC().NetworkInstance(vrfName).Afts().Ipv4Entry(prefix + "/" + mask)
+	aftPfxVal, found := gnmi.Watch(t, a.dut, aftPfxPath.State(), 2*time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		value, present := val.Val()
+		return present && value.GetNextHopGroup() != 0
 	}).Await(t)
 	if !found {
 		t.Fatalf("Could not find prefix %s in telemetry AFT", prefix+"/"+mask)
 	}
-	nhg, _ := aftPfxNHGVal.Val()
+	aftPfx, _ := aftPfxVal.Val()
 
-	aftNHG := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(a.dut)).Afts().NextHopGroup(nhg).State())
+	aftNHG := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(a.dut)).Afts().NextHopGroup(aftPfx.GetNextHopGroup()).State())
 	if got := len(aftNHG.NextHop); got != 1 {
 		t.Fatalf("Prefix %s next-hop entry count: got %d, want 1", prefix+"/"+mask, got)
 	}

--- a/feature/experimental/gribi/ate_tests/dut_daemon_failure/dut_daemon_failure_test.go
+++ b/feature/experimental/gribi/ate_tests/dut_daemon_failure/dut_daemon_failure_test.go
@@ -207,9 +207,9 @@ func addRoute(ctx context.Context, t *testing.T, args *testArgs, clientA *gribi.
 func verifyAFT(ctx context.Context, t *testing.T, args *testArgs) {
 	t.Logf("Verify through AFT Telemetry that %s is active", ateDstNetCIDR)
 	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		prefix, present := val.Val()
-		return present && prefix == ateDstNetCIDR
+	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 	}).Await(t); !ok {
 		t.Errorf("ipv4-entry/state/prefix got %v, want %s", got, ateDstNetCIDR)
 	}

--- a/feature/experimental/gribi/otg_tests/dut_daemon_failure/dut_daemon_failure_test.go
+++ b/feature/experimental/gribi/otg_tests/dut_daemon_failure/dut_daemon_failure_test.go
@@ -201,9 +201,9 @@ func addRoute(ctx context.Context, t *testing.T, args *testArgs, clientA *gribi.
 func verifyAFT(ctx context.Context, t *testing.T, args *testArgs) {
 	t.Logf("Verify through AFT Telemetry that %s is active", ateDstNetCIDR)
 	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		prefix, present := val.Val()
-		return present && prefix == ateDstNetCIDR
+	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 	}).Await(t); !ok {
 		t.Errorf("ipv4-entry/state/prefix got %v, want %s", got, ateDstNetCIDR)
 	}

--- a/feature/experimental/p4rt/ate_tests/p4rt_daemon_failure_test/p4rt_daemon_failure_test.go
+++ b/feature/experimental/p4rt/ate_tests/p4rt_daemon_failure_test/p4rt_daemon_failure_test.go
@@ -227,9 +227,9 @@ func installRoutes(t *testing.T, dut *ondatra.DUTDevice) error {
 
 	t.Logf("Verify through AFT Telemetry that %s is active", ateDstNetCIDR)
 	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		prefix, present := val.Val()
-		return present && prefix == ateDstNetCIDR
+	if got, ok := gnmi.Watch(t, dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 	}).Await(t); !ok {
 		return fmt.Errorf("ipv4-entry/state/prefix got %v, want %s", got, ateDstNetCIDR)
 	}

--- a/feature/experimental/p4rt/otg_tests/p4rt_daemon_failure_test/p4rt_daemon_failure_test.go
+++ b/feature/experimental/p4rt/otg_tests/p4rt_daemon_failure_test/p4rt_daemon_failure_test.go
@@ -221,9 +221,9 @@ func installRoutes(t *testing.T, dut *ondatra.DUTDevice) error {
 
 	t.Logf("Verify through AFT Telemetry that %s is active", ateDstNetCIDR)
 	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		prefix, present := val.Val()
-		return present && prefix == ateDstNetCIDR
+	if got, ok := gnmi.Watch(t, dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 	}).Await(t); !ok {
 		return fmt.Errorf("ipv4-entry/state/prefix got %v, want %s", got, ateDstNetCIDR)
 	}

--- a/feature/gribi/ate_tests/ack_in_presence_other_routes/route_ack_test.go
+++ b/feature/gribi/ate_tests/ack_in_presence_other_routes/route_ack_test.go
@@ -234,9 +234,9 @@ func routeAck(ctx context.Context, t *testing.T, args *testArgs) {
 
 	// Verify the entry for 203.0.113.0/24 is active through AFT Telemetry.
 	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
+	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
 		pre, present := val.Val()
-		return present && pre == ateDstNetCIDR
+		return present && pre.GetPrefix() == ateDstNetCIDR
 	}).Await(t); !ok {
 		t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, ateDstNetCIDR)
 	}
@@ -265,9 +265,9 @@ func TestRouteAck(t *testing.T) {
 	configStaticRoute(t, dut, ateDstNetCIDR, staticNH)
 	// Verify the entry for 203.0.113.0/24 is active through AFT Telemetry.
 	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		pre, present := val.Val()
-		return present && pre == ateDstNetCIDR
+	if got, ok := gnmi.Watch(t, dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 	}).Await(t); !ok {
 		t.Errorf("ipv4-entry/state/prefix got %v, want %s", got, ateDstNetCIDR)
 	} else {

--- a/feature/gribi/ate_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
+++ b/feature/gribi/ate_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
@@ -442,17 +442,18 @@ func (a *testArgs) flapinterface(t *testing.T, port string, action bool) {
 
 func (a *testArgs) aftCheck(t testing.TB, prefix string, instance string) {
 	// check prefix and get NHG ID
-	aftPfxNHG := gnmi.OC().NetworkInstance(instance).Afts().Ipv4Entry(prefix).NextHopGroup()
-	aftPfxNHGVal, found := gnmi.Watch(t, a.dut, aftPfxNHG.State(), 2*time.Minute, func(val *ygnmi.Value[uint64]) bool {
-		return val.IsPresent()
+	aftPfxPath := gnmi.OC().NetworkInstance(instance).Afts().Ipv4Entry(prefix)
+	aftPfxVal, found := gnmi.Watch(t, a.dut, aftPfxPath.State(), 2*time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.NextHopGroup != nil
 	}).Await(t)
 	if !found {
 		t.Fatalf("Could not find prefix %s in telemetry AFT", dstPfx)
 	}
-	nhg, _ := aftPfxNHGVal.Val()
+	aftPfx, _ := aftPfxVal.Val()
 
 	// using NHG ID validate NH
-	aftNHG := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(a.dut)).Afts().NextHopGroup(nhg).State())
+	aftNHG := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(a.dut)).Afts().NextHopGroup(aftPfx.GetNextHopGroup()).State())
 	if len(aftNHG.NextHop) == 0 && aftNHG.BackupNextHopGroup == nil {
 		t.Fatalf("Prefix %s references a NHG that has neither NH or backup NHG", prefix)
 	}

--- a/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
+++ b/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )
 

--- a/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
+++ b/feature/gribi/ate_tests/base_leader_election_test/base_leader_election_test.go
@@ -204,6 +204,19 @@ type testArgs struct {
 	top     *ondatra.ATETopology
 }
 
+// checkAftIPv4Entry verifies that the prefix exists as an AFT IPv4 Entry.
+func checkAftIPv4Entry(t *testing.T, dut *ondatra.DUTDevice, instance string, prefix string) {
+	t.Helper()
+	ipv4Path := gnmi.OC().NetworkInstance(instance).Afts().Ipv4Entry(prefix)
+	_, found := gnmi.Watch(t, dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.GetPrefix() == prefix
+	}).Await(t)
+	if !found {
+		t.Fatalf("Could not find prefix %s in AFT telemetry", prefix)
+	}
+}
+
 // testIPv4LeaderActiveChange first configures an IPV4 Entry through clientB
 // and ensures that the entry is active by checking AFT Telemetry and traffic.
 // It then configures an IPv4 entry through clientA without updating the election
@@ -221,8 +234,7 @@ func testIPv4LeaderActiveChange(ctx context.Context, t *testing.T, args *testArg
 
 	// Verify the entry for 198.51.100.0/24 is active through AFT Telemetry.
 	t.Logf("Verify the entry for %s is active through AFT Telemetry.", ateDstNetCIDR)
-	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	gnmi.Await(t, args.dut, ipv4Path.Prefix().State(), time.Minute, ateDstNetCIDR)
+	checkAftIPv4Entry(t, args.dut, deviations.DefaultNetworkInstance(args.dut), ateDstNetCIDR)
 
 	// Verify the entry for 198.51.100.0/24 is active through Traffic.
 	srcEndPoint := args.top.Interfaces()[atePort1.Name]
@@ -247,8 +259,7 @@ func testIPv4LeaderActiveChange(ctx context.Context, t *testing.T, args *testArg
 
 	// Verify the entry for 198.51.100.0/24 is active through AFT Telemetry.
 	t.Logf("Verify the entry for %s is active through AFT Telemetry.", ateDstNetCIDR)
-	ipv4Path = gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	gnmi.Await(t, args.dut, ipv4Path.Prefix().State(), time.Minute, ateDstNetCIDR)
+	checkAftIPv4Entry(t, args.dut, deviations.DefaultNetworkInstance(args.dut), ateDstNetCIDR)
 
 	// Verify with traffic that the entry for 198.51.100.0/24 is installed through the ATE port-2.
 	srcEndPoint = args.top.Interfaces()[atePort1.Name]

--- a/feature/gribi/ate_tests/get_rpc_test/get_rpc_test.go
+++ b/feature/gribi/ate_tests/get_rpc_test/get_rpc_test.go
@@ -308,7 +308,7 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	// Verify the above entries are active through AFT Telemetry.
 	for ip := range ateDstNetCIDR {
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR[ip])
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR[ip]; got != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR[ip]; got.GetPrefix() != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	}
@@ -339,7 +339,7 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	validateGetRPC(ctx, t, args.clientA)
 	for ip := range ateDstNetCIDR {
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR[ip])
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR[ip]; got != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR[ip]; got.GetPrefix() != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	}

--- a/feature/gribi/ate_tests/get_rpc_test/get_rpc_test.go
+++ b/feature/gribi/ate_tests/get_rpc_test/get_rpc_test.go
@@ -308,7 +308,7 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	// Verify the above entries are active through AFT Telemetry.
 	for ip := range ateDstNetCIDR {
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR[ip])
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR[ip]; got.GetPrefix() != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()).GetPrefix(), ateDstNetCIDR[ip]; got != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	}
@@ -339,7 +339,7 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	validateGetRPC(ctx, t, args.clientA)
 	for ip := range ateDstNetCIDR {
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR[ip])
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR[ip]; got.GetPrefix() != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()).GetPrefix(), ateDstNetCIDR[ip]; got != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	}

--- a/feature/gribi/ate_tests/ordering_ack_test/ordering_ack_test.go
+++ b/feature/gribi/ate_tests/ordering_ack_test/ordering_ack_test.go
@@ -351,7 +351,7 @@ func testModifyNHGIPv4(t *testing.T, args *testArgs) {
 				}
 			}
 			ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-			if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR; got != want {
+			if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR; got.GetPrefix() != want {
 				t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 			}
 		}
@@ -431,7 +431,7 @@ func testModifyIPv4AddDelAdd(t *testing.T, args *testArgs) {
 
 	t.Run("Telemetry", func(t *testing.T) {
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR; got != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR; got.GetPrefix() != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	})

--- a/feature/gribi/ate_tests/ordering_ack_test/ordering_ack_test.go
+++ b/feature/gribi/ate_tests/ordering_ack_test/ordering_ack_test.go
@@ -351,7 +351,7 @@ func testModifyNHGIPv4(t *testing.T, args *testArgs) {
 				}
 			}
 			ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-			if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR; got.GetPrefix() != want {
+			if got, want := gnmi.Get(t, args.dut, ipv4Path.State()).GetPrefix(), ateDstNetCIDR; got != want {
 				t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 			}
 		}
@@ -431,7 +431,7 @@ func testModifyIPv4AddDelAdd(t *testing.T, args *testArgs) {
 
 	t.Run("Telemetry", func(t *testing.T) {
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR; got.GetPrefix() != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()).GetPrefix(), ateDstNetCIDR; got != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	})

--- a/feature/gribi/ate_tests/persistence_mode_test/persistence_mode_test.go
+++ b/feature/gribi/ate_tests/persistence_mode_test/persistence_mode_test.go
@@ -201,9 +201,9 @@ func addRoute(ctx context.Context, t *testing.T, args *testArgs, clientA *gribi.
 func verifyAFT(ctx context.Context, t *testing.T, args *testArgs) {
 	t.Logf("Verify through AFT Telemetry that %s is active", ateDstNetCIDR)
 	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		prefix, present := val.Val()
-		return present && prefix == ateDstNetCIDR
+	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 	}).Await(t); !ok {
 		t.Errorf("ipv4-entry/state/prefix got %v, want %s", got, ateDstNetCIDR)
 	}
@@ -213,9 +213,9 @@ func verifyAFT(ctx context.Context, t *testing.T, args *testArgs) {
 func verifyNoAFT(ctx context.Context, t *testing.T, args *testArgs) {
 	t.Logf("Verify through Telemetry that the route to %s is not present", ateDstNetCIDR)
 	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		prefix, present := val.Val()
-		return !present || (present && prefix == "")
+	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return !present || (present && ipv4Entry.Prefix == nil)
 	}).Await(t); !ok {
 		t.Errorf("ipv4-entry/state/prefix got %s, want nil", got)
 	}

--- a/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/ate_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -398,10 +398,10 @@ func testTraffic(t *testing.T, ate *ondatra.ATEDevice, top *ondatra.ATETopology,
 
 // verifyEntry checks if the entry is active through AFT Telemetry.
 func verifyEntry(t *testing.T, dut *ondatra.DUTDevice, networkInstanceName string, ateDstNetCIDR string) bool {
-	ipv4Entry := gnmi.OC().NetworkInstance(networkInstanceName).Afts().Ipv4Entry(ateDstNetCIDR)
-	got := gnmi.Lookup(t, dut, ipv4Entry.Prefix().State())
-	prefix, present := got.Val()
-	return present && prefix == ateDstNetCIDR
+	ipv4EntryPath := gnmi.OC().NetworkInstance(networkInstanceName).Afts().Ipv4Entry(ateDstNetCIDR)
+	got := gnmi.Lookup(t, dut, ipv4EntryPath.State())
+	ipv4Entry, present := got.Val()
+	return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 }
 
 // injectEntries adds a fully referenced IP Entry, NH and NHG.
@@ -419,9 +419,9 @@ func injectIPEntry(ctx context.Context, t *testing.T, dut *ondatra.DUTDevice, cl
 
 	// After adding the entry, verify the entry is active through AFT Telemetry.
 	ipv4Path := gnmi.OC().NetworkInstance(networkInstanceName).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		prefix, present := val.Val()
-		return present && prefix == ateDstNetCIDR
+	if got, ok := gnmi.Watch(t, dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 	}).Await(t); !ok {
 		t.Errorf("ipv4-entry/state/prefix got %v, want %s", got, ateDstNetCIDR)
 	}

--- a/feature/gribi/otg_tests/ack_in_presence_other_routes/route_ack_test.go
+++ b/feature/gribi/otg_tests/ack_in_presence_other_routes/route_ack_test.go
@@ -269,9 +269,9 @@ func routeAck(ctx context.Context, t *testing.T, args *testArgs) {
 
 	// Verify the entry for 203.0.113.0/24 is active through AFT Telemetry.
 	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		pre, present := val.Val()
-		return present && pre == ateDstNetCIDR
+	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 	}).Await(t); !ok {
 		t.Errorf("ipv4-entry/state/prefix got %v, want %s", got, ateDstNetCIDR)
 	}
@@ -302,9 +302,9 @@ func TestRouteAck(t *testing.T) {
 	configStaticRoute(t, dut, ateDstNetCIDR, staticNH)
 	// Verify the entry for 203.0.113.0/24 is active through AFT Telemetry.
 	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		pre, present := val.Val()
-		return present && pre == ateDstNetCIDR
+	if got, ok := gnmi.Watch(t, dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 	}).Await(t); !ok {
 		t.Errorf("ipv4-entry/state/prefix got %v, want %s", got, ateDstNetCIDR)
 	} else {

--- a/feature/gribi/otg_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
+++ b/feature/gribi/otg_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
@@ -433,17 +433,18 @@ func (a *testArgs) flapinterface(t *testing.T, port string, action bool) {
 
 func (a *testArgs) aftCheck(t testing.TB, prefix string, instance string) {
 	// check prefix and get NHG ID
-	aftPfxNHG := gnmi.OC().NetworkInstance(instance).Afts().Ipv4Entry(prefix).NextHopGroup()
-	aftPfxNHGVal, found := gnmi.Watch(t, a.dut, aftPfxNHG.State(), 2*time.Minute, func(val *ygnmi.Value[uint64]) bool {
-		return val.IsPresent()
+	aftPfxPath := gnmi.OC().NetworkInstance(instance).Afts().Ipv4Entry(prefix)
+	aftPfxVal, found := gnmi.Watch(t, a.dut, aftPfxPath.State(), 2*time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.NextHopGroup != nil
 	}).Await(t)
 	if !found {
 		t.Fatalf("Could not find prefix %s in telemetry AFT", dstPfx)
 	}
-	nhg, _ := aftPfxNHGVal.Val()
+	aftPfx, _ := aftPfxVal.Val()
 
 	// using NHG ID validate NH
-	aftNHG := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(a.dut)).Afts().NextHopGroup(nhg).State())
+	aftNHG := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(a.dut)).Afts().NextHopGroup(aftPfx.GetNextHopGroup()).State())
 	if len(aftNHG.NextHop) == 0 && aftNHG.BackupNextHopGroup == nil {
 		t.Fatalf("Prefix %s references a NHG that has neither NH or backup NHG", prefix)
 	}

--- a/feature/gribi/otg_tests/base_leader_election_test/base_leader_election_test.go
+++ b/feature/gribi/otg_tests/base_leader_election_test/base_leader_election_test.go
@@ -252,6 +252,19 @@ type testArgs struct {
 	top     gosnappi.Config
 }
 
+// checkAftIPv4Entry verifies that the prefix exists as an AFT IPv4 Entry.
+func checkAftIPv4Entry(t *testing.T, dut *ondatra.DUTDevice, instance string, prefix string) {
+	t.Helper()
+	ipv4Path := gnmi.OC().NetworkInstance(instance).Afts().Ipv4Entry(prefix)
+	_, found := gnmi.Watch(t, dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.GetPrefix() == prefix
+	}).Await(t)
+	if !found {
+		t.Fatalf("Could not find prefix %s in AFT telemetry", prefix)
+	}
+}
+
 // testIPv4LeaderActiveChange first configures an IPV4 Entry through clientB
 // and ensures that the entry is active by checking AFT Telemetry and traffic.
 // It then configures an IPv4 entry through clientA without updating the election
@@ -269,8 +282,7 @@ func testIPv4LeaderActiveChange(ctx context.Context, t *testing.T, args *testArg
 
 	// Verify the entry for 198.51.100.0/24 is active through AFT Telemetry.
 	t.Logf("Verify the entry for %s is active through AFT Telemetry.", ateDstNetCIDR)
-	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	gnmi.Await(t, args.dut, ipv4Path.Prefix().State(), time.Minute, ateDstNetCIDR)
+	checkAftIPv4Entry(t, args.dut, deviations.DefaultNetworkInstance(args.dut), ateDstNetCIDR)
 
 	// Verify the entry for 198.51.100.0/24 is active through Traffic.
 	testTraffic(t, args.ate, args.top, atePort1, atePort3)
@@ -293,8 +305,7 @@ func testIPv4LeaderActiveChange(ctx context.Context, t *testing.T, args *testArg
 
 	// Verify the entry for 198.51.100.0/24 is active through AFT Telemetry.
 	t.Logf("Verify the entry for %s is active through AFT Telemetry.", ateDstNetCIDR)
-	ipv4Path = gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	gnmi.Await(t, args.dut, ipv4Path.Prefix().State(), time.Minute, ateDstNetCIDR)
+	checkAftIPv4Entry(t, args.dut, deviations.DefaultNetworkInstance(args.dut), ateDstNetCIDR)
 
 	// Verify with traffic that the entry for 198.51.100.0/24 is installed through the ATE port-2.
 	testTraffic(t, args.ate, args.top, atePort1, atePort2)

--- a/feature/gribi/otg_tests/get_rpc_test/get_rpc_test.go
+++ b/feature/gribi/otg_tests/get_rpc_test/get_rpc_test.go
@@ -317,7 +317,7 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	// Verify the above entries are active through AFT Telemetry.
 	for ip := range ateDstNetCIDR {
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR[ip])
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR[ip]; got != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR[ip]; got.GetPrefix() != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	}
@@ -346,7 +346,7 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	validateGetRPC(ctx, t, args.clientA)
 	for ip := range ateDstNetCIDR {
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR[ip])
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR[ip]; got != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR[ip]; got.GetPrefix() != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	}

--- a/feature/gribi/otg_tests/get_rpc_test/get_rpc_test.go
+++ b/feature/gribi/otg_tests/get_rpc_test/get_rpc_test.go
@@ -317,7 +317,7 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	// Verify the above entries are active through AFT Telemetry.
 	for ip := range ateDstNetCIDR {
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR[ip])
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR[ip]; got.GetPrefix() != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()).GetPrefix(), ateDstNetCIDR[ip]; got != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	}
@@ -346,7 +346,7 @@ func testIPv4LeaderActive(ctx context.Context, t *testing.T, args *testArgs) {
 	validateGetRPC(ctx, t, args.clientA)
 	for ip := range ateDstNetCIDR {
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR[ip])
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR[ip]; got.GetPrefix() != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()).GetPrefix(), ateDstNetCIDR[ip]; got != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	}

--- a/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
+++ b/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
@@ -284,11 +284,11 @@ func testModifyNHG(t *testing.T, args *testArgs) {
 		if !*checkTelemetry {
 			t.Skip()
 		}
-		nhgNhPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().NextHopGroup(nhgIndex).NextHop(nhIndex)
-		if got, want := gnmi.Get(t, args.dut, nhgNhPath.Index().State()), uint64(nhIndex); got != want {
+		nhgPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().NextHopGroup(nhgIndex)
+		if got, want := gnmi.Get(t, args.dut, nhgPath.State()), uint64(nhIndex); got.GetNextHop(nhIndex).GetIndex() != want {
 			t.Errorf("next-hop-group/next-hop/state/index got %d, want %d", got, want)
 		}
-		if got, want := gnmi.Get(t, args.dut, nhgNhPath.Weight().State()), uint64(nhWeight); got != want {
+		if got, want := gnmi.Get(t, args.dut, nhgPath.State()), uint64(nhWeight); got.GetNextHop(nhIndex).GetWeight() != want {
 			t.Errorf("next-hop-group/next-hop/state/weight got %d, want %d", got, want)
 		}
 	})
@@ -376,19 +376,19 @@ func testModifyNHGIPv4(t *testing.T, args *testArgs) {
 		if !*checkTelemetry {
 			t.Skip()
 		}
-		nhgNhPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().NextHopGroup(nhgIndex).NextHop(nhIndex)
-		if got, want := gnmi.Get(t, args.dut, nhgNhPath.Index().State()), uint64(nhIndex); got != want {
+		nhgPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().NextHopGroup(nhgIndex)
+		if got, want := gnmi.Get(t, args.dut, nhgPath.State()), uint64(nhIndex); got.GetNextHop(nhIndex).GetIndex() != want {
 			t.Errorf("next-hop-group/next-hop/state/index got %d, want %d", got, want)
 		}
-		if got, want := gnmi.Get(t, args.dut, nhgNhPath.Weight().State()), uint64(nhWeight); got != want {
+		if got, want := gnmi.Get(t, args.dut, nhgPath.State()), uint64(nhWeight); got.GetNextHop(nhIndex).GetWeight() != want {
 			t.Errorf("next-hop-group/next-hop/state/weight got %d, want %d", got, want)
 		}
 
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.NextHopGroup().State()), uint64(nhgIndex); got != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), uint64(nhgIndex); got.GetNextHopGroup() != want {
 			t.Errorf("ipv4-entry/state/next-hop-group got %d, want %d", got, want)
 		}
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR; got != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR; got.GetPrefix() != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	})
@@ -447,10 +447,10 @@ func testModifyIPv4AddDelAdd(t *testing.T, args *testArgs) {
 			t.Skip()
 		}
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.NextHopGroup().State()), uint64(nhgIndex); got != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), uint64(nhgIndex); got.GetNextHopGroup() != want {
 			t.Errorf("ipv4-entry/state/next-hop-group got %d, want %d", got, want)
 		}
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.Prefix().State()), ateDstNetCIDR; got != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR; got.GetPrefix() != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	})

--- a/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
+++ b/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
@@ -285,10 +285,10 @@ func testModifyNHG(t *testing.T, args *testArgs) {
 			t.Skip()
 		}
 		nhgPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().NextHopGroup(nhgIndex)
-		if got, want := gnmi.Get(t, args.dut, nhgPath.State()), uint64(nhIndex); got.GetNextHop(nhIndex).GetIndex() != want {
+		if got, want := gnmi.Get(t, args.dut, nhgPath.State()).GetNextHop(nhIndex).GetIndex(), uint64(nhIndex); got != want {
 			t.Errorf("next-hop-group/next-hop/state/index got %d, want %d", got, want)
 		}
-		if got, want := gnmi.Get(t, args.dut, nhgPath.State()), uint64(nhWeight); got.GetNextHop(nhIndex).GetWeight() != want {
+		if got, want := gnmi.Get(t, args.dut, nhgPath.State()).GetNextHop(nhIndex).GetWeight(), uint64(nhWeight); got != want {
 			t.Errorf("next-hop-group/next-hop/state/weight got %d, want %d", got, want)
 		}
 	})
@@ -377,18 +377,18 @@ func testModifyNHGIPv4(t *testing.T, args *testArgs) {
 			t.Skip()
 		}
 		nhgPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().NextHopGroup(nhgIndex)
-		if got, want := gnmi.Get(t, args.dut, nhgPath.State()), uint64(nhIndex); got.GetNextHop(nhIndex).GetIndex() != want {
+		if got, want := gnmi.Get(t, args.dut, nhgPath.State()).GetNextHop(nhIndex).GetIndex(), uint64(nhIndex); got != want {
 			t.Errorf("next-hop-group/next-hop/state/index got %d, want %d", got, want)
 		}
-		if got, want := gnmi.Get(t, args.dut, nhgPath.State()), uint64(nhWeight); got.GetNextHop(nhIndex).GetWeight() != want {
+		if got, want := gnmi.Get(t, args.dut, nhgPath.State()).GetNextHop(nhIndex).GetWeight(), uint64(nhWeight); got != want {
 			t.Errorf("next-hop-group/next-hop/state/weight got %d, want %d", got, want)
 		}
 
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), uint64(nhgIndex); got.GetNextHopGroup() != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()).GetNextHopGroup(), uint64(nhgIndex); got != want {
 			t.Errorf("ipv4-entry/state/next-hop-group got %d, want %d", got, want)
 		}
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR; got.GetPrefix() != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()).GetPrefix(), ateDstNetCIDR; got != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	})
@@ -447,10 +447,10 @@ func testModifyIPv4AddDelAdd(t *testing.T, args *testArgs) {
 			t.Skip()
 		}
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), uint64(nhgIndex); got.GetNextHopGroup() != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()).GetNextHopGroup(), uint64(nhgIndex); got != want {
 			t.Errorf("ipv4-entry/state/next-hop-group got %d, want %d", got, want)
 		}
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()), ateDstNetCIDR; got.GetPrefix() != want {
+		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()).GetPrefix(), ateDstNetCIDR; got != want {
 			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
 		}
 	})

--- a/feature/gribi/otg_tests/persistence_mode_test/persistence_mode_test.go
+++ b/feature/gribi/otg_tests/persistence_mode_test/persistence_mode_test.go
@@ -229,9 +229,9 @@ func addRoute(ctx context.Context, t *testing.T, args *testArgs, clientA *gribi.
 func verifyAFT(ctx context.Context, t *testing.T, args *testArgs) {
 	t.Logf("Verify through AFT Telemetry that %s is active", ateDstNetCIDR)
 	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		prefix, present := val.Val()
-		return present && prefix == ateDstNetCIDR
+	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 	}).Await(t); !ok {
 		t.Errorf("ipv4-entry/state/prefix got %v, want %s", got, ateDstNetCIDR)
 	}
@@ -241,9 +241,9 @@ func verifyAFT(ctx context.Context, t *testing.T, args *testArgs) {
 func verifyNoAFT(ctx context.Context, t *testing.T, args *testArgs) {
 	t.Logf("Verify through Telemetry that the route to %s is not present", ateDstNetCIDR)
 	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		prefix, present := val.Val()
-		return !present || (present && prefix == "")
+	if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return !present || (present && ipv4Entry.Prefix == nil)
 	}).Await(t); !ok {
 		t.Errorf("ipv4-entry/state/prefix got %v, want nil", got)
 	}

--- a/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -396,10 +396,10 @@ func computeLossPct(t *testing.T, ate *ondatra.ATEDevice, config gosnappi.Config
 
 // verifyEntry checks if the entry is active through AFT Telemetry.
 func verifyEntry(t *testing.T, dut *ondatra.DUTDevice, networkInstanceName string, ateDstNetCIDR string) bool {
-	ipv4Entry := gnmi.OC().NetworkInstance(networkInstanceName).Afts().Ipv4Entry(ateDstNetCIDR)
-	got := gnmi.Lookup(t, dut, ipv4Entry.Prefix().State())
-	prefix, present := got.Val()
-	return present && prefix == ateDstNetCIDR
+	ipv4EntryPath := gnmi.OC().NetworkInstance(networkInstanceName).Afts().Ipv4Entry(ateDstNetCIDR)
+	got := gnmi.Lookup(t, dut, ipv4EntryPath.State())
+	ipv4Entry, present := got.Val()
+	return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 }
 
 // injectEntries adds a fully referenced IP Entry, NH and NHG.
@@ -417,9 +417,9 @@ func injectIPEntry(ctx context.Context, t *testing.T, dut *ondatra.DUTDevice, cl
 
 	// After adding the entry, verify the entry is active through AFT Telemetry.
 	ipv4Path := gnmi.OC().NetworkInstance(networkInstanceName).Afts().Ipv4Entry(ateDstNetCIDR)
-	if got, ok := gnmi.Watch(t, dut, ipv4Path.Prefix().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		prefix, present := val.Val()
-		return present && prefix == ateDstNetCIDR
+	if got, ok := gnmi.Watch(t, dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		ipv4Entry, present := val.Val()
+		return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 	}).Await(t); !ok {
 		t.Errorf("ipv4-entry/state/prefix got %v, want %s", got, ateDstNetCIDR)
 	}

--- a/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
+++ b/feature/gribi/otg_tests/route_removal_non_default_vrf_test/route_removal_non_default_vrf_test.go
@@ -284,7 +284,7 @@ func flushNonZeroReference(ctx context.Context, t *testing.T, dut *ondatra.DUTDe
 		t.Log("Traffic can be forwarded between ATE port-1 and ATE port-2")
 	}
 
-	entry := verifyEntry(t, dut, nonDefaultVRF, ateDstNetEntryNonDefault)
+	entry := hasIPv4Entry(t, dut, nonDefaultVRF, ateDstNetEntryNonDefault)
 	if !entry {
 		t.Errorf("ipv4-entry/state/prefix does not contain entry, expected: %s", ateDstNetEntryNonDefault)
 	} else {
@@ -292,7 +292,7 @@ func flushNonZeroReference(ctx context.Context, t *testing.T, dut *ondatra.DUTDe
 	}
 
 	t.Log("Ensure that 203.0.113.0/24 (ateDstNetEntryDefault) has been removed by validating telemetry.")
-	entry = verifyEntry(t, dut, deviations.DefaultNetworkInstance(dut), ateDstNetEntryDefault)
+	entry = hasIPv4Entry(t, dut, deviations.DefaultNetworkInstance(dut), ateDstNetEntryDefault)
 	if entry {
 		t.Errorf("ipv4-entry/state/prefix contains entry %s, expected no entry", ateDstNetEntryDefault)
 	} else {
@@ -394,12 +394,11 @@ func computeLossPct(t *testing.T, ate *ondatra.ATEDevice, config gosnappi.Config
 	return lossPct
 }
 
-// verifyEntry checks if the entry is active through AFT Telemetry.
-func verifyEntry(t *testing.T, dut *ondatra.DUTDevice, networkInstanceName string, ateDstNetCIDR string) bool {
+// hasIPv4Entry checks if the entry is active through AFT Telemetry.
+func hasIPv4Entry(t *testing.T, dut *ondatra.DUTDevice, networkInstanceName string, ateDstNetCIDR string) bool {
 	ipv4EntryPath := gnmi.OC().NetworkInstance(networkInstanceName).Afts().Ipv4Entry(ateDstNetCIDR)
 	got := gnmi.Lookup(t, dut, ipv4EntryPath.State())
-	ipv4Entry, present := got.Val()
-	return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
+	return got.IsPresent()
 }
 
 // injectEntries adds a fully referenced IP Entry, NH and NHG.

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/openconfig/gribi v1.0.0
 	github.com/openconfig/gribigo v0.0.0-20230207233343-ef59db57c4fc
 	github.com/openconfig/kne v0.1.13
-	github.com/openconfig/ondatra v0.1.24-0.20230713143210-d81989ceab89
+	github.com/openconfig/ondatra v0.1.24
 	github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07
 	github.com/openconfig/ygnmi v0.8.1
 	github.com/openconfig/ygot v0.29.0

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/openconfig/gribi v1.0.0
 	github.com/openconfig/gribigo v0.0.0-20230207233343-ef59db57c4fc
 	github.com/openconfig/kne v0.1.13
-	github.com/openconfig/ondatra v0.1.24
+	github.com/openconfig/ondatra v0.2.0
 	github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07
 	github.com/openconfig/ygnmi v0.8.1
 	github.com/openconfig/ygot v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -911,8 +911,8 @@ github.com/openconfig/kne v0.1.13 h1:CXcy95vrUDAA7nTPGekwJXunlt2kBwM/oMQUlbDzmFM
 github.com/openconfig/kne v0.1.13/go.mod h1:L3y17JPcmU06vcTFRssYynUdKS7HfcGJUJNVvwkl5S8=
 github.com/openconfig/lemming/operator v0.2.0 h1:dovZnR6lQkOHXcODli1NDOr/GVYrBY05KS5X11jxVbw=
 github.com/openconfig/lemming/operator v0.2.0/go.mod h1:LKgEXSR5VK2CAeh2uKijKAXFj42uQuwakrCHVPF0iII=
-github.com/openconfig/ondatra v0.1.24 h1:T2oCCm7xVCxTi9suOeXLAFiNvJXCy7RzdDK3IGSC3TA=
-github.com/openconfig/ondatra v0.1.24/go.mod h1:prhnBnjQC64W5wFbjNqSEomoUb6eWjJiTlAPHhZt2yE=
+github.com/openconfig/ondatra v0.2.0 h1:kaYEnVOZgIyEIL6FWQwBv8i/tvp78ptrCUfMP+trLYU=
+github.com/openconfig/ondatra v0.2.0/go.mod h1:prhnBnjQC64W5wFbjNqSEomoUb6eWjJiTlAPHhZt2yE=
 github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07 h1:X631iD/B0ximGFb5P9LY5wHju4SiedxUhc5UZEo7VSw=
 github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07/go.mod h1:bmpU0kIsCiXuncozViVuQx1HqolC3C94H7lD9KKmoTo=
 github.com/openconfig/ygnmi v0.8.1 h1:wdjrn1wBBBTCSQGO94ht0CY2zyJdoOe4G6rmjsMdPdc=

--- a/go.sum
+++ b/go.sum
@@ -911,8 +911,8 @@ github.com/openconfig/kne v0.1.13 h1:CXcy95vrUDAA7nTPGekwJXunlt2kBwM/oMQUlbDzmFM
 github.com/openconfig/kne v0.1.13/go.mod h1:L3y17JPcmU06vcTFRssYynUdKS7HfcGJUJNVvwkl5S8=
 github.com/openconfig/lemming/operator v0.2.0 h1:dovZnR6lQkOHXcODli1NDOr/GVYrBY05KS5X11jxVbw=
 github.com/openconfig/lemming/operator v0.2.0/go.mod h1:LKgEXSR5VK2CAeh2uKijKAXFj42uQuwakrCHVPF0iII=
-github.com/openconfig/ondatra v0.1.24-0.20230713143210-d81989ceab89 h1:LmY4N2mt43E7NCfvH2PfS39bYaGt1uLz3ptCKAAE4po=
-github.com/openconfig/ondatra v0.1.24-0.20230713143210-d81989ceab89/go.mod h1:prhnBnjQC64W5wFbjNqSEomoUb6eWjJiTlAPHhZt2yE=
+github.com/openconfig/ondatra v0.1.24 h1:T2oCCm7xVCxTi9suOeXLAFiNvJXCy7RzdDK3IGSC3TA=
+github.com/openconfig/ondatra v0.1.24/go.mod h1:prhnBnjQC64W5wFbjNqSEomoUb6eWjJiTlAPHhZt2yE=
 github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07 h1:X631iD/B0ximGFb5P9LY5wHju4SiedxUhc5UZEo7VSw=
 github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07/go.mod h1:bmpU0kIsCiXuncozViVuQx1HqolC3C94H7lD9KKmoTo=
 github.com/openconfig/ygnmi v0.8.1 h1:wdjrn1wBBBTCSQGO94ht0CY2zyJdoOe4G6rmjsMdPdc=


### PR DESCRIPTION
Per ondatra@v0.2.0 `telemetry-atomic` nodes no longer provide path access to descendants: https://github.com/openconfig/ondatra/releases/tag/v0.2.0