### PR TITLE
set link_qual_wait_after_delete_required in metadata.proto

### DIFF
--- a/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/metadata.textproto
+++ b/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/metadata.textproto
@@ -20,6 +20,7 @@ platform_exceptions: {
   deviations: {
     omit_l2_mtu: true
     interface_enabled: true
+    link_qual_wait_after_delete_required: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
update packet_link_qual metadata to enable deviation_link_qual_wait_after_delete_required