### PR TITLE
P4RT-1.1 , update DUT links from 2 to 4

### DIFF
--- a/feature/experimental/p4rt/ate_tests/base_p4rt/metadata.textproto
+++ b/feature/experimental/p4rt/ate_tests/base_p4rt/metadata.textproto
@@ -4,7 +4,7 @@
 uuid: "ac980b1f-2139-48c1-8146-37a25d3eb980"
 plan_id: "P4RT-1.1"
 description: "Base P4RT Functionality"
-testbed: TESTBED_DUT_ATE_2LINKS
+testbed: TESTBED_DUT_ATE_4LINKS
 platform_exceptions: {
   platform: {
     vendor: NOKIA

--- a/feature/experimental/p4rt/otg_tests/base_p4rt/metadata.textproto
+++ b/feature/experimental/p4rt/otg_tests/base_p4rt/metadata.textproto
@@ -4,7 +4,7 @@
 uuid: "ac980b1f-2139-48c1-8146-37a25d3eb980"
 plan_id: "P4RT-1.1"
 description: "Base P4RT Functionality"
-testbed: TESTBED_DUT_ATE_2LINKS
+testbed: TESTBED_DUT_ATE_4LINKS
 platform_exceptions: {
   platform: {
     vendor: NOKIA

--- a/feature/experimental/p4rt/tests/p4rt_election/metadata.textproto
+++ b/feature/experimental/p4rt/tests/p4rt_election/metadata.textproto
@@ -4,4 +4,4 @@
 uuid: "73bf3d88-e5c1-4d30-9fae-f40b8363044f"
 plan_id: "P4RT-2.1"
 description: "P4RT Election"
-testbed: TESTBED_DUT_ATE_2LINKS
+testbed: TESTBED_DUT_ATE_4LINKS

--- a/feature/experimental/p4rt/tests/p4rt_election/metadata.textproto
+++ b/feature/experimental/p4rt/tests/p4rt_election/metadata.textproto
@@ -4,4 +4,4 @@
 uuid: "73bf3d88-e5c1-4d30-9fae-f40b8363044f"
 plan_id: "P4RT-2.1"
 description: "P4RT Election"
-testbed: TESTBED_DUT_ATE_4LINKS
+testbed: TESTBED_DUT_ATE_2LINKS


### PR DESCRIPTION
Changed metadata.textproto from TESTBED_DUT_ATE_2LINKS to TESTBED_DUT_ATE_4LINKS, to have a better chance of different nodes getting selected during run. 