### PR TITLE
gnmi-1.2/1.3 - updating range of LSP refresh interval

### DIFF
--- a/feature/experimental/system/gnmi/benchmarking/ate_tests/internal/setup/setup.go
+++ b/feature/experimental/system/gnmi/benchmarking/ate_tests/internal/setup/setup.go
@@ -171,7 +171,7 @@ func BuildBenchmarkingConfig(t *testing.T) *oc.Root {
 	lspBit.SetBit = ygot.Bool(false)
 	isisTimers := globalISIS.GetOrCreateTimers()
 	isisTimers.LspLifetimeInterval = ygot.Uint16(600)
-	isisTimers.LspRefreshInterval = ygot.Uint16(200)
+	isisTimers.LspRefreshInterval = ygot.Uint16(250)
 	if deviations.ISISTimersLspRefreshIntervalUnsupported(dut) {
 		isisTimers.LspRefreshInterval = nil
 	}


### PR DESCRIPTION
Hi,

LSP refresh interval range is updated from 200 to 250.

