### PR TITLE
p4rt-2.2: fix writeReadTableEntry()

### DIFF
--- a/feature/experimental/p4rt/tests/metadata_validation_test/metadata_validation_test.go
+++ b/feature/experimental/p4rt/tests/metadata_validation_test/metadata_validation_test.go
@@ -98,7 +98,7 @@ func TestP4RTMetadata(t *testing.T) {
 }
 
 func writeReadTableEntry(c *p4rt_client.P4RTClient, metadata string, action p4v1pb.Update_Type) (string, bool, error) {
-	if err := writeTableEntry(c, metadata, p4v1pb.Update_INSERT); err != nil {
+	if err := writeTableEntry(c, metadata, action); err != nil {
 		return "", false, fmt.Errorf("error in writing Table Entry: %v", err)
 	}
 	resp, err := readTableEntry(c)


### PR DESCRIPTION
This PR fixes writeReadTableEntry(), previous version was ignoring `action` argument and always used an insert 

---
<sup>
This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.</sup>