### PR TITLE
TE-8.2 : fixed error in validating AFT entry

### DIFF
--- a/feature/gribi/otg_tests/supervisor_failure_test/supervisor_failure_test.go
+++ b/feature/gribi/otg_tests/supervisor_failure_test/supervisor_failure_test.go
@@ -378,7 +378,7 @@ func TestSupFailure(t *testing.T) {
 	ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Afts().Ipv4Entry(ateDstNetCIDR)
 	if _, found := gnmi.Watch(t, args.dut, ipv4Path.State(), 2*time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
 		value, present := val.Val()
-		return present && value.GetPrefix() != ateDstNetCIDR
+		return present && value.GetPrefix() == ateDstNetCIDR
 	}).Await(t); !found {
 		t.Fatalf("Could not find prefix %s in telemetry AFT", ateDstNetCIDR)
 	}


### PR DESCRIPTION
"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."