### PR TITLE
Add logging details to ci-trigger

### DIFF
--- a/tools/ci-trigger/main.go
+++ b/tools/ci-trigger/main.go
@@ -67,14 +67,14 @@ func ghWebhook(_ http.ResponseWriter, r *http.Request) {
 	case *github.PullRequestEvent:
 		if event.GetAction() == "opened" || event.GetAction() == "synchronize" {
 			if err := t.processPullRequest(r.Context(), event); err != nil {
-				glog.Errorf("ProcessPullRequest error: %s", err)
+				glog.Errorf("ProcessPullRequest PR%d user %q error: %s", event.GetPullRequest().GetNumber(), event.GetPullRequest().GetUser().GetLogin(), err)
 				return
 			}
 		}
 	case *github.IssueCommentEvent:
 		if event.GetAction() == "created" {
 			if err := t.processIssueComment(r.Context(), event); err != nil {
-				glog.Errorf("ProcessIssueComment error: %s", err)
+				glog.Errorf("ProcessIssueComment PR%d comment %d user %q error: %s", event.GetIssue().GetNumber(), event.GetComment().GetID(), event.GetComment().GetUser().GetLogin(), err)
 				return
 			}
 		}

--- a/tools/ci-trigger/pr.go
+++ b/tools/ci-trigger/pr.go
@@ -102,8 +102,9 @@ func (p *pullRequest) createBuild(ctx context.Context, buildClient *cloudbuild.S
 				}
 				jobID, logURL, err := cb.submitBuild(ctx)
 				if err != nil {
-					return fmt.Errorf("error creating CloudBuild job for PR%d: %w", p.ID, err)
+					return fmt.Errorf("submitBuild device %q: %w", virtualDevice.Type.String(), err)
 				}
+				glog.Infof("Created CloudBuild Job %s for PR%d at commit %q for device %q", jobID, p.ID, p.HeadSHA, virtualDevice.Type.String())
 				p.Virtual[i].CloudBuildID = jobID
 				p.Virtual[i].CloudBuildLogURL = logURL
 				vendor := strings.ToLower(virtualDevice.Type.Vendor.String())


### PR DESCRIPTION
Improve logging of ci-trigger.  If there are any errors while handling an event, it is difficult to figure out which event caused the error.  Additionally, there was no logging for when a job was successfully created - this makes it a bit easier to understand which user approved a job.