### PR TITLE
Update metadata.textproto for gNMI-1.11 for Arista

### DIFF
--- a/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/metadata.textproto
+++ b/feature/gnmi/ate_tests/telemetry_interface_packet_counters_test/metadata.textproto
@@ -39,7 +39,7 @@ platform_exceptions: {
     vendor: ARISTA
   }
   deviations: {
-    subinterface_packet_counters_missing: true
+    ipv6_discarded_pkts_unsupported: true
     default_network_instance: "default"
   }
 }

--- a/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/metadata.textproto
+++ b/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/metadata.textproto
@@ -39,7 +39,7 @@ platform_exceptions: {
     vendor: ARISTA
   }
   deviations: {
-    subinterface_packet_counters_missing: true
+    ipv6_discarded_pkts_unsupported: true
     default_network_instance: "default"
   }
 }


### PR DESCRIPTION
This PR intends to fix the gNMI-1.11 test for Arista to use the right deviation. The `subinterface_packet_counters_missing` is not required and instead the existing `ipv6_discarded_pkts_unsupported` deviation can be used. This PR changes this aspect for both the ATE and OTG tests.