### PR TITLE
Default label for issues

### DIFF
--- a/.github/workflows/label-issue
+++ b/.github/workflows/label-issue
@@ -1,0 +1,21 @@
+name: Default enhancement label for issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["enhancement"]
+            })


### PR DESCRIPTION
Automatically set the 'enhancement' label for new github issues.   This means new issues are considered 'feature requests' instead of 'bugs' by default.  

The enhancement label can be manually removed to be treated like a bug.