### PR TITLE
p4rt-2.2: remove deviation for nokia

### DIFF
--- a/feature/experimental/p4rt/tests/metadata_validation_test/metadata.textproto
+++ b/feature/experimental/p4rt/tests/metadata_validation_test/metadata.textproto
@@ -7,14 +7,6 @@ description: "P4RT Metadata Validation"
 testbed: TESTBED_DUT
 platform_exceptions: {
   platform: {
-    vendor: NOKIA
-  }
-  deviations: {
-    p4rt_modify_table_entry_unsupported: true
-  }
-}
-platform_exceptions: {
-  platform: {
     vendor: JUNIPER
   }
   deviations: {


### PR DESCRIPTION
This PR removes `p4rt_modify_table_entry_unsupported` deviation for nokia 

---
<sup>
This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.
</sup>