### PR TITLE
Update ci-trigger archive creation

### DIFF
--- a/tools/ci-trigger/Dockerfile
+++ b/tools/ci-trigger/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 WORKDIR /app
 COPY . /app/
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server github.com/openconfig/featureprofiles/tools/ci-trigger
-FROM alpine:3
-RUN apk add --no-cache ca-certificates
+FROM golang:1.21-alpine
 COPY --from=builder /app/server /server
-CMD ["/server"]
+ENTRYPOINT ["/server"]
+CMD ["-alsologtostderr"]

--- a/tools/ci-trigger/README.md
+++ b/tools/ci-trigger/README.md
@@ -123,7 +123,7 @@ export GITHUB_WEBHOOK_SECRET=shared_secret
 export GITHUB_API_SECRET=api_secret
 
 umask 0022
-go run github.com/openconfig/featureprofiles/tools/ci-trigger
+go run github.com/openconfig/featureprofiles/tools/ci-trigger -alsologtostderr
 ```
 
 You may need to customize the config.go files based on your environment.  You will also need to have some form of [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) available.

--- a/tools/ci-trigger/cloudbuild.go
+++ b/tools/ci-trigger/cloudbuild.go
@@ -19,20 +19,15 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
-	"strconv"
 	"strings"
-	"time"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/cloudbuild/v1"
 	"gopkg.in/yaml.v2"
-
-	"github.com/google/uuid"
 )
 
 type cloudBuild struct {
@@ -43,8 +38,9 @@ type cloudBuild struct {
 	f           fs.FS
 }
 
-// submitBuild creates a CB Build and returns the jobID and log URL created.
-func (c *cloudBuild) submitBuild(ctx context.Context) (string, string, error) {
+// submitBuild creates a CB Build using the data from objPath in Cloud Storage
+// and returns the jobID and log URL created.
+func (c *cloudBuild) submitBuild(ctx context.Context, objPath string) (string, string, error) {
 	build, err := c.defaultBuild()
 	if err != nil {
 		return "", "", err
@@ -70,11 +66,6 @@ func (c *cloudBuild) submitBuild(ctx context.Context) (string, string, error) {
 	}
 	build.Substitutions["_DUT_TESTS"] = testPaths.String()
 
-	objPath, err := c.prepareBuild(ctx)
-	if err != nil {
-		return "", "", err
-	}
-
 	build.LogsBucket = "gs://featureprofiles-ci-logs-" + vendor
 	build.Source = &cloudbuild.Source{
 		StorageSource: &cloudbuild.StorageSource{
@@ -95,8 +86,20 @@ func (c *cloudBuild) submitBuild(ctx context.Context) (string, string, error) {
 	return bom.Build.Id, bom.Build.LogUrl, nil
 }
 
+// defaultBuild returns the Cloud Build configuration stored in the repository.
+func (c *cloudBuild) defaultBuild() (*cloudbuild.Build, error) {
+	buildYAML, err := fs.ReadFile(c.f, "cloudbuild/virtual.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	var build *cloudbuild.Build
+	err = yaml.Unmarshal(buildYAML, &build)
+	return build, err
+}
+
 // createTGZArchive returns a tar.gz compressed archive of the cloudBuild fs.
-func (c *cloudBuild) createTGZArchive() (*bytes.Buffer, error) {
+func createTGZArchive(f fs.FS) (*bytes.Buffer, error) {
 	var buf bytes.Buffer
 
 	gzWriter := gzip.NewWriter(&buf)
@@ -105,7 +108,7 @@ func (c *cloudBuild) createTGZArchive() (*bytes.Buffer, error) {
 	tarWriter := tar.NewWriter(gzWriter)
 	defer tarWriter.Close()
 
-	err := fs.WalkDir(c.f, ".", func(path string, d fs.DirEntry, err error) error {
+	err := fs.WalkDir(f, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -132,7 +135,7 @@ func (c *cloudBuild) createTGZArchive() (*bytes.Buffer, error) {
 			return nil
 		}
 
-		file, err := c.f.Open(path)
+		file, err := f.Open(path)
 		if err != nil {
 			return err
 		}
@@ -142,37 +145,4 @@ func (c *cloudBuild) createTGZArchive() (*bytes.Buffer, error) {
 		return err
 	})
 	return &buf, err
-}
-
-// prepareBuild uploads the compressed repository to Object Store and returns the path to the object.
-func (c *cloudBuild) prepareBuild(ctx context.Context) (string, error) {
-	data, err := c.createTGZArchive()
-	if err != nil {
-		return "", err
-	}
-
-	u, err := uuid.NewRandom()
-	if err != nil {
-		return "", err
-	}
-
-	objPath := "source/" + strconv.FormatInt(time.Now().UTC().Unix(), 10) + "-" + hex.EncodeToString(u[:]) + ".tgz"
-	obj := c.storClient.Bucket(gcpCloudBuildBucketName).Object(objPath).NewWriter(ctx)
-	obj.ContentType = "application/x-tar"
-	if _, err := data.WriteTo(obj); err != nil {
-		return "", err
-	}
-	return objPath, obj.Close()
-}
-
-// defaultBuild returns the Cloud Build configuration stored in the repository.
-func (c *cloudBuild) defaultBuild() (*cloudbuild.Build, error) {
-	buildYAML, err := fs.ReadFile(c.f, "cloudbuild/virtual.yaml")
-	if err != nil {
-		return nil, err
-	}
-
-	var build *cloudbuild.Build
-	err = yaml.Unmarshal(buildYAML, &build)
-	return build, err
 }

--- a/tools/ci-trigger/cloudbuild.go
+++ b/tools/ci-trigger/cloudbuild.go
@@ -18,7 +18,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -40,7 +39,7 @@ type cloudBuild struct {
 
 // submitBuild creates a CB Build using the data from objPath in Cloud Storage
 // and returns the jobID and log URL created.
-func (c *cloudBuild) submitBuild(ctx context.Context, objPath string) (string, string, error) {
+func (c *cloudBuild) submitBuild(objPath string) (string, string, error) {
 	build, err := c.defaultBuild()
 	if err != nil {
 		return "", "", err

--- a/tools/ci-trigger/cloudbuild.yaml
+++ b/tools/ci-trigger/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: golang:1.20
+  - name: golang:1.21
     entrypoint: /bin/bash
     args: [ '-c', 'go test -timeout 5m -v github.com/openconfig/featureprofiles/tools/ci-trigger/...']
   - name: 'gcr.io/cloud-builders/docker'

--- a/tools/ci-trigger/cloudbuild_test.go
+++ b/tools/ci-trigger/cloudbuild_test.go
@@ -36,11 +36,7 @@ func TestCreateTGZArchive(t *testing.T) {
 		"dir2/file5.txt": {Data: []byte("Executable Inside dir2"), Mode: 0755},
 	}
 
-	cb := cloudBuild{
-		f: f,
-	}
-
-	buf, err := cb.createTGZArchive()
+	buf, err := createTGZArchive(f)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/ci-trigger/pr.go
+++ b/tools/ci-trigger/pr.go
@@ -18,8 +18,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io/fs"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -27,6 +29,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/google/go-github/v50/github"
+	"github.com/google/uuid"
 	"google.golang.org/api/cloudbuild/v1"
 
 	"github.com/go-git/go-git/v5"
@@ -78,22 +81,54 @@ func (d *deviceType) String() string {
 	return d.Vendor.String() + " " + d.HardwareModel
 }
 
+// createArchive uploads the compressed repository to Object Store and returns the path to the object.
+func (p *pullRequest) createArchive(ctx context.Context, storClient *storage.Client) (string, error) {
+	data, err := createTGZArchive(p.localFS)
+	if err != nil {
+		return "", err
+	}
+
+	u, err := uuid.NewRandom()
+	if err != nil {
+		return "", err
+	}
+
+	objPath := "source/" + strconv.FormatInt(time.Now().UTC().Unix(), 10) + "-" + hex.EncodeToString(u[:]) + ".tgz"
+	obj := storClient.Bucket(gcpCloudBuildBucketName).Object(objPath).NewWriter(ctx)
+	obj.ContentType = "application/x-tar"
+	obj.Metadata = map[string]string{
+		"pr":      strconv.Itoa(p.ID),
+		"headSHA": p.HeadSHA,
+	}
+	if _, err := data.WriteTo(obj); err != nil {
+		return "", err
+	}
+	return objPath, obj.Close()
+}
+
 // createBuild creates a GCB build for each of the deviceTypes.
 func (p *pullRequest) createBuild(ctx context.Context, buildClient *cloudbuild.Service, storClient *storage.Client, devices []deviceType) error {
+	err := p.fetchGoDeps()
+	if err != nil {
+		return err
+	}
+
+	objPath, err := p.createArchive(ctx, storClient)
+	if err != nil {
+		return err
+	}
+
 	for _, d := range devices {
+	virtualDeviceLoop:
 		for i, virtualDevice := range p.Virtual {
 			if virtualDevice.Type == d {
 				if len(virtualDevice.Tests) == 0 {
 					continue
 				}
-				skip := false
 				for _, v := range virtualDevice.Tests {
 					if v.Status != "pending authorization" {
-						skip = true
+						continue virtualDeviceLoop
 					}
-				}
-				if skip {
-					continue
 				}
 				cb := &cloudBuild{
 					device:      virtualDevice,
@@ -101,7 +136,7 @@ func (p *pullRequest) createBuild(ctx context.Context, buildClient *cloudbuild.S
 					storClient:  storClient,
 					f:           p.localFS,
 				}
-				jobID, logURL, err := cb.submitBuild(ctx)
+				jobID, logURL, err := cb.submitBuild(ctx, objPath)
 				if err != nil {
 					return fmt.Errorf("submitBuild device %q: %w", virtualDevice.Type.String(), err)
 				}
@@ -118,6 +153,20 @@ func (p *pullRequest) createBuild(ctx context.Context, buildClient *cloudbuild.S
 		}
 	}
 
+	return nil
+}
+
+// fetchGoDeps downloads the Golang module dependencies into a local vendor cache.
+func (p *pullRequest) fetchGoDeps() error {
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(goBin, "mod", "vendor")
+	cmd.Dir = p.localPath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("vendoring dependencies: %v, output:\n%s", err, out)
+	}
 	return nil
 }
 

--- a/tools/ci-trigger/pr.go
+++ b/tools/ci-trigger/pr.go
@@ -136,7 +136,7 @@ func (p *pullRequest) createBuild(ctx context.Context, buildClient *cloudbuild.S
 					storClient:  storClient,
 					f:           p.localFS,
 				}
-				jobID, logURL, err := cb.submitBuild(ctx, objPath)
+				jobID, logURL, err := cb.submitBuild(objPath)
 				if err != nil {
 					return fmt.Errorf("submitBuild device %q: %w", virtualDevice.Type.String(), err)
 				}

--- a/tools/ci-trigger/pr.go
+++ b/tools/ci-trigger/pr.go
@@ -212,7 +212,7 @@ func (p *pullRequest) populateObjectMetadata(ctx context.Context, storClient *st
 			if cloudBuildLogURL, ok := objAttrs.Metadata["cloudBuildLogURL"]; ok {
 				p.Virtual[i].CloudBuildLogURL = cloudBuildLogURL
 			}
-			if cloudBuildRawLogURL, ok := objAttrs.Metadata["CloudBuildRawLogURL"]; ok {
+			if cloudBuildRawLogURL, ok := objAttrs.Metadata["cloudBuildRawLogURL"]; ok {
 				p.Virtual[i].CloudBuildRawLogURL = cloudBuildRawLogURL
 			}
 		}

--- a/tools/ci-trigger/trigger.go
+++ b/tools/ci-trigger/trigger.go
@@ -30,21 +30,9 @@ import (
 
 // trigger contains the functions used to process a GitHub Webhook event
 type trigger struct {
-	webhookSecret []byte
-
 	githubClient *github.Client
 	storClient   *storage.Client
 	buildClient  *cloudbuild.Service
-}
-
-// githubEvent returns the validated Github event from an HTTP request.
-func (t *trigger) githubEvent(r *http.Request) (any, error) {
-	payload, err := github.ValidatePayload(r, t.webhookSecret)
-	if err != nil {
-		return nil, err
-	}
-
-	return github.ParseWebHook(github.WebHookType(r), payload)
 }
 
 // processIssueComment handles a GitHub issue event.
@@ -184,12 +172,11 @@ func (t *trigger) authorizedUser(ctx context.Context, username string) (bool, er
 func newTrigger(ctx context.Context) (*trigger, error) {
 	t := &trigger{}
 
-	webhookSecret, apiSecret, err := fetchSecrets()
+	apiSecret, err := fetchAPISecret()
 	if err != nil {
 		return nil, err
 	}
 
-	t.webhookSecret = webhookSecret
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: string(apiSecret)},
 	)


### PR DESCRIPTION
This PR updates ci-trigger code archive creation behavior.  This is necessary to support offline compilation of Go tests.

* Generate/reuse a single code archive for all vendors instead of per-vendor.
* Vendor go deps into code archive to support offline compilation.
* Process events asynchronously from the GitHub API HTTP triggering event.
* Write PR and SHA to code archive metadata.
* Use go1.21 for ci-trigger container.
* Enable stderr logging in ci-trigger container.
* Add badge_pubsub arg to optionally disable processing badge pubsub events.
* Fix a typo in metadata restoration that could break the "raw log" comment link.