### PR TITLE
Adding tags to metadata.textproto

### DIFF
--- a/feature/experimental/bgp/ate_tests/bgp_2byte_4byte_asn/metadata.textproto
+++ b/feature/experimental/bgp/ate_tests/bgp_2byte_4byte_asn/metadata.textproto
@@ -16,4 +16,4 @@ platform_exceptions: {
     default_network_instance: "default"
   }
 }
-tags: TAGS_EDGE
+tags: TAGS_AGGREGATION

--- a/feature/experimental/bgp/ate_tests/bgp_2byte_4byte_asn_policy_test/metadata.textproto
+++ b/feature/experimental/bgp/ate_tests/bgp_2byte_4byte_asn_policy_test/metadata.textproto
@@ -42,3 +42,4 @@ platform_exceptions: {
     default_network_instance: "default"
   }
 }
+tags: TAGS_AGGREGATION

--- a/feature/experimental/bgp/ate_tests/bgp_always_compare_med/metadata.textproto
+++ b/feature/experimental/bgp/ate_tests/bgp_always_compare_med/metadata.textproto
@@ -33,4 +33,4 @@ platform_exceptions: {
     default_network_instance: "default"
   }
 }
-tags: TAGS_EDGE
+tags: TAGS_AGGREGATION

--- a/feature/experimental/bgp/ate_tests/bgp_long_lived_graceful_restart/metadata.textproto
+++ b/feature/experimental/bgp/ate_tests/bgp_long_lived_graceful_restart/metadata.textproto
@@ -47,4 +47,4 @@ platform_exceptions: {
     interface_config_vrf_before_address: true
   }
 }
-tags: TAGS_EDGE
+tags: TAGS_AGGREGATION

--- a/feature/experimental/bgp/otg_tests/bgp_afi_safi_defaults/metadata.textproto
+++ b/feature/experimental/bgp/otg_tests/bgp_afi_safi_defaults/metadata.textproto
@@ -33,3 +33,4 @@ platform_exceptions: {
     default_network_instance: "default"
   }
 }
+tags: TAGS_AGGREGATION

--- a/feature/experimental/bgp/otg_tests/bgp_always_compare_med/metadata.textproto
+++ b/feature/experimental/bgp/otg_tests/bgp_always_compare_med/metadata.textproto
@@ -41,4 +41,4 @@ platform_exceptions: {
     default_network_instance: "default"
   }
 }
-tags: TAGS_EDGE
+tags: TAGS_AGGREGATION

--- a/feature/experimental/isis/ate_tests/isis_change_lsp_lifetime_test/metadata.textproto
+++ b/feature/experimental/isis/ate_tests/isis_change_lsp_lifetime_test/metadata.textproto
@@ -41,4 +41,4 @@ platform_exceptions: {
     isis_lsp_lifetime_interval_requires_lsp_refresh_interval: true
   }
 }
-tags: TAGS_EDGE
+tags: TAGS_AGGREGATION

--- a/feature/experimental/isis/otg_tests/isis_interface_hello_padding_enable_test/metadata.textproto
+++ b/feature/experimental/isis/otg_tests/isis_interface_hello_padding_enable_test/metadata.textproto
@@ -41,3 +41,4 @@ platform_exceptions: {
     isis_lsp_lifetime_interval_requires_lsp_refresh_interval: true
   }
 }
+tags: TAGS_AGGREGATION

--- a/feature/experimental/isis/otg_tests/isis_interface_passive_test/metadata.textproto
+++ b/feature/experimental/isis/otg_tests/isis_interface_passive_test/metadata.textproto
@@ -44,3 +44,4 @@ platform_exceptions: {
     isis_counter_part_changes_unsupported: true
   }
 }
+tags: TAGS_AGGREGATION

--- a/feature/experimental/isis/otg_tests/isis_metric_style_wide_enabled_test/metadata.textproto
+++ b/feature/experimental/isis/otg_tests/isis_metric_style_wide_enabled_test/metadata.textproto
@@ -41,3 +41,4 @@ platform_exceptions: {
     isis_lsp_lifetime_interval_requires_lsp_refresh_interval: true
   }
 }
+tags: TAGS_AGGREGATION

--- a/feature/experimental/isis/otg_tests/isis_metric_style_wide_not_enabled_test/metadata.textproto
+++ b/feature/experimental/isis/otg_tests/isis_metric_style_wide_not_enabled_test/metadata.textproto
@@ -41,3 +41,4 @@ platform_exceptions: {
     isis_lsp_lifetime_interval_requires_lsp_refresh_interval: true
   }
 }
+tags: TAGS_AGGREGATION

--- a/feature/experimental/system/health/tests/system_generic_health_check/metadata.textproto
+++ b/feature/experimental/system/health/tests/system_generic_health_check/metadata.textproto
@@ -18,3 +18,4 @@ platform_exceptions: {
     qos_voq_drop_counter_unsupported: true
   }
 }
+tags: TAGS_AGGREGATION

--- a/feature/experimental/tunnel/otg_tests/tunnel_acl_based_test/metadata.textproto
+++ b/feature/experimental/tunnel/otg_tests/tunnel_acl_based_test/metadata.textproto
@@ -5,3 +5,4 @@ uuid:  "5e46a336-0e6c-4b65-ac49-8b925aacb46c"
 plan_id:  "TUN-1.9"
 description:  "GRE inner packet DSCP"
 testbed:  TESTBED_DUT_ATE_2LINKS
+tags: TAGS_AGGREGATION


### PR DESCRIPTION
Updating metadata.textproto for the following tests with `tags: TAGS_AGGREGATION`:
- RT-1.12
- RT-2.7
- RT-1.19
- RT-1.14
- RT-2.10
- RT-1.24
- Health-1.1
- RT-2.8
- RT-2.9
- RT-2.6
- TUN-1.9
- RT-1.23