### PR TITLE
[3/5] Add gRIBI control plane only pop top MPLS label test.

### DIFF
--- a/feature/gribi/mplsutil/compliance.go
+++ b/feature/gribi/mplsutil/compliance.go
@@ -210,7 +210,7 @@ func PushToIPPacket(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, b
 // The DUT is expected to be in a topology where 192.0.2.2 is a valid next-hop. Packets
 // with label 100 will have this label popped from the stack.
 func PopTopLabel(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, trafficFunc TrafficFunc) {
-	defer electionID.Inc()
+	defer electionID.Add(1)
 	defer flushServer(t, c)
 
 	ops := []func(){

--- a/feature/gribi/mplsutil/compliance.go
+++ b/feature/gribi/mplsutil/compliance.go
@@ -270,3 +270,139 @@ func PopTopLabel(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, traf
 		})
 	}
 }
+
+// PopNLabels programs a gRIBI server with a LFIB entry matching label 100
+// that pops the labels specified in popLabels from the stack. If trafficFunc
+// is non-nil it is called after the gRIBI programming is verified.
+//
+// The DUT is expected to be in a topology where 192.0.2.2 resolves to
+// a valid next-hop.
+func PopNLabels(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, popLabels []uint32, trafficFunc TrafficFunc) {
+	defer electionID.Add(1)
+	defer flushServer(t, c)
+
+	ops := []func(){
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopEntry().
+					WithNetworkInstance(defaultNIName).
+					WithIndex(1).
+					WithIPAddress("192.0.2.2"))
+
+			c.Modify().AddEntry(t,
+				fluent.NextHopGroupEntry().
+					WithNetworkInstance(defaultNIName).
+					WithID(1).
+					AddNextHop(1, 1))
+
+			c.Modify().AddEntry(t,
+				fluent.LabelEntry().
+					WithLabel(100).
+					WithPoppedLabelStack(popLabels...).
+					WithNetworkInstance(defaultNIName).
+					WithNextHopGroup(1))
+		},
+	}
+
+	res := modify(t, c, ops)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithMPLSOperation(100).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopGroupOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	if trafficFunc != nil {
+		t.Run("pop-n-labels, traffic test", func(t *testing.T) {
+			trafficFunc(t, nil)
+		})
+	}
+}
+
+// PopOnePushN implements a test whereby one (the top) label is popped, and N labels as specified
+// by pushLabels are pushed to the stack for an input MPLS packet. Two LFIB entries (100 and 200)
+// are created. If trafficFunc is non-nil it is called after the gRIBI programming has been validated.
+//
+// The DUT is expected to be in a topology where 192.0.2.2 is a resolvable next-hop.
+func PopOnePushN(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, pushLabels []uint32, trafficFunc TrafficFunc) {
+	defer electionID.Add(1)
+	defer flushServer(t, c)
+
+	ops := []func(){
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopEntry().
+					WithNetworkInstance(defaultNIName).
+					WithIndex(1).
+					WithIPAddress("192.0.2.2").
+					WithPopTopLabel().
+					WithPushedLabelStack(pushLabels...))
+
+			c.Modify().AddEntry(t,
+				fluent.NextHopGroupEntry().
+					WithNetworkInstance(defaultNIName).
+					WithID(1).
+					AddNextHop(1, 1))
+
+			for _, label := range []uint32{100, 200} {
+				c.Modify().AddEntry(t,
+					fluent.LabelEntry().
+						WithLabel(label).
+						WithNetworkInstance(defaultNIName).
+						WithNextHopGroup(1))
+			}
+		},
+	}
+
+	res := modify(t, c, ops)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopGroupOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopOperation(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			WithOperationType(constants.Add).
+			AsResult(),
+		chk.IgnoreOperationID())
+
+	for _, label := range []uint64{100, 200} {
+		chk.HasResult(t, res,
+			fluent.OperationResult().
+				WithMPLSOperation(label).
+				WithProgrammingResult(fluent.InstalledInRIB).
+				WithOperationType(constants.Add).
+				AsResult(),
+			chk.IgnoreOperationID())
+	}
+
+	if trafficFunc != nil {
+		t.Run("pop-one-push-N, traffic test", func(t *testing.T) {
+			trafficFunc(t, nil)
+		})
+	}
+}

--- a/feature/gribi/mplsutil/compliance.go
+++ b/feature/gribi/mplsutil/compliance.go
@@ -165,7 +165,7 @@ func PushToIPPacket(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, b
 
 			c.Modify().AddEntry(t,
 				fluent.IPv4Entry().
-					WithPrefix("10.0.0.0/24").
+					WithPrefix("198.18.1.0/24").
 					WithNetworkInstance(defaultNIName).
 					WithNextHopGroupNetworkInstance(defaultNIName).
 					WithNextHopGroup(1))
@@ -177,7 +177,7 @@ func PushToIPPacket(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, b
 
 	chk.HasResult(t, res,
 		fluent.OperationResult().
-			WithIPv4Operation("10.0.0.0/24").
+			WithIPv4Operation("198.18.1.0/24").
 			WithProgrammingResult(fluent.InstalledInRIB).
 			WithOperationType(constants.Add).
 			AsResult(),

--- a/feature/gribi/mplsutil/compliance.go
+++ b/feature/gribi/mplsutil/compliance.go
@@ -135,7 +135,7 @@ func PushLabelStack(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, b
 //
 // The DUT is expected to be within a topology where 192.0.2.2 is a valid next-hop.
 func PushToIPPacket(t *testing.T, c *fluent.GRIBIClient, defaultNIName string, baseLabel, numLabels int, trafficFunc TrafficFunc) {
-	defer electionID.Inc()
+	defer electionID.Add(1)
 	defer flushServer(t, c)
 
 	c.Connection().

--- a/feature/gribi/otg_tests/mpls_compliance/README.md
+++ b/feature/gribi/otg_tests/mpls_compliance/README.md
@@ -40,6 +40,27 @@ traffic validation.
   pop the top label.
 * Validate that gRIBI transactions are successfully processed by the server.
 
+## TE-9.4: Pop N Labels from Stack
+
+* Configure DUT with destination interface connected to an ATE. The ATE is
+  configured to have assigned address `192.0.2.2`.
+* Program DUT with a label forwarding entry matching label 100 and specifying to
+  pop:
+    * Label `100`
+    * Label stack `[100, 42]`
+    * Label stack `[100, 42, 43, 44, 45]`
+
+## TE-9.5: Pop 1 Push N Labels
+
+* Configure DUT with destination interface connected to an ATE. The ATE is
+  configured to have assigned address `192.0.2.2`.
+* Program DUT with a label forwarding entry matching label 100 and label 200,
+  pointing to a next-hop that is programmed to pop the top label, and:
+   - push label 100 - resulting in a swap for incoming label 100, and a push of
+     100 for incoming label 200.
+   - push stack `[100, 200, 300, 400]`
+   - push stack `[100, 200, 300, 400, 500, 600]`
+
 ## Protocol/RPC Parameter coverage
 
 *   gRIBI:
@@ -60,6 +81,8 @@ traffic validation.
             * `id`
             * `ip_address`
             * `pushed_label_stack`
+            * `pop_top_label`
+            * `popped_label_stack`
     *   `ModifyResponse`:
     *   `AFTResult`:
         *   `id`

--- a/feature/gribi/otg_tests/mpls_compliance/README.md
+++ b/feature/gribi/otg_tests/mpls_compliance/README.md
@@ -32,6 +32,14 @@ traffic validation.
        additional labels onto the packet.
 * Validate that gRIBI transactions are successfully processed by the server.
 
+### TE-9.3: Pop Top MPLS Label
+
+* Configure DUT with a destination interface connected to an ATE. The ATE is
+  configured to have assigned address 192.0.2.2.
+* Program DUT with a label forwarding entry matching label 100 and specifying to
+  pop the top label.
+* Validate that gRIBI transactions are successfully processed by the server.
+
 ## Protocol/RPC Parameter coverage
 
 *   gRIBI:

--- a/feature/gribi/otg_tests/mpls_compliance/README.md
+++ b/feature/gribi/otg_tests/mpls_compliance/README.md
@@ -20,7 +20,17 @@ traffic validation.
      containing a single NH.
    - Program a `NextHopEntry` which points to `192.0.2.2` pushing `[baseLabel,
      ..., baseLabel+numLabels]` onto the MPLS label stack.
+* Validate that gRIBI transactions are successfully processed by the server.
 
+### TE-9.2: Push MPLS Labels to IP Packet
+
+* Configure DUT with a destination interface connected to an ATE. The ATE is
+  configured to have an assigned address of `192.0.2.2`, and the interface to
+  the DUT is enabled.
+* For label stack depths from `N=1...numLabels` program:
+     * an IPv4 entry for `10.0.0.0/24` with a next-hop of `192.0.2.2` pushing N
+       additional labels onto the packet.
+* Validate that gRIBI transactions are successfully processed by the server.
 
 ## Protocol/RPC Parameter coverage
 
@@ -31,6 +41,8 @@ traffic validation.
           *   `id`
           *   `network_instance`
           *   `op`: `ADD`
+          *  `ipv4`:
+            *  `prefix`
           *  `mpls`:
             *   `next_hop_group`
           *   `next_hop_group`

--- a/feature/gribi/otg_tests/mpls_compliance/gribi_mpls_compliance_test.go
+++ b/feature/gribi/otg_tests/mpls_compliance/gribi_mpls_compliance_test.go
@@ -52,3 +52,22 @@ func TestMPLSLabelPushDepth(t *testing.T) {
 		})
 	}
 }
+
+// TestMPLSPushToIP validates the gRIBI actions that are used to push N labels onto
+// an IP packet. Note that this test does not validate against the dataplane.
+func TestMPLSPushToIP(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	gribic := dut.RawAPIs().GRIBI(t)
+	c := fluent.NewClient()
+	c.Connection().WithStub(gribic)
+
+	_ = mplsutil.PushBaseConfigs(t, ondatra.DUT(t, "dut"), ondatra.ATE(t, "ate"))
+
+	baseLabel := 42
+	numLabels := 20
+	for i := 1; i <= numLabels; i++ {
+		t.Run(fmt.Sprintf("push %d labels to IP", i), func(t *testing.T) {
+			mplsutil.PushToIPPacket(t, c, deviations.DefaultNetworkInstance(dut), baseLabel, i, sleepFn)
+		})
+	}
+}

--- a/feature/gribi/otg_tests/mpls_compliance/gribi_mpls_compliance_test.go
+++ b/feature/gribi/otg_tests/mpls_compliance/gribi_mpls_compliance_test.go
@@ -84,3 +84,42 @@ func TestPopTopLabel(t *testing.T) {
 
 	mplsutil.PopTopLabel(t, c, deviations.DefaultNetworkInstance(dut), sleepFn)
 }
+
+// TestPopNLabels validates the gRIBI actions that are used to pop N labels from a
+// label stack when specified in a next-hop.
+func TestPopNLabels(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	gribic := dut.RawAPIs().GRIBI(t)
+	c := fluent.NewClient()
+	c.Connection().WithStub(gribic)
+
+	_ = mplsutil.PushBaseConfigs(t, ondatra.DUT(t, "dut"), ondatra.ATE(t, "ate"))
+
+	for _, stack := range [][]uint32{{100}, {100, 42}, {100, 42, 43, 44, 45}} {
+		t.Run(fmt.Sprintf("pop N labels, stack %v", stack), func(t *testing.T) {
+			mplsutil.PopNLabels(t, c, deviations.DefaultNetworkInstance(dut), stack, sleepFn)
+		})
+	}
+}
+
+// TestPopOnePushN validates the gRIBI actions that are used to pop 1 label and then
+// push N when specified in a next-hop.
+func TestPopOnePushN(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	gribic := dut.RawAPIs().GRIBI(t)
+	c := fluent.NewClient()
+	c.Connection().WithStub(gribic)
+
+	_ = mplsutil.PushBaseConfigs(t, ondatra.DUT(t, "dut"), ondatra.ATE(t, "ate"))
+
+	stacks := [][]uint32{
+		{100}, // swap for label 100, pop+push for label 200
+		{100, 200, 300, 400},
+		{100, 200, 300, 400, 500, 600},
+	}
+	for _, stack := range stacks {
+		t.Run(fmt.Sprintf("pop one, push N, stack: %v", stack), func(t *testing.T) {
+			mplsutil.PopOnePushN(t, c, deviations.DefaultNetworkInstance(dut), stack, sleepFn)
+		})
+	}
+}

--- a/feature/gribi/otg_tests/mpls_compliance/gribi_mpls_compliance_test.go
+++ b/feature/gribi/otg_tests/mpls_compliance/gribi_mpls_compliance_test.go
@@ -71,3 +71,16 @@ func TestMPLSPushToIP(t *testing.T) {
 		})
 	}
 }
+
+// TestPopTopLabel validates the gRIBI actions that are used to pop the top label
+// when specified in a next-hop.
+func TestPopTopLabel(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	gribic := dut.RawAPIs().GRIBI(t)
+	c := fluent.NewClient()
+	c.Connection().WithStub(gribic)
+
+	_ = mplsutil.PushBaseConfigs(t, ondatra.DUT(t, "dut"), ondatra.ATE(t, "ate"))
+
+	mplsutil.PopTopLabel(t, c, deviations.DefaultNetworkInstance(dut), sleepFn)
+}

--- a/feature/gribi/otg_tests/mpls_forwarding/gribi_mpls_forwarding_test.go
+++ b/feature/gribi/otg_tests/mpls_forwarding/gribi_mpls_forwarding_test.go
@@ -100,8 +100,8 @@ func TestMPLSLabelPushDepth(t *testing.T) {
 		mplsInner.BottomOfStack().SetChoice("value").SetValue(1)
 
 		ip4 := mplsFlow.Packet().Add().Ipv4()
-		ip4.Src().SetChoice("value").SetValue("100.64.1.1")
-		ip4.Dst().SetChoice("value").SetValue("100.64.2.1")
+		ip4.Src().SetChoice("value").SetValue("198.18.1.1")
+		ip4.Dst().SetChoice("value").SetValue("198.18.2.1")
 		ip4.Version().SetChoice("value").SetValue(4)
 
 		otg.PushConfig(t, otgCfg)


### PR DESCRIPTION
```
commit 37e396225e625adff4c628d0414821749cc5cabd
Author: Rob Shakir <robjs@google.com>
Date:   Fri Sep 22 23:17:04 2023 +0000

    Add gRIBI control plane only pop top MPLS label test.
    
     * (M) feature/gribi/mplsutil:
      - Add test case for popping top MPLS label.
     * (M) feature/gribi/otg_tests/mpls_compliance:
      - Add control plane only test for popping the top MPLS label from a
        stack.
```

