### PR TITLE
[4/5] gRIBI MPLS compliance test for popping N labels from stack.

### DIFF
--- a/feature/gribi/otg_tests/mpls_compliance/README.md
+++ b/feature/gribi/otg_tests/mpls_compliance/README.md
@@ -40,6 +40,16 @@ traffic validation.
   pop the top label.
 * Validate that gRIBI transactions are successfully processed by the server.
 
+## TE-9.4: Pop N Labels from Stack
+
+* Configure DUT with destination interface connected to an ATE. The ATE is
+  configured to have assigned address `192.0.2.2`.
+* Program DUT with a label forwarding entry matching label 100 and specifying to
+  pop:
+    * Label `100`
+    * Label stack `[100, 42]`
+    * Label stack `[100, 42, 43, 44, 45]`
+
 ## Protocol/RPC Parameter coverage
 
 *   gRIBI:
@@ -60,6 +70,8 @@ traffic validation.
             * `id`
             * `ip_address`
             * `pushed_label_stack`
+            * `pop_top_label`
+            * `popped_label_stack`
     *   `ModifyResponse`:
     *   `AFTResult`:
         *   `id`

--- a/feature/gribi/otg_tests/mpls_compliance/README.md
+++ b/feature/gribi/otg_tests/mpls_compliance/README.md
@@ -50,13 +50,16 @@ traffic validation.
     * Label stack `[100, 42]`
     * Label stack `[100, 42, 43, 44, 45]`
 
-### TE-9.3: Pop Top MPLS Label
+## TE-9.5: Pop 1 Push N Labels
 
-* Configure DUT with a destination interface connected to an ATE. The ATE is
-  configured to have assigned address 192.0.2.2.
-* Program DUT with a label forwarding entry matching label 100 and specifying to
-  pop the top label.
-* Validate that gRIBI transactions are successfully processed by the server.
+* Configure DUT with destination interface connected to an ATE. The ATE is
+  configured to have assigned address `192.0.2.2`.
+* Program DUT with a label forwarding entry matching label 100 and label 200,
+  pointing to a next-hop that is programmed to pop the top label, and:
+   - push label 100 - resulting in a swap for incoming label 100, and a push of
+     100 for incoming label 200.
+   - push stack `[100, 200, 300, 400]`
+   - push stack `[100, 200, 300, 400, 500, 600]`
 
 ## Protocol/RPC Parameter coverage
 

--- a/feature/gribi/otg_tests/mpls_compliance/README.md
+++ b/feature/gribi/otg_tests/mpls_compliance/README.md
@@ -31,7 +31,6 @@ traffic validation.
      * an IPv4 entry for `10.0.0.0/24` with a next-hop of `192.0.2.2` pushing N
        additional labels onto the packet.
 * Validate that gRIBI transactions are successfully processed by the server.
-<<<<<<< HEAD
 
 ### TE-9.3: Pop Top MPLS Label
 
@@ -50,8 +49,14 @@ traffic validation.
     * Label `100`
     * Label stack `[100, 42]`
     * Label stack `[100, 42, 43, 44, 45]`
-=======
->>>>>>> 16dfc334 (Add gRIBI IP2MPLS compliance test.)
+
+### TE-9.3: Pop Top MPLS Label
+
+* Configure DUT with a destination interface connected to an ATE. The ATE is
+  configured to have assigned address 192.0.2.2.
+* Program DUT with a label forwarding entry matching label 100 and specifying to
+  pop the top label.
+* Validate that gRIBI transactions are successfully processed by the server.
 
 ## Protocol/RPC Parameter coverage
 

--- a/feature/gribi/otg_tests/mpls_compliance/README.md
+++ b/feature/gribi/otg_tests/mpls_compliance/README.md
@@ -31,6 +31,7 @@ traffic validation.
      * an IPv4 entry for `10.0.0.0/24` with a next-hop of `192.0.2.2` pushing N
        additional labels onto the packet.
 * Validate that gRIBI transactions are successfully processed by the server.
+<<<<<<< HEAD
 
 ### TE-9.3: Pop Top MPLS Label
 
@@ -49,6 +50,8 @@ traffic validation.
     * Label `100`
     * Label stack `[100, 42]`
     * Label stack `[100, 42, 43, 44, 45]`
+=======
+>>>>>>> 16dfc334 (Add gRIBI IP2MPLS compliance test.)
 
 ## Protocol/RPC Parameter coverage
 

--- a/feature/gribi/otg_tests/mpls_compliance/gribi_mpls_compliance_test.go
+++ b/feature/gribi/otg_tests/mpls_compliance/gribi_mpls_compliance_test.go
@@ -101,3 +101,25 @@ func TestPopNLabels(t *testing.T) {
 		})
 	}
 }
+
+// TestPopOnePushN validates the gRIBI actions that are used to pop 1 label and then
+// push N when specified in a next-hop.
+func TestPopOnePushN(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	gribic := dut.RawAPIs().GRIBI(t)
+	c := fluent.NewClient()
+	c.Connection().WithStub(gribic)
+
+	_ = mplsutil.PushBaseConfigs(t, ondatra.DUT(t, "dut"), ondatra.ATE(t, "ate"))
+
+	stacks := [][]uint32{
+		{100}, // swap for label 100, pop+push for label 200
+		{100, 200, 300, 400},
+		{100, 200, 300, 400, 500, 600},
+	}
+	for _, stack := range stacks {
+		t.Run(fmt.Sprintf("pop one, push N, stack: %v", stack), func(t *testing.T) {
+			mplsutil.PopOnePushN(t, c, deviations.DefaultNetworkInstance(dut), stack, sleepFn)
+		})
+	}
+}

--- a/feature/gribi/otg_tests/mpls_compliance/gribi_mpls_compliance_test.go
+++ b/feature/gribi/otg_tests/mpls_compliance/gribi_mpls_compliance_test.go
@@ -84,3 +84,20 @@ func TestPopTopLabel(t *testing.T) {
 
 	mplsutil.PopTopLabel(t, c, deviations.DefaultNetworkInstance(dut), sleepFn)
 }
+
+// TestPopNLabels validates the gRIBI actions that are used to pop N labels from a
+// label stack when specified in a next-hop.
+func TestPopNLabels(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	gribic := dut.RawAPIs().GRIBI(t)
+	c := fluent.NewClient()
+	c.Connection().WithStub(gribic)
+
+	_ = mplsutil.PushBaseConfigs(t, ondatra.DUT(t, "dut"), ondatra.ATE(t, "ate"))
+
+	for _, stack := range [][]uint32{{100}, {100, 42}, {100, 42, 43, 44, 45}} {
+		t.Run(fmt.Sprintf("pop N labels, stack %v", stack), func(t *testing.T) {
+			mplsutil.PopNLabels(t, c, deviations.DefaultNetworkInstance(dut), stack, sleepFn)
+		})
+	}
+}


### PR DESCRIPTION
```
* (M) feature/gribi/mplsutil:
  - Add compliance test for popping N labels from an incoming packet
    programmed by gRIBI.
 * (M) feature/gribi/otg_tests/mpls_compliance:
  - Add test with no traffic verification for validating gRIBI
    programming API.
```
