### PR TITLE
Using correct global AS variable for bgp_2byte_4byte_asn_test

### DIFF
--- a/feature/experimental/bgp/ate_tests/bgp_2byte_4byte_asn/bgp_2byte_4byte_asn_test.go
+++ b/feature/experimental/bgp/ate_tests/bgp_2byte_4byte_asn/bgp_2byte_4byte_asn_test.go
@@ -222,7 +222,7 @@ func createBgpNeighbor(nbr *bgpNbr, dut *ondatra.DUTDevice) *oc.NetworkInstance_
 	bgp := niProto.GetOrCreateBgp()
 
 	global := bgp.GetOrCreateGlobal()
-	global.As = ygot.Uint32(nbr.localAS)
+	global.As = ygot.Uint32(nbr.globalAS)
 	global.RouterId = ygot.String(dutSrc.IPv4)
 
 	pg := bgp.GetOrCreatePeerGroup("ATE")


### PR DESCRIPTION

Current test fails while verifying Global AS an localAS variable is used for configuration
Using globalAS solves the issue