### PR TITLE
Relax filter to allow all pem file types

### DIFF
--- a/tools/allowed_file_types.sh
+++ b/tools/allowed_file_types.sh
@@ -7,7 +7,7 @@ echo "Checking for allowed file types..." >&2
 if
   find . -name .git -prune -o -name openconfig_public -prune -o \
     -type f -exec file \{} \+ |
-  egrep -vi '(ASCII|UTF-8|JSON|Perl|shell|PEM certificate)'
+  egrep -vi '(ASCII|UTF-8|JSON|Perl|shell|PEM)'
 then
   echo "Error: files should be in plain text or non-empty." >&2
   exitcode=1


### PR DESCRIPTION
current script only allows PEM Certificate, but we should allow more:

```
dloher@nettool:~/src/moji$ find . -name .git -prune -o -name openconfig_public -prune -o     -type f -exec file \{} \+ |   egrep -vi '(ASCII|UTF-8|JSON|Perl|shell|PEM certificate)'
./internal/security/svid/testdata/rsa/ca-rsa-key.pem:                                                                                                  PEM RSA private key
./internal/security/svid/testdata/ecdsa/ca-ecdsa-key.pem:                                                                                              PEM EC private key
```

Fixes an issue in PR #2092 CI checks