### PR TITLE
gNOI-2.1: Add support for Nokia to PLQ test

### DIFF
--- a/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/metadata.textproto
+++ b/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/metadata.textproto
@@ -29,5 +29,6 @@ platform_exceptions: {
   }
   deviations: {
     interface_enabled: true
+    explicit_port_speed: true
   }
 }

--- a/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/packet_link_qualification_test.go
+++ b/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/packet_link_qualification_test.go
@@ -225,6 +225,9 @@ func TestLinkQualification(t *testing.T) {
 		p := dut.Port(t, "port1")
 		i := &oc.Interface{Name: ygot.String(p.Name())}
 		gnmi.Replace(t, dut, d.Interface(p.Name()).Config(), configInterfaceMTU(i, dut))
+		if deviations.ExplicitPortSpeed(dut) {
+			fptest.SetPortSpeed(t, p)
+		}
 	}
 
 	plqID := dut1.Name() + ":" + dp1.Name() + "<->" + dut2.Name() + ":" + dp2.Name()
@@ -291,7 +294,7 @@ func TestLinkQualification(t *testing.T) {
 	}
 
 	switch dut2.Vendor() {
-	case ondatra.JUNIPER:
+	case ondatra.NOKIA, ondatra.JUNIPER:
 		intf.EndpointType = &plqpb.QualificationConfiguration_AsicLoopback{
 			AsicLoopback: &plqpb.AsicLoopbackConfiguration{},
 		}


### PR DESCRIPTION
1. Added portSpeed deviation
2. set Reflector to ASIC loopback
"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."