### PR TITLE
Reassign controller card redundancy test to gNMI-1.17

### DIFF
--- a/feature/platform/controllercard/tests/controller_card_redundancy_test/README.md
+++ b/feature/platform/controllercard/tests/controller_card_redundancy_test/README.md
@@ -1,4 +1,4 @@
-# gNMI-1.15 Controller Card redundnacy test
+# gNMI-1.17 Controller Card redundnacy test
 
 ## Summary
 - collect inventory data for each controller card

--- a/feature/platform/controllercard/tests/controller_card_redundancy_test/metadata.textproto
+++ b/feature/platform/controllercard/tests/controller_card_redundancy_test/metadata.textproto
@@ -2,6 +2,6 @@
 # proto-message: Metadata
 
 uuid: ""
-plan_id: "gNMI-1.15"
+plan_id: "gNMI-1.17"
 description: "Controller Card redundancy test"
 testbed: TESTBED_DUT


### PR DESCRIPTION
  * It was conflicting with gNMI-1.15: Set Requests.
  * Also moved the files to the correct test path.