### PR TITLE
Adding state_path_unsupported deviation for QOS ECN test

### DIFF
--- a/feature/qos/tests/qos_ecn_config_test/metadata.textproto
+++ b/feature/qos/tests/qos_ecn_config_test/metadata.textproto
@@ -23,3 +23,11 @@ platform_exceptions: {
     qos_buffer_allocation_config_required: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: ARISTA
+  }
+  deviations: {
+    state_path_unsupported: true
+  }
+}


### PR DESCRIPTION
The test was modified recently and we need to add deviation for Arista.