### PR TITLE
Free up space for staticcheck

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/go/pkg/mod
@@ -35,7 +35,7 @@ jobs:
         with:
           go-version: 1.21.x
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod
@@ -62,7 +62,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/go/pkg/mod

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -73,8 +73,8 @@ jobs:
     # Dependency for Go module github.com/google/gopacket
     - name: Install libpcap-dev
       run: sudo apt-get -y install libpcap-dev
-#    - name: Go vet
-#      run: GOGC=30 go vet ./...
+    - name: Go vet
+      run: GOGC=30 go vet ./...
     - name: Gofmt
       run: |
         # gofmt always returns true, so we use grep '^' which returns

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -108,5 +108,5 @@ jobs:
         # space by removing unnecessary tooling.
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /opt/hostedtoolcache
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
         GOGC=30 staticcheck ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -103,4 +103,10 @@ jobs:
     - name: Get staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@latest
     - name: Run staticcheck
-      run: GOGC=30 staticcheck ./...
+      run: |
+        # staticcheck requires a lot of free disk space in /tmp.  Free up worker
+        # space by removing unnecessary tooling.
+        rm -rf /usr/share/dotnet
+        rm -rf /usr/local/lib/android
+        rm -rf /opt/hostedtoolcache
+        GOGC=30 staticcheck ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -73,8 +73,8 @@ jobs:
     # Dependency for Go module github.com/google/gopacket
     - name: Install libpcap-dev
       run: sudo apt-get -y install libpcap-dev
-    - name: Go vet
-      run: GOGC=30 go vet ./...
+#    - name: Go vet
+#      run: GOGC=30 go vet ./...
     - name: Gofmt
       run: |
         # gofmt always returns true, so we use grep '^' which returns
@@ -106,7 +106,7 @@ jobs:
       run: |
         # staticcheck requires a lot of free disk space in /tmp.  Free up worker
         # space by removing unnecessary tooling.
-        rm -rf /usr/share/dotnet
-        rm -rf /usr/local/lib/android
-        rm -rf /opt/hostedtoolcache
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/hostedtoolcache
         GOGC=30 staticcheck ./...

--- a/.github/workflows/protobufs.yml
+++ b/.github/workflows/protobufs.yml
@@ -93,7 +93,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/go/pkg/mod

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/go/pkg/mod


### PR DESCRIPTION
This roughly doubles the available disk space for staticcheck from 20GB to 40GB in my testing by removing other language tooling from the base github action image.

This is intended to help this CI step failure:

```
Run GOGC=30 staticcheck ./...
-: # github.com/openconfig/featureprofiles/feature/system/gnmi/get/tests/system_gnmi_get_test_test [github.com/openconfig/featureprofiles/feature/system/gnmi/get/tests/system_gnmi_get_test.test]
compile: writing output: write $WORK/b1301/_pkg_.a: no space left on device (compile)
-: # github.com/openconfig/featureprofiles/feature/system/gnmi/metadata/tests/annotation_test_test [github.com/openconfig/featureprofiles/feature/system/gnmi/metadata/tests/annotation_test.test]
compile: writing output: write $WORK/b1303/_pkg_.a: no space left on device (compile)
-: mkdir /tmp/go-build42[8](https://github.com/openconfig/featureprofiles/actions/runs/6591979368/job/17911691513?pr=2270#step:13:9)04[9](https://github.com/openconfig/featureprofiles/actions/runs/6591979368/job/17911691513?pr=2270#step:13:10)[10](https://github.com/openconfig/featureprofiles/actions/runs/6591979368/job/17911691513?pr=2270#step:13:11)08/b1305/: no space left on device (compile)
```