### PR TITLE
Improve staticcheck available disk space

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,48 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2.1.3
+      with:
+        go-version: 1.21.x
+    - name: Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
+    - name: Build
+      run: go build -v ./...
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: 1.21.x
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
+      # Dependency for Go module github.com/google/gopacket
+      - name: Install libpcap-dev
+        run: sudo apt-get -y install libpcap-dev
+      - run: go test -v -coverprofile=profile.cov $(go list ./... | grep -v /.*test.*)
+      - name: Send coverage
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: profile.cov
   static_analysis:
     name: Static Analysis
     runs-on: ubuntu-latest
@@ -16,20 +58,15 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.21'
+    # Go & staticcheck build cache require a lot of disk space.  Reclaim extra
+    # space for the container by removing unnecessary tooling.
     - name: Free additional disk space
       run: |
-        # Go build cache requires a lot of disk.  Reclaim
-        # extra container space by removing unnecessary tooling.
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /opt/hostedtoolcache/CodeQL
     - name: Checkout code
       uses: actions/checkout@v3
-    - name: Check disk usage
-      run: |
-        df -h
-        du -sh /home/runner
-        du --max-depth=4 -h /home/runner | sort -rh
     - name: Cache
       uses: actions/cache@v3
       with:
@@ -39,11 +76,6 @@ jobs:
           ~/.cache/staticcheck
         key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
         restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
-    - name: Check cache
-      run: |
-        df -h
-        du -sh /home/runner
-        du --max-depth=4 -h /home/runner | sort -rh
     # Dependency for Go module github.com/google/gopacket
     - name: Install libpcap-dev
       run: sudo apt-get -y install libpcap-dev
@@ -78,4 +110,3 @@ jobs:
       run: go install honnef.co/go/tools/cmd/staticcheck@latest
     - name: Run staticcheck
       run: GOGC=30 staticcheck ./...
-

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,11 @@ jobs:
         go-version: '1.21'
     - name: Checkout code
       uses: actions/checkout@v3
+    - name: Check disk usage
+      run: |
+        df -h
+        du -sh /home/runner
+        ls -laR /home/runner
     - name: Cache
       uses: actions/cache@v3
       with:
@@ -30,9 +35,8 @@ jobs:
     - name: Check cache
       run: |
         df -h
-        du -sh /home/runner/work
-        du -sh /home/runner/work/featureprofiles/featureprofiles
-        ls -laR /home/runner/work
+        du -sh /home/runner
+        ls -laR /home/runner
     # Dependency for Go module github.com/google/gopacket
     - name: Install libpcap-dev
       run: sudo apt-get -y install libpcap-dev

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,49 +8,6 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Go
-      uses: actions/setup-go@v2.1.3
-      with:
-        go-version: 1.21.x
-    - name: Cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
-    - name: Build
-      run: go build -v ./...
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Go
-        uses: actions/setup-go@v2.1.3
-        with:
-          go-version: 1.21.x
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
-      # Dependency for Go module github.com/google/gopacket
-      - name: Install libpcap-dev
-        run: sudo apt-get -y install libpcap-dev
-      - run: go test -v -coverprofile=profile.cov $(go list ./... | grep -v /.*test.*)
-      - name: Send coverage
-        uses: shogo82148/actions-goveralls@v1
-        with:
-          path-to-profile: profile.cov
-
   static_analysis:
     name: Static Analysis
     runs-on: ubuntu-latest
@@ -70,6 +27,12 @@ jobs:
           ~/.cache/staticcheck
         key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
         restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
+    - name: Check cache
+      run: |
+        df -h
+        du -sh /home/runner/work
+        du -sh /home/runner/work/featureprofiles/featureprofiles
+        ls -laR /home/runner/work
     # Dependency for Go module github.com/google/gopacket
     - name: Install libpcap-dev
       run: sudo apt-get -y install libpcap-dev

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,13 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.21'
+    - name: Free additional disk space
+      run: |
+        # Go build cache requires a lot of disk.  Reclaim
+        # extra container space by removing unnecessary tooling.
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Check disk usage
@@ -37,7 +44,6 @@ jobs:
         df -h
         du -sh /home/runner
         du --max-depth=4 -h /home/runner | sort -rh
-        go clean -cache
     # Dependency for Go module github.com/google/gopacket
     - name: Install libpcap-dev
       run: sudo apt-get -y install libpcap-dev
@@ -71,16 +77,5 @@ jobs:
     - name: Get staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@latest
     - name: Run staticcheck
-      run: |
-        # staticcheck requires a lot of free disk space in /tmp.  Free up worker
-        # space by removing unnecessary tooling.
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-        GOGC=30 staticcheck ./...
-    - name: Check disk ending usage
-      run: |
-        df -h
-        du -sh /home/runner
-        du --max-depth=4 -h /home/runner | sort -rh
+      run: GOGC=30 staticcheck ./...
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,7 @@ jobs:
         df -h
         du -sh /home/runner
         du --max-depth=4 -h /home/runner | sort -rh
+        go clean -cache
     # Dependency for Go module github.com/google/gopacket
     - name: Install libpcap-dev
       run: sudo apt-get -y install libpcap-dev
@@ -77,3 +78,9 @@ jobs:
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /opt/hostedtoolcache/CodeQL
         GOGC=30 staticcheck ./...
+    - name: Check disk ending usage
+      run: |
+        df -h
+        du -sh /home/runner
+        du --max-depth=4 -h /home/runner | sort -rh
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         df -h
         du -sh /home/runner
-        ls -laR /home/runner
+        du --max-depth=4 -h /home/runner | sort -rh
     - name: Cache
       uses: actions/cache@v3
       with:
@@ -36,7 +36,7 @@ jobs:
       run: |
         df -h
         du -sh /home/runner
-        ls -laR /home/runner
+        du --max-depth=4 -h /home/runner | sort -rh
     # Dependency for Go module github.com/google/gopacket
     - name: Install libpcap-dev
       run: sudo apt-get -y install libpcap-dev

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -75,7 +75,6 @@ type checker struct {
 
 	mu        sync.Mutex
 	startTime time.Time
-	endTime   time.Time
 	prevCores coreFiles
 }
 


### PR DESCRIPTION
Static analysis checks were having issues after #2270 ([example](https://github.com/openconfig/featureprofiles/actions/runs/6672480176/job/18136468288)).  #2270 included a change to free up disk space, but the increased disk usage got cached and filled up the CI runner disk after uncompressing the cache.  This change frees up space earlier so the entire process has extra disk space to work with.

The go build cache & staticcheck cache are around 20GB combined, and the CI runner only has about 20GB of disk space to work with.  By removing some tooling for languages not used, we get about 40GB of space to work with.

The build cache dramatically reduces CI run times so we really want to have caching available.