### PR TITLE
gnmi-1.10 & gnmi-1.11: remove an unused deviation for nokia

### DIFF
--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/metadata.textproto
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/metadata.textproto
@@ -31,7 +31,6 @@ platform_exceptions: {
     vendor: NOKIA
   }
   deviations: {
-    interface_counters_from_container: true
     explicit_p4rt_node_component: true
     explicit_port_speed: true
     explicit_interface_in_default_vrf: true

--- a/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/metadata.textproto
+++ b/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/metadata.textproto
@@ -28,7 +28,6 @@ platform_exceptions: {
     vendor: NOKIA
   }
   deviations: {
-    interface_counters_from_container: true
     explicit_port_speed: true
     explicit_interface_in_default_vrf: true
     subinterface_packet_counters_missing: true


### PR DESCRIPTION
`interface_counters_from_container` deviation is not required for nokia 

---
This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.