### PR TITLE
gnmi-1.10: add default num of queues for nokia

### DIFF
--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -51,6 +51,7 @@ var (
 		ondatra.ARISTA:  16,
 		ondatra.CISCO:   6,
 		ondatra.JUNIPER: 8,
+		ondatra.NOKIA:   16,
 	}
 )
 


### PR DESCRIPTION
adds nokia support for qos counters test 

---
This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.