### PR TITLE
Nokia KNE fixes for OC-1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ kne create topologies/kne/nokia/srlinux/topology.textproto
 2. Run a sample test:
 
 ```
-go test ./feature/example/tests/... -kne-topo $PWD/topologies/kne/nokia/srlinux/topology.textproto -vendor_creds NOKIA/admin/NokiaSrl1!
+go test ./feature/example/tests/... -kne-topo $PWD/topologies/kne/nokia/srlinux/topology.textproto -vendor_creds NOKIA/admin/admin
 ```
 
 3. Cleanup:

--- a/cloudbuild/virtual.sh
+++ b/cloudbuild/virtual.sh
@@ -63,7 +63,7 @@ case ${platform} in
     vendor_creds=CISCO/cisco/cisco123
     ;;
   nokia_srlinux)
-    vendor_creds=NOKIA/admin/NokiaSrl1!
+    vendor_creds=NOKIA/admin/admin
     ;;
   openconfig_lemming)
     vendor_creds=OPENCONFIG/admin/admin

--- a/topologies/kne/nokia/srlinux/config.cfg
+++ b/topologies/kne/nokia/srlinux/config.cfg
@@ -1,4 +1,73 @@
+acl {
+    cpm-filter {
+        ipv4-filter {
+            entry 261 {
+                description "Accept incoming gNMI packets with IANA port 9339"
+                action {
+                    accept {
+                    }
+                }
+                match {
+                    protocol tcp
+                    destination-port {
+                        operator eq
+                        value 9339
+                    }
+                }
+            }
+            entry 351 {
+                description "Accept incoming gRIBI packets with IANA port 9340"
+                action {
+                    accept {
+                    }
+                }
+                match {
+                    protocol tcp
+                    destination-port {
+                        operator eq
+                        value 9340
+                    }
+                }
+            }
+        }
+        ipv6-filter {
+            entry 301 {
+                description "Accept incoming gNMI packets with IANA port 9339"
+                action {
+                    accept {
+                    }
+                }
+                match {
+                    next-header tcp
+                    destination-port {
+                        operator eq
+                        value 9339
+                    }
+                }
+            }
+            entry 361 {
+                description "Accept incoming gRIBI packets with IANA port 9340"
+                action {
+                    accept {
+                    }
+                }
+                match {
+                    next-header tcp
+                    destination-port {
+                        operator eq
+                        value 9340
+                    }
+                }
+            }
+        }
+    }
+}
 system {
+    aaa {
+        admin-user {
+            password $ar2$+1AExYIA2+Y=$qXbPx5xv3d8s48/mWLZ4GQ==
+        }
+    }
     management {
         openconfig {
             admin-state enable
@@ -17,6 +86,7 @@ system {
         ]
         network-instance mgmt {
             admin-state enable
+            port 9339
             yang-models openconfig
             tls-profile kne-profile
         }
@@ -56,6 +126,7 @@ ufJifhmpItpy3mkUCLEJ33ex2AA6
         admin-state enable
         network-instance mgmt {
             admin-state enable
+            port 9340
             tls-profile kne-profile
         }
     }

--- a/topologies/kne/nokia/srlinux/dut.textproto
+++ b/topologies/kne/nokia/srlinux/dut.textproto
@@ -14,4 +14,32 @@ nodes: {
             }
         }
     }
+    services: {
+        key: 9339
+        value: {
+            name: "gnmi"
+            inside: 9339
+        }
+    }
+    services: {
+        key: 9340
+        value: {
+            name: "gribi"
+            inside: 9340
+        }
+    }
+    services: {
+        key: 22
+        value: {
+            name: "ssh"
+            inside: 22
+        }
+    }
+    services: {
+        key: 9559
+        value: {
+            name: "p4rt"
+            inside: 9559
+        }
+    }
 }

--- a/topologies/kne/nokia/srlinux/dutate.textproto
+++ b/topologies/kne/nokia/srlinux/dutate.textproto
@@ -14,6 +14,34 @@ nodes: {
             }
         }
     }
+    services: {
+        key: 9339
+        value: {
+            name: "gnmi"
+            inside: 9339
+        }
+    }
+    services: {
+        key: 9340
+        value: {
+            name: "gribi"
+            inside: 9340
+        }
+    }
+    services: {
+        key: 22
+        value: {
+            name: "ssh"
+            inside: 22
+        }
+    }
+    services: {
+        key: 9559
+        value: {
+            name: "p4rt"
+            inside: 9559
+        }
+    }
     interfaces: {
         key: "e1-1"
         value: {

--- a/topologies/kne/nokia/srlinux/dutate_lag.textproto
+++ b/topologies/kne/nokia/srlinux/dutate_lag.textproto
@@ -14,6 +14,34 @@ nodes: {
             }
         }
     }
+    services: {
+        key: 9339
+        value: {
+            name: "gnmi"
+            inside: 9339
+        }
+    }
+    services: {
+        key: 9340
+        value: {
+            name: "gribi"
+            inside: 9340
+        }
+    }
+    services: {
+        key: 22
+        value: {
+            name: "ssh"
+            inside: 22
+        }
+    }
+    services: {
+        key: 9559
+        value: {
+            name: "p4rt"
+            inside: 9559
+        }
+    }
     interfaces: {
         key: "e1-1"
         value: {

--- a/topologies/kne/nokia/srlinux/dutdut.textproto
+++ b/topologies/kne/nokia/srlinux/dutdut.textproto
@@ -14,6 +14,34 @@ nodes: {
             }
         }
     }
+    services: {
+        key: 9339
+        value: {
+            name: "gnmi"
+            inside: 9339
+        }
+    }
+    services: {
+        key: 9340
+        value: {
+            name: "gribi"
+            inside: 9340
+        }
+    }
+    services: {
+        key: 22
+        value: {
+            name: "ssh"
+            inside: 22
+        }
+    }
+    services: {
+        key: 9559
+        value: {
+            name: "p4rt"
+            inside: 9559
+        }
+    }
     interfaces: {
         key: "e1-1"
         value: {
@@ -52,6 +80,34 @@ nodes: {
                 key_name: "N/A"
                 key_size: 4096
             }
+        }
+    }
+    services: {
+        key: 9339
+        value: {
+            name: "gnmi"
+            inside: 9339
+        }
+    }
+    services: {
+        key: 9340
+        value: {
+            name: "gribi"
+            inside: 9340
+        }
+    }
+    services: {
+        key: 22
+        value: {
+            name: "ssh"
+            inside: 22
+        }
+    }
+    services: {
+        key: 9559
+        value: {
+            name: "p4rt"
+            inside: 9559
         }
     }
     interfaces: {

--- a/topologies/kne/nokia/srlinux/dutdutate.textproto
+++ b/topologies/kne/nokia/srlinux/dutdutate.textproto
@@ -14,6 +14,34 @@ nodes: {
             }
         }
     }
+    services: {
+        key: 9339
+        value: {
+            name: "gnmi"
+            inside: 9339
+        }
+    }
+    services: {
+        key: 9340
+        value: {
+            name: "gribi"
+            inside: 9340
+        }
+    }
+    services: {
+        key: 22
+        value: {
+            name: "ssh"
+            inside: 22
+        }
+    }
+    services: {
+        key: 9559
+        value: {
+            name: "p4rt"
+            inside: 9559
+        }
+    }
     interfaces: {
         key: "e1-1"
         value: {
@@ -40,6 +68,34 @@ nodes: {
                 key_name: "N/A"
                 key_size: 4096
             }
+        }
+    }
+    services: {
+        key: 9339
+        value: {
+            name: "gnmi"
+            inside: 9339
+        }
+    }
+    services: {
+        key: 9340
+        value: {
+            name: "gribi"
+            inside: 9340
+        }
+    }
+    services: {
+        key: 22
+        value: {
+            name: "ssh"
+            inside: 22
+        }
+    }
+    services: {
+        key: 9559
+        value: {
+            name: "p4rt"
+            inside: 9559
         }
     }
     interfaces: {

--- a/topologies/kne/nokia/srlinux/topology.textproto
+++ b/topologies/kne/nokia/srlinux/topology.textproto
@@ -14,6 +14,34 @@ nodes: {
             }
         }
     }
+    services: {
+        key: 9339
+        value: {
+            name: "gnmi"
+            inside: 9339
+        }
+    }
+    services: {
+        key: 9340
+        value: {
+            name: "gribi"
+            inside: 9340
+        }
+    }
+    services: {
+        key: 22
+        value: {
+            name: "ssh"
+            inside: 22
+        }
+    }
+    services: {
+        key: 9559
+        value: {
+            name: "p4rt"
+            inside: 9559
+        }
+    }
     interfaces: {
         key: "e1-1"
         value: {

--- a/topologies/kne/nokia/srlinux/topology.textproto
+++ b/topologies/kne/nokia/srlinux/topology.textproto
@@ -112,6 +112,34 @@ nodes: {
             }
         }
     }
+    services: {
+        key: 9339
+        value: {
+            name: "gnmi"
+            inside: 9339
+        }
+    }
+    services: {
+        key: 9340
+        value: {
+            name: "gribi"
+            inside: 9340
+        }
+    }
+    services: {
+        key: 22
+        value: {
+            name: "ssh"
+            inside: 22
+        }
+    }
+    services: {
+        key: 9559
+        value: {
+            name: "p4rt"
+            inside: 9559
+        }
+    }
     interfaces: {
         key: "e1-1"
         value: {


### PR DESCRIPTION
1. Add cpm filters for grIBI/gNMI/gNOI IANA ports
2. Change the default login to admin/admin
3. Change the gNMI port the server is listening on (9339)
4. Change the gRIBI port the server is listening on (9340)
5. Add the Service Key/Value pairs for gRIBI/gNOI/P4RT/SSH 

This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.