### PR TITLE
p4rt-1.1: include traceroute ipv6 and ttl0/ttl2 use cases

### DIFF
--- a/feature/experimental/p4rt/otg_tests/base_p4rt/base_p4rt_test.go
+++ b/feature/experimental/p4rt/otg_tests/base_p4rt/base_p4rt_test.go
@@ -277,16 +277,12 @@ func setupP4RTClient(ctx context.Context, args *testArgs) error {
 
 // Function to compare and check if the expected table is present in RPC ReadResponse
 func verifyReadReceiveMatch(t *testing.T, expected_table *p4_v1.Update, received_entry *p4_v1.ReadResponse) error {
-	matches := 0
 	for _, table := range received_entry.Entities {
 		if cmp.Equal(table, expected_table.Entity, protocmp.Transform(), protocmp.IgnoreFields(&p4_v1.TableEntry{}, "meter_config", "counter_data")) {
-			matches++
+			return nil
 		}
 	}
-	if matches == 0 {
-		return errors.New("no matches found")
-	}
-	return nil
+	return fmt.Errorf("no matches found: \ngot %+v, \nwant: %+v", received_entry, expected_table)
 }
 
 // TestP4rtConnect connects to the P4Runtime server over grpc
@@ -357,7 +353,42 @@ func TestP4rtConnect(t *testing.T) {
 				{
 					Type:     p4_v1.Update_INSERT,
 					IsIpv4:   0x1,
+					TTL:      0x0,
+					TTLMask:  0xFF,
+					Priority: 1,
+				},
+				{
+					Type:     p4_v1.Update_INSERT,
+					IsIpv4:   0x1,
 					TTL:      0x1,
+					TTLMask:  0xFF,
+					Priority: 1,
+				},
+				{
+					Type:     p4_v1.Update_INSERT,
+					IsIpv4:   0x1,
+					TTL:      0x2,
+					TTLMask:  0xFF,
+					Priority: 1,
+				},
+				{
+					Type:     p4_v1.Update_INSERT,
+					IsIpv6:   0x1,
+					TTL:      0x0,
+					TTLMask:  0xFF,
+					Priority: 1,
+				},
+				{
+					Type:     p4_v1.Update_INSERT,
+					IsIpv6:   0x1,
+					TTL:      0x1,
+					TTLMask:  0xFF,
+					Priority: 1,
+				},
+				{
+					Type:     p4_v1.Update_INSERT,
+					IsIpv6:   0x1,
+					TTL:      0x2,
 					TTLMask:  0xFF,
 					Priority: 1,
 				},
@@ -372,7 +403,6 @@ func TestP4rtConnect(t *testing.T) {
 		}
 	}
 
-	nomatch := 0 // To count no matches for Table entries
 	// Receive read response
 	for index, client := range clients {
 		rStream, rErr := client.Read(&p4_v1.ReadRequest{
@@ -407,7 +437,6 @@ func TestP4rtConnect(t *testing.T) {
 		expected_entity := expected_update[0]
 		if err := verifyReadReceiveMatch(t, expected_entity, readResp); err != nil {
 			t.Errorf("Table entry for GDP %s", err)
-			nomatch += 1
 		}
 
 		// Construct expected table for LLDP to match with received table entry
@@ -422,10 +451,9 @@ func TestP4rtConnect(t *testing.T) {
 		expected_entity = expected_update[0]
 		if err := verifyReadReceiveMatch(t, expected_entity, readResp); err != nil {
 			t.Errorf("Table entry for LLDP %s", err)
-			nomatch += 1
 		}
 
-		// Construct expected table for traceroute to match with received table entry
+		// Construct expected table for traceroute v4 & TTL = 1 to match with received table entry
 		expected_update = p4rtutils.ACLWbbIngressTableEntryGet([]*p4rtutils.ACLWbbIngressTableEntryInfo{
 			{
 				Type:     p4_v1.Update_INSERT,
@@ -438,10 +466,80 @@ func TestP4rtConnect(t *testing.T) {
 		expected_entity = expected_update[0]
 		if err := verifyReadReceiveMatch(t, expected_entity, readResp); err != nil {
 			t.Errorf("Table entry for traceroute %s", err)
-			nomatch += 1
 		}
-	}
-	if nomatch > 0 {
-		t.Fatalf("Table entry matches failed")
+
+		// Construct expected table for traceroute v4 & TTL = 0 to match with received table entry
+		expected_update = p4rtutils.ACLWbbIngressTableEntryGet([]*p4rtutils.ACLWbbIngressTableEntryInfo{
+			{
+				Type:     p4_v1.Update_INSERT,
+				IsIpv4:   0x1,
+				TTL:      0x0,
+				TTLMask:  0xFF,
+				Priority: 1,
+			},
+		})
+		expected_entity = expected_update[0]
+		if err := verifyReadReceiveMatch(t, expected_entity, readResp); err != nil {
+			t.Errorf("Table entry for traceroute %s", err)
+		}
+		// Construct expected table for traceroute v4 & TTL = 2 to match with received table entry
+		expected_update = p4rtutils.ACLWbbIngressTableEntryGet([]*p4rtutils.ACLWbbIngressTableEntryInfo{
+			{
+				Type:     p4_v1.Update_INSERT,
+				IsIpv4:   0x1,
+				TTL:      0x2,
+				TTLMask:  0xFF,
+				Priority: 1,
+			},
+		})
+		expected_entity = expected_update[0]
+		if err := verifyReadReceiveMatch(t, expected_entity, readResp); err != nil {
+			t.Errorf("Table entry for traceroute %s", err)
+		}
+
+		// Construct expected table for traceroute v6 & TTL = 0 to match with received table entry
+		expected_update = p4rtutils.ACLWbbIngressTableEntryGet([]*p4rtutils.ACLWbbIngressTableEntryInfo{
+			{
+				Type:     p4_v1.Update_INSERT,
+				IsIpv6:   0x1,
+				TTL:      0x0,
+				TTLMask:  0xFF,
+				Priority: 1,
+			},
+		})
+		expected_entity = expected_update[0]
+		if err := verifyReadReceiveMatch(t, expected_entity, readResp); err != nil {
+			t.Errorf("Table entry for traceroute %s", err)
+		}
+
+		// Construct expected table for traceroute v6 & TTL = 1 to match with received table entry
+		expected_update = p4rtutils.ACLWbbIngressTableEntryGet([]*p4rtutils.ACLWbbIngressTableEntryInfo{
+			{
+				Type:     p4_v1.Update_INSERT,
+				IsIpv6:   0x1,
+				TTL:      0x1,
+				TTLMask:  0xFF,
+				Priority: 1,
+			},
+		})
+		expected_entity = expected_update[0]
+		if err := verifyReadReceiveMatch(t, expected_entity, readResp); err != nil {
+			t.Errorf("Table entry for traceroute %s", err)
+		}
+		// Construct expected table for traceroute v6 & TTL = 2 to match with received table entry
+		expected_update = p4rtutils.ACLWbbIngressTableEntryGet([]*p4rtutils.ACLWbbIngressTableEntryInfo{
+			{
+				Type:     p4_v1.Update_INSERT,
+				IsIpv6:   0x1,
+				TTL:      0x2,
+				TTLMask:  0xFF,
+				Priority: 1,
+			},
+		})
+		expected_entity = expected_update[0]
+		if err := verifyReadReceiveMatch(t, expected_entity, readResp); err != nil {
+			t.Errorf("Receoved wrong TableEntry for traceroute: %s", err)
+		}
+
 	}
 }


### PR DESCRIPTION
Changes: 
* Validate Read/Write RPCs for all 8 entries instead of only 3 (traceroute ipv4 & ipv6 with TTLs=0/1/2 + gdp + lldp)
* Minor optimization: remove unnecessary match counters 

--
This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.