### PR TITLE
Example nosimage.textproto and validator script.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/openconfig/gribi v1.0.0
 	github.com/openconfig/gribigo v0.0.0-20231031140438-9a293da13ff9
 	github.com/openconfig/kne v0.1.14
+	github.com/openconfig/models-ci v1.0.2-0.20231113233730-f0986391428e
 	github.com/openconfig/ondatra v0.4.3
 	github.com/openconfig/replayer v0.0.0-20231031192218-5462382820d4
 	github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07

--- a/go.sum
+++ b/go.sum
@@ -1166,6 +1166,8 @@ github.com/openconfig/lemming v0.3.2-0.20230914210403-c6484d12af0a h1:JNiu6/3IWt
 github.com/openconfig/lemming v0.3.2-0.20230914210403-c6484d12af0a/go.mod h1:fC8o1NYR9yEmDmoIVaCZQY+iP9RSxujYzckUGSkpWD8=
 github.com/openconfig/lemming/operator v0.2.0 h1:dovZnR6lQkOHXcODli1NDOr/GVYrBY05KS5X11jxVbw=
 github.com/openconfig/lemming/operator v0.2.0/go.mod h1:LKgEXSR5VK2CAeh2uKijKAXFj42uQuwakrCHVPF0iII=
+github.com/openconfig/models-ci v1.0.2-0.20231113233730-f0986391428e h1:6N4jXpZa/SXYcNpJFjjZvenxO/xnTwuUCgCEinhNLfU=
+github.com/openconfig/models-ci v1.0.2-0.20231113233730-f0986391428e/go.mod h1:w38G/kObu95PbtwMYVp6SKhkHCegJFwL8B58Ns84g4s=
 github.com/openconfig/ondatra v0.4.3 h1:M6moqZRuA87aXNbHkZgj/U+Jj4WOjzgTC/EM1ARqt+E=
 github.com/openconfig/ondatra v0.4.3/go.mod h1:WEZ0twDTtctPYDJ6D0zeyKwdXfEHRpKV7At0xPHMrBs=
 github.com/openconfig/replayer v0.0.0-20231031192218-5462382820d4 h1:ohE/OcV38lEOt7IHOtFzjYVzzoCgMYp3sqJBKmVwuw0=

--- a/proto/ocrpcs.proto
+++ b/proto/ocrpcs.proto
@@ -35,10 +35,10 @@ message OCRPCs {
 // belong to the same OpenConfig RPC service (e.g. gnoi.healthz.Healthz,
 // gnmi.gNMI).
 message OCRPCService {
-  // Full name of the gRPC method specification.
-  // Format: <package>.<service>.<rpc>
-  // Example: gnoi.healthz.Healthz.Get
-  // Example: gnmi.gNMI.Subscribe
+  // Name of the gRPC method specification.
+  // Format: <rpc>
+  // Example: Get
+  // Example: Subscribe
   repeated string method_name = 1;
 
   // The semantic version of the gRPC service.

--- a/tools/internal/ocpaths/ocpaths.go
+++ b/tools/internal/ocpaths/ocpaths.go
@@ -1,0 +1,195 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocpaths
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/openconfig/gnmi/errlist"
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/goyang/pkg/yangentry"
+	"github.com/openconfig/models-ci/yangutil"
+	"github.com/openconfig/ondatra/gnmi/oc"
+
+	ppb "github.com/openconfig/featureprofiles/proto/ocpaths_go_proto"
+)
+
+const (
+	componentPrefix = "/components/component"
+)
+
+// OCPathKey contains the fields that uniquely identify an OC path.
+type OCPathKey struct {
+	Path      string
+	Component string
+}
+
+// OCPath is the parsed version of the spreadsheet's paths.
+type OCPath struct {
+	Key              OCPathKey
+	FeatureprofileID string
+}
+
+func getSchemaFakeroot(publicPath string) (*yang.Entry, error) {
+	files, err := yangutil.GetAllYANGFiles(publicPath)
+	if err != nil {
+		return nil, err
+	}
+
+	moduleEntryMap, errs := yangentry.Parse(files, []string{publicPath})
+	if errs != nil {
+		return nil, err
+	}
+	root := &yang.Entry{
+		Dir: map[string]*yang.Entry{},
+	}
+	for _, entry := range moduleEntryMap {
+		// Skip IETF modules.
+		if !strings.HasPrefix(entry.Name, "openconfig-") {
+			continue
+		}
+		for name, ch := range entry.Dir {
+			root.Dir[name] = ch
+		}
+	}
+
+	return root, nil
+}
+
+func validatePath(ocpathProto *ppb.OCPath, root *yang.Entry) (*OCPath, error) {
+	ocpath := &OCPath{
+		Key: OCPathKey{
+			Path:      ocpathProto.GetName(),
+			Component: ocpathProto.GetOcpathConstraint().GetPlatformType(),
+		},
+		FeatureprofileID: ocpathProto.GetFeatureprofileid(),
+	}
+
+	// Validate path
+	path := ocpath.Key.Path
+	if !strings.HasPrefix(path, "/") {
+		return nil, fmt.Errorf("path does not begin with slash: %q", path)
+	}
+	if strings.HasSuffix(path, "/") {
+		return nil, fmt.Errorf("path must not end with slash: %q", path)
+	}
+	if entry := root.Find(path); entry == nil {
+		deepestEntry := root
+		var entryNotFound string
+		splitEles := strings.Split(path, "/")
+		for i, ele := range splitEles {
+			// Skip the first element, which must be empty.
+			if i == 0 {
+				continue
+			}
+			next := deepestEntry.Dir[ele]
+			if next == nil {
+				entryNotFound = strings.Join(splitEles[i:], "/")
+				break
+			}
+			deepestEntry = next
+		}
+		return nil, fmt.Errorf("path not found: %q, remaining path: %q", path, entryNotFound)
+	} else if !entry.IsLeaf() && !entry.IsLeafList() {
+		return nil, fmt.Errorf("path %q is not a leaf: got kind %s", path, entry.Kind)
+	}
+
+	// Validate component
+	component := ocpath.Key.Component
+	isComponent := strings.HasPrefix(path, componentPrefix)
+	matched, err := regexp.MatchString("^[A-Z_]+$", component)
+	if err != nil {
+		return nil, err
+	}
+CONSTRAINT_CHECK:
+	switch {
+	case !isComponent && component != "":
+		return nil, fmt.Errorf("non-component path %q has component value %q", path, component)
+	case !isComponent:
+		// valid
+	case matched:
+		for _, enum := range []string{
+			reflect.TypeOf(oc.E_PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT(0)).Name(),
+			reflect.TypeOf(oc.E_PlatformTypes_OPENCONFIG_SOFTWARE_COMPONENT(0)).Name(),
+		} {
+			for _, v := range oc.ΛEnum[enum] {
+				if v.Name == component {
+					ocpath.Key.Component = component
+					break CONSTRAINT_CHECK
+				}
+			}
+		}
+		fallthrough
+	default:
+		return nil, fmt.Errorf("path %q has invalid component %q", path, component)
+	}
+
+	// Basic validation of featureprofileid if it exists
+	featureprofileID := ocpath.FeatureprofileID
+	if featureprofileID != "" {
+		matched, err := regexp.MatchString("^([a-z0-9]+_)*[a-z0-9]+$", featureprofileID)
+		if err != nil {
+			return nil, err
+		}
+		switch {
+		case matched:
+			ocpath.FeatureprofileID = featureprofileID
+		default:
+			return nil, fmt.Errorf("unexpected featureprofileID string %q for path %v", featureprofileID, path)
+		}
+	}
+
+	return ocpath, nil
+}
+
+func insert(dstMap map[OCPathKey]*OCPath, src *OCPath) error {
+	if src == nil {
+		return fmt.Errorf("provided OCPath is nil")
+	}
+	if _, ok := dstMap[src.Key]; ok {
+		return fmt.Errorf("duplicate entry: %+v", src.Key)
+	}
+	dstMap[src.Key] = src
+	return nil
+}
+
+// ValidatePaths parses and validates ocpaths, and puts them into a more
+// user-friendly Go structure.
+func ValidatePaths(ocpathsProto []*ppb.OCPath, publicPath string) (map[OCPathKey]*OCPath, error) {
+	root, err := getSchemaFakeroot(publicPath)
+	if err != nil {
+		return nil, err
+	}
+
+	ocpaths := map[OCPathKey]*OCPath{}
+	errs := errlist.List{
+		Separator: "\n",
+	}
+	for _, ocpathProto := range ocpathsProto {
+		ocpath, err := validatePath(ocpathProto, root)
+		if err != nil {
+			errs.Add(err)
+		} else if ocpath == nil {
+			errs.Add(fmt.Errorf("failed to parse proto: %v", ocpathProto))
+		} else if err := insert(ocpaths, ocpath); err != nil {
+			errs.Add(err)
+		}
+	}
+
+	return ocpaths, errs.Err()
+}

--- a/tools/internal/ocpaths/ocpaths_test.go
+++ b/tools/internal/ocpaths/ocpaths_test.go
@@ -52,6 +52,13 @@ func TestValidatePath(t *testing.T) {
 			FeatureprofileID: "interface_base",
 		},
 	}, {
+		desc: "non-leaf path",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "/interfaces/interface",
+			Featureprofileid: "interface_base",
+		},
+		wantErr: true,
+	}, {
 		desc: "with-component",
 		inOcPathProto: &ppb.OCPath{
 			Name:             "/components/component/state/name",
@@ -214,6 +221,13 @@ func TestValidatePaths(t *testing.T) {
 				FeatureprofileID: "interface_basic",
 			},
 		},
+	}, {
+		desc: "invalid-path",
+		inOcPathsProto: []*ppb.OCPath{{
+			Name:             "/interfaces/interface/config",
+			Featureprofileid: "interface_base",
+		}},
+		wantErr: true,
 	}, {
 		desc: "duplicate",
 		inOcPathsProto: []*ppb.OCPath{{

--- a/tools/internal/ocpaths/ocpaths_test.go
+++ b/tools/internal/ocpaths/ocpaths_test.go
@@ -1,0 +1,249 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocpaths
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/goyang/pkg/yang"
+
+	ppb "github.com/openconfig/featureprofiles/proto/ocpaths_go_proto"
+)
+
+func getFakeroot(t *testing.T) *yang.Entry {
+	root, err := getSchemaFakeroot("testdata/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return root
+}
+
+func TestValidatePath(t *testing.T) {
+	tests := []struct {
+		desc          string
+		inOcPathProto *ppb.OCPath
+		wantOCPath    *OCPath
+		wantErr       bool
+	}{{
+		desc: "no-component",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "/interfaces/interface/config/name",
+			Featureprofileid: "interface_base",
+		},
+		wantOCPath: &OCPath{
+			Key: OCPathKey{
+				Path:      "/interfaces/interface/config/name",
+				Component: "",
+			},
+			FeatureprofileID: "interface_base",
+		},
+	}, {
+		desc: "with-component",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "/components/component/state/name",
+			OcpathConstraint: &ppb.OCPathConstraint{Constraint: &ppb.OCPathConstraint_PlatformType{PlatformType: "CPU"}},
+			Featureprofileid: "interface_base",
+		},
+		wantOCPath: &OCPath{
+			Key: OCPathKey{
+				Path:      "/components/component/state/name",
+				Component: "CPU",
+			},
+			FeatureprofileID: "interface_base",
+		},
+	}, {
+		desc: "component-path-doesnt-have-component",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "/components/component/state/name",
+			Featureprofileid: "interface_base",
+		},
+		wantErr: true,
+	}, {
+		desc: "non-component-path-has-component",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "/interfaces/interface/config/name",
+			OcpathConstraint: &ppb.OCPathConstraint{Constraint: &ppb.OCPathConstraint_PlatformType{PlatformType: "CPU"}},
+			Featureprofileid: "interface_base",
+		},
+		wantErr: true,
+	}, {
+		desc: "invalid-component",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "/components/component/state/name",
+			OcpathConstraint: &ppb.OCPathConstraint{Constraint: &ppb.OCPathConstraint_PlatformType{PlatformType: "cpu"}},
+			Featureprofileid: "interface_base",
+		},
+		wantErr: true,
+	}, {
+		desc: "with-bad-component",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "/components/component/state/name",
+			OcpathConstraint: &ppb.OCPathConstraint{Constraint: &ppb.OCPathConstraint_PlatformType{PlatformType: "NOT-A-COMPONENT"}},
+			Featureprofileid: "interface_base",
+		},
+		wantErr: true,
+	}, {
+		desc: "spaces-after-path",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "/interfaces/interface/config/name   ",
+			Featureprofileid: "interface_base",
+		},
+		wantErr: true,
+	}, {
+		desc: "extra-slash",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "/interfaces/interface/config//name",
+			Featureprofileid: "interface_base",
+		},
+		wantErr: true,
+	}, {
+		desc: "no-starting-slash",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "interfaces/interface/config/name",
+			Featureprofileid: "interface_base",
+		},
+		wantErr: true,
+	}, {
+		desc: "ending-slash",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "/interfaces/interface/config/name/",
+			Featureprofileid: "interface_base",
+		},
+		wantErr: true,
+	}, {
+		desc: "path-not-found",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "/interfaces/interface/intraface/config/name",
+			Featureprofileid: "interface_base",
+		},
+		wantErr: true,
+	}, {
+		desc: "invalid-featureprofileid",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "/interfaces/interface/config/name",
+			Featureprofileid: "Interface_Base",
+		},
+		wantErr: true,
+	}, {
+		desc: "invalid-featureprofileid-2",
+		inOcPathProto: &ppb.OCPath{
+			Name:             "/interfaces/interface/config/name",
+			Featureprofileid: "interface-base",
+		},
+		wantErr: true,
+	}}
+
+	root := getFakeroot(t)
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := validatePath(tt.inOcPathProto, root)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("gotErr: %v, wantErr: %v", err, tt.wantErr)
+			}
+
+			if diff := cmp.Diff(tt.wantOCPath, got); diff != "" {
+				t.Errorf("(-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValidatePaths(t *testing.T) {
+	tests := []struct {
+		desc           string
+		inOcPathsProto []*ppb.OCPath
+		wantOCPaths    map[OCPathKey]*OCPath
+		wantErr        bool
+	}{{
+		desc: "valid",
+		inOcPathsProto: []*ppb.OCPath{{
+			Name:             "/interfaces/interface/config/name",
+			Featureprofileid: "interface_base",
+		}, {
+			Name:             "/components/component/config/description",
+			OcpathConstraint: &ppb.OCPathConstraint{Constraint: &ppb.OCPathConstraint_PlatformType{PlatformType: "CPU"}},
+			Featureprofileid: "interface_base",
+		}, {
+			Name:             "/components/component/config/description",
+			OcpathConstraint: &ppb.OCPathConstraint{Constraint: &ppb.OCPathConstraint_PlatformType{PlatformType: "PORT"}},
+			Featureprofileid: "interface_basic",
+		}},
+		wantOCPaths: map[OCPathKey]*OCPath{
+			{
+				Path:      "/interfaces/interface/config/name",
+				Component: "",
+			}: {
+				Key: OCPathKey{
+					Path: "/interfaces/interface/config/name",
+				},
+				FeatureprofileID: "interface_base",
+			},
+			{
+				Path:      "/components/component/config/description",
+				Component: "CPU",
+			}: {
+				Key: OCPathKey{
+					Path:      "/components/component/config/description",
+					Component: "CPU",
+				},
+				FeatureprofileID: "interface_base",
+			},
+			{
+				Path:      "/components/component/config/description",
+				Component: "PORT",
+			}: {
+				Key: OCPathKey{
+					Path:      "/components/component/config/description",
+					Component: "PORT",
+				},
+				FeatureprofileID: "interface_basic",
+			},
+		},
+	}, {
+		desc: "duplicate",
+		inOcPathsProto: []*ppb.OCPath{{
+			Name:             "/interfaces/interface/config/name",
+			Featureprofileid: "interface_base",
+		}, {
+			Name:             "/components/component/config/description",
+			OcpathConstraint: &ppb.OCPathConstraint{Constraint: &ppb.OCPathConstraint_PlatformType{PlatformType: "CPU"}},
+			Featureprofileid: "interface_base",
+		}, {
+			Name:             "/components/component/config/description",
+			OcpathConstraint: &ppb.OCPathConstraint{Constraint: &ppb.OCPathConstraint_PlatformType{PlatformType: "CPU"}},
+			Featureprofileid: "interface_basic",
+		}},
+		wantErr: true,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := ValidatePaths(tt.inOcPathsProto, "testdata/models")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("gotErr: %v, wantErr: %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tt.wantOCPaths, got); diff != "" {
+				t.Errorf("(-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/tools/internal/ocpaths/testdata/models/ietf/iana-if-type.yang
+++ b/tools/internal/ocpaths/testdata/models/ietf/iana-if-type.yang
@@ -1,0 +1,1619 @@
+module iana-if-type {
+  namespace "urn:ietf:params:xml:ns:yang:iana-if-type";
+  prefix ianaift;
+
+  import ietf-interfaces {
+    prefix if;
+  }
+
+  organization "IANA";
+  contact
+    "        Internet Assigned Numbers Authority
+
+     Postal: ICANN
+             12025 Waterfront Drive, Suite 300
+             Los Angeles, CA 90094-2536
+             United States
+
+     Tel:    +1 310 301 5800
+     <mailto:iana&iana.org>";
+  description
+    "This YANG module defines YANG identities for IANA-registered
+     interface types.
+
+     This YANG module is maintained by IANA and reflects the
+     'ifType definitions' registry.
+
+     The latest revision of this YANG module can be obtained from
+     the IANA web site.
+
+     Requests for new values should be made to IANA via
+     email (iana&iana.org).
+
+     Copyright (c) 2014 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     The initial version of this YANG module is part of RFC 7224;
+     see the RFC itself for full legal notices.";
+  reference
+    "IANA 'ifType definitions' registry.
+     <http://www.iana.org/assignments/smi-numbers>";
+
+  revision 2017-01-19 {
+    description
+      "Registered ifType 289.";
+  }
+
+  revision 2016-11-23 {
+    description
+      "Registered ifTypes 283-288.";
+  }
+
+  revision 2016-06-09 {
+    description
+      "Registered ifType 282.";
+  }
+  revision 2016-05-03 {
+    description
+      "Registered ifType 281.";
+  }
+  revision 2015-06-12 {
+    description
+      "Corrected formatting issue.";
+  }  
+  revision 2014-09-24 {
+    description
+      "Registered ifType 280.";
+  }
+  revision 2014-09-19 {
+    description
+      "Registered ifType 279.";
+  }
+  revision 2014-07-03 {
+    description
+      "Registered ifTypes 277-278.";
+  }
+  revision 2014-05-19 {
+    description
+      "Updated the contact address.";
+  }
+  revision 2014-05-08 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7224: IANA Interface Type YANG Module";
+  }
+
+  identity iana-interface-type {
+    base if:interface-type;
+    description
+      "This identity is used as a base for all interface types
+       defined in the 'ifType definitions' registry.";
+  }
+
+  identity other {
+    base iana-interface-type;
+  }
+  identity regular1822 {
+    base iana-interface-type;
+  }
+  identity hdh1822 {
+    base iana-interface-type;
+  }
+  identity ddnX25 {
+    base iana-interface-type;
+  }
+  identity rfc877x25 {
+    base iana-interface-type;
+    reference
+      "RFC 1382 - SNMP MIB Extension for the X.25 Packet Layer";
+  }
+  identity ethernetCsmacd {
+    base iana-interface-type;
+    description
+      "For all Ethernet-like interfaces, regardless of speed,
+       as per RFC 3635.";
+    reference
+      "RFC 3635 - Definitions of Managed Objects for the
+                  Ethernet-like Interface Types";
+  }
+  identity iso88023Csmacd {
+    base iana-interface-type;
+    status deprecated;
+    description
+      "Deprecated via RFC 3635.
+       Use ethernetCsmacd(6) instead.";
+    reference
+      "RFC 3635 - Definitions of Managed Objects for the
+                  Ethernet-like Interface Types";
+  }
+  identity iso88024TokenBus {
+    base iana-interface-type;
+  }
+  identity iso88025TokenRing {
+    base iana-interface-type;
+  }
+  identity iso88026Man {
+    base iana-interface-type;
+  }
+  identity starLan {
+    base iana-interface-type;
+    status deprecated;
+    description
+      "Deprecated via RFC 3635.
+       Use ethernetCsmacd(6) instead.";
+    reference
+      "RFC 3635 - Definitions of Managed Objects for the
+                  Ethernet-like Interface Types";
+  }
+  identity proteon10Mbit {
+    base iana-interface-type;
+  }
+  identity proteon80Mbit {
+    base iana-interface-type;
+  }
+  identity hyperchannel {
+    base iana-interface-type;
+  }
+  identity fddi {
+    base iana-interface-type;
+    reference
+      "RFC 1512 - FDDI Management Information Base";
+  }
+  identity lapb {
+    base iana-interface-type;
+    reference
+      "RFC 1381 - SNMP MIB Extension for X.25 LAPB";
+  }
+  identity sdlc {
+    base iana-interface-type;
+  }
+  identity ds1 {
+    base iana-interface-type;
+    description
+      "DS1-MIB.";
+    reference
+      "RFC 4805 - Definitions of Managed Objects for the
+                  DS1, J1, E1, DS2, and E2 Interface Types";
+  }
+  identity e1 {
+    base iana-interface-type;
+    status obsolete;
+    description
+      "Obsolete; see DS1-MIB.";
+    reference
+      "RFC 4805 - Definitions of Managed Objects for the
+                  DS1, J1, E1, DS2, and E2 Interface Types";
+  }
+  identity basicISDN {
+    base iana-interface-type;
+    description
+      "No longer used.  See also RFC 2127.";
+  }
+  identity primaryISDN {
+    base iana-interface-type;
+    description
+      "No longer used.  See also RFC 2127.";
+  }
+  identity propPointToPointSerial {
+    base iana-interface-type;
+    description
+      "Proprietary serial.";
+  }
+  identity ppp {
+    base iana-interface-type;
+  }
+  identity softwareLoopback {
+    base iana-interface-type;
+  }
+  identity eon {
+    base iana-interface-type;
+    description
+      "CLNP over IP.";
+  }
+  identity ethernet3Mbit {
+    base iana-interface-type;
+  }
+  identity nsip {
+    base iana-interface-type;
+    description
+      "XNS over IP.";
+  }
+  identity slip {
+    base iana-interface-type;
+    description
+      "Generic SLIP.";
+  }
+  identity ultra {
+    base iana-interface-type;
+    description
+      "Ultra Technologies.";
+  }
+  identity ds3 {
+    base iana-interface-type;
+    description
+      "DS3-MIB.";
+    reference
+      "RFC 3896 - Definitions of Managed Objects for the
+                  DS3/E3 Interface Type";
+  }
+  identity sip {
+    base iana-interface-type;
+    description
+      "SMDS, coffee.";
+    reference
+      "RFC 1694 - Definitions of Managed Objects for SMDS
+                  Interfaces using SMIv2";
+  }
+  identity frameRelay {
+    base iana-interface-type;
+    description
+      "DTE only.";
+    reference
+      "RFC 2115 - Management Information Base for Frame Relay
+                  DTEs Using SMIv2";
+  }
+  identity rs232 {
+    base iana-interface-type;
+    reference
+      "RFC 1659 - Definitions of Managed Objects for RS-232-like
+                  Hardware Devices using SMIv2";
+  }
+  identity para {
+    base iana-interface-type;
+    description
+      "Parallel-port.";
+    reference
+      "RFC 1660 - Definitions of Managed Objects for
+                  Parallel-printer-like Hardware Devices using
+                  SMIv2";
+  }
+  identity arcnet {
+    base iana-interface-type;
+    description
+      "ARCnet.";
+  }
+  identity arcnetPlus {
+    base iana-interface-type;
+    description
+      "ARCnet Plus.";
+  }
+  identity atm {
+    base iana-interface-type;
+    description
+      "ATM cells.";
+  }
+  identity miox25 {
+    base iana-interface-type;
+    reference
+      "RFC 1461 - SNMP MIB extension for Multiprotocol
+                  Interconnect over X.25";
+  }
+  identity sonet {
+    base iana-interface-type;
+    description
+      "SONET or SDH.";
+  }
+  identity x25ple {
+    base iana-interface-type;
+    reference
+      "RFC 2127 - ISDN Management Information Base using SMIv2";
+  }
+  identity iso88022llc {
+    base iana-interface-type;
+  }
+  identity localTalk {
+    base iana-interface-type;
+  }
+  identity smdsDxi {
+    base iana-interface-type;
+  }
+  identity frameRelayService {
+    base iana-interface-type;
+    description
+      "FRNETSERV-MIB.";
+    reference
+      "RFC 2954 - Definitions of Managed Objects for Frame
+                  Relay Service";
+  }
+  identity v35 {
+    base iana-interface-type;
+  }
+  identity hssi {
+    base iana-interface-type;
+  }
+  identity hippi {
+    base iana-interface-type;
+  }
+  identity modem {
+    base iana-interface-type;
+    description
+      "Generic modem.";
+  }
+  identity aal5 {
+    base iana-interface-type;
+    description
+      "AAL5 over ATM.";
+  }
+  identity sonetPath {
+    base iana-interface-type;
+  }
+  identity sonetVT {
+    base iana-interface-type;
+  }
+  identity smdsIcip {
+    base iana-interface-type;
+    description
+      "SMDS InterCarrier Interface.";
+  }
+  identity propVirtual {
+    base iana-interface-type;
+    description
+      "Proprietary virtual/internal.";
+    reference
+      "RFC 2863 - The Interfaces Group MIB";
+  }
+  identity propMultiplexor {
+    base iana-interface-type;
+    description
+      "Proprietary multiplexing.";
+    reference
+      "RFC 2863 - The Interfaces Group MIB";
+  }
+  identity ieee80212 {
+    base iana-interface-type;
+    description
+      "100BaseVG.";
+  }
+  identity fibreChannel {
+    base iana-interface-type;
+    description
+      "Fibre Channel.";
+  }
+  identity hippiInterface {
+    base iana-interface-type;
+    description
+      "HIPPI interfaces.";
+  }
+  identity frameRelayInterconnect {
+    base iana-interface-type;
+    status obsolete;
+    description
+      "Obsolete; use either
+       frameRelay(32) or frameRelayService(44).";
+  }
+  identity aflane8023 {
+    base iana-interface-type;
+    description
+      "ATM Emulated LAN for 802.3.";
+  }
+  identity aflane8025 {
+    base iana-interface-type;
+    description
+      "ATM Emulated LAN for 802.5.";
+  }
+  identity cctEmul {
+    base iana-interface-type;
+    description
+      "ATM Emulated circuit.";
+  }
+  identity fastEther {
+    base iana-interface-type;
+    status deprecated;
+    description
+      "Obsoleted via RFC 3635.
+       ethernetCsmacd(6) should be used instead.";
+    reference
+      "RFC 3635 - Definitions of Managed Objects for the
+                  Ethernet-like Interface Types";
+  }
+  identity isdn {
+    base iana-interface-type;
+    description
+      "ISDN and X.25.";
+    reference
+      "RFC 1356 - Multiprotocol Interconnect on X.25 and ISDN
+                  in the Packet Mode";
+  }
+  identity v11 {
+    base iana-interface-type;
+    description
+      "CCITT V.11/X.21.";
+  }
+  identity v36 {
+    base iana-interface-type;
+    description
+      "CCITT V.36.";
+  }
+  identity g703at64k {
+    base iana-interface-type;
+    description
+      "CCITT G703 at 64Kbps.";
+  }
+  identity g703at2mb {
+    base iana-interface-type;
+    status obsolete;
+    description
+      "Obsolete; see DS1-MIB.";
+  }
+  identity qllc {
+    base iana-interface-type;
+    description
+      "SNA QLLC.";
+  }
+  identity fastEtherFX {
+    base iana-interface-type;
+    status deprecated;
+    description
+      "Obsoleted via RFC 3635.
+       ethernetCsmacd(6) should be used instead.";
+    reference
+      "RFC 3635 - Definitions of Managed Objects for the
+                  Ethernet-like Interface Types";
+  }
+  identity channel {
+    base iana-interface-type;
+    description
+      "Channel.";
+  }
+  identity ieee80211 {
+    base iana-interface-type;
+    description
+      "Radio spread spectrum.";
+  }
+  identity ibm370parChan {
+    base iana-interface-type;
+    description
+      "IBM System 360/370 OEMI Channel.";
+  }
+  identity escon {
+    base iana-interface-type;
+    description
+      "IBM Enterprise Systems Connection.";
+  }
+  identity dlsw {
+    base iana-interface-type;
+    description
+      "Data Link Switching.";
+  }
+  identity isdns {
+    base iana-interface-type;
+    description
+      "ISDN S/T interface.";
+  }
+  identity isdnu {
+    base iana-interface-type;
+    description
+      "ISDN U interface.";
+  }
+  identity lapd {
+    base iana-interface-type;
+    description
+      "Link Access Protocol D.";
+  }
+  identity ipSwitch {
+    base iana-interface-type;
+    description
+      "IP Switching Objects.";
+  }
+  identity rsrb {
+    base iana-interface-type;
+    description
+      "Remote Source Route Bridging.";
+  }
+  identity atmLogical {
+    base iana-interface-type;
+    description
+      "ATM Logical Port.";
+    reference
+      "RFC 3606 - Definitions of Supplemental Managed Objects
+                  for ATM Interface";
+  }
+  identity ds0 {
+    base iana-interface-type;
+    description
+      "Digital Signal Level 0.";
+    reference
+      "RFC 2494 - Definitions of Managed Objects for the DS0
+                  and DS0 Bundle Interface Type";
+  }
+  identity ds0Bundle {
+    base iana-interface-type;
+    description
+      "Group of ds0s on the same ds1.";
+    reference
+      "RFC 2494 - Definitions of Managed Objects for the DS0
+                  and DS0 Bundle Interface Type";
+  }
+  identity bsc {
+    base iana-interface-type;
+    description
+      "Bisynchronous Protocol.";
+  }
+  identity async {
+    base iana-interface-type;
+    description
+      "Asynchronous Protocol.";
+  }
+  identity cnr {
+    base iana-interface-type;
+    description
+      "Combat Net Radio.";
+  }
+  identity iso88025Dtr {
+    base iana-interface-type;
+    description
+      "ISO 802.5r DTR.";
+  }
+  identity eplrs {
+    base iana-interface-type;
+    description
+      "Ext Pos Loc Report Sys.";
+  }
+  identity arap {
+    base iana-interface-type;
+    description
+      "Appletalk Remote Access Protocol.";
+  }
+  identity propCnls {
+    base iana-interface-type;
+    description
+      "Proprietary Connectionless Protocol.";
+  }
+  identity hostPad {
+    base iana-interface-type;
+    description
+      "CCITT-ITU X.29 PAD Protocol.";
+  }
+  identity termPad {
+    base iana-interface-type;
+    description
+      "CCITT-ITU X.3 PAD Facility.";
+  }
+  identity frameRelayMPI {
+    base iana-interface-type;
+    description
+      "Multiproto Interconnect over FR.";
+  }
+  identity x213 {
+    base iana-interface-type;
+    description
+      "CCITT-ITU X213.";
+  }
+  identity adsl {
+    base iana-interface-type;
+    description
+      "Asymmetric Digital Subscriber Loop.";
+  }
+  identity radsl {
+    base iana-interface-type;
+    description
+      "Rate-Adapt. Digital Subscriber Loop.";
+  }
+  identity sdsl {
+    base iana-interface-type;
+    description
+      "Symmetric Digital Subscriber Loop.";
+  }
+  identity vdsl {
+    base iana-interface-type;
+    description
+      "Very H-Speed Digital Subscrib. Loop.";
+  }
+  identity iso88025CRFPInt {
+    base iana-interface-type;
+    description
+      "ISO 802.5 CRFP.";
+  }
+  identity myrinet {
+    base iana-interface-type;
+    description
+      "Myricom Myrinet.";
+  }
+  identity voiceEM {
+    base iana-interface-type;
+    description
+      "Voice recEive and transMit.";
+  }
+  identity voiceFXO {
+    base iana-interface-type;
+    description
+      "Voice Foreign Exchange Office.";
+  }
+  identity voiceFXS {
+    base iana-interface-type;
+    description
+      "Voice Foreign Exchange Station.";
+  }
+  identity voiceEncap {
+    base iana-interface-type;
+    description
+      "Voice encapsulation.";
+  }
+  identity voiceOverIp {
+    base iana-interface-type;
+    description
+      "Voice over IP encapsulation.";
+  }
+  identity atmDxi {
+    base iana-interface-type;
+    description
+      "ATM DXI.";
+  }
+  identity atmFuni {
+    base iana-interface-type;
+    description
+      "ATM FUNI.";
+  }
+  identity atmIma {
+    base iana-interface-type;
+    description
+      "ATM IMA.";
+  }
+  identity pppMultilinkBundle {
+    base iana-interface-type;
+    description
+      "PPP Multilink Bundle.";
+  }
+  identity ipOverCdlc {
+    base iana-interface-type;
+    description
+      "IBM ipOverCdlc.";
+  }
+  identity ipOverClaw {
+    base iana-interface-type;
+    description
+      "IBM Common Link Access to Workstn.";
+  }
+  identity stackToStack {
+    base iana-interface-type;
+    description
+      "IBM stackToStack.";
+  }
+  identity virtualIpAddress {
+    base iana-interface-type;
+    description
+      "IBM VIPA.";
+  }
+  identity mpc {
+    base iana-interface-type;
+    description
+      "IBM multi-protocol channel support.";
+  }
+  identity ipOverAtm {
+    base iana-interface-type;
+    description
+      "IBM ipOverAtm.";
+    reference
+      "RFC 2320 - Definitions of Managed Objects for Classical IP
+                  and ARP Over ATM Using SMIv2 (IPOA-MIB)";
+  }
+  identity iso88025Fiber {
+    base iana-interface-type;
+    description
+      "ISO 802.5j Fiber Token Ring.";
+  }
+  identity tdlc {
+    base iana-interface-type;
+    description
+      "IBM twinaxial data link control.";
+  }
+  identity gigabitEthernet {
+    base iana-interface-type;
+    status deprecated;
+    description
+      "Obsoleted via RFC 3635.
+       ethernetCsmacd(6) should be used instead.";
+    reference
+      "RFC 3635 - Definitions of Managed Objects for the
+                  Ethernet-like Interface Types";
+  }
+  identity hdlc {
+    base iana-interface-type;
+    description
+      "HDLC.";
+  }
+  identity lapf {
+    base iana-interface-type;
+    description
+      "LAP F.";
+  }
+  identity v37 {
+    base iana-interface-type;
+    description
+      "V.37.";
+  }
+  identity x25mlp {
+    base iana-interface-type;
+    description
+      "Multi-Link Protocol.";
+  }
+  identity x25huntGroup {
+    base iana-interface-type;
+    description
+      "X25 Hunt Group.";
+  }
+  identity transpHdlc {
+    base iana-interface-type;
+    description
+      "Transp HDLC.";
+  }
+  identity interleave {
+    base iana-interface-type;
+    description
+      "Interleave channel.";
+  }
+  identity fast {
+    base iana-interface-type;
+    description
+      "Fast channel.";
+  }
+  identity ip {
+    base iana-interface-type;
+    description
+      "IP (for APPN HPR in IP networks).";
+  }
+  identity docsCableMaclayer {
+    base iana-interface-type;
+    description
+      "CATV Mac Layer.";
+  }
+  identity docsCableDownstream {
+    base iana-interface-type;
+    description
+      "CATV Downstream interface.";
+  }
+  identity docsCableUpstream {
+    base iana-interface-type;
+    description
+      "CATV Upstream interface.";
+  }
+  identity a12MppSwitch {
+    base iana-interface-type;
+    description
+      "Avalon Parallel Processor.";
+  }
+  identity tunnel {
+    base iana-interface-type;
+    description
+      "Encapsulation interface.";
+  }
+  identity coffee {
+    base iana-interface-type;
+    description
+      "Coffee pot.";
+    reference
+      "RFC 2325 - Coffee MIB";
+  }
+  identity ces {
+    base iana-interface-type;
+    description
+      "Circuit Emulation Service.";
+  }
+  identity atmSubInterface {
+    base iana-interface-type;
+    description
+      "ATM Sub Interface.";
+  }
+  identity l2vlan {
+    base iana-interface-type;
+    description
+      "Layer 2 Virtual LAN using 802.1Q.";
+  }
+  identity l3ipvlan {
+    base iana-interface-type;
+    description
+      "Layer 3 Virtual LAN using IP.";
+  }
+  identity l3ipxvlan {
+    base iana-interface-type;
+    description
+      "Layer 3 Virtual LAN using IPX.";
+  }
+  identity digitalPowerline {
+    base iana-interface-type;
+    description
+      "IP over Power Lines.";
+  }
+  identity mediaMailOverIp {
+    base iana-interface-type;
+    description
+      "Multimedia Mail over IP.";
+  }
+  identity dtm {
+    base iana-interface-type;
+    description
+      "Dynamic synchronous Transfer Mode.";
+  }
+  identity dcn {
+    base iana-interface-type;
+    description
+      "Data Communications Network.";
+  }
+  identity ipForward {
+    base iana-interface-type;
+    description
+      "IP Forwarding Interface.";
+  }
+  identity msdsl {
+    base iana-interface-type;
+    description
+      "Multi-rate Symmetric DSL.";
+  }
+  identity ieee1394 {
+    base iana-interface-type;
+
+    description
+      "IEEE1394 High Performance Serial Bus.";
+  }
+  identity if-gsn {
+    base iana-interface-type;
+    description
+      "HIPPI-6400.";
+  }
+  identity dvbRccMacLayer {
+    base iana-interface-type;
+    description
+      "DVB-RCC MAC Layer.";
+  }
+  identity dvbRccDownstream {
+    base iana-interface-type;
+    description
+      "DVB-RCC Downstream Channel.";
+  }
+  identity dvbRccUpstream {
+    base iana-interface-type;
+    description
+      "DVB-RCC Upstream Channel.";
+  }
+  identity atmVirtual {
+    base iana-interface-type;
+    description
+      "ATM Virtual Interface.";
+  }
+  identity mplsTunnel {
+    base iana-interface-type;
+    description
+      "MPLS Tunnel Virtual Interface.";
+  }
+  identity srp {
+    base iana-interface-type;
+    description
+      "Spatial Reuse Protocol.";
+  }
+  identity voiceOverAtm {
+    base iana-interface-type;
+    description
+      "Voice over ATM.";
+  }
+  identity voiceOverFrameRelay {
+    base iana-interface-type;
+    description
+      "Voice Over Frame Relay.";
+  }
+  identity idsl {
+    base iana-interface-type;
+    description
+      "Digital Subscriber Loop over ISDN.";
+  }
+  identity compositeLink {
+    base iana-interface-type;
+    description
+      "Avici Composite Link Interface.";
+  }
+  identity ss7SigLink {
+    base iana-interface-type;
+    description
+      "SS7 Signaling Link.";
+  }
+  identity propWirelessP2P {
+    base iana-interface-type;
+    description
+      "Prop. P2P wireless interface.";
+  }
+  identity frForward {
+    base iana-interface-type;
+    description
+      "Frame Forward Interface.";
+  }
+  identity rfc1483 {
+    base iana-interface-type;
+    description
+      "Multiprotocol over ATM AAL5.";
+    reference
+      "RFC 1483 - Multiprotocol Encapsulation over ATM
+                  Adaptation Layer 5";
+  }
+  identity usb {
+    base iana-interface-type;
+    description
+      "USB Interface.";
+  }
+  identity ieee8023adLag {
+    base iana-interface-type;
+    description
+      "IEEE 802.3ad Link Aggregate.";
+  }
+  identity bgppolicyaccounting {
+    base iana-interface-type;
+    description
+      "BGP Policy Accounting.";
+  }
+  identity frf16MfrBundle {
+    base iana-interface-type;
+    description
+      "FRF.16 Multilink Frame Relay.";
+  }
+  identity h323Gatekeeper {
+    base iana-interface-type;
+    description
+      "H323 Gatekeeper.";
+  }
+  identity h323Proxy {
+    base iana-interface-type;
+    description
+      "H323 Voice and Video Proxy.";
+  }
+  identity mpls {
+    base iana-interface-type;
+    description
+      "MPLS.";
+  }
+  identity mfSigLink {
+    base iana-interface-type;
+    description
+      "Multi-frequency signaling link.";
+  }
+  identity hdsl2 {
+    base iana-interface-type;
+    description
+      "High Bit-Rate DSL - 2nd generation.";
+  }
+  identity shdsl {
+    base iana-interface-type;
+    description
+      "Multirate HDSL2.";
+  }
+  identity ds1FDL {
+    base iana-interface-type;
+    description
+      "Facility Data Link (4Kbps) on a DS1.";
+  }
+  identity pos {
+    base iana-interface-type;
+    description
+      "Packet over SONET/SDH Interface.";
+  }
+  identity dvbAsiIn {
+    base iana-interface-type;
+    description
+      "DVB-ASI Input.";
+  }
+  identity dvbAsiOut {
+    base iana-interface-type;
+    description
+      "DVB-ASI Output.";
+  }
+  identity plc {
+    base iana-interface-type;
+    description
+      "Power Line Communications.";
+  }
+  identity nfas {
+    base iana-interface-type;
+    description
+      "Non-Facility Associated Signaling.";
+  }
+  identity tr008 {
+    base iana-interface-type;
+    description
+      "TR008.";
+  }
+  identity gr303RDT {
+    base iana-interface-type;
+    description
+      "Remote Digital Terminal.";
+  }
+  identity gr303IDT {
+    base iana-interface-type;
+    description
+      "Integrated Digital Terminal.";
+  }
+  identity isup {
+    base iana-interface-type;
+    description
+      "ISUP.";
+  }
+  identity propDocsWirelessMaclayer {
+    base iana-interface-type;
+    description
+      "Cisco proprietary Maclayer.";
+  }
+  identity propDocsWirelessDownstream {
+    base iana-interface-type;
+    description
+      "Cisco proprietary Downstream.";
+  }
+  identity propDocsWirelessUpstream {
+    base iana-interface-type;
+    description
+      "Cisco proprietary Upstream.";
+  }
+  identity hiperlan2 {
+    base iana-interface-type;
+    description
+      "HIPERLAN Type 2 Radio Interface.";
+  }
+  identity propBWAp2Mp {
+    base iana-interface-type;
+    description
+      "PropBroadbandWirelessAccesspt2Multipt (use of this value
+       for IEEE 802.16 WMAN interfaces as per IEEE Std 802.16f
+       is deprecated, and ieee80216WMAN(237) should be used
+       instead).";
+  }
+  identity sonetOverheadChannel {
+    base iana-interface-type;
+    description
+      "SONET Overhead Channel.";
+  }
+  identity digitalWrapperOverheadChannel {
+    base iana-interface-type;
+    description
+      "Digital Wrapper.";
+  }
+  identity aal2 {
+    base iana-interface-type;
+    description
+      "ATM adaptation layer 2.";
+  }
+  identity radioMAC {
+    base iana-interface-type;
+    description
+      "MAC layer over radio links.";
+  }
+  identity atmRadio {
+    base iana-interface-type;
+    description
+      "ATM over radio links.";
+  }
+  identity imt {
+    base iana-interface-type;
+    description
+      "Inter-Machine Trunks.";
+  }
+  identity mvl {
+    base iana-interface-type;
+    description
+      "Multiple Virtual Lines DSL.";
+  }
+  identity reachDSL {
+    base iana-interface-type;
+    description
+      "Long Reach DSL.";
+  }
+  identity frDlciEndPt {
+    base iana-interface-type;
+    description
+      "Frame Relay DLCI End Point.";
+  }
+  identity atmVciEndPt {
+    base iana-interface-type;
+    description
+      "ATM VCI End Point.";
+  }
+  identity opticalChannel {
+    base iana-interface-type;
+    description
+      "Optical Channel.";
+  }
+  identity opticalTransport {
+    base iana-interface-type;
+    description
+      "Optical Transport.";
+  }
+  identity propAtm {
+    base iana-interface-type;
+    description
+      "Proprietary ATM.";
+  }
+  identity voiceOverCable {
+    base iana-interface-type;
+    description
+      "Voice Over Cable Interface.";
+  }
+  identity infiniband {
+    base iana-interface-type;
+    description
+      "Infiniband.";
+  }
+  identity teLink {
+    base iana-interface-type;
+    description
+      "TE Link.";
+  }
+  identity q2931 {
+    base iana-interface-type;
+    description
+      "Q.2931.";
+  }
+  identity virtualTg {
+    base iana-interface-type;
+    description
+      "Virtual Trunk Group.";
+  }
+  identity sipTg {
+    base iana-interface-type;
+    description
+      "SIP Trunk Group.";
+  }
+  identity sipSig {
+    base iana-interface-type;
+    description
+      "SIP Signaling.";
+  }
+  identity docsCableUpstreamChannel {
+    base iana-interface-type;
+    description
+      "CATV Upstream Channel.";
+  }
+  identity econet {
+    base iana-interface-type;
+    description
+      "Acorn Econet.";
+  }
+  identity pon155 {
+    base iana-interface-type;
+    description
+      "FSAN 155Mb Symetrical PON interface.";
+  }
+  identity pon622 {
+    base iana-interface-type;
+    description
+      "FSAN 622Mb Symetrical PON interface.";
+  }
+  identity bridge {
+    base iana-interface-type;
+    description
+      "Transparent bridge interface.";
+  }
+  identity linegroup {
+    base iana-interface-type;
+    description
+      "Interface common to multiple lines.";
+  }
+  identity voiceEMFGD {
+    base iana-interface-type;
+    description
+      "Voice E&M Feature Group D.";
+  }
+  identity voiceFGDEANA {
+    base iana-interface-type;
+    description
+      "Voice FGD Exchange Access North American.";
+  }
+  identity voiceDID {
+    base iana-interface-type;
+    description
+      "Voice Direct Inward Dialing.";
+  }
+  identity mpegTransport {
+    base iana-interface-type;
+    description
+      "MPEG transport interface.";
+  }
+  identity sixToFour {
+    base iana-interface-type;
+    status deprecated;
+    description
+      "6to4 interface (DEPRECATED).";
+    reference
+      "RFC 4087 - IP Tunnel MIB";
+  }
+  identity gtp {
+    base iana-interface-type;
+    description
+      "GTP (GPRS Tunneling Protocol).";
+  }
+  identity pdnEtherLoop1 {
+    base iana-interface-type;
+    description
+      "Paradyne EtherLoop 1.";
+  }
+  identity pdnEtherLoop2 {
+    base iana-interface-type;
+    description
+      "Paradyne EtherLoop 2.";
+  }
+  identity opticalChannelGroup {
+    base iana-interface-type;
+    description
+      "Optical Channel Group.";
+  }
+  identity homepna {
+    base iana-interface-type;
+    description
+      "HomePNA ITU-T G.989.";
+  }
+  identity gfp {
+    base iana-interface-type;
+    description
+      "Generic Framing Procedure (GFP).";
+  }
+  identity ciscoISLvlan {
+    base iana-interface-type;
+    description
+      "Layer 2 Virtual LAN using Cisco ISL.";
+  }
+  identity actelisMetaLOOP {
+    base iana-interface-type;
+    description
+      "Acteleis proprietary MetaLOOP High Speed Link.";
+  }
+  identity fcipLink {
+    base iana-interface-type;
+    description
+      "FCIP Link.";
+  }
+  identity rpr {
+    base iana-interface-type;
+    description
+      "Resilient Packet Ring Interface Type.";
+  }
+  identity qam {
+    base iana-interface-type;
+    description
+      "RF Qam Interface.";
+  }
+  identity lmp {
+    base iana-interface-type;
+    description
+      "Link Management Protocol.";
+    reference
+      "RFC 4327 - Link Management Protocol (LMP) Management
+                  Information Base (MIB)";
+  }
+  identity cblVectaStar {
+    base iana-interface-type;
+    description
+      "Cambridge Broadband Networks Limited VectaStar.";
+  }
+  identity docsCableMCmtsDownstream {
+    base iana-interface-type;
+    description
+      "CATV Modular CMTS Downstream Interface.";
+  }
+  identity adsl2 {
+    base iana-interface-type;
+    status deprecated;
+    description
+      "Asymmetric Digital Subscriber Loop Version 2
+       (DEPRECATED/OBSOLETED - please use adsl2plus(238)
+       instead).";
+    reference
+      "RFC 4706 - Definitions of Managed Objects for Asymmetric
+                  Digital Subscriber Line 2 (ADSL2)";
+  }
+  identity macSecControlledIF {
+    base iana-interface-type;
+    description
+      "MACSecControlled.";
+  }
+  identity macSecUncontrolledIF {
+    base iana-interface-type;
+    description
+      "MACSecUncontrolled.";
+  }
+  identity aviciOpticalEther {
+    base iana-interface-type;
+    description
+      "Avici Optical Ethernet Aggregate.";
+  }
+  identity atmbond {
+    base iana-interface-type;
+    description
+      "atmbond.";
+  }
+  identity voiceFGDOS {
+    base iana-interface-type;
+    description
+      "Voice FGD Operator Services.";
+  }
+  identity mocaVersion1 {
+    base iana-interface-type;
+    description
+      "MultiMedia over Coax Alliance (MoCA) Interface
+       as documented in information provided privately to IANA.";
+  }
+  identity ieee80216WMAN {
+    base iana-interface-type;
+    description
+      "IEEE 802.16 WMAN interface.";
+  }
+  identity adsl2plus {
+    base iana-interface-type;
+    description
+      "Asymmetric Digital Subscriber Loop Version 2 -
+       Version 2 Plus and all variants.";
+  }
+  identity dvbRcsMacLayer {
+    base iana-interface-type;
+    description
+      "DVB-RCS MAC Layer.";
+    reference
+      "RFC 5728 - The SatLabs Group DVB-RCS MIB";
+  }
+  identity dvbTdm {
+    base iana-interface-type;
+    description
+      "DVB Satellite TDM.";
+    reference
+      "RFC 5728 - The SatLabs Group DVB-RCS MIB";
+  }
+  identity dvbRcsTdma {
+    base iana-interface-type;
+    description
+      "DVB-RCS TDMA.";
+    reference
+      "RFC 5728 - The SatLabs Group DVB-RCS MIB";
+  }
+  identity x86Laps {
+    base iana-interface-type;
+    description
+      "LAPS based on ITU-T X.86/Y.1323.";
+  }
+  identity wwanPP {
+    base iana-interface-type;
+    description
+      "3GPP WWAN.";
+  }
+  identity wwanPP2 {
+    base iana-interface-type;
+    description
+      "3GPP2 WWAN.";
+  }
+  identity voiceEBS {
+    base iana-interface-type;
+    description
+      "Voice P-phone EBS physical interface.";
+  }
+  identity ifPwType {
+    base iana-interface-type;
+    description
+      "Pseudowire interface type.";
+    reference
+      "RFC 5601 - Pseudowire (PW) Management Information Base (MIB)";
+  }
+  identity ilan {
+    base iana-interface-type;
+    description
+      "Internal LAN on a bridge per IEEE 802.1ap.";
+  }
+  identity pip {
+    base iana-interface-type;
+    description
+      "Provider Instance Port on a bridge per IEEE 802.1ah PBB.";
+  }
+  identity aluELP {
+    base iana-interface-type;
+    description
+      "Alcatel-Lucent Ethernet Link Protection.";
+  }
+  identity gpon {
+    base iana-interface-type;
+    description
+      "Gigabit-capable passive optical networks (G-PON) as per
+       ITU-T G.948.";
+  }
+  identity vdsl2 {
+    base iana-interface-type;
+    description
+      "Very high speed digital subscriber line Version 2
+       (as per ITU-T Recommendation G.993.2).";
+    reference
+      "RFC 5650 - Definitions of Managed Objects for Very High
+                  Speed Digital Subscriber Line 2 (VDSL2)";
+  }
+  identity capwapDot11Profile {
+    base iana-interface-type;
+    description
+      "WLAN Profile Interface.";
+    reference
+      "RFC 5834 - Control and Provisioning of Wireless Access
+                  Points (CAPWAP) Protocol Binding MIB for
+                  IEEE 802.11";
+  }
+  identity capwapDot11Bss {
+    base iana-interface-type;
+    description
+      "WLAN BSS Interface.";
+    reference
+      "RFC 5834 - Control and Provisioning of Wireless Access
+                  Points (CAPWAP) Protocol Binding MIB for
+                  IEEE 802.11";
+  }
+  identity capwapWtpVirtualRadio {
+    base iana-interface-type;
+    description
+      "WTP Virtual Radio Interface.";
+    reference
+      "RFC 5833 - Control and Provisioning of Wireless Access
+                  Points (CAPWAP) Protocol Base MIB";
+  }
+  identity bits {
+    base iana-interface-type;
+    description
+      "bitsport.";
+  }
+  identity docsCableUpstreamRfPort {
+    base iana-interface-type;
+    description
+      "DOCSIS CATV Upstream RF Port.";
+  }
+  identity cableDownstreamRfPort {
+    base iana-interface-type;
+    description
+      "CATV downstream RF Port.";
+  }
+  identity vmwareVirtualNic {
+    base iana-interface-type;
+    description
+      "VMware Virtual Network Interface.";
+  }
+  identity ieee802154 {
+    base iana-interface-type;
+    description
+      "IEEE 802.15.4 WPAN interface.";
+    reference
+      "IEEE 802.15.4-2006";
+  }
+  identity otnOdu {
+    base iana-interface-type;
+    description
+      "OTN Optical Data Unit.";
+  }
+  identity otnOtu {
+    base iana-interface-type;
+    description
+      "OTN Optical channel Transport Unit.";
+  }
+  identity ifVfiType {
+    base iana-interface-type;
+    description
+      "VPLS Forwarding Instance Interface Type.";
+  }
+  identity g9981 {
+    base iana-interface-type;
+    description
+      "G.998.1 bonded interface.";
+  }
+  identity g9982 {
+    base iana-interface-type;
+    description
+      "G.998.2 bonded interface.";
+  }
+  identity g9983 {
+    base iana-interface-type;
+    description
+      "G.998.3 bonded interface.";
+  }
+
+  identity aluEpon {
+    base iana-interface-type;
+    description
+      "Ethernet Passive Optical Networks (E-PON).";
+  }
+  identity aluEponOnu {
+    base iana-interface-type;
+    description
+      "EPON Optical Network Unit.";
+  }
+  identity aluEponPhysicalUni {
+    base iana-interface-type;
+    description
+      "EPON physical User to Network interface.";
+  }
+  identity aluEponLogicalLink {
+    base iana-interface-type;
+    description
+      "The emulation of a point-to-point link over the EPON
+       layer.";
+  }
+  identity aluGponOnu {
+    base iana-interface-type;
+    description
+      "GPON Optical Network Unit.";
+    reference
+      "ITU-T G.984.2";
+  }
+  identity aluGponPhysicalUni {
+    base iana-interface-type;
+    description
+      "GPON physical User to Network interface.";
+    reference
+      "ITU-T G.984.2";
+  }
+  identity vmwareNicTeam {
+    base iana-interface-type;
+    description
+      "VMware NIC Team.";
+  }
+  identity docsOfdmDownstream {
+    base iana-interface-type;
+    description
+      "CATV Downstream OFDM interface.";
+  }
+  identity docsOfdmaUpstream {
+    base iana-interface-type;
+    description
+      "CATV Upstream OFDMA interface.";
+  }
+  identity gfast {
+    base iana-interface-type;
+    description
+      "G.fast port.";
+    reference
+      "ITU-T G.9701";
+  }
+  identity sdci {
+    base iana-interface-type;
+    description
+      "SDCI (IO-Link).";
+    reference
+      "IEC 61131-9 Edition 1.0 2013-09";
+  }
+  identity xboxWireless {
+    base iana-interface-type;
+    description
+      "Xbox wireless.";
+  }
+  identity fastdsl {
+    base iana-interface-type;
+    description
+      "FastDSL.";
+    reference
+      "BBF TR-355";
+  }
+  identity docsCableScte55d1FwdOob {
+    base iana-interface-type;
+    description
+      "Cable SCTE 55-1 OOB Forward Channel.";
+  }
+  identity docsCableScte55d1RetOob {
+    base iana-interface-type;
+    description
+      "Cable SCTE 55-1 OOB Return Channel.";
+  }
+  identity docsCableScte55d2DsOob {
+    base iana-interface-type;
+    description
+      "Cable SCTE 55-2 OOB Downstream Channel.";
+  }
+  identity docsCableScte55d2UsOob {
+    base iana-interface-type;
+    description
+      "Cable SCTE 55-2 OOB Upstream Channel.";
+  }
+  identity docsCableNdf {
+    base iana-interface-type;
+    description
+      "Cable Narrowband Digital Forward.";
+  }
+  identity docsCableNdr {
+    base iana-interface-type;
+    description
+      "Cable Narrowband Digital Return.";
+  }
+  identity ptm {
+    base iana-interface-type;
+    description
+      "Packet Transfer Mode.";
+  }
+}

--- a/tools/internal/ocpaths/testdata/models/ietf/ietf-inet-types.yang
+++ b/tools/internal/ocpaths/testdata/models/ietf/ietf-inet-types.yang
@@ -1,0 +1,458 @@
+module ietf-inet-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
+  prefix "inet";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types for Internet addresses and related things.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - ip-address-no-zone
+      - ipv4-address-no-zone
+      - ipv6-address-no-zone";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of types related to protocol fields ***/
+
+  typedef ip-version {
+    type enumeration {
+      enum unknown {
+        value "0";
+        description
+         "An unknown or unspecified version of the Internet
+          protocol.";
+      }
+      enum ipv4 {
+        value "1";
+        description
+         "The IPv4 protocol as defined in RFC 791.";
+      }
+      enum ipv6 {
+        value "2";
+        description
+         "The IPv6 protocol as defined in RFC 2460.";
+      }
+    }
+    description
+     "This value represents the version of the IP protocol.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetVersion textual convention of the SMIv2.";
+    reference
+     "RFC  791: Internet Protocol
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+      RFC 4001: Textual Conventions for Internet Network Addresses";
+  }
+
+  typedef dscp {
+    type uint8 {
+      range "0..63";
+    }
+    description
+     "The dscp type represents a Differentiated Services Code Point
+      that may be used for marking packets in a traffic stream.
+      In the value set and its semantics, this type is equivalent
+      to the Dscp textual convention of the SMIv2.";
+    reference
+     "RFC 3289: Management Information Base for the Differentiated
+                Services Architecture
+      RFC 2474: Definition of the Differentiated Services Field
+                (DS Field) in the IPv4 and IPv6 Headers
+      RFC 2780: IANA Allocation Guidelines For Values In
+                the Internet Protocol and Related Headers";
+  }
+
+  typedef ipv6-flow-label {
+    type uint32 {
+      range "0..1048575";
+    }
+    description
+     "The ipv6-flow-label type represents the flow identifier or Flow
+      Label in an IPv6 packet header that may be used to
+      discriminate traffic flows.
+
+      In the value set and its semantics, this type is equivalent
+      to the IPv6FlowLabel textual convention of the SMIv2.";
+    reference
+     "RFC 3595: Textual Conventions for IPv6 Flow Label
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification";
+  }
+
+  typedef port-number {
+    type uint16 {
+      range "0..65535";
+    }
+    description
+     "The port-number type represents a 16-bit port number of an
+      Internet transport-layer protocol such as UDP, TCP, DCCP, or
+      SCTP.  Port numbers are assigned by IANA.  A current list of
+      all assignments is available from <http://www.iana.org/>.
+
+      Note that the port number value zero is reserved by IANA.  In
+      situations where the value zero does not make sense, it can
+      be excluded by subtyping the port-number type.
+      In the value set and its semantics, this type is equivalent
+      to the InetPortNumber textual convention of the SMIv2.";
+    reference
+     "RFC  768: User Datagram Protocol
+      RFC  793: Transmission Control Protocol
+      RFC 4960: Stream Control Transmission Protocol
+      RFC 4340: Datagram Congestion Control Protocol (DCCP)
+      RFC 4001: Textual Conventions for Internet Network Addresses";
+  }
+
+  /*** collection of types related to autonomous systems ***/
+
+  typedef as-number {
+    type uint32;
+    description
+     "The as-number type represents autonomous system numbers
+      which identify an Autonomous System (AS).  An AS is a set
+      of routers under a single technical administration, using
+      an interior gateway protocol and common metrics to route
+      packets within the AS, and using an exterior gateway
+      protocol to route packets to other ASes.  IANA maintains
+      the AS number space and has delegated large parts to the
+      regional registries.
+
+      Autonomous system numbers were originally limited to 16
+      bits.  BGP extensions have enlarged the autonomous system
+      number space to 32 bits.  This type therefore uses an uint32
+      base type without a range restriction in order to support
+      a larger autonomous system number space.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetAutonomousSystemNumber textual convention of
+      the SMIv2.";
+    reference
+     "RFC 1930: Guidelines for creation, selection, and registration
+                of an Autonomous System (AS)
+      RFC 4271: A Border Gateway Protocol 4 (BGP-4)
+      RFC 4001: Textual Conventions for Internet Network Addresses
+      RFC 6793: BGP Support for Four-Octet Autonomous System (AS)
+                Number Space";
+  }
+
+  /*** collection of types related to IP addresses and hostnames ***/
+
+  typedef ip-address {
+    type union {
+      type inet:ipv4-address;
+      type inet:ipv6-address;
+    }
+    description
+     "The ip-address type represents an IP address and is IP
+      version neutral.  The format of the textual representation
+      implies the IP version.  This type supports scoped addresses
+      by allowing zone identifiers in the address format.";
+    reference
+     "RFC 4007: IPv6 Scoped Address Architecture";
+  }
+
+  typedef ipv4-address {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+      + '(%[\p{N}\p{L}]+)?';
+    }
+    description
+      "The ipv4-address type represents an IPv4 address in
+       dotted-quad notation.  The IPv4 address may include a zone
+       index, separated by a % sign.
+
+       The zone index is used to disambiguate identical address
+       values.  For link-local addresses, the zone index will
+       typically be the interface index number or the name of an
+       interface.  If the zone index is not present, the default
+       zone of the device will be used.
+
+       The canonical format for the zone index is the numerical
+       format";
+  }
+
+  typedef ipv6-address {
+    type string {
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+            + '(%[\p{N}\p{L}]+)?';
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+            + '(%.+)?';
+    }
+    description
+     "The ipv6-address type represents an IPv6 address in full,
+      mixed, shortened, and shortened-mixed notation.  The IPv6
+      address may include a zone index, separated by a % sign.
+
+      The zone index is used to disambiguate identical address
+      values.  For link-local addresses, the zone index will
+      typically be the interface index number or the name of an
+      interface.  If the zone index is not present, the default
+      zone of the device will be used.
+
+      The canonical format of IPv6 addresses uses the textual
+      representation defined in Section 4 of RFC 5952.  The
+      canonical format for the zone index is the numerical
+      format as described in Section 11.2 of RFC 4007.";
+    reference
+     "RFC 4291: IP Version 6 Addressing Architecture
+      RFC 4007: IPv6 Scoped Address Architecture
+      RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  typedef ip-address-no-zone {
+    type union {
+      type inet:ipv4-address-no-zone;
+      type inet:ipv6-address-no-zone;
+    }
+    description
+     "The ip-address-no-zone type represents an IP address and is
+      IP version neutral.  The format of the textual representation
+      implies the IP version.  This type does not support scoped
+      addresses since it does not allow zone identifiers in the
+      address format.";
+    reference
+     "RFC 4007: IPv6 Scoped Address Architecture";
+  }
+
+  typedef ipv4-address-no-zone {
+    type inet:ipv4-address {
+      pattern '[0-9\.]*';
+    }
+    description
+      "An IPv4 address without a zone index.  This type, derived from
+       ipv4-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+  }
+
+  typedef ipv6-address-no-zone {
+    type inet:ipv6-address {
+      pattern '[0-9a-fA-F:\.]*';
+    }
+    description
+      "An IPv6 address without a zone index.  This type, derived from
+       ipv6-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+    reference
+     "RFC 4291: IP Version 6 Addressing Architecture
+      RFC 4007: IPv6 Scoped Address Architecture
+      RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  typedef ip-prefix {
+    type union {
+      type inet:ipv4-prefix;
+      type inet:ipv6-prefix;
+    }
+    description
+     "The ip-prefix type represents an IP prefix and is IP
+      version neutral.  The format of the textual representations
+      implies the IP version.";
+  }
+
+  typedef ipv4-prefix {
+    type string {
+      pattern
+         '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+       +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+       + '/(([0-9])|([1-2][0-9])|(3[0-2]))';
+    }
+    description
+     "The ipv4-prefix type represents an IPv4 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 32.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The canonical format of an IPv4 prefix has all bits of
+      the IPv4 address set to zero that are not part of the
+      IPv4 prefix.";
+  }
+
+  typedef ipv6-prefix {
+    type string {
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+            + '(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))';
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+            + '(/.+)';
+    }
+
+    description
+     "The ipv6-prefix type represents an IPv6 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 128.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The IPv6 address should have all bits that do not belong
+      to the prefix set to zero.
+
+      The canonical format of an IPv6 prefix has all bits of
+      the IPv6 address set to zero that are not part of the
+      IPv6 prefix.  Furthermore, the IPv6 address is represented
+      as defined in Section 4 of RFC 5952.";
+    reference
+     "RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  /*** collection of domain name and URI types ***/
+
+  typedef domain-name {
+    type string {
+      pattern
+        '((([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.)*'
+      + '([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.?)'
+      + '|\.';
+      length "1..253";
+    }
+    description
+     "The domain-name type represents a DNS domain name.  The
+      name SHOULD be fully qualified whenever possible.
+
+      Internet domain names are only loosely specified.  Section
+      3.5 of RFC 1034 recommends a syntax (modified in Section
+      2.1 of RFC 1123).  The pattern above is intended to allow
+      for current practice in domain name use, and some possible
+      future expansion.  It is designed to hold various types of
+      domain names, including names used for A or AAAA records
+      (host names) and other records, such as SRV records.  Note
+      that Internet host names have a stricter syntax (described
+      in RFC 952) than the DNS recommendations in RFCs 1034 and
+      1123, and that systems that want to store host names in
+      schema nodes using the domain-name type are recommended to
+      adhere to this stricter standard to ensure interoperability.
+
+      The encoding of DNS names in the DNS protocol is limited
+      to 255 characters.  Since the encoding consists of labels
+      prefixed by a length bytes and there is a trailing NULL
+      byte, only 253 characters can appear in the textual dotted
+      notation.
+
+      The description clause of schema nodes using the domain-name
+      type MUST describe when and how these names are resolved to
+      IP addresses.  Note that the resolution of a domain-name value
+      may require to query multiple DNS records (e.g., A for IPv4
+      and AAAA for IPv6).  The order of the resolution process and
+      which DNS record takes precedence can either be defined
+      explicitly or may depend on the configuration of the
+      resolver.
+
+      Domain-name values use the US-ASCII encoding.  Their canonical
+      format uses lowercase US-ASCII characters.  Internationalized
+      domain names MUST be A-labels as per RFC 5890.";
+    reference
+     "RFC  952: DoD Internet Host Table Specification
+      RFC 1034: Domain Names - Concepts and Facilities
+      RFC 1123: Requirements for Internet Hosts -- Application
+                and Support
+      RFC 2782: A DNS RR for specifying the location of services
+                (DNS SRV)
+      RFC 5890: Internationalized Domain Names in Applications
+                (IDNA): Definitions and Document Framework";
+  }
+
+  typedef host {
+    type union {
+      type inet:ip-address;
+      type inet:domain-name;
+    }
+    description
+     "The host type represents either an IP address or a DNS
+      domain name.";
+  }
+
+  typedef uri {
+    type string;
+    description
+     "The uri type represents a Uniform Resource Identifier
+      (URI) as defined by STD 66.
+
+      Objects using the uri type MUST be in US-ASCII encoding,
+      and MUST be normalized as described by RFC 3986 Sections
+      6.2.1, 6.2.2.1, and 6.2.2.2.  All unnecessary
+      percent-encoding is removed, and all case-insensitive
+      characters are set to lowercase except for hexadecimal
+      digits, which are normalized to uppercase as described in
+      Section 6.2.2.1.
+
+      The purpose of this normalization is to help provide
+      unique URIs.  Note that this normalization is not
+      sufficient to provide uniqueness.  Two URIs that are
+      textually distinct after this normalization may still be
+      equivalent.
+
+      Objects using the uri type may restrict the schemes that
+      they permit.  For example, 'data:' and 'urn:' schemes
+      might not be appropriate.
+
+      A zero-length URI is not a valid URI.  This can be used to
+      express 'URI absent' where required.
+
+      In the value set and its semantics, this type is equivalent
+      to the Uri SMIv2 textual convention defined in RFC 5017.";
+    reference
+     "RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
+      RFC 3305: Report from the Joint W3C/IETF URI Planning Interest
+                Group: Uniform Resource Identifiers (URIs), URLs,
+                and Uniform Resource Names (URNs): Clarifications
+                and Recommendations
+      RFC 5017: MIB Textual Conventions for Uniform Resource
+                Identifiers (URIs)";
+  }
+
+}

--- a/tools/internal/ocpaths/testdata/models/ietf/ietf-interfaces.yang
+++ b/tools/internal/ocpaths/testdata/models/ietf/ietf-interfaces.yang
@@ -1,0 +1,1123 @@
+module ietf-interfaces {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-interfaces";
+  prefix if;
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  organization
+    "IETF NETMOD (Network Modeling) Working Group";
+
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>";
+
+  description
+    "This module contains a collection of YANG definitions for
+     managing network interfaces.
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8343; see
+     the RFC itself for full legal notices.";
+
+  revision 2018-02-20 {
+    description
+      "Updated to support NMDA.";
+    reference
+      "RFC 8343: A YANG Data Model for Interface Management";
+  }
+
+  revision 2014-05-08 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7223: A YANG Data Model for Interface Management";
+  }
+
+  /*
+   * Typedefs
+   */
+
+  typedef interface-ref {
+    type leafref {
+      path "/if:interfaces/if:interface/if:name";
+    }
+    description
+      "This type is used by data models that need to reference
+       interfaces.";
+  }
+
+  /*
+   * Identities
+   */
+
+  identity interface-type {
+    description
+      "Base identity from which specific interface types are
+       derived.";
+  }
+
+  /*
+   * Features
+   */
+
+  feature arbitrary-names {
+    description
+      "This feature indicates that the device allows user-controlled
+       interfaces to be named arbitrarily.";
+  }
+  feature pre-provisioning {
+    description
+      "This feature indicates that the device supports
+       pre-provisioning of interface configuration, i.e., it is
+       possible to configure an interface whose physical interface
+       hardware is not present on the device.";
+  }
+  feature if-mib {
+    description
+      "This feature indicates that the device implements
+       the IF-MIB.";
+    reference
+      "RFC 2863: The Interfaces Group MIB";
+  }
+
+  /*
+   * Data nodes
+   */
+
+  container interfaces {
+    description
+      "Interface parameters.";
+
+    list interface {
+      key "name";
+
+      description
+        "The list of interfaces on the device.
+
+         The status of an interface is available in this list in the
+         operational state.  If the configuration of a
+         system-controlled interface cannot be used by the system
+         (e.g., the interface hardware present does not match the
+         interface type), then the configuration is not applied to
+         the system-controlled interface shown in the operational
+         state.  If the configuration of a user-controlled interface
+         cannot be used by the system, the configured interface is
+         not instantiated in the operational state.
+
+         System-controlled interfaces created by the system are
+         always present in this list in the operational state,
+         whether or not they are configured.";
+
+     leaf name {
+        type string;
+        description
+          "The name of the interface.
+
+           A device MAY restrict the allowed values for this leaf,
+           possibly depending on the type of the interface.
+           For system-controlled interfaces, this leaf is the
+           device-specific name of the interface.
+
+           If a client tries to create configuration for a
+           system-controlled interface that is not present in the
+           operational state, the server MAY reject the request if
+           the implementation does not support pre-provisioning of
+           interfaces or if the name refers to an interface that can
+           never exist in the system.  A Network Configuration
+           Protocol (NETCONF) server MUST reply with an rpc-error
+           with the error-tag 'invalid-value' in this case.
+
+           If the device supports pre-provisioning of interface
+           configuration, the 'pre-provisioning' feature is
+           advertised.
+
+           If the device allows arbitrarily named user-controlled
+           interfaces, the 'arbitrary-names' feature is advertised.
+
+           When a configured user-controlled interface is created by
+           the system, it is instantiated with the same name in the
+           operational state.
+
+           A server implementation MAY map this leaf to the ifName
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifName.  The definition of
+           such a mechanism is outside the scope of this document.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifName";
+      }
+
+      leaf description {
+        type string;
+        description
+          "A textual description of the interface.
+
+           A server implementation MAY map this leaf to the ifAlias
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifAlias.  The definition of
+           such a mechanism is outside the scope of this document.
+
+           Since ifAlias is defined to be stored in non-volatile
+           storage, the MIB implementation MUST map ifAlias to the
+           value of 'description' in the persistently stored
+           configuration.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAlias";
+      }
+
+      leaf type {
+        type identityref {
+          base interface-type;
+        }
+        mandatory true;
+        description
+          "The type of the interface.
+
+           When an interface entry is created, a server MAY
+           initialize the type leaf with a valid value, e.g., if it
+           is possible to derive the type from the name of the
+           interface.
+
+           If a client tries to set the type of an interface to a
+           value that can never be used by the system, e.g., if the
+           type is not supported or if the type does not match the
+           name of the interface, the server MUST reject the request.
+           A NETCONF server MUST reply with an rpc-error with the
+           error-tag 'invalid-value' in this case.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifType";
+      }
+
+      leaf enabled {
+        type boolean;
+        default "true";
+        description
+          "This leaf contains the configured, desired state of the
+           interface.
+
+           Systems that implement the IF-MIB use the value of this
+           leaf in the intended configuration to set
+           IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
+           has been initialized, as described in RFC 2863.
+
+           Changes in this leaf in the intended configuration are
+           reflected in ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+
+      leaf link-up-down-trap-enable {
+        if-feature if-mib;
+        type enumeration {
+          enum enabled {
+            value 1;
+            description
+              "The device will generate linkUp/linkDown SNMP
+               notifications for this interface.";
+          }
+          enum disabled {
+            value 2;
+            description
+              "The device will not generate linkUp/linkDown SNMP
+               notifications for this interface.";
+          }
+        }
+        description
+          "Controls whether linkUp/linkDown SNMP notifications
+           should be generated for this interface.
+
+           If this node is not configured, the value 'enabled' is
+           operationally used by the server for interfaces that do
+           not operate on top of any other interface (i.e., there are
+           no 'lower-layer-if' entries), and 'disabled' otherwise.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifLinkUpDownTrapEnable";
+      }
+
+      leaf admin-status {
+        if-feature if-mib;
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+            description
+              "Not ready to pass packets and not in some test mode.";
+          }
+          enum testing {
+            value 3;
+            description
+              "In some test mode.";
+          }
+        }
+        config false;
+        mandatory true;
+        description
+          "The desired state of the interface.
+
+           This leaf has the same read semantics as ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+
+      leaf oper-status {
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+
+            description
+              "The interface does not pass any packets.";
+          }
+          enum testing {
+            value 3;
+            description
+              "In some test mode.  No operational packets can
+               be passed.";
+          }
+          enum unknown {
+            value 4;
+            description
+              "Status cannot be determined for some reason.";
+          }
+          enum dormant {
+            value 5;
+            description
+              "Waiting for some external event.";
+          }
+          enum not-present {
+            value 6;
+            description
+              "Some component (typically hardware) is missing.";
+          }
+          enum lower-layer-down {
+            value 7;
+            description
+              "Down due to state of lower-layer interface(s).";
+          }
+        }
+        config false;
+        mandatory true;
+        description
+          "The current operational state of the interface.
+
+           This leaf has the same semantics as ifOperStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+      }
+
+      leaf last-change {
+        type yang:date-and-time;
+        config false;
+        description
+          "The time the interface entered its current operational
+           state.  If the current state was entered prior to the
+           last re-initialization of the local network management
+           subsystem, then this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifLastChange";
+      }
+
+      leaf if-index {
+        if-feature if-mib;
+        type int32 {
+          range "1..2147483647";
+        }
+        config false;
+        mandatory true;
+        description
+          "The ifIndex value for the ifEntry represented by this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifIndex";
+      }
+
+      leaf phys-address {
+        type yang:phys-address;
+        config false;
+        description
+          "The interface's address at its protocol sub-layer.  For
+           example, for an 802.x interface, this object normally
+           contains a Media Access Control (MAC) address.  The
+           interface's media-specific modules must define the bit
+           and byte ordering and the format of the value of this
+           object.  For interfaces that do not have such an address
+           (e.g., a serial line), this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifPhysAddress";
+      }
+
+      leaf-list higher-layer-if {
+        type interface-ref;
+        config false;
+        description
+          "A list of references to interfaces layered on top of this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf-list lower-layer-if {
+        type interface-ref;
+        config false;
+
+        description
+          "A list of references to interfaces layered underneath this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf speed {
+        type yang:gauge64;
+        units "bits/second";
+        config false;
+        description
+            "An estimate of the interface's current bandwidth in bits
+             per second.  For interfaces that do not vary in
+             bandwidth or for those where no accurate estimation can
+             be made, this node should contain the nominal bandwidth.
+             For interfaces that have no concept of bandwidth, this
+             node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifSpeed, ifHighSpeed";
+      }
+
+      container statistics {
+        config false;
+        description
+          "A collection of interface-related statistics objects.";
+
+        leaf discontinuity-time {
+          type yang:date-and-time;
+          mandatory true;
+          description
+            "The time on the most recent occasion at which any one or
+             more of this interface's counters suffered a
+             discontinuity.  If no such discontinuities have occurred
+             since the last re-initialization of the local management
+             subsystem, then this node contains the time the local
+             management subsystem re-initialized itself.";
+        }
+
+        leaf in-octets {
+          type yang:counter64;
+          description
+            "The total number of octets received on the interface,
+             including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+        }
+
+        leaf in-unicast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were not addressed to a
+             multicast or broadcast address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+        }
+
+        leaf in-broadcast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a broadcast
+             address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInBroadcastPkts";
+        }
+
+        leaf in-multicast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a multicast
+             address at this sub-layer.  For a MAC-layer protocol,
+             this includes both Group and Functional addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInMulticastPkts";
+        }
+
+        leaf in-discards {
+          type yang:counter32;
+          description
+            "The number of inbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being deliverable to a higher-layer
+             protocol.  One possible reason for discarding such a
+             packet could be to free up buffer space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+        }
+
+        leaf in-errors {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of inbound
+             packets that contained errors preventing them from being
+             deliverable to a higher-layer protocol.  For character-
+             oriented or fixed-length interfaces, the number of
+             inbound transmission units that contained errors
+             preventing them from being deliverable to a higher-layer
+             protocol.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInErrors";
+        }
+
+        leaf in-unknown-protos {
+          type yang:counter32;
+
+          description
+            "For packet-oriented interfaces, the number of packets
+             received via the interface that were discarded because
+             of an unknown or unsupported protocol.  For
+             character-oriented or fixed-length interfaces that
+             support protocol multiplexing, the number of
+             transmission units received via the interface that were
+             discarded because of an unknown or unsupported protocol.
+             For any interface that does not support protocol
+             multiplexing, this counter is not present.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+        }
+
+        leaf out-octets {
+          type yang:counter64;
+          description
+            "The total number of octets transmitted out of the
+             interface, including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+        }
+
+        leaf out-unicast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were not addressed
+             to a multicast or broadcast address at this sub-layer,
+             including those that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+        }
+
+        leaf out-broadcast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             broadcast address at this sub-layer, including those
+             that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutBroadcastPkts";
+        }
+
+        leaf out-multicast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             multicast address at this sub-layer, including those
+             that were discarded or not sent.  For a MAC-layer
+             protocol, this includes both Group and Functional
+             addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutMulticastPkts";
+        }
+
+        leaf out-discards {
+          type yang:counter32;
+          description
+            "The number of outbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being transmitted.  One possible reason
+             for discarding such a packet could be to free up buffer
+             space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+        }
+
+        leaf out-errors {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of outbound
+             packets that could not be transmitted because of errors.
+             For character-oriented or fixed-length interfaces, the
+             number of outbound transmission units that could not be
+             transmitted because of errors.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+        }
+      }
+
+    }
+  }
+
+  /*
+   * Legacy typedefs
+   */
+
+  typedef interface-state-ref {
+    type leafref {
+      path "/if:interfaces-state/if:interface/if:name";
+    }
+    status deprecated;
+    description
+      "This type is used by data models that need to reference
+       the operationally present interfaces.";
+  }
+
+  /*
+   * Legacy operational state data nodes
+   */
+
+  container interfaces-state {
+    config false;
+    status deprecated;
+    description
+      "Data nodes for the operational state of interfaces.";
+
+    list interface {
+      key "name";
+      status deprecated;
+
+      description
+        "The list of interfaces on the device.
+
+         System-controlled interfaces created by the system are
+         always present in this list, whether or not they are
+         configured.";
+
+      leaf name {
+        type string;
+        status deprecated;
+        description
+          "The name of the interface.
+
+           A server implementation MAY map this leaf to the ifName
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifName.  The definition of
+           such a mechanism is outside the scope of this document.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifName";
+      }
+
+      leaf type {
+        type identityref {
+          base interface-type;
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The type of the interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifType";
+      }
+
+      leaf admin-status {
+        if-feature if-mib;
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+            description
+              "Not ready to pass packets and not in some test mode.";
+          }
+          enum testing {
+            value 3;
+            description
+              "In some test mode.";
+          }
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The desired state of the interface.
+
+           This leaf has the same read semantics as ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+
+      leaf oper-status {
+        type enumeration {
+          enum up {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum down {
+            value 2;
+            description
+              "The interface does not pass any packets.";
+          }
+          enum testing {
+            value 3;
+            description
+              "In some test mode.  No operational packets can
+               be passed.";
+          }
+          enum unknown {
+            value 4;
+            description
+              "Status cannot be determined for some reason.";
+          }
+          enum dormant {
+            value 5;
+            description
+              "Waiting for some external event.";
+          }
+          enum not-present {
+            value 6;
+            description
+              "Some component (typically hardware) is missing.";
+          }
+          enum lower-layer-down {
+            value 7;
+            description
+              "Down due to state of lower-layer interface(s).";
+          }
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The current operational state of the interface.
+
+           This leaf has the same semantics as ifOperStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+      }
+
+      leaf last-change {
+        type yang:date-and-time;
+        status deprecated;
+        description
+          "The time the interface entered its current operational
+           state.  If the current state was entered prior to the
+           last re-initialization of the local network management
+           subsystem, then this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifLastChange";
+      }
+
+      leaf if-index {
+        if-feature if-mib;
+        type int32 {
+          range "1..2147483647";
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The ifIndex value for the ifEntry represented by this
+           interface.";
+
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifIndex";
+      }
+
+      leaf phys-address {
+        type yang:phys-address;
+        status deprecated;
+        description
+          "The interface's address at its protocol sub-layer.  For
+           example, for an 802.x interface, this object normally
+           contains a Media Access Control (MAC) address.  The
+           interface's media-specific modules must define the bit
+           and byte ordering and the format of the value of this
+           object.  For interfaces that do not have such an address
+           (e.g., a serial line), this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifPhysAddress";
+      }
+
+      leaf-list higher-layer-if {
+        type interface-state-ref;
+        status deprecated;
+        description
+          "A list of references to interfaces layered on top of this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf-list lower-layer-if {
+        type interface-state-ref;
+        status deprecated;
+        description
+          "A list of references to interfaces layered underneath this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+
+      leaf speed {
+        type yang:gauge64;
+        units "bits/second";
+        status deprecated;
+        description
+            "An estimate of the interface's current bandwidth in bits
+             per second.  For interfaces that do not vary in
+             bandwidth or for those where no accurate estimation can
+
+             be made, this node should contain the nominal bandwidth.
+             For interfaces that have no concept of bandwidth, this
+             node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifSpeed, ifHighSpeed";
+      }
+
+      container statistics {
+        status deprecated;
+        description
+          "A collection of interface-related statistics objects.";
+
+        leaf discontinuity-time {
+          type yang:date-and-time;
+          mandatory true;
+          status deprecated;
+          description
+            "The time on the most recent occasion at which any one or
+             more of this interface's counters suffered a
+             discontinuity.  If no such discontinuities have occurred
+             since the last re-initialization of the local management
+             subsystem, then this node contains the time the local
+             management subsystem re-initialized itself.";
+        }
+
+        leaf in-octets {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of octets received on the interface,
+             including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+        }
+
+        leaf in-unicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were not addressed to a
+             multicast or broadcast address at this sub-layer.
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+        }
+
+        leaf in-broadcast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a broadcast
+             address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInBroadcastPkts";
+        }
+
+        leaf in-multicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a multicast
+             address at this sub-layer.  For a MAC-layer protocol,
+             this includes both Group and Functional addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInMulticastPkts";
+        }
+
+        leaf in-discards {
+          type yang:counter32;
+          status deprecated;
+
+          description
+            "The number of inbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being deliverable to a higher-layer
+             protocol.  One possible reason for discarding such a
+             packet could be to free up buffer space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+        }
+
+        leaf in-errors {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of inbound
+             packets that contained errors preventing them from being
+             deliverable to a higher-layer protocol.  For character-
+             oriented or fixed-length interfaces, the number of
+             inbound transmission units that contained errors
+             preventing them from being deliverable to a higher-layer
+             protocol.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInErrors";
+        }
+
+        leaf in-unknown-protos {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of packets
+             received via the interface that were discarded because
+             of an unknown or unsupported protocol.  For
+             character-oriented or fixed-length interfaces that
+             support protocol multiplexing, the number of
+             transmission units received via the interface that were
+             discarded because of an unknown or unsupported protocol.
+             For any interface that does not support protocol
+             multiplexing, this counter is not present.
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+        }
+
+        leaf out-octets {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of octets transmitted out of the
+             interface, including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+        }
+
+        leaf out-unicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were not addressed
+             to a multicast or broadcast address at this sub-layer,
+             including those that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+        }
+
+        leaf out-broadcast-pkts {
+          type yang:counter64;
+          status deprecated;
+
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             broadcast address at this sub-layer, including those
+             that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutBroadcastPkts";
+        }
+
+        leaf out-multicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             multicast address at this sub-layer, including those
+             that were discarded or not sent.  For a MAC-layer
+             protocol, this includes both Group and Functional
+             addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutMulticastPkts";
+        }
+
+        leaf out-discards {
+          type yang:counter32;
+          status deprecated;
+          description
+            "The number of outbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being transmitted.  One possible reason
+             for discarding such a packet could be to free up buffer
+             space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+        }
+
+        leaf out-errors {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of outbound
+             packets that could not be transmitted because of errors.
+             For character-oriented or fixed-length interfaces, the
+             number of outbound transmission units that could not be
+             transmitted because of errors.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+        }
+      }
+    }
+  }
+}

--- a/tools/internal/ocpaths/testdata/models/ietf/ietf-yang-metadata.yang
+++ b/tools/internal/ocpaths/testdata/models/ietf/ietf-yang-metadata.yang
@@ -1,0 +1,84 @@
+module ietf-yang-metadata {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-metadata";
+
+  prefix "md";
+
+  organization
+    "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+
+     WG List:  <mailto:netmod@ietf.org>
+
+     WG Chair: Lou Berger
+               <mailto:lberger@labn.net>
+
+     WG Chair: Kent Watsen
+               <mailto:kwatsen@juniper.net>
+
+     Editor:   Ladislav Lhotka
+               <mailto:lhotka@nic.cz>";
+
+  description
+    "This YANG module defines an 'extension' statement that allows
+     for defining metadata annotations.
+
+     Copyright (c) 2016 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 7952
+     (http://www.rfc-editor.org/info/rfc7952); see the RFC itself
+     for full legal notices.";
+
+  revision 2016-08-05 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7952: Defining and Using Metadata with YANG";
+  }
+
+  extension annotation {
+    argument name;
+    description
+      "This extension allows for defining metadata annotations in
+       YANG modules.  The 'md:annotation' statement can appear only
+       at the top level of a YANG module or submodule, i.e., it
+       becomes a new alternative in the ABNF production rule for
+       'body-stmts' (Section 14 in RFC 7950).
+
+       The argument of the 'md:annotation' statement defines the name
+       of the annotation.  Syntactically, it is a YANG identifier as
+       defined in Section 6.2 of RFC 7950.
+
+       An annotation defined with this 'extension' statement inherits
+       the namespace and other context from the YANG module in which
+       it is defined.
+
+       The data type of the annotation value is specified in the same
+       way as for a leaf data node using the 'type' statement.
+
+       The semantics of the annotation and other documentation can be
+       specified using the following standard YANG substatements (all
+       are optional): 'description', 'if-feature', 'reference',
+       'status', and 'units'.
+
+       A server announces support for a particular annotation by
+       including the module in which the annotation is defined among
+       the advertised YANG modules, e.g., in a NETCONF <hello>
+       message or in the YANG library (RFC 7950).  The annotation can
+       then be attached to any instance of a data node defined in any
+       YANG module that is advertised by the server.
+
+       XML encoding and JSON encoding of annotations are defined in
+       RFC 7952.";
+  }
+}

--- a/tools/internal/ocpaths/testdata/models/ietf/ietf-yang-types.yang
+++ b/tools/internal/ocpaths/testdata/models/ietf/ietf-yang-types.yang
@@ -1,0 +1,474 @@
+module ietf-yang-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
+  prefix "yang";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - yang-identifier
+      - hex-string
+      - uuid
+      - dotted-quad";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of counter and gauge types ***/
+
+  typedef counter32 {
+    type uint32;
+    description
+     "The counter32 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter32 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter32 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter32.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter32 {
+    type yang:counter32;
+    default "0";
+    description
+     "The zero-based-counter32 type represents a counter32
+      that has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter32 textual convention of the SMIv2.";
+    reference
+      "RFC 4502: Remote Network Monitoring Management Information
+                 Base Version 2";
+  }
+
+  typedef counter64 {
+    type uint64;
+    description
+     "The counter64 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter64 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter64 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter64.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter64 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter64 {
+    type yang:counter64;
+    default "0";
+    description
+     "The zero-based-counter64 type represents a counter64 that
+      has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter64 textual convention of the SMIv2.";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  typedef gauge32 {
+    type uint32;
+    description
+     "The gauge32 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^32-1 (4294967295 decimal), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge32 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge32 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the Gauge32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef gauge64 {
+    type uint64;
+    description
+     "The gauge64 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^64-1 (18446744073709551615), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge64 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge64 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the CounterBasedGauge64 SMIv2 textual convention defined
+      in RFC 2856";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  /*** collection of identifier-related types ***/
+
+  typedef object-identifier {
+    type string {
+      pattern '(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))'
+            + '(\.(0|([1-9]\d*)))*';
+    }
+    description
+     "The object-identifier type represents administratively
+      assigned names in a registration-hierarchical-name tree.
+
+      Values of this type are denoted as a sequence of numerical
+      non-negative sub-identifier values.  Each sub-identifier
+      value MUST NOT exceed 2^32-1 (4294967295).  Sub-identifiers
+      are separated by single dots and without any intermediate
+      whitespace.
+
+      The ASN.1 standard restricts the value space of the first
+      sub-identifier to 0, 1, or 2.  Furthermore, the value space
+      of the second sub-identifier is restricted to the range
+      0 to 39 if the first sub-identifier is 0 or 1.  Finally,
+      the ASN.1 standard requires that an object identifier
+      has always at least two sub-identifiers.  The pattern
+      captures these restrictions.
+
+      Although the number of sub-identifiers is not limited,
+      module designers should realize that there may be
+      implementations that stick with the SMIv2 limit of 128
+      sub-identifiers.
+
+      This type is a superset of the SMIv2 OBJECT IDENTIFIER type
+      since it is not restricted to 128 sub-identifiers.  Hence,
+      this type SHOULD NOT be used to represent the SMIv2 OBJECT
+      IDENTIFIER type; the object-identifier-128 type SHOULD be
+      used instead.";
+    reference
+     "ISO9834-1: Information technology -- Open Systems
+      Interconnection -- Procedures for the operation of OSI
+      Registration Authorities: General procedures and top
+      arcs of the ASN.1 Object Identifier tree";
+  }
+
+  typedef object-identifier-128 {
+    type object-identifier {
+      pattern '\d*(\.\d*){1,127}';
+    }
+    description
+     "This type represents object-identifiers restricted to 128
+      sub-identifiers.
+
+      In the value set and its semantics, this type is equivalent
+      to the OBJECT IDENTIFIER type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef yang-identifier {
+    type string {
+      length "1..max";
+      pattern '[a-zA-Z_][a-zA-Z0-9\-_.]*';
+      pattern '.|..|[^xX].*|.[^mM].*|..[^lL].*';
+    }
+    description
+      "A YANG identifier string as defined by the 'identifier'
+       rule in Section 12 of RFC 6020.  An identifier must
+       start with an alphabetic character or an underscore
+       followed by an arbitrary sequence of alphabetic or
+       numeric characters, underscores, hyphens, or dots.
+
+       A YANG identifier MUST NOT start with any possible
+       combination of the lowercase or uppercase character
+       sequence 'xml'.";
+    reference
+      "RFC 6020: YANG - A Data Modeling Language for the Network
+                 Configuration Protocol (NETCONF)";
+  }
+
+  /*** collection of types related to date and time***/
+
+  typedef date-and-time {
+    type string {
+      pattern '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?'
+            + '(Z|[\+\-]\d{2}:\d{2})';
+    }
+    description
+     "The date-and-time type is a profile of the ISO 8601
+      standard for representation of dates and times using the
+      Gregorian calendar.  The profile is defined by the
+      date-time production in Section 5.6 of RFC 3339.
+
+      The date-and-time type is compatible with the dateTime XML
+      schema type with the following notable exceptions:
+
+      (a) The date-and-time type does not allow negative years.
+
+      (b) The date-and-time time-offset -00:00 indicates an unknown
+          time zone (see RFC 3339) while -00:00 and +00:00 and Z
+          all represent the same time zone in dateTime.
+
+      (c) The canonical format (see below) of data-and-time values
+          differs from the canonical format used by the dateTime XML
+          schema type, which requires all times to be in UTC using
+          the time-offset 'Z'.
+
+      This type is not equivalent to the DateAndTime textual
+      convention of the SMIv2 since RFC 3339 uses a different
+      separator between full-date and full-time and provides
+      higher resolution of time-secfrac.
+
+      The canonical format for date-and-time values with a known time
+      zone uses a numeric time zone offset that is calculated using
+      the device's configured known offset to UTC time.  A change of
+      the device's offset to UTC time will cause date-and-time values
+      to change accordingly.  Such changes might happen periodically
+      in case a server follows automatically daylight saving time
+      (DST) time zone offset changes.  The canonical format for
+      date-and-time values with an unknown time zone (usually
+      referring to the notion of local time) uses the time-offset
+      -00:00.";
+    reference
+     "RFC 3339: Date and Time on the Internet: Timestamps
+      RFC 2579: Textual Conventions for SMIv2
+      XSD-TYPES: XML Schema Part 2: Datatypes Second Edition";
+  }
+
+  typedef timeticks {
+    type uint32;
+    description
+     "The timeticks type represents a non-negative integer that
+      represents the time, modulo 2^32 (4294967296 decimal), in
+      hundredths of a second between two epochs.  When a schema
+      node is defined that uses this type, the description of
+      the schema node identifies both of the reference epochs.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeTicks type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef timestamp {
+    type yang:timeticks;
+    description
+     "The timestamp type represents the value of an associated
+      timeticks schema node at which a specific occurrence
+      happened.  The specific occurrence must be defined in the
+      description of any schema node defined using this type.  When
+      the specific occurrence occurred prior to the last time the
+      associated timeticks attribute was zero, then the timestamp
+      value is zero.  Note that this requires all timestamp values
+      to be reset to zero when the value of the associated timeticks
+      attribute reaches 497+ days and wraps around to zero.
+
+      The associated timeticks schema node must be specified
+      in the description of any schema node using this type.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeStamp textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of generic address types ***/
+
+  typedef phys-address {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+
+    description
+     "Represents media- or physical-level addresses represented
+      as a sequence octets, each octet represented by two hexadecimal
+      numbers.  Octets are separated by colons.  The canonical
+      representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the PhysAddress textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  typedef mac-address {
+    type string {
+      pattern '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}';
+    }
+    description
+     "The mac-address type represents an IEEE 802 MAC address.
+      The canonical representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the MacAddress textual convention of the SMIv2.";
+    reference
+     "IEEE 802: IEEE Standard for Local and Metropolitan Area
+                Networks: Overview and Architecture
+      RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of XML-specific types ***/
+
+  typedef xpath1.0 {
+    type string;
+    description
+     "This type represents an XPATH 1.0 expression.
+
+      When a schema node is defined that uses this type, the
+      description of the schema node MUST specify the XPath
+      context in which the XPath expression is evaluated.";
+    reference
+     "XPATH: XML Path Language (XPath) Version 1.0";
+  }
+
+  /*** collection of string types ***/
+
+  typedef hex-string {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+    description
+     "A hexadecimal string with octets represented as hex digits
+      separated by colons.  The canonical representation uses
+      lowercase characters.";
+  }
+
+  typedef uuid {
+    type string {
+      pattern '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+            + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+    }
+    description
+     "A Universally Unique IDentifier in the string representation
+      defined in RFC 4122.  The canonical representation uses
+      lowercase characters.
+
+      The following is an example of a UUID in string representation:
+      f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+      ";
+    reference
+     "RFC 4122: A Universally Unique IDentifier (UUID) URN
+                Namespace";
+  }
+
+  typedef dotted-quad {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
+    }
+    description
+      "An unsigned 32-bit number expressed in the dotted-quad
+       notation, i.e., four octets written as decimal numbers
+       and separated with the '.' (full stop) character.";
+  }
+}

--- a/tools/internal/ocpaths/testdata/models/oc-models/interfaces/openconfig-interfaces.yang
+++ b/tools/internal/ocpaths/testdata/models/oc-models/interfaces/openconfig-interfaces.yang
@@ -1,0 +1,1223 @@
+module openconfig-interfaces {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/interfaces";
+
+  prefix "oc-if";
+
+  // import some basic types
+  import ietf-interfaces { prefix ietf-if; }
+  import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "Model for managing network interfaces and subinterfaces.  This
+    module also defines convenience types / groupings for other
+    models to create references to interfaces:
+
+      base-interface-ref (type) -  reference to a base interface
+      interface-ref (grouping) -  container for reference to a
+        interface + subinterface
+      interface-ref-state (grouping) - container for read-only
+        (opstate) reference to interface + subinterface
+
+    This model reuses data items defined in the IETF YANG model for
+    interfaces described by RFC 7223 with an alternate structure
+    (particularly for operational state data) and with
+    additional configuration items.
+
+    Portions of this code were derived from IETF RFC 7223.
+    Please reproduce this note if possible.
+
+    IETF code is subject to the following copyright and license:
+    Copyright (c) IETF Trust and the persons identified as authors of
+    the code.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, is permitted pursuant to, and subject to the license
+    terms contained in, the Simplified BSD License set forth in
+    Section 4.c of the IETF Trust's Legal Provisions Relating
+    to IETF Documents (http://trustee.ietf.org/license-info).";
+
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2023-07-14" {
+    description
+      "Move counters which apply to both interfaces and subinterfaces to
+      a common grouping.  Deprecate physical counters from subinterface";
+    reference "3.5.0";
+  }
+
+  revision "2023-02-06" {
+    description
+      "Add further specification to interface-ref type to
+       clarify that the interface and subinterface leaves
+       are how an interface is referenced, regardless of
+       context.";
+    reference "3.0.2";
+  }
+
+  revision "2022-10-25" {
+    description
+      "change loopback-mode to align with available modes";
+    reference "3.0.1";
+  }
+
+  revision "2021-04-06" {
+    description
+      "Add leaves for management and cpu interfaces";
+    reference "2.5.0";
+  }
+
+  revision "2019-11-19" {
+    description
+      "Update description of interface name.";
+    reference "2.4.3";
+  }
+
+  revision "2019-07-10" {
+    description
+      "Remove redundant nanosecond units statements to reflect
+      universal definition of timeticks64 type.";
+    reference "2.4.2";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "2.4.1";
+  }
+
+  revision "2018-08-07" {
+    description
+      "Add leaf to indicate whether an interface is physical or
+      logical.";
+    reference "2.4.0";
+  }
+
+  revision "2018-07-02" {
+    description
+      "Add in-pkts and out-pkts in counters";
+    reference "2.3.2";
+  }
+
+  revision "2018-04-24" {
+    description
+      "Clarified behavior of last-change state leaf";
+    reference "2.3.1";
+  }
+
+  revision "2018-01-05" {
+    description
+      "Add logical loopback to interface.";
+    reference "2.3.0";
+  }
+
+  revision "2017-12-22" {
+    description
+      "Add IPv4 proxy ARP configuration.";
+    reference "2.2.0";
+  }
+
+  revision "2017-12-21" {
+    description
+      "Added IPv6 router advertisement configuration.";
+    reference "2.1.0";
+  }
+
+  revision "2017-07-14" {
+    description
+      "Added Ethernet/IP state data; Add dhcp-client;
+      migrate to OpenConfig types modules; Removed or
+      renamed opstate values";
+    reference "2.0.0";
+  }
+
+  revision "2017-04-03" {
+    description
+      "Update copyright notice.";
+    reference "1.1.1";
+  }
+
+  revision "2016-12-22" {
+    description
+      "Fixes to Ethernet interfaces model";
+    reference "1.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // typedef statements
+
+  typedef base-interface-ref {
+    type leafref {
+      path "/oc-if:interfaces/oc-if:interface/oc-if:name";
+    }
+    description
+      "Reusable type for by-name reference to a base interface.
+      This type may be used in cases where ability to reference
+      a subinterface is not required.";
+  }
+
+  typedef interface-id {
+    type string;
+    description
+      "User-defined identifier for an interface, generally used to
+      name a interface reference.  The id can be arbitrary but a
+      useful convention is to use a combination of base interface
+      name and subinterface index.";
+  }
+
+  // grouping statements
+
+  grouping interface-ref-common {
+    description
+      "Reference leafrefs to interface / subinterface";
+
+    leaf interface {
+      type leafref {
+        path "/oc-if:interfaces/oc-if:interface/oc-if:name";
+      }
+      description
+        "Reference to a base interface.  If a reference to a
+        subinterface is required, this leaf must be specified
+        to indicate the base interface.";
+    }
+
+    leaf subinterface {
+      type leafref {
+        path "/oc-if:interfaces/" +
+          "oc-if:interface[oc-if:name=current()/../interface]/" +
+          "oc-if:subinterfaces/oc-if:subinterface/oc-if:index";
+      }
+      description
+        "Reference to a subinterface -- this requires the base
+        interface to be specified using the interface leaf in
+        this container.  If only a reference to a base interface
+        is requuired, this leaf should not be set.";
+    }
+  }
+
+  grouping interface-ref-state-container {
+    description
+      "Reusable opstate w/container for a reference to an
+      interface or subinterface";
+
+    container state {
+      config false;
+      description
+        "Operational state for interface-ref";
+
+      uses interface-ref-common;
+    }
+  }
+
+  grouping interface-ref {
+    description
+      "Reusable definition for a reference to an interface or
+      subinterface";
+
+    container interface-ref {
+      description
+        "Reference to an interface or subinterface. The interface
+        that is being referenced is uniquely referenced based on
+        the specified interface and subinterface leaves. In contexts
+        where a Layer 3 interface is to be referenced, both the
+        interface and subinterface leaves must be populated, as
+        Layer 3 configuration within the OpenConfig models is
+        associated with a subinterface. In the case where a
+        Layer 2 interface is to be referenced, only the
+        interface is specified.
+
+        The interface/subinterface leaf tuple must be used as
+        the means by which the interface is specified, regardless
+        of any other context information (e.g., key in a list).";
+
+      container config {
+        description
+          "Configured reference to interface / subinterface";
+        oc-ext:telemetry-on-change;
+
+        uses interface-ref-common;
+      }
+
+      uses interface-ref-state-container;
+    }
+  }
+
+  grouping interface-ref-state {
+    description
+      "Reusable opstate w/container for a reference to an
+      interface or subinterface";
+
+    container interface-ref {
+      description
+        "Reference to an interface or subinterface";
+
+      uses interface-ref-state-container;
+    }
+  }
+
+  grouping base-interface-ref-state {
+    description
+      "Reusable opstate w/container for a reference to a
+      base interface (no subinterface).";
+
+      container state {
+        config false;
+        description
+          "Operational state for base interface reference";
+
+        leaf interface {
+          type base-interface-ref;
+          description
+            "Reference to a base interface.";
+        }
+      }
+  }
+
+
+  grouping interface-common-config {
+    description
+      "Configuration data data nodes common to physical interfaces
+      and subinterfaces";
+
+    leaf description {
+      type string;
+      description
+        "A textual description of the interface.
+
+        A server implementation MAY map this leaf to the ifAlias
+        MIB object.  Such an implementation needs to use some
+        mechanism to handle the differences in size and characters
+        allowed between this leaf and ifAlias.  The definition of
+        such a mechanism is outside the scope of this document.
+
+        Since ifAlias is defined to be stored in non-volatile
+        storage, the MIB implementation MUST map ifAlias to the
+        value of 'description' in the persistently stored
+        datastore.
+
+        Specifically, if the device supports ':startup', when
+        ifAlias is read the device MUST return the value of
+        'description' in the 'startup' datastore, and when it is
+        written, it MUST be written to the 'running' and 'startup'
+        datastores.  Note that it is up to the implementation to
+
+        decide whether to modify this single leaf in 'startup' or
+        perform an implicit copy-config from 'running' to
+        'startup'.
+
+        If the device does not support ':startup', ifAlias MUST
+        be mapped to the 'description' leaf in the 'running'
+        datastore.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifAlias";
+    }
+
+    leaf enabled {
+      type boolean;
+      default "true";
+      description
+        "This leaf contains the configured, desired state of the
+        interface.
+
+        Systems that implement the IF-MIB use the value of this
+        leaf in the 'running' datastore to set
+        IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
+        has been initialized, as described in RFC 2863.
+
+        Changes in this leaf in the 'running' datastore are
+        reflected in ifAdminStatus, but if ifAdminStatus is
+        changed over SNMP, this leaf is not affected.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+    }
+
+  }
+
+  grouping interface-phys-config {
+    description
+      "Configuration data for physical interfaces";
+
+    leaf name {
+      type string;
+      description
+        "The name of the interface.
+
+        A device MAY restrict the allowed values for this leaf,
+        possibly depending on the type of the interface.
+        For system-controlled interfaces, this leaf is the
+        device-specific name of the interface.  The 'config false'
+        list interfaces/interface[name]/state contains the currently
+        existing interfaces on the device.
+
+        If a client tries to create configuration for a
+        system-controlled interface that is not present in the
+        corresponding state list, the server MAY reject
+        the request if the implementation does not support
+        pre-provisioning of interfaces or if the name refers to
+        an interface that can never exist in the system.  A
+        NETCONF server MUST reply with an rpc-error with the
+        error-tag 'invalid-value' in this case.
+
+        The IETF model in RFC 7223 provides YANG features for the
+        following (i.e., pre-provisioning and arbitrary-names),
+        however they are omitted here:
+
+          If the device supports pre-provisioning of interface
+          configuration, the 'pre-provisioning' feature is
+          advertised.
+
+          If the device allows arbitrarily named user-controlled
+          interfaces, the 'arbitrary-names' feature is advertised.
+
+        When a configured user-controlled interface is created by
+        the system, it is instantiated with the same name in the
+        /interfaces/interface[name]/state list.";
+    }
+
+    leaf type {
+      type identityref {
+        base ietf-if:interface-type;
+      }
+      mandatory true;
+      description
+        "The type of the interface.
+
+        When an interface entry is created, a server MAY
+        initialize the type leaf with a valid value, e.g., if it
+        is possible to derive the type from the name of the
+        interface.
+
+        If a client tries to set the type of an interface to a
+        value that can never be used by the system, e.g., if the
+        type is not supported or if the type does not match the
+        name of the interface, the server MUST reject the request.
+        A NETCONF server MUST reply with an rpc-error with the
+        error-tag 'invalid-value' in this case.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifType";
+    }
+
+    leaf mtu {
+      type uint16;
+      description
+        "Set the max transmission unit size in octets
+        for the physical interface.  If this is not set, the mtu is
+        set to the operational default -- e.g., 1514 bytes on an
+        Ethernet interface.";
+    }
+
+    uses interface-common-config;
+  }
+
+  grouping interface-phys-holdtime-config {
+    description
+      "Configuration data for interface hold-time settings --
+      applies to physical interfaces.";
+
+    leaf up {
+      type uint32;
+      units milliseconds;
+      default 0;
+      description
+        "Dampens advertisement when the interface
+        transitions from down to up.  A zero value means dampening
+        is turned off, i.e., immediate notification.";
+    }
+
+    leaf down {
+      type uint32;
+      units milliseconds;
+      default 0;
+      description
+        "Dampens advertisement when the interface transitions from
+        up to down.  A zero value means dampening is turned off,
+        i.e., immediate notification.";
+    }
+  }
+
+  grouping interface-phys-holdtime-state {
+    description
+      "Operational state data for interface hold-time.";
+  }
+
+  grouping interface-phys-holdtime-top {
+    description
+      "Top-level grouping for setting link transition
+      dampening on physical and other types of interfaces.";
+
+    container hold-time {
+      description
+        "Top-level container for hold-time settings to enable
+        dampening advertisements of interface transitions.";
+
+      container config {
+        description
+          "Configuration data for interface hold-time settings.";
+        oc-ext:telemetry-on-change;
+
+        uses interface-phys-holdtime-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for interface hold-time.";
+
+        uses interface-phys-holdtime-config;
+        uses interface-phys-holdtime-state;
+      }
+    }
+  }
+
+  grouping interface-common-state {
+    description
+      "Operational state data (in addition to intended configuration)
+      at the global level for this interface";
+
+    oc-ext:operational;
+
+    leaf ifindex {
+      type uint32;
+      description
+        "System assigned number for each interface.  Corresponds to
+        ifIndex object in SNMP Interface MIB";
+      reference
+        "RFC 2863 - The Interfaces Group MIB";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf admin-status {
+      type enumeration {
+        enum UP {
+          description
+            "Ready to pass packets.";
+        }
+        enum DOWN {
+          description
+            "Not ready to pass packets and not in some test mode.";
+        }
+        enum TESTING {
+          //TODO: This is generally not supported as a configured
+          //admin state, though it's in the standard interfaces MIB.
+          //Consider removing it.
+          description
+            "In some test mode.";
+        }
+      }
+      //TODO:consider converting to an identity to have the
+      //flexibility to remove some values defined by RFC 7223 that
+      //are not used or not implemented consistently.
+      mandatory true;
+      description
+        "The desired state of the interface.  In RFC 7223 this leaf
+        has the same read semantics as ifAdminStatus.  Here, it
+        reflects the administrative state as set by enabling or
+        disabling the interface.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf oper-status {
+      type enumeration {
+        enum UP {
+          value 1;
+          description
+            "Ready to pass packets.";
+        }
+        enum DOWN {
+          value 2;
+          description
+            "The interface does not pass any packets.";
+        }
+        enum TESTING {
+          value 3;
+          description
+            "In some test mode.  No operational packets can
+             be passed.";
+        }
+        enum UNKNOWN {
+          value 4;
+          description
+            "Status cannot be determined for some reason.";
+        }
+        enum DORMANT {
+          value 5;
+          description
+            "Waiting for some external event.";
+        }
+        enum NOT_PRESENT {
+          value 6;
+          description
+            "Some component (typically hardware) is missing.";
+        }
+        enum LOWER_LAYER_DOWN {
+          value 7;
+          description
+            "Down due to state of lower-layer interface(s).";
+        }
+      }
+      //TODO:consider converting to an identity to have the
+      //flexibility to remove some values defined by RFC 7223 that
+      //are not used or not implemented consistently.
+      mandatory true;
+      description
+        "The current operational state of the interface.
+
+         This leaf has the same semantics as ifOperStatus.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf last-change {
+      type oc-types:timeticks64;
+      description
+        "This timestamp indicates the absolute time of the last
+        state change of the interface (e.g., up-to-down transition).
+        This is different than the SNMP ifLastChange object in the
+        standard interface MIB in that it is not relative to the
+        system boot time (i.e,. sysUpTime).
+
+        The value is the timestamp in nanoseconds relative to
+        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf logical {
+      type boolean;
+      description
+        "When set to true, the interface is a logical interface
+        which does not have an associated physical port or
+        channel on the system.";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf management {
+      type boolean;
+      description
+        "When set to true, the interface is a dedicated
+        management interface that is not connected to dataplane
+        interfaces.  It may be used to connect the system to an
+        out-of-band management network, for example.";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf cpu {
+      type boolean;
+      description
+        "When set to true, the interface is for traffic
+        that is handled by the system CPU, sometimes also called the
+        control plane interface.  On systems that represent the CPU
+        interface as an Ethernet interface, for example, this leaf
+        should be used to distinguish the CPU interface from dataplane
+        interfaces.";
+      oc-ext:telemetry-on-change;
+    }
+  }
+
+  grouping interface-common-counters-state {
+    description
+      "Operational state representing interface counters and statistics
+      applicable to (physical) interfaces and (logical) subinterfaces.";
+
+    leaf in-octets {
+      type oc-yang:counter64;
+      description
+        "The total number of octets received on the interface,
+        including framing characters.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifHCInOctets.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf in-pkts {
+      type oc-yang:counter64;
+      description
+        "The total number of packets received on the interface,
+        including all unicast, multicast, broadcast and bad packets
+        etc.";
+      reference
+        "RFC 2819: Remote Network Monitoring Management Information Base.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf in-unicast-pkts {
+      type oc-yang:counter64;
+      description
+        "The number of packets, delivered by this sub-layer to a
+        higher (sub-)layer, that were not addressed to a
+        multicast or broadcast address at this sub-layer.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf in-broadcast-pkts {
+      type oc-yang:counter64;
+      description
+        "The number of packets, delivered by this sub-layer to a
+        higher (sub-)layer, that were addressed to a broadcast
+        address at this sub-layer.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifHCInBroadcastPkts.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf in-multicast-pkts {
+      type oc-yang:counter64;
+      description
+        "The number of packets, delivered by this sub-layer to a
+        higher (sub-)layer, that were addressed to a multicast
+        address at this sub-layer.  For a MAC-layer protocol,
+        this includes both Group and Functional addresses.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifHCInMulticastPkts.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf in-errors {
+      type oc-yang:counter64;
+      description
+        "For packet-oriented interfaces, the number of inbound
+        packets that contained errors preventing them from being
+        deliverable to a higher-layer protocol.  For character-
+        oriented or fixed-length interfaces, the number of
+        inbound transmission units that contained errors
+        preventing them from being deliverable to a higher-layer
+        protocol.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifInErrors.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf in-discards {
+      type oc-yang:counter64;
+      description
+        "The number of inbound packets that were chosen to be
+        discarded even though no errors had been detected to
+        prevent their being deliverable to a higher-layer
+        protocol.  One possible reason for discarding such a
+        packet could be to free up buffer space.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+
+
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifInDiscards.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf out-octets {
+      type oc-yang:counter64;
+      description
+        "The total number of octets transmitted out of the
+        interface, including framing characters.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifHCOutOctets.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf out-pkts {
+      type oc-yang:counter64;
+      description
+        "The total number of packets transmitted out of the
+        interface, including all unicast, multicast, broadcast,
+        and bad packets etc.";
+      reference
+        "RFC 2819: Remote Network Monitoring Management Information Base.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf out-unicast-pkts {
+      type oc-yang:counter64;
+      description
+        "The total number of packets that higher-level protocols
+        requested be transmitted, and that were not addressed
+        to a multicast or broadcast address at this sub-layer,
+        including those that were discarded or not sent.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf out-broadcast-pkts {
+      type oc-yang:counter64;
+      description
+        "The total number of packets that higher-level protocols
+        requested be transmitted, and that were addressed to a
+        broadcast address at this sub-layer, including those
+        that were discarded or not sent.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifHCOutBroadcastPkts.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf out-multicast-pkts {
+      type oc-yang:counter64;
+      description
+        "The total number of packets that higher-level protocols
+        requested be transmitted, and that were addressed to a
+        multicast address at this sub-layer, including those
+        that were discarded or not sent.  For a MAC-layer
+        protocol, this includes both Group and Functional
+        addresses.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifHCOutMulticastPkts.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf out-discards {
+      type oc-yang:counter64;
+      description
+        "The number of outbound packets that were chosen to be
+        discarded even though no errors had been detected to
+        prevent their being transmitted.  One possible reason
+        for discarding such a packet could be to free up buffer
+        space.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifOutDiscards.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf out-errors {
+      type oc-yang:counter64;
+      description
+        "For packet-oriented interfaces, the number of outbound
+        packets that could not be transmitted because of errors.
+        For character-oriented or fixed-length interfaces, the
+        number of outbound transmission units that could not be
+        transmitted because of errors.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifOutErrors.
+        RFC 4293: Management Information Base for the
+        Internet Protocol (IP).";
+    }
+
+    leaf last-clear {
+      type oc-types:timeticks64;
+      description
+        "Timestamp of the last time the interface counters were
+        cleared.
+
+        The value is the timestamp in nanoseconds relative to
+        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+      oc-ext:telemetry-on-change;
+    }
+  }
+
+  grouping interface-counters-state {
+    description
+      "Operational state representing interface counters
+      and statistics.";
+
+    oc-ext:operational;
+
+    leaf in-unknown-protos {
+      type oc-yang:counter64;
+      description
+        "For packet-oriented interfaces, the number of packets
+        received via the interface that were discarded because
+        of an unknown or unsupported protocol.  For
+        character-oriented or fixed-length interfaces that
+        support protocol multiplexing, the number of
+        transmission units received via the interface that were
+        discarded because of an unknown or unsupported protocol.
+        For any interface that does not support protocol
+        multiplexing, this counter is not present.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+    }
+
+    leaf in-fcs-errors {
+      type oc-yang:counter64;
+      description
+        "Number of received packets which had errors in the
+        frame check sequence (FCS), i.e., framing errors.
+
+        Discontinuities in the value of this counter can occur
+        when the device is re-initialization as indicated by the
+        value of 'last-clear'.";
+    }
+
+    leaf carrier-transitions {
+      type oc-yang:counter64;
+      description
+        "Number of times the interface state has transitioned
+        between up and down since the time the device restarted
+        or the last-clear time, whichever is most recent.";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf resets {
+      type oc-yang:counter64;
+      description
+        "Number of times the interface hardware has been reset.  The
+        triggers and effects of this event are hardware-specifc.";
+      oc-ext:telemetry-on-change;
+
+    }
+  }
+
+  grouping subinterfaces-counters-state {
+    description
+      "Operational state representing counters unique to subinterfaces";
+
+    oc-ext:operational;
+    leaf in-unknown-protos {
+      type oc-yang:counter64;
+      status deprecated;
+      description
+        "For packet-oriented interfaces, the number of packets
+        received via the interface that were discarded because
+        of an unknown or unsupported protocol.  For
+        character-oriented or fixed-length interfaces that
+        support protocol multiplexing, the number of
+        transmission units received via the interface that were
+        discarded because of an unknown or unsupported protocol.
+        For any interface that does not support protocol
+        multiplexing, this counter is not present.
+
+        Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'last-clear'.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+    }
+
+    leaf in-fcs-errors {
+      type oc-yang:counter64;
+      status deprecated;
+      description
+        "Number of received packets which had errors in the
+        frame check sequence (FCS), i.e., framing errors.
+
+        Discontinuities in the value of this counter can occur
+        when the device is re-initialization as indicated by the
+        value of 'last-clear'.";
+    }
+
+    leaf carrier-transitions {
+      type oc-yang:counter64;
+      status deprecated;
+      description
+        "Number of times the interface state has transitioned
+        between up and down since the time the device restarted
+        or the last-clear time, whichever is most recent.";
+      oc-ext:telemetry-on-change;
+    }
+
+  }
+
+  // data definition statements
+
+  grouping sub-unnumbered-config {
+    description
+      "Configuration data for unnumbered subinterfaces";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "Indicates that the subinterface is unnumbered.  By default
+        the subinterface is numbered, i.e., expected to have an
+        IP address configuration.";
+    }
+  }
+
+  grouping sub-unnumbered-state {
+    description
+      "Operational state data unnumbered subinterfaces";
+  }
+
+  grouping sub-unnumbered-top {
+    description
+      "Top-level grouping unnumbered subinterfaces";
+
+    container unnumbered {
+      description
+        "Top-level container for setting unnumbered interfaces.
+        Includes reference the interface that provides the
+        address information";
+
+      container config {
+        description
+          "Configuration data for unnumbered interface";
+        oc-ext:telemetry-on-change;
+
+        uses sub-unnumbered-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for unnumbered interfaces";
+
+        uses sub-unnumbered-config;
+        uses sub-unnumbered-state;
+      }
+
+      uses oc-if:interface-ref;
+    }
+  }
+
+  grouping subinterfaces-config {
+    description
+      "Configuration data for subinterfaces";
+
+    leaf index {
+      type uint32;
+      default 0;
+      description
+        "The index of the subinterface, or logical interface number.
+        On systems with no support for subinterfaces, or not using
+        subinterfaces, this value should default to 0, i.e., the
+        default subinterface.";
+    }
+
+    uses interface-common-config;
+
+  }
+
+  grouping subinterfaces-state {
+    description
+      "Operational state data for subinterfaces";
+
+    oc-ext:operational;
+
+    leaf name {
+      type string;
+      description
+        "The system-assigned name for the sub-interface.  This MAY
+        be a combination of the base interface name and the
+        subinterface index, or some other convention used by the
+        system.";
+      oc-ext:telemetry-on-change;
+    }
+
+    uses interface-common-state;
+
+    container counters {
+      description
+        "A collection of interface specific statistics entitites which are
+        not common to subinterfaces.";
+
+      uses interface-common-counters-state;
+      uses subinterfaces-counters-state;
+     }
+  }
+
+  grouping subinterfaces-top {
+    description
+      "Subinterface data for logical interfaces associated with a
+      given interface";
+
+    container subinterfaces {
+      description
+        "Enclosing container for the list of subinterfaces associated
+        with a physical interface";
+
+      list subinterface {
+        key "index";
+
+        description
+          "The list of subinterfaces (logical interfaces) associated
+          with a physical interface";
+
+        leaf index {
+          type leafref {
+            path "../config/index";
+          }
+          description
+            "The index number of the subinterface -- used to address
+            the logical interface";
+        }
+
+        container config {
+          description
+            "Configurable items at the subinterface level";
+          oc-ext:telemetry-on-change;
+
+          uses subinterfaces-config;
+        }
+
+        container state {
+
+          config false;
+          description
+            "Operational state data for logical interfaces";
+
+          uses subinterfaces-config;
+          uses subinterfaces-state;
+        }
+      }
+    }
+  }
+
+  grouping interfaces-top {
+    description
+      "Top-level grouping for interface configuration and
+      operational state data";
+
+    container interfaces {
+      description
+        "Top level container for interfaces, including configuration
+        and state data.";
+
+
+      list interface {
+        key "name";
+
+        description
+          "The list of named interfaces on the device.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "References the name of the interface";
+            //TODO: need to consider whether this should actually
+            //reference the name in the state subtree, which
+            //presumably would be the system-assigned name, or the
+            //configured name.  Points to the config/name now
+            //because of YANG 1.0 limitation that the list
+            //key must have the same "config" as the list, and
+            //also can't point to a non-config node.
+        }
+
+        container config {
+          description
+            "Configurable items at the global, physical interface
+            level";
+          oc-ext:telemetry-on-change;
+
+          uses interface-phys-config;
+        }
+
+        container state {
+
+          config false;
+          description
+            "Operational state data at the global interface level";
+
+          uses interface-phys-config;
+          uses interface-common-state;
+
+          container counters {
+            description
+              "A collection of interface specific statistics entitites which are
+              not common to subinterfaces.";
+
+            uses interface-common-counters-state;
+            uses interface-counters-state;
+          }
+        }
+
+        uses interface-phys-holdtime-top;
+        uses subinterfaces-top;
+      }
+    }
+  }
+
+  uses interfaces-top;
+
+}

--- a/tools/internal/ocpaths/testdata/models/oc-models/openconfig-extensions.yang
+++ b/tools/internal/ocpaths/testdata/models/oc-models/openconfig-extensions.yang
@@ -1,0 +1,206 @@
+module openconfig-extensions {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/openconfig-ext";
+
+  prefix "oc-ext";
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module provides extensions to the YANG language to allow
+    OpenConfig specific functionality and meta-data to be defined.";
+
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2022-10-05" {
+    description
+      "Add missing version statement.";
+    reference "0.5.1";
+  }
+
+  revision "2020-06-16" {
+    description
+      "Add extension for POSIX pattern statements.";
+    reference "0.5.0";
+  }
+
+  revision "2018-10-17" {
+    description
+      "Add extension for regular expression type.";
+    reference "0.4.0";
+  }
+
+  revision "2017-04-11" {
+    description
+      "rename password type to 'hashed' and clarify description";
+    reference "0.3.0";
+  }
+
+  revision "2017-01-29" {
+    description
+      "Added extension for annotating encrypted values.";
+    reference "0.2.0";
+  }
+
+  revision "2015-10-09" {
+    description
+      "Initial OpenConfig public release";
+    reference "0.1.0";
+  }
+
+
+  // extension statements
+  extension openconfig-version {
+    argument "semver" {
+      yin-element false;
+    }
+    description
+      "The OpenConfig version number for the module. This is
+      expressed as a semantic version number of the form:
+        x.y.z
+      where:
+        * x corresponds to the major version,
+        * y corresponds to a minor version,
+        * z corresponds to a patch version.
+      This version corresponds to the model file within which it is
+      defined, and does not cover the whole set of OpenConfig models.
+
+      Individual YANG modules are versioned independently -- the
+      semantic version is generally incremented only when there is a
+      change in the corresponding file.  Submodules should always
+      have the same semantic version as their parent modules.
+
+      A major version number of 0 indicates that this model is still
+      in development (whether within OpenConfig or with industry
+      partners), and is potentially subject to change.
+
+      Following a release of major version 1, all modules will
+      increment major revision number where backwards incompatible
+      changes to the model are made.
+
+      The minor version is changed when features are added to the
+      model that do not impact current clients use of the model.
+
+      The patch-level version is incremented when non-feature changes
+      (such as bugfixes or clarifications to human-readable
+      descriptions that do not impact model functionality) are made
+      that maintain backwards compatibility.
+
+      The version number is stored in the module meta-data.";
+  }
+
+  extension openconfig-hashed-value {
+    description
+      "This extension provides an annotation on schema nodes to
+      indicate that the corresponding value should be stored and
+      reported in hashed form.
+
+      Hash algorithms are by definition not reversible. Clients
+      reading the configuration or applied configuration for the node
+      should expect to receive only the hashed value. Values written
+      in cleartext will be hashed. This annotation may be used on
+      nodes such as secure passwords in which the device never reports
+      a cleartext value, even if the input is provided as cleartext.";
+  }
+
+  extension regexp-posix {
+     description
+      "This extension indicates that the regular expressions included
+      within the YANG module specified are conformant with the POSIX
+      regular expression format rather than the W3C standard that is
+      specified by RFC6020 and RFC7950.";
+  }
+
+  extension posix-pattern {
+    argument "pattern" {
+      yin-element false;
+    }
+    description
+      "Provides a POSIX ERE regular expression pattern statement as an
+      alternative to YANG regular expresssions based on XML Schema Datatypes.
+      It is used the same way as the standard YANG pattern statement defined in
+      RFC6020 and RFC7950, but takes an argument that is a POSIX ERE regular
+      expression string.";
+    reference
+      "POSIX Extended Regular Expressions (ERE) Specification:
+      https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_04";
+  }
+
+  extension telemetry-on-change {
+    description
+      "The telemetry-on-change annotation is specified in the context
+      of a particular subtree (container, or list) or leaf within the
+      YANG schema. Where specified, it indicates that the value stored
+      by the nodes within the context change their value only in response
+      to an event occurring. The event may be local to the target, for
+      example - a configuration change, or external - such as the failure
+      of a link.
+
+      When a telemetry subscription allows the target to determine whether
+      to export the value of a leaf in a periodic or event-based fashion
+      (e.g., TARGET_DEFINED mode in gNMI), leaves marked as
+      telemetry-on-change should only be exported when they change,
+      i.e., event-based.";
+  }
+
+  extension telemetry-atomic {
+    description
+      "The telemetry-atomic annotation is specified in the context of
+      a subtree (containre, or list), and indicates that all nodes
+      within the subtree are always updated together within the data
+      model. For example, all elements under the subtree may be updated
+      as a result of a new alarm being raised, or the arrival of a new
+       protocol message.
+
+      Transport protocols may use the atomic specification to determine
+      optimisations for sending or storing the corresponding data.";
+  }
+
+  extension operational {
+    description
+      "The operational annotation is specified in the context of a
+      grouping, leaf, or leaf-list within a YANG module. It indicates
+      that the nodes within the context are derived state on the device.
+
+      OpenConfig data models divide nodes into the following three categories:
+
+       - intended configuration - these are leaves within a container named
+         'config', and are the writable configuration of a target.
+       - applied configuration - these are leaves within a container named
+         'state' and are the currently running value of the intended configuration.
+       - derived state - these are the values within the 'state' container which
+         are not part of the applied configuration of the device. Typically, they
+         represent state values reflecting underlying operational counters, or
+         protocol statuses.";
+  }
+
+  extension catalog-organization {
+    argument "org" {
+      yin-element false;
+    }
+    description
+      "This extension specifies the organization name that should be used within
+      the module catalogue on the device for the specified YANG module. It stores
+      a pithy string where the YANG organization statement may contain more
+      details.";
+  }
+
+  extension origin {
+    argument "origin" {
+      yin-element false;
+    }
+    description
+      "This extension specifies the name of the origin that the YANG module
+      falls within. This allows multiple overlapping schema trees to be used
+      on a single network element without requiring module based prefixing
+      of paths.";
+  }
+}

--- a/tools/internal/ocpaths/testdata/models/oc-models/platform/openconfig-platform.yang
+++ b/tools/internal/ocpaths/testdata/models/oc-models/platform/openconfig-platform.yang
@@ -1,0 +1,142 @@
+module openconfig-platform {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform";
+
+  prefix "oc-platform";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines a data model for representing a system
+    component inventory, which can include hardware or software
+    elements arranged in an arbitrary structure. The primary
+    relationship supported by the model is containment, e.g.,
+    components containing subcomponents.
+
+    It is expected that this model reflects every field replacable
+    unit on the device at a minimum (i.e., additional information
+    may be supplied about non-replacable components).
+
+    Every element in the inventory is termed a 'component' with each
+    component expected to have a unique name and type, and optionally
+    a unique system-assigned identifier and FRU number.  The
+    uniqueness is guaranteed by the system within the device.
+
+    Components may have properties defined by the system that are
+    modeled as a list of key-value pairs. These may or may not be
+    user-configurable.  The model provides a flag for the system
+    to optionally indicate which properties are user configurable.
+
+    Each component also has a list of 'subcomponents' which are
+    references to other components. Appearance in a list of
+    subcomponents indicates a containment relationship as described
+    above.  For example, a linecard component may have a list of
+    references to port components that reside on the linecard.
+
+    This schema is generic to allow devices to express their own
+    platform-specific structure.  It may be augmented by additional
+    component type-specific schemas that provide a common structure
+    for well-known component types.  In these cases, the system is
+    expected to populate the common component schema, and may
+    optionally also represent the component and its properties in the
+    generic structure.
+
+    The properties for each component may include dynamic values,
+    e.g., in the 'state' part of the schema.  For example, a CPU
+    component may report its utilization, temperature, or other
+    physical properties.  The intent is to capture all platform-
+    specific physical data in one location, including inventory
+    (presence or absence of a component) and state (physical
+    attributes or status).";
+
+  oc-ext:openconfig-version "0.23.0";
+
+  revision "2023-02-13" {
+    description
+      "Refactor resource utilization threshold config into a separate grouping.
+      Update 'utilization resource' to 'resource utilization'.";
+    reference "0.23.0";
+  }
+
+  grouping platform-component-config {
+    description
+      "Configuration data for components";
+
+    leaf name {
+      type string;
+      description
+        "Device name for the component -- this may not be a
+        configurable parameter on many implementations.  Where
+        component preconfiguration is supported, for example,
+        the component name may be configurable.";
+    }
+
+    leaf description {
+      type string;
+      description
+        "System-supplied description of the component";
+    }
+  }
+
+  grouping platform-component-top {
+    description
+      "Top-level grouping for components in the device inventory";
+
+    container components {
+      description
+        "Enclosing container for the components in the system.";
+
+      list component {
+        key "name";
+        description
+          "List of components, keyed by component name.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "References the component name";
+        }
+
+        container config {
+          description
+            "Configuration data for each component";
+
+          uses platform-component-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for each component";
+
+          uses platform-component-config;
+        }
+
+      }
+    }
+  }
+
+
+  // data definition statements
+
+  uses platform-component-top;
+
+
+  // augments
+
+
+}

--- a/tools/internal/ocpaths/testdata/models/oc-models/types/openconfig-inet-types.yang
+++ b/tools/internal/ocpaths/testdata/models/oc-models/types/openconfig-inet-types.yang
@@ -1,0 +1,478 @@
+module openconfig-inet-types {
+
+  yang-version "1";
+  namespace "http://openconfig.net/yang/types/inet";
+  prefix "oc-inet";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module contains a set of Internet address related
+    types for use in OpenConfig modules.
+
+    Portions of this code were derived from IETF RFC 6021.
+    Please reproduce this note if possible.
+
+    IETF code is subject to the following copyright and license:
+    Copyright (c) IETF Trust and the persons identified as authors of
+    the code.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, is permitted pursuant to, and subject to the license
+    terms contained in, the Simplified BSD License set forth in
+    Section 4.c of the IETF Trust's Legal Provisions Relating
+    to IETF Documents (http://trustee.ietf.org/license-info).";
+
+  oc-ext:openconfig-version "0.6.0";
+
+  revision "2023-02-06" {
+    description
+      "Add ipv6-link-local and ipv6-address-type";
+    reference "0.6.0";
+  }
+
+  revision "2021-08-17" {
+    description
+      "Add ip-address-zoned typedef as a union between ipv4-address-zoned
+      and ipv6-address-zoned types.";
+    reference "0.5.0";
+  }
+
+  revision "2021-07-14" {
+    description
+      "Use auto-generated regex for ipv4 pattern statements:
+      - ipv4-address
+      - ipv4-address-zoned
+      - ipv4-prefix";
+    reference "0.4.1";
+  }
+
+  revision "2021-01-07" {
+    description
+      "Remove module extension oc-ext:regexp-posix by making pattern regexes
+      conform to RFC7950.
+
+      Types impacted:
+      - ipv4-address
+      - ipv4-address-zoned
+      - ipv6-address
+      - domain-name";
+    reference "0.4.0";
+  }
+
+  revision "2020-10-12" {
+    description
+      "Fix anchors for domain-name pattern.";
+    reference "0.3.5";
+  }
+
+  revision "2020-06-30" {
+    description
+      "Add OpenConfig POSIX pattern extensions and add anchors for domain-name
+      pattern.";
+    reference "0.3.4";
+  }
+
+  revision "2019-04-25" {
+    description
+      "Fix regex bug for ipv6-prefix type";
+    reference "0.3.3";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.2";
+  }
+
+  revision 2017-08-24 {
+    description
+      "Minor formatting fixes.";
+    reference "0.3.1";
+  }
+
+  revision 2017-07-06 {
+    description
+      "Add domain-name and host typedefs";
+    reference "0.3.0";
+  }
+
+  revision 2017-04-03 {
+    description
+      "Add ip-version typedef.";
+    reference "0.2.0";
+  }
+
+  revision 2017-04-03 {
+    description
+      "Update copyright notice.";
+    reference "0.1.1";
+  }
+
+  revision 2017-01-26 {
+    description
+      "Initial module for inet types";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // IPv4 and IPv6 types.
+
+  typedef ipv4-address {
+    type string {
+      pattern
+        '([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\.([0-9]|'
+        + '[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3}';
+      oc-ext:posix-pattern
+        '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\.([0-9]|'
+        + '[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3})$';
+    }
+    description
+      "An IPv4 address in dotted quad notation using the default
+      zone.";
+  }
+
+  typedef ipv4-address-zoned {
+    type string {
+      pattern
+        '([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\.([0-9]|'
+        + '[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3}(%[a-zA-Z0-9_]+)';
+      oc-ext:posix-pattern
+        '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\.([0-9]|'
+        + '[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3}(%[a-zA-Z0-9_]+))$';
+    }
+    description
+      "An IPv4 address in dotted quad notation.  This type allows
+      specification of a zone index to disambiguate identical
+      address values.  For link-local addresses, the index is
+      typically the interface index or interface name.";
+  }
+
+  typedef ipv6-address {
+    type string {
+        pattern
+          // Must support compression through different lengths
+          // therefore this regexp is complex.
+          '(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|'         +
+          '([0-9a-fA-F]{1,4}:){1,7}:|'                        +
+          '([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|'        +
+          '([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|' +
+          '([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|' +
+          '([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|' +
+          '([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|' +
+          '[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|'      +
+          ':((:[0-9a-fA-F]{1,4}){1,7}|:)'                     +
+          ')';
+        oc-ext:posix-pattern
+          // Must support compression through different lengths
+          // therefore this regexp is complex.
+          '^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|'         +
+          '([0-9a-fA-F]{1,4}:){1,7}:|'                        +
+          '([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|'        +
+          '([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|' +
+          '([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|' +
+          '([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|' +
+          '([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|' +
+          '[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|'      +
+          ':((:[0-9a-fA-F]{1,4}){1,7}|:)'                     +
+          ')$';
+    }
+    description
+      "An IPv6 address represented as either a full address; shortened
+      or mixed-shortened formats, using the default zone.";
+  }
+
+  typedef ipv6-address-zoned {
+    type string {
+        pattern
+          // Must support compression through different lengths
+          // therefore this regexp is complex.
+          '^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|'         +
+          '([0-9a-fA-F]{1,4}:){1,7}:|'                        +
+          '([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|'        +
+          '([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|' +
+          '([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|' +
+          '([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|' +
+          '([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|' +
+          '[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|'      +
+          ':((:[0-9a-fA-F]{1,4}){1,7}|:)'                     +
+          ')(%[a-zA-Z0-9_]+)$';
+        oc-ext:posix-pattern
+          // Must support compression through different lengths
+          // therefore this regexp is complex.
+          '^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|'         +
+          '([0-9a-fA-F]{1,4}:){1,7}:|'                        +
+          '([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|'        +
+          '([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|' +
+          '([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|' +
+          '([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|' +
+          '([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|' +
+          '[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|'      +
+          ':((:[0-9a-fA-F]{1,4}){1,7}|:)'                     +
+          ')(%[a-zA-Z0-9_]+)$';
+    }
+    description
+      "An IPv6 address represented as either a full address; shortened
+      or mixed-shortened formats.  This type allows specification of
+      a zone index to disambiguate identical address values.  For
+      link-local addresses, the index is typically the interface
+      index or interface name.";
+  }
+
+  typedef ipv4-prefix {
+    type string {
+      pattern
+        '([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\.([0-9]|'
+        + '[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3}/([0-9]|[12][0-9]|'
+        + '3[0-2])';
+      oc-ext:posix-pattern
+        '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\.([0-9]|'
+        + '[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3}/([0-9]|[12][0-9]|'
+        + '3[0-2]))$';
+    }
+    description
+      "An IPv4 prefix represented in dotted quad notation followed by
+      a slash and a CIDR mask (0 <= mask <= 32).";
+  }
+
+  typedef ipv6-prefix {
+    type string {
+        pattern
+          '(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|'         +
+          '([0-9a-fA-F]{1,4}:){1,7}:|'                        +
+          '([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|'         +
+          '([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|' +
+          '([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|' +
+          '([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|' +
+          '([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|' +
+          '[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|'      +
+          ':((:[0-9a-fA-F]{1,4}){1,7}|:)'                     +
+          ')/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9])';
+        oc-ext:posix-pattern
+          '^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|'         +
+          '([0-9a-fA-F]{1,4}:){1,7}:|'                        +
+          '([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|'         +
+          '([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|' +
+          '([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|' +
+          '([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|' +
+          '([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|' +
+          '[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|'      +
+          ':((:[0-9a-fA-F]{1,4}){1,7}|:)'                     +
+          ')/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9])$';
+    }
+    description
+      "An IPv6 prefix represented in full, shortened, or mixed
+      shortened format followed by a slash and CIDR mask
+      (0 <= mask <= 128).";
+  }
+
+  typedef ip-address {
+    type union {
+      type ipv4-address;
+      type ipv6-address;
+    }
+    description
+      "An IPv4 or IPv6 address with no prefix specified.";
+  }
+
+  typedef ip-address-zoned {
+    type union {
+      type ipv4-address-zoned;
+      type ipv6-address-zoned;
+    }
+    description
+      "An IPv4 or IPv6 address with no prefix specified and an optional
+      zone index.";
+  }
+
+  typedef ip-prefix {
+    type union {
+      type ipv4-prefix;
+      type ipv6-prefix;
+    }
+    description
+      "An IPv4 or IPv6 prefix.";
+  }
+
+  typedef ip-version {
+    type enumeration {
+      enum UNKNOWN {
+        value 0;
+        description
+         "An unknown or unspecified version of the Internet
+          protocol.";
+      }
+      enum IPV4 {
+        value 4;
+        description
+         "The IPv4 protocol as defined in RFC 791.";
+      }
+      enum IPV6 {
+        value 6;
+        description
+         "The IPv6 protocol as defined in RFC 2460.";
+      }
+    }
+    description
+     "This value represents the version of the IP protocol.
+      Note that integer representation of the enumerated values
+      are not specified, and are not required to follow the
+      InetVersion textual convention in SMIv2.";
+    reference
+     "RFC  791: Internet Protocol
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+      RFC 4001: Textual Conventions for Internet Network Addresses";
+  }
+
+  typedef ipv6-address-type {
+    type enumeration {
+      enum GLOBAL_UNICAST {
+        description
+          "The IPv6 address is a global unicast address type and must be in
+          the format defined in RFC 4291 section 2.4.";
+      }
+      enum LINK_LOCAL_UNICAST {
+        description
+          "The IPv6 address is a Link-Local unicast address type and must be
+          in the format defined in RFC 4291 section 2.4.";
+      }
+    }
+    description
+      "The value represents the type of IPv6 address";
+    reference
+      "RFC 4291: IP Version 6 Addressing Architecture
+      section 2.5";
+  }
+
+  typedef domain-name {
+    type string {
+      length "1..253";
+      pattern
+        '(((([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.)*' +
+        '([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.?)'    +
+        '|\.)';
+      oc-ext:posix-pattern
+        '^(((([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.)*' +
+        '([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.?)'    +
+        '|\.)$';
+    }
+    description
+      "The domain-name type represents a DNS domain name.
+      Fully quallified left to the models which utilize this type.
+
+      Internet domain names are only loosely specified.  Section
+      3.5 of RFC 1034 recommends a syntax (modified in Section
+      2.1 of RFC 1123).  The pattern above is intended to allow
+      for current practice in domain name use, and some possible
+      future expansion.  It is designed to hold various types of
+      domain names, including names used for A or AAAA records
+      (host names) and other records, such as SRV records.  Note
+      that Internet host names have a stricter syntax (described
+      in RFC 952) than the DNS recommendations in RFCs 1034 and
+      1123, and that systems that want to store host names in
+      schema nodes using the domain-name type are recommended to
+      adhere to this stricter standard to ensure interoperability.
+
+      The encoding of DNS names in the DNS protocol is limited
+      to 255 characters.  Since the encoding consists of labels
+      prefixed by a length bytes and there is a trailing NULL
+      byte, only 253 characters can appear in the textual dotted
+      notation.
+
+      Domain-name values use the US-ASCII encoding.  Their canonical
+      format uses lowercase US-ASCII characters.  Internationalized
+      domain names MUST be encoded in punycode as described in RFC
+      3492";
+  }
+
+  typedef host {
+    type union {
+      type ip-address;
+      type domain-name;
+    }
+    description
+      "The host type represents either an unzoned IP address or a DNS
+      domain name.";
+  }
+
+  typedef as-number {
+    type uint32;
+    description
+      "A numeric identifier for an autonomous system (AS). An AS is a
+      single domain, under common administrative control, which forms
+      a unit of routing policy. Autonomous systems can be assigned a
+      2-byte identifier, or a 4-byte identifier which may have public
+      or private scope. Private ASNs are assigned from dedicated
+      ranges. Public ASNs are assigned from ranges allocated by IANA
+      to the regional internet registries (RIRs).";
+    reference
+      "RFC 1930 Guidelines for creation, selection, and registration
+                of an Autonomous System (AS)
+       RFC 4271 A Border Gateway Protocol 4 (BGP-4)";
+  }
+
+  typedef dscp {
+    type uint8 {
+      range "0..63";
+    }
+    description
+      "A differentiated services code point (DSCP) marking within the
+      IP header.";
+    reference
+      "RFC 2474 Definition of the Differentiated Services Field
+                 (DS Field) in the IPv4 and IPv6 Headers";
+  }
+
+  typedef ipv6-flow-label {
+    type uint32 {
+      range "0..1048575";
+    }
+    description
+      "The IPv6 flow-label is a 20-bit value within the IPv6 header
+      which is optionally used by the source of the IPv6 packet to
+      label sets of packets for which special handling may be
+      required.";
+    reference
+      "RFC 2460 Internet Protocol, Version 6 (IPv6) Specification";
+  }
+
+  typedef port-number {
+    type uint16;
+    description
+      "A 16-bit port number used by a transport protocol such as TCP
+      or UDP.";
+    reference
+      "RFC 768 User Datagram Protocol
+       RFC 793 Transmission Control Protocol";
+  }
+
+  typedef uri {
+    type string;
+    description
+      "An ASCII-encoded Uniform Resource Identifier (URI) as defined
+      in RFC 3986.";
+    reference
+      "RFC 3986 Uniform Resource Identifier (URI): Generic Syntax";
+  }
+
+  typedef url {
+    type string;
+    description
+      "An ASCII-encoded Uniform Resource Locator (URL) as defined
+      in RFC 3986, section 1.1.3";
+    reference
+      "RFC 3986, paragraph 1.1.3";
+  }
+
+}

--- a/tools/internal/ocpaths/testdata/models/oc-models/types/openconfig-types.yang
+++ b/tools/internal/ocpaths/testdata/models/oc-models/types/openconfig-types.yang
@@ -1,0 +1,471 @@
+module openconfig-types {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/openconfig-types";
+
+  prefix "oc-types";
+
+  // import statements
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module contains a set of general type definitions that
+    are used across OpenConfig models. It can be imported by modules
+    that make use of these types.";
+
+  oc-ext:openconfig-version "0.6.0";
+
+  revision "2019-04-16" {
+    description
+      "Clarify definition of timeticks64.";
+    reference "0.6.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.5.1";
+  }
+
+  revision "2018-05-05" {
+    description
+      "Add grouping of min-max-time and
+       included them to all stats with min/max/avg";
+    reference "0.5.0";
+  }
+
+  revision "2018-01-16" {
+    description
+      "Add interval to min/max/avg stats; add percentage stat";
+    reference "0.4.0";
+  }
+
+  revision "2017-08-16" {
+    description
+      "Apply fix for ieetfloat32 length parameter";
+    reference "0.3.3";
+  }
+
+  revision "2017-01-13" {
+    description
+      "Add ADDRESS_FAMILY identity";
+    reference "0.3.2";
+  }
+
+  revision "2016-11-14" {
+    description
+      "Correct length of ieeefloat32";
+    reference "0.3.1";
+  }
+
+  revision "2016-11-11" {
+    description
+      "Additional types - ieeefloat32 and routing-password";
+    reference "0.3.0";
+  }
+
+  revision "2016-05-31" {
+    description
+      "OpenConfig public release";
+    reference "0.2.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  typedef percentage {
+    type uint8 {
+      range "0..100";
+    }
+    description
+      "Integer indicating a percentage value";
+  }
+
+  typedef std-regexp {
+    type string;
+    description
+      "This type definition is a placeholder for a standard
+      definition of a regular expression that can be utilised in
+      OpenConfig models. Further discussion is required to
+      consider the type of regular expressions that are to be
+      supported. An initial proposal is POSIX compatible.";
+  }
+
+  typedef timeticks64 {
+    type uint64;
+    units "nanoseconds";
+    description
+     "The timeticks64 represents the time, modulo 2^64 in
+     nanoseconds between two epochs. The leaf using this
+     type must define the epochs that tests are relative to.";
+  }
+
+  typedef ieeefloat32 {
+    type binary {
+      length "4";
+    }
+    description
+      "An IEEE 32-bit floating point number. The format of this number
+      is of the form:
+        1-bit  sign
+        8-bit  exponent
+        23-bit fraction
+      The floating point value is calculated using:
+        (-1)**S * 2**(Exponent-127) * (1+Fraction)";
+  }
+
+  typedef routing-password {
+    type string;
+    description
+      "This type is indicative of a password that is used within
+      a routing protocol which can be returned in plain text to the
+      NMS by the local system. Such passwords are typically stored
+      as encrypted strings. Since the encryption used is generally
+      well known, it is possible to extract the original value from
+      the string - and hence this format is not considered secure.
+      Leaves specified with this type should not be modified by
+      the system, and should be returned to the end-user in plain
+      text. This type exists to differentiate passwords, which
+      may be sensitive, from other string leaves. It could, for
+      example, be used by the NMS to censor this data when
+      viewed by particular users.";
+  }
+
+  typedef stat-interval {
+    type uint64;
+    units nanoseconds;
+    description
+      "A time interval over which a set of statistics is computed.
+      A common usage is to report the interval over which
+      avg/min/max stats are computed and reported.";
+  }
+
+  grouping stat-interval-state {
+    description
+      "Reusable leaf definition for stats computation interval";
+
+    leaf interval {
+      type oc-types:stat-interval;
+      description
+        "If supported by the system, this reports the time interval
+        over which the min/max/average statistics are computed by
+        the system.";
+    }
+  }
+
+  grouping min-max-time {
+    description
+      "Common grouping for recording the absolute time at which
+      the minimum and maximum values occurred in the statistics";
+
+    leaf min-time {
+      type oc-types:timeticks64;
+      description
+        "The absolute time at which the minimum value occurred.
+         The value is the timestamp in nanoseconds relative to
+          the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf max-time {
+      type oc-types:timeticks64;
+      description
+        "The absolute time at which the maximum value occurred.
+         The value is the timestamp in nanoseconds relative to
+          the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+  }
+
+  grouping avg-min-max-stats-precision1 {
+    description
+      "Common nodes for recording average, minimum, and
+      maximum values for a statistic.  These values all have
+      fraction-digits set to 1.  Statistics are computed
+      and reported based on a moving time interval (e.g., the last
+      30s).  If supported by the device, the time interval over which
+      the statistics are computed is also reported.";
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      description
+        "The minimum value of the statistic over the time
+        interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      description
+        "The maximum value of the statitic over the time
+        interval.";
+    }
+
+    uses stat-interval-state;
+    uses min-max-time;
+  }
+
+  grouping avg-min-max-instant-stats-precision1 {
+    description
+      "Common grouping for recording an instantaneous statistic value
+      in addition to avg-min-max stats";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    uses avg-min-max-stats-precision1;
+  }
+
+  grouping avg-min-max-instant-stats-precision2-dB {
+    description
+      "Common grouping for recording dB values with 2 decimal
+      precision. Values include the instantaneous, average,
+      minimum, and maximum statistics.  Statistics are computed
+      and reported based on a moving time interval (e.g., the last
+      30s).  If supported by the device, the time interval over which
+      the statistics are computed, and the times at which the minimum
+      and maximum values occurred, are also reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dB;
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dB;
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dB;
+      description
+        "The minimum value of the statistic over the time interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dB;
+      description
+        "The maximum value of the statistic over the time
+        interval.";
+    }
+
+    uses stat-interval-state;
+    uses min-max-time;
+  }
+
+  grouping avg-min-max-instant-stats-precision2-dBm {
+    description
+      "Common grouping for recording dBm values with 2 decimal
+      precision. Values include the instantaneous, average,
+      minimum, and maximum statistics.  Statistics are computed
+      and reported based on a moving time interval (e.g., the last
+      30s).  If supported by the device, the time interval over which
+      the statistics are computed, and the times at which the minimum
+      and maximum values occurred, are also reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "The minimum value of the statistic over the time
+        interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "The maximum value of the statistic over the time interval.";
+    }
+
+    uses stat-interval-state;
+    uses min-max-time;
+  }
+
+  grouping avg-min-max-instant-stats-precision2-mA {
+    description
+      "Common grouping for recording mA values with 2 decimal
+      precision. Values include the instantaneous, average,
+      minimum, and maximum statistics.  Statistics are computed
+      and reported based on a moving time interval (e.g., the last
+      30s).  If supported by the device, the time interval over which
+      the statistics are computed, and the times at which the minimum
+      and maximum values occurred, are also reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units mA;
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units mA;
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units mA;
+      description
+        "The minimum value of the statistic over the time
+        interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units mA;
+      description
+        "The maximum value of the statistic over the time
+        interval.";
+    }
+
+    uses stat-interval-state;
+    uses min-max-time;
+  }
+
+  grouping avg-min-max-instant-stats-pct {
+    description
+      "Common grouping for percentage statistics.
+      Values include the instantaneous, average,
+      minimum, and maximum statistics.  Statistics are computed
+      and reported based on a moving time interval (e.g., the last
+      30s).  If supported by the device, the time interval over which
+      the statistics are computed, and the times at which the minimum
+      and maximum values occurred, are also reported.";
+
+    leaf instant {
+      type oc-types:percentage;
+      description
+        "The instantaneous percentage value.";
+    }
+
+    leaf avg {
+      type oc-types:percentage;
+      description
+        "The arithmetic mean value of the percentage measure of the
+        statistic over the time interval.";
+    }
+
+    leaf min {
+      type oc-types:percentage;
+      description
+        "The minimum value of the percentage measure of the
+        statistic over the time interval.";
+    }
+
+    leaf max {
+      type oc-types:percentage;
+      description
+        "The maximum value of the percentage measure of the
+        statistic over the time interval.";
+    }
+
+    uses stat-interval-state;
+    uses min-max-time;
+  }
+
+  identity ADDRESS_FAMILY {
+    description
+      "A base identity for all address families";
+  }
+
+  identity IPV4 {
+    base ADDRESS_FAMILY;
+    description
+      "The IPv4 address family";
+  }
+
+  identity IPV6 {
+    base ADDRESS_FAMILY;
+    description
+      "The IPv6 address family";
+  }
+
+  identity MPLS {
+    base ADDRESS_FAMILY;
+    description
+      "The MPLS address family";
+  }
+
+  identity L2_ETHERNET {
+    base ADDRESS_FAMILY;
+    description
+      "The 802.3 Ethernet address family";
+  }
+
+}

--- a/tools/internal/ocpaths/testdata/models/oc-models/types/openconfig-yang-types.yang
+++ b/tools/internal/ocpaths/testdata/models/oc-models/types/openconfig-yang-types.yang
@@ -1,0 +1,230 @@
+module openconfig-yang-types {
+
+  yang-version "1";
+  namespace "http://openconfig.net/yang/types/yang";
+  prefix "oc-yang";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module contains a set of extension types to the
+    YANG builtin types that are used across multiple
+    OpenConfig models.
+
+    Portions of this code were derived from IETF RFC 6021.
+    Please reproduce this note if possible.
+
+    IETF code is subject to the following copyright and license:
+    Copyright (c) IETF Trust and the persons identified as authors of
+    the code.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, is permitted pursuant to, and subject to the license
+    terms contained in, the Simplified BSD License set forth in
+    Section 4.c of the IETF Trust's Legal Provisions Relating
+    to IETF Documents (http://trustee.ietf.org/license-info).";
+
+  oc-ext:openconfig-version "0.3.1";
+
+  revision "2021-07-14" {
+    description
+      "Use auto-generated regex for certain pattern statements:
+      - dotted-quad
+      - date-and-time
+      - date
+
+      For date-and-time, allow lowercase z and t in the pattern.";
+    reference "0.3.1";
+  }
+
+  revision "2021-03-02" {
+    description
+      "Fix date-and-time and date's pattern statement, and remove the
+      regexp-posix extension, which makes pattern statements conform to the
+      YANG standard.";
+    reference "0.3.0";
+  }
+
+  revision "2020-06-30" {
+    description
+      "Add OpenConfig POSIX pattern extensions.";
+    reference "0.2.2";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.2.1";
+  }
+
+  revision 2018-04-24 {
+    description
+      "Add date typedef";
+    reference "0.2.0";
+  }
+
+  revision 2017-07-30 {
+    description
+      "Fixed unprintable character";
+    reference "0.1.2";
+  }
+
+  revision 2017-04-03 {
+    description
+      "Update copyright notice.";
+    reference "0.1.1";
+  }
+
+  revision 2017-01-26 {
+    description
+      "Initial module for inet types";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  typedef dotted-quad {
+    type string {
+      pattern
+        '([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\.([0-9]|'
+        + '[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3}';
+      oc-ext:posix-pattern
+        '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\.([0-9]|'
+        + '[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3})$';
+    }
+    description
+      "An unsigned 32-bit integer expressed as a dotted quad. The
+      format is four octets written as decimal numbers separated
+      with a period character.";
+  }
+
+  typedef hex-string {
+    type string {
+      pattern '[0-9a-fA-F]*';
+      oc-ext:posix-pattern '^[0-9a-fA-F]*$';
+    }
+    description
+      "A string consisting of a hexadecimal characters.";
+  }
+
+  typedef counter32 {
+    type uint32;
+    description
+
+      "A 32-bit counter. A counter value is a monotonically increasing
+      value which is used to express a count of a number of
+      occurrences of a particular event or entity. When the counter
+      reaches its maximum value, in this case 2^32-1, it wraps to 0.
+
+      Discontinuities in the counter are generally triggered only when
+      the counter is reset to zero.";
+  }
+
+  typedef counter64 {
+    type uint64;
+    description
+      "A 64-bit counter. A counter value is a monotonically increasing
+      value which is used to express a count of a number of
+      occurrences of a particular event or entity. When a counter64
+      reaches its maximum value, 2^64-1, it loops to zero.
+      Discontinuities in a counter are generally triggered only when
+      the counter is reset to zero, through operator or system
+      intervention.";
+  }
+
+  typedef date-and-time {
+    type string {
+      pattern
+        '[0-9]{4}\-(0[1-9]|1[0-2])\-(0[1-9]|[12][0-9]|3[01])[Tt](0[0-9]|'
+        + '1[0-9]|2[0-3]):(0[0-9]|[1-5][0-9]):(0[0-9]|[1-5][0-9]|'
+        + '60)(\.[0-9]+)?([Zz]|([+-](0[0-9]|1[0-9]|2[0-3]):(0[0-9]|'
+        + '[1-5][0-9])))';
+      oc-ext:posix-pattern
+        '^([0-9]{4}\-(0[1-9]|1[0-2])\-(0[1-9]|[12][0-9]|3[01])[Tt](0[0-9]|'
+        + '1[0-9]|2[0-3]):(0[0-9]|[1-5][0-9]):(0[0-9]|[1-5][0-9]|'
+        + '60)(\.[0-9]+)?([Zz]|([+-](0[0-9]|1[0-9]|2[0-3]):(0[0-9]|'
+        + '[1-5][0-9]))))$';
+    }
+    description
+      "A date and time, expressed in the format described in RFC3339.
+      That is to say:
+
+      YYYY-MM-DDTHH:MM:SSZ+-hh:mm
+
+      where YYYY is the year, MM is the month expressed as a two-digit
+      month (zero padding if required), DD is the day of the month,
+      expressed as a two digit value. T is the literal character 'T',
+      HH is the hour of the day expressed as a two digit number, using
+      the 24-hour clock, MM is the minute of the hour expressed as a
+      two digit number. Z is the literal character 'Z', followed by a
+      timezone offset expressed in hours (hh) and minutes (mm), both
+      expressed as two digit numbers. The time offset is specified as
+      a positive or negative offset to UTC using the '+' or '-'
+      character preceding the offset.
+
+      Optionally, fractional seconds can be expressed after the minute
+      of the hour as a decimal number of unspecified precision
+      reflecting fractions of a second.";
+    reference
+      "RFC3339 - Date and Time on the Internet: Timestamps";
+  }
+
+  typedef date {
+    type string {
+      pattern
+        '[0-9]{4}\-(0[1-9]|1[0-2])\-(0[1-9]|[12][0-9]|3[01])';
+      oc-ext:posix-pattern
+        '^([0-9]{4}\-(0[1-9]|1[0-2])\-(0[1-9]|[12][0-9]|3[01]))$';
+    }
+    description
+      "A full UTC date, expressed in the format described in RFC3339.
+      That is to say:
+
+      YYYY-MM-DD
+
+      where YYYY is the year, MM is the month expressed as a two-digit
+      month (zero padding if required), DD is the day of the month,
+      expressed as a two digit value.";
+
+    reference
+      "RFC3339 - Date and Time on the Internet: full-date";
+  }
+
+  typedef gauge64 {
+    type uint64;
+    description
+      "A gauge value may increase or decrease - and reflects a value
+      at a particular point in time. If the value of the variable
+      being modeled using the gauge exceeds its maximum - 2^64-1 in
+      this case - the gauge is set to its maximum value.";
+  }
+
+  typedef phys-address {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+      oc-ext:posix-pattern '^([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?$';
+    }
+    description
+      "A physical layer address, expressed as a series of pairs of
+      hexadecimal digits.";
+  }
+
+  typedef mac-address {
+    type string {
+      pattern '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}';
+      oc-ext:posix-pattern '^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$';
+    }
+    description
+      "An IEEE 802 MAC address";
+  }
+}

--- a/tools/nosimage/README.md
+++ b/tools/nosimage/README.md
@@ -1,0 +1,21 @@
+## Using the NOSImageProfile Validator Script
+
+### Running on Example Files
+
+```
+cd $GOPATH/src/github.com/openconfig/featureprofiles/tools/nosimage
+go run validate/validate.go -file example/example_nosimageprofile.textproto; rm -rf public
+```
+
+```
+cd $GOPATH/src/github.com/openconfig/featureprofiles/tools/nosimage
+go run validate/validate.go -file example/example_nosimageprofile_invalid.textproto; rm -rf public
+```
+
+### Re-generating Example Files
+
+```
+cd $GOPATH/src/github.com/openconfig/featureprofiles/tools/nosimage
+go run example/generate_example.go -file-path example/example_nosimageprofile.textproto
+go run example/generate_example.go -file-path example/example_nosimageprofile_invalid.textproto -invalid
+```

--- a/tools/nosimage/example/example_nosimageprofile.textproto
+++ b/tools/nosimage/example/example_nosimageprofile.textproto
@@ -1,0 +1,65 @@
+# proto-file: github.com/openconfig/featureprofiles/proto/nosimage.proto
+# proto-message: NOSImageProfile
+# txtpbfmt: expand_all_children
+# txtpbfmt: sort_repeated_fields_by_content
+vendor_id: OPENCONFIG
+nos: "lemming"
+software_version: "7a1cb734c83f0d9ba5b273f920bc002ad0056178"
+release_date: {
+  seconds: 1700180400
+}
+ocpaths: {
+  ocpaths: {
+    name: "/interfaces/interface/config/name"
+  }
+  ocpaths: {
+    name: "/components/component/state/location"
+    ocpath_constraint: {
+      platform_type: "PORT"
+    }
+  }
+  ocpaths: {
+    name: "/components/component/state/serial-no"
+    ocpath_constraint: {
+      platform_type: "STORAGE"
+    }
+  }
+  ocpaths: {
+    name: "/components/component/state/software-version"
+    ocpath_constraint: {
+      platform_type: "OPERATING_SYSTEM"
+    }
+  }
+  ocpaths: {
+    name: "/network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/peer-as"
+  }
+  version: "2.5.0"
+}
+ocrpcs: {
+  ocservices: {
+    key: "gnmi.gNMI"
+    value: {
+      method_name: "Set"
+      method_name: "Subscribe"
+      version: "0.10.0"
+    }
+  }
+  ocservices: {
+    key: "gnoi.bgp.BGP"
+    value: {
+      method_name: "ClearBGPNeighbor"
+      version: "0.1.0"
+    }
+  }
+  ocservices: {
+    key: "gnoi.healthz.Healthz"
+    value: {
+      method_name: "Acknowledge"
+      method_name: "Artifact"
+      method_name: "Check"
+      method_name: "Get"
+      method_name: "List"
+      version: "1.3.0"
+    }
+  }
+}

--- a/tools/nosimage/example/example_nosimageprofile_invalid.textproto
+++ b/tools/nosimage/example/example_nosimageprofile_invalid.textproto
@@ -1,0 +1,65 @@
+# proto-file: github.com/openconfig/featureprofiles/proto/nosimage.proto
+# proto-message: NOSImageProfile
+# txtpbfmt: expand_all_children
+# txtpbfmt: sort_repeated_fields_by_content
+vendor_id: OPENCONFIG
+nos: "lemming"
+software_version: "7a1cb734c83f0d9ba5b273f920bc002ad0056178"
+release_date: {
+  seconds: 1700180400
+}
+ocpaths: {
+  ocpaths: {
+    name: "/interfaces/interface/config/name"
+  }
+  ocpaths: {
+    name: "/componentsssssssssss/component/state/location"
+    ocpath_constraint: {
+      platform_type: "PORT"
+    }
+  }
+  ocpaths: {
+    name: "/componentsssssssssss/component/state/serial-no"
+    ocpath_constraint: {
+      platform_type: "STORAGE"
+    }
+  }
+  ocpaths: {
+    name: "/components/component/state/software-version"
+    ocpath_constraint: {
+      platform_type: "JOVIAN_ATMOSPHERE"
+    }
+  }
+  ocpaths: {
+    name: "/network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/peer-as"
+  }
+  version: "2.5.0"
+}
+ocrpcs: {
+  ocservices: {
+    key: "gnmi.gNMI"
+    value: {
+      method_name: "Set"
+      method_name: "Subscribe"
+      version: "0.10.0"
+    }
+  }
+  ocservices: {
+    key: "gnoi.bgp.BGP"
+    value: {
+      method_name: "ClearBGPNeighbor"
+      version: "0.1.0"
+    }
+  }
+  ocservices: {
+    key: "gnoi.healthz.Healthz"
+    value: {
+      method_name: "Acknowledge"
+      method_name: "Artifact"
+      method_name: "Check"
+      method_name: "Get"
+      method_name: "List"
+      version: "1.3.0"
+    }
+  }
+}

--- a/tools/nosimage/example/example_nosimageprofile_invalid.textproto
+++ b/tools/nosimage/example/example_nosimageprofile_invalid.textproto
@@ -10,7 +10,7 @@ release_date: {
 }
 ocpaths: {
   ocpaths: {
-    name: "/interfaces/interface/config/name"
+    name: "/interfaces/interface/config/does-not-exist"
   }
   ocpaths: {
     name: "/componentsssssssssss/component/state/location"

--- a/tools/nosimage/example/generate_example.go
+++ b/tools/nosimage/example/generate_example.go
@@ -1,0 +1,156 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/protocolbuffers/txtpbfmt/parser"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+
+	npb "github.com/openconfig/featureprofiles/proto/nosimage_go_proto"
+	ppb "github.com/openconfig/featureprofiles/proto/ocpaths_go_proto"
+	rpb "github.com/openconfig/featureprofiles/proto/ocrpcs_go_proto"
+	opb "github.com/openconfig/ondatra/proto"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type Config struct {
+	FilePath string
+	Invalid  bool
+}
+
+func New(fs *flag.FlagSet) *Config {
+	c := &Config{}
+
+	if fs == nil {
+		fs = flag.CommandLine
+	}
+	fs.StringVar(&c.FilePath, "file-path", "example_nosimage.textproto", "generate an example file at the given path rather than validating a file.")
+	fs.BoolVar(&c.Invalid, "invalid", false, "generate an invalid example")
+
+	return c
+}
+
+var (
+	config *Config
+)
+
+func init() {
+	config = New(nil)
+}
+
+func generateExample(filepath string, invalid bool) error {
+	componentPrefix := "/components/component"
+	softwareComponent := "OPERATING_SYTEM"
+	if invalid {
+		componentPrefix = "/componentsssssssssss/component"
+		softwareComponent = "JOVIAN_ATMOSPHERE"
+	}
+	bs, err := formatTxtpb(&npb.NOSImageProfile{
+		VendorId:        opb.Device_OPENCONFIG,
+		Nos:             "lemming",
+		SoftwareVersion: "7a1cb734c83f0d9ba5b273f920bc002ad0056178",
+		ReleaseDate:     timestamppb.New(time.Date(2023, time.November, 16, 16, 20, 0, 0, time.FixedZone("UTC-8", -8*60*60))),
+		Ocpaths: &ppb.OCPaths{
+			Version: "2.5.0",
+			Ocpaths: []*ppb.OCPath{{
+				Name: "/interfaces/interface/config/name",
+				// Featureprofileid is not required when specifying OCPath support.
+			}, {
+				Name: componentPrefix + "/state/location",
+				// OcpathConstraint MUST be specified if and only if the path belongs to /components/component.
+				OcpathConstraint: &ppb.OCPathConstraint{Constraint: &ppb.OCPathConstraint_PlatformType{PlatformType: "PORT"}},
+			}, {
+				Name:             componentPrefix + "/state/serial-no",
+				OcpathConstraint: &ppb.OCPathConstraint{Constraint: &ppb.OCPathConstraint_PlatformType{PlatformType: "STORAGE"}},
+			}, {
+				Name:             "/components/component/state/software-version",
+				OcpathConstraint: &ppb.OCPathConstraint{Constraint: &ppb.OCPathConstraint_PlatformType{PlatformType: softwareComponent}},
+			}, {
+				Name: "/network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/peer-as",
+			}},
+		},
+		Ocrpcs: &rpb.OCRPCs{
+			Ocservices: map[string]*rpb.OCRPCService{
+				"gnmi.gNMI": {
+					Version: "0.10.0",
+					MethodName: []string{
+						"Set",
+						"Subscribe",
+					},
+				},
+				"gnoi.healthz.Healthz": {
+					Version: "1.3.0",
+					MethodName: []string{
+						"Get",
+						"List",
+						"Acknowledge",
+						"Artifact",
+						"Check",
+					},
+				},
+				"gnoi.bgp.BGP": {
+					Version: "0.1.0",
+					MethodName: []string{
+						"ClearBGPNeighbor",
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath, bs, 0664)
+}
+
+func formatTxtpb(msg proto.Message) ([]byte, error) {
+	out := bytes.NewBuffer(nil)
+	desc := msg.ProtoReflect().Descriptor()
+	fmt.Fprintln(out, "# proto-file: github.com/openconfig/featureprofiles/proto/"+desc.ParentFile().Path())
+	fmt.Fprintln(out, "# proto-message:", desc.Name())
+	fmt.Fprintln(out, "# txtpbfmt: expand_all_children")
+	fmt.Fprintln(out, "# txtpbfmt: sort_repeated_fields_by_content")
+	b, err := prototext.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+	out.Write(b)
+	b, err = parser.Format(out.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func main() {
+	flag.Parse()
+
+	if config.FilePath == "" {
+		fmt.Println("must provide example file path to write")
+		os.Exit(1)
+	}
+
+	if err := generateExample(config.FilePath, config.Invalid); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/tools/nosimage/example/generate_example.go
+++ b/tools/nosimage/example/generate_example.go
@@ -59,10 +59,12 @@ func init() {
 
 func generateExample(filepath string, invalid bool) error {
 	componentPrefix := "/components/component"
-	softwareComponent := "OPERATING_SYTEM"
+	softwareComponent := "OPERATING_SYSTEM"
+	interfaceLeafName := "name"
 	if invalid {
 		componentPrefix = "/componentsssssssssss/component"
 		softwareComponent = "JOVIAN_ATMOSPHERE"
+		interfaceLeafName = "does-not-exist"
 	}
 	bs, err := formatTxtpb(&npb.NOSImageProfile{
 		VendorId:        opb.Device_OPENCONFIG,
@@ -72,7 +74,7 @@ func generateExample(filepath string, invalid bool) error {
 		Ocpaths: &ppb.OCPaths{
 			Version: "2.5.0",
 			Ocpaths: []*ppb.OCPath{{
-				Name: "/interfaces/interface/config/name",
+				Name: "/interfaces/interface/config/" + interfaceLeafName,
 				// Featureprofileid is not required when specifying OCPath support.
 			}, {
 				Name: componentPrefix + "/state/location",

--- a/tools/nosimage/validate/validate.go
+++ b/tools/nosimage/validate/validate.go
@@ -1,0 +1,116 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/openconfig/featureprofiles/tools/internal/ocpaths"
+	"google.golang.org/protobuf/encoding/prototext"
+
+	npb "github.com/openconfig/featureprofiles/proto/nosimage_go_proto"
+)
+
+type Config struct {
+	FilePath     string
+	DownloadPath string
+}
+
+func New(fs *flag.FlagSet) *Config {
+	c := &Config{}
+
+	if fs == nil {
+		fs = flag.CommandLine
+	}
+	fs.StringVar(&c.FilePath, "file", "", "txtpb file containing an instance of nosimage.proto data")
+	// TODO(wenovus): Consider allowing using a manual location to avoid git clone.
+	fs.StringVar(&c.DownloadPath, "download-path", "./", "path into which to download OpenConfig GitHub repos for validation")
+
+	return c
+}
+
+var (
+	config *Config
+)
+
+func init() {
+	config = New(nil)
+}
+
+func clonePublicRepo(downloadPath, branch string) (string, error) {
+	if downloadPath == "" {
+		return "", fmt.Errorf("must provide download path")
+	}
+	publicPath := filepath.Join(config.DownloadPath, "public")
+
+	cmd := exec.Command("git", "clone", "-b", branch, "--single-branch", "--depth", "1", "git@github.com:openconfig/public.git", publicPath)
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return "", err
+	}
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("failed to clone public repo: %v, command failed to start: %q", err, cmd.String())
+	}
+	stderrOutput, _ := io.ReadAll(stderr)
+	fmt.Printf("%s\n", stderrOutput)
+	if err := cmd.Wait(); err != nil {
+		return "", fmt.Errorf("failed to clone public repo: %v, command failed during execution: %q", err, cmd.String())
+	}
+	return publicPath, nil
+}
+
+func unmarshalFile(filePath string) (*npb.NOSImageProfile, error) {
+	if filePath == "" {
+		return nil, fmt.Errorf("must provide non-empty file path to read from")
+	}
+	profile := &npb.NOSImageProfile{}
+	bs, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	if err := prototext.Unmarshal(bs, profile); err != nil {
+		return nil, err
+	}
+	return profile, nil
+
+}
+
+func main() {
+	flag.Parse()
+
+	profile, err := unmarshalFile(config.FilePath)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	publicPath, err := clonePublicRepo(config.DownloadPath, "v"+profile.Ocpaths.GetVersion())
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	paths, err := ocpaths.ValidatePaths(profile.GetOcpaths().GetOcpaths(), publicPath)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fmt.Printf("profile contains %d valid OCPaths\n", len(paths))
+}

--- a/tools/nosimage/validate/validate.go
+++ b/tools/nosimage/validate/validate.go
@@ -69,9 +69,8 @@ func clonePublicRepo(downloadPath, branch string) (string, error) {
 		return "", fmt.Errorf("failed to clone public repo: %v, command failed to start: %q", err, cmd.String())
 	}
 	stderrOutput, _ := io.ReadAll(stderr)
-	fmt.Printf("%s\n", stderrOutput)
 	if err := cmd.Wait(); err != nil {
-		return "", fmt.Errorf("failed to clone public repo: %v, command failed during execution: %q", err, cmd.String())
+		return "", fmt.Errorf("failed to clone public repo: %v, command failed during execution: %q\n%s", err, cmd.String(), stderrOutput)
 	}
 	return publicPath, nil
 }


### PR DESCRIPTION
**Limitation**: Validator script currently only validates OCPaths, and not RPCs.

Tested generator manually:
```
go run validate/validate.go -file example/example_nosimageprofile.textproto; rm -rf public
```
```
go run validate/validate.go -file example/example_nosimageprofile_invalid.textproto; rm -rf public
```