### PR TITLE
Minor fixes for gRIBI MPLS tests.

### DIFF
--- a/feature/gribi/mplsutil/mplsutil.go
+++ b/feature/gribi/mplsutil/mplsutil.go
@@ -381,7 +381,7 @@ func (g *GRIBIMPLSTest) ConfigureFlows(t *testing.T, ate *ondatra.ATEDevice) {
 	case PushToMPLS:
 		t.Logf("looking on interface %s_ETH for %s", ATESrc.Name, DUTSrc.IPv4)
 		var dstMAC string
-		gnmi.WatchAll(t, ate, gnmi.OTG().Interface(ATESrc.Name+"_ETH").Ipv4NeighborAny().LinkLayerAddress().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
+		gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().Interface(ATESrc.Name+"_ETH").Ipv4NeighborAny().LinkLayerAddress().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
 			dstMAC, _ = val.Val()
 			return val.IsPresent()
 		}).Await(t)

--- a/feature/gribi/otg_tests/mpls_compliance/gribi_mpls_compliance_test.go
+++ b/feature/gribi/otg_tests/mpls_compliance/gribi_mpls_compliance_test.go
@@ -63,10 +63,10 @@ func TestMPLSPushToIP(t *testing.T) {
 
 	baseLabel := 42
 	numLabels := 20
-	for i := 1; i <= numLabels; i++ {
-		t.Run(fmt.Sprintf("TE-9.2: Push MPLS labels to IP packet: %d labels", i), func(t *testing.T) {
+	for labelc := 1; labelc <= numLabels; labelc++ {
+		t.Run(fmt.Sprintf("TE-9.2: Push MPLS labels to IP packet: %d labels", labelc), func(t *testing.T) {
 			labels := []uint32{}
-			for i := 0; i < numLabels; i++ {
+			for i := 0; i < labelc; i++ {
 				labels = append(labels, uint32(baseLabel+i))
 			}
 			mplsT := mplsutil.New(c, mplsutil.PushToIP, deviations.DefaultNetworkInstance(dut), &mplsutil.Args{
@@ -93,6 +93,7 @@ func TestPopTopLabel(t *testing.T) {
 		mplsT.ConfigureDevices(t, ondatra.DUT(t, "dut"), ondatra.ATE(t, "ate"))
 		mplsT.ProgramGRIBI(t)
 		mplsT.ValidateProgramming(t)
+		mplsT.Cleanup(t)
 	})
 }
 

--- a/feature/gribi/otg_tests/mpls_compliance/metadata.textproto
+++ b/feature/gribi/otg_tests/mpls_compliance/metadata.textproto
@@ -5,3 +5,13 @@ uuid:  "835d2c66-3b57-4a62-99df-05120e282786"
 plan_id:  "TE-9"
 description:  "gRIBI MPLS Compliance"
 testbed:  TESTBED_DUT_ATE_2LINKS
+platform_exceptions: {
+  platform: {
+    vendor: ARISTA
+  }
+  deviations: {
+    default_network_instance: "default"
+  }
+}
+
+

--- a/feature/gribi/otg_tests/mpls_forwarding/gribi_mpls_forwarding_test.go
+++ b/feature/gribi/otg_tests/mpls_forwarding/gribi_mpls_forwarding_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// baseLabel indicates the minimum label to use on a packet.
-	baseLabel = 42
+	baseLabel = 32768
 	// maximumStackDepth is the maximum number of labels to be pushed onto the packet.
 	maximumStackDepth = 20
 	// lossTolerance is the number of packets that can be lost within a flow before the
@@ -37,7 +37,7 @@ func TestMPLSLabelPushDepth(t *testing.T) {
 	c.Connection().WithStub(gribic)
 
 	for numLabels := 1; numLabels <= maximumStackDepth; numLabels++ {
-		t.Run(fmt.Sprintf("TE-10.1: Push MPLS labels to MPLS: sh %d labels", numLabels), func(t *testing.T) {
+		t.Run(fmt.Sprintf("TE-10.1: Push MPLS labels to MPLS: Push %d labels", numLabels), func(t *testing.T) {
 			labels := []uint32{}
 			for i := 0; i < numLabels; i++ {
 				labels = append(labels, uint32(baseLabel+i))

--- a/feature/gribi/otg_tests/mpls_forwarding/metadata.textproto
+++ b/feature/gribi/otg_tests/mpls_forwarding/metadata.textproto
@@ -5,3 +5,11 @@ uuid:  "74fe316d-c8f4-48fe-b6fa-092e87be9ec3"
 plan_id:  "TE-10"
 description:  "gRIBI MPLS Forwarding"
 testbed:  TESTBED_DUT_ATE_2LINKS
+platform_exceptions: {
+  platform: {
+    vendor: ARISTA
+  }
+  deviations: {
+    default_network_instance: "default"
+  }
+}


### PR DESCRIPTION
```
- Fix error in `gribi/mpls_compliance`, add EOS deviations.
- Fix label assingmentas in MPLS forwarding test.
```

Note that these tests should be run with a reset so that gRIBI starts with
acquiring a new election ID.
