### PR TITLE
Changed testbed file for gNMI-1.14

### DIFF
--- a/feature/system/gnmi/metadata/tests/large_set_consistency_test/metadata.textproto
+++ b/feature/system/gnmi/metadata/tests/large_set_consistency_test/metadata.textproto
@@ -4,7 +4,7 @@
 uuid: "e9cdd09c-14b9-4e3c-b38c-584ef9611c3f"
 plan_id: "gNMI-1.14"
 description: "OpenConfig metadata consistency during large config push"
-testbed: TESTBED_DUT
+testbed: TESTBED_DUT_ATE_2LINKS
 platform_exceptions: {
   platform: {
     vendor: ARISTA


### PR DESCRIPTION
Test uses 2 ports. This allows run this test to run without explicitly calling the `--testbed` (to point to a 2port testbed file) flag. 

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."