### PR TITLE
Update ipv6 link local test -  Add traffic to subtest 3

### DIFF
--- a/feature/interface/ip/ipv6_link_local/otg_tests/ipv6_link_local_test/README.md
+++ b/feature/interface/ip/ipv6_link_local/otg_tests/ipv6_link_local_test/README.md
@@ -16,12 +16,14 @@ Configure an IPv6 address which is in link local scope. Verify the link local IP
   * Send IPv6 traffic from OTG port 1 to DUT port 1, validate DUT port 1 receives the traffic
   
 * Subtest #3 - Verify adding and removing global unicast address does not affect link local address
-  * Add configuration for a global unicast address on DUT port 1 
+  * Add configuration for a global unicast address on DUT port 1 and DUT port 2
   * Validate config and state paths are set
-  * Send IPv6 traffic from OTG port 1 to DUT port 1, validate DUT port 1 receives the traffic
+  * Send IPv6 traffic from OTG port 1 to OTG port 2, validate OTG port 2 receives the traffic
   * Remove configuration for the global unitcast address on DUT port 1
   * Validate that DUT port 1 link local address is still configured
   * Send IPv6 traffic from OTG port 1 to DUT port 1, validate DUT port 1 receives the traffic
+  * Send IPv6 traffic from OTG port 1 to OTG port 2, validate OTG port 2 does not receive the traffic
+
 
 * Subtest #4 - Verify enable/disable of DUT port 1 does not affect link local address
   * Disable/enable the port and see if the configured link-local address stays?

--- a/feature/interface/ip/ipv6_link_local/otg_tests/ipv6_link_local_test/README.md
+++ b/feature/interface/ip/ipv6_link_local/otg_tests/ipv6_link_local_test/README.md
@@ -18,6 +18,7 @@ Configure an IPv6 address which is in link local scope. Verify the link local IP
 * Subtest #3 - Verify adding and removing global unicast address does not affect link local address
   * Add configuration for a global unicast address on DUT port 1 
   * Validate config and state paths are set
+  * Send IPv6 traffic from OTG port 1 to DUT port 1, validate DUT port 1 receives the traffic
   * Remove configuration for the global unitcast address on DUT port 1
   * Validate that DUT port 1 link local address is still configured
   * Send IPv6 traffic from OTG port 1 to DUT port 1, validate DUT port 1 receives the traffic


### PR DESCRIPTION
Add traffic verification when both a global and link local address are configured.