### PR TITLE
Fix metadata.textproto changed from PR 2461

### DIFF
--- a/feature/interface/aggregate/otg_tests/aggregate_forwarding_viable_test/metadata.textproto
+++ b/feature/interface/aggregate/otg_tests/aggregate_forwarding_viable_test/metadata.textproto
@@ -14,6 +14,7 @@ platform_exceptions: {
     explicit_interface_in_default_vrf: true
     aggregate_atomic_update: true
     interface_enabled: true
+    missing_value_for_defaults: true
   }
 }
 platform_exceptions: {
@@ -24,14 +25,6 @@ platform_exceptions: {
     aggregate_atomic_update: true
     interface_enabled: true
     default_network_instance: "default"
-    missing_value_for_defaults: true
-  }
-}
-platform_exceptions: {
-  platform: {
-    vendor: NOKIA
-  }
-  deviations: {
     missing_value_for_defaults: true
   }
 }


### PR DESCRIPTION
put deviations under one platform exception per vendor

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."