### PR TITLE
Updated the test case id number for IPv6 ND RA disable.

### DIFF
--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -393,7 +393,7 @@ test: {
   exec: " "
 }
 test: {
-  id: "RT-5.6"
+  id: "RT-9"
   description: "Interface IPv6 ND RA disable"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/interface/holdtime/otg_tests/holdtime_test/README.md"
   exec: " "


### PR DESCRIPTION
Updated the test case number for IPv6 ND RA disable to RT-9 based on the comment in pull/2485