### PR TITLE
Pin revive CI check to v1.3.4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -103,7 +103,7 @@ jobs:
           exit 1
         fi
     - name: Get revive
-      run: go install github.com/mgechev/revive@latest
+      run: go install github.com/mgechev/revive@v1.3.4
     - name: Run revive
       run: revive ./...
     - name: Get staticcheck


### PR DESCRIPTION
The latest release tag on revive has a problem that breaks `go install`.  Issue is tracked in mgechev/revive#956 - it seems like the bug is fixed but there isn't a new release tag with the fix yet.  This change will pin the older working version.