### PR TITLE
adding missing path

### DIFF
--- a/feature/bgp/policybase/otg_tests/route_installation_test/README.md
+++ b/feature/bgp/policybase/otg_tests/route_installation_test/README.md
@@ -35,8 +35,8 @@ paths:
   /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-as-path-prepend/config/asn:
 
   ## Telemetry Parameter Coverage
-  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor:
-  /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/neighbor-address:
+  /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/state/peer-group-name:
   /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/apply-policy/state/export-policy:
   /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/apply-policy/state/import-policy:
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/installed:

--- a/feature/bgp/policybase/otg_tests/route_installation_test/README.md
+++ b/feature/bgp/policybase/otg_tests/route_installation_test/README.md
@@ -24,26 +24,29 @@ Base BGP policy configuration and route installation.
     *   Validate that traffic is not forwarded to withdrawn routes between ATE
         port-1 and ATE port-2.
 
-## Config Parameter Coverage
+## OpenConfig Path and RPC Coverage
+```yaml
+paths:
+  ## Config Parameter Coverage
+  - /routing-policy/policy-definitions/policy-definition/config/name:
+  - /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-local-pref:
+  - /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-med:
+  - /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-as-path-prepend/config/repeat-n:
+  - /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-as-path-prepend/config/asn:
 
-*   /routing-policy/policy-definitions/policy-definition/config/name
-*   /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-local-pref
-*   /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-med
-*   /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-as-path-prepend/config/repeat-n
-*   /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-as-path-prepend/config/asn
+  ## Telemetry Parameter Coverage
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor:
+  - /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group:
+  - /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/apply-policy/state/export-policy:
+  - /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/apply-policy/state/import-policy:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/installed:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received-pre-policy:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/sent:
 
-## Telemetry Parameter Coverage
+rpcs:
+  gnmi:
+    gNMI.Get:
+    gNMI.Subscribe:
 
-For prefixes:
-
-*   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor
-*   /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group
-
-Paths:
-
-*   afi-safis/afi-safi/apply-policy/state/export-policy
-*   afi-safis/afi-safi/apply-policy/state/import-policy
-*   afi-safis/afi-safi/state/prefixes/installed
-*   afi-safis/afi-safi/state/prefixes/received
-*   afi-safis/afi-safi/state/prefixes/received-pre-policy
-*   afi-safis/afi-safi/state/prefixes/sent
+```

--- a/feature/bgp/policybase/otg_tests/route_installation_test/README.md
+++ b/feature/bgp/policybase/otg_tests/route_installation_test/README.md
@@ -28,21 +28,21 @@ Base BGP policy configuration and route installation.
 ```yaml
 paths:
   ## Config Parameter Coverage
-  - /routing-policy/policy-definitions/policy-definition/config/name:
-  - /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-local-pref:
-  - /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-med:
-  - /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-as-path-prepend/config/repeat-n:
-  - /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-as-path-prepend/config/asn:
+  /routing-policy/policy-definitions/policy-definition/config/name:
+  /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-local-pref:
+  /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-med:
+  /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-as-path-prepend/config/repeat-n:
+  /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-as-path-prepend/config/asn:
 
   ## Telemetry Parameter Coverage
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor:
-  - /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group:
-  - /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/apply-policy/state/export-policy:
-  - /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/apply-policy/state/import-policy:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/installed:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received-pre-policy:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/sent:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor:
+  /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group:
+  /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/apply-policy/state/export-policy:
+  /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/apply-policy/state/import-policy:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/installed:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received-pre-policy:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/sent:
 
 rpcs:
   gnmi:

--- a/feature/bgp/policybase/otg_tests/route_installation_test/README.md
+++ b/feature/bgp/policybase/otg_tests/route_installation_test/README.md
@@ -30,6 +30,7 @@ Base BGP policy configuration and route installation.
 *   /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-local-pref
 *   /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-med
 *   /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-as-path-prepend/config/repeat-n
+*   /routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-as-path-prepend/config/asn
 
 ## Telemetry Parameter Coverage
 


### PR DESCRIPTION
As per PROCEDURE description below path is needed: `/routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/set-as-path-prepend/config/asn `
This patch is adding it explicitly in "Config Parameter Coverage"