### PR TITLE
SFLOW-1.1: Updating metadata with static_protocol_name deviation

### DIFF
--- a/feature/sflow/otg_tests/sflow_base_test/metadata.textproto
+++ b/feature/sflow/otg_tests/sflow_base_test/metadata.textproto
@@ -21,6 +21,7 @@ platform_exceptions: {
     explicit_port_speed: true
     explicit_interface_in_default_vrf: true
     interface_enabled: true
+    static_protocol_name: "static"
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
Adding deviation `static_protocol_name` to metadata.textproto.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."