### PR TITLE
Fix GRPC timeout for OTG

### DIFF
--- a/topologies/binding/binding.go
+++ b/topologies/binding/binding.go
@@ -255,7 +255,7 @@ func (a *staticATE) DialOTG(ctx context.Context, opts ...grpc.DialOption) (gosna
 
 	api := gosnappi.NewApi()
 	transport := api.NewGrpcTransport().SetClientConnection(conn)
-	if timeout := a.r.dutGRPC(a.dev, dutSvcParams[introspect.OTG]).Timeout; timeout != 0 {
+	if timeout := a.r.dutGRPC(a.dev, ateSvcParams[introspect.OTG]).Timeout; timeout != 0 {
 		transport.SetRequestTimeout(time.Duration(timeout) * time.Second)
 	}
 	return api, nil


### PR DESCRIPTION
should point to `ateSvcParams` not `dutSvcParams`
"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."