### PR TITLE
Adding PKCS8 to LoadKeyPair()

### DIFF
--- a/internal/security/svid/svid.go
+++ b/internal/security/svid/svid.go
@@ -108,6 +108,11 @@ func LoadKeyPair(keyPath, certPath string) (any, *x509.Certificate, error) {
 		if err != nil {
 			return nil, nil, err
 		}
+	case "PRIVATE KEY":
+		caPrivateKey, err = x509.ParsePKCS8PrivateKey(caKeyPem.Bytes)
+		if err != nil {
+			return nil, nil, err
+		}
 	default:
 		return nil, nil, fmt.Errorf("file does not contain an ECDSA/RSA private key")
 


### PR DESCRIPTION
openssl 3.X defaults to PKCS8
This prevents the requirement to use openssl 1.x or migrate certs from PKCS8->PKCS1
Using `PRIAVE KEY` as case since the preamble is `-----BEGIN PRIVATE KEY-----` "This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."