### PR TITLE
Fix for system_base_test

### DIFF
--- a/feature/system/tests/system_base_test/g_protocol_test.go
+++ b/feature/system/tests/system_base_test/g_protocol_test.go
@@ -38,7 +38,7 @@ func dialConn(t *testing.T, dut *ondatra.DUTDevice, svc introspect.Service, want
 		// Renaming service name due to gnoi and gnsi always residing on same port as gnmi.
 		svc = introspect.GNMI
 	}
-	dialer := introspect.DUTDialer(t, dut, introspect.GNMI)
+	dialer := introspect.DUTDialer(t, dut, svc)
 	if dialer.DevicePort != int(wantPort) {
 		t.Fatalf("DUT is not listening on correct port for %q: got %d, want %d", svc, dialer.DevicePort, wantPort)
 	}

--- a/topologies/binding/options.go
+++ b/topologies/binding/options.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// IANA assigns 9339 for gNxI, 9559 for P4RT and 9340 for gRIBI.  
+// IANA assigns 9339 for gNxI, 9559 for P4RT and 9340 for gRIBI.
 var (
 	gnmiPort    = flag.Int("gnmi_port", 9339, "default gNMI port")
 	gnoiPort    = flag.Int("gnoi_port", 9339, "default gNOI port")

--- a/topologies/binding/options.go
+++ b/topologies/binding/options.go
@@ -23,13 +23,12 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// IANA assigns 9339 for gNxI, and 9559 for P4RT.  There hasn't been a
-// port assignment for gRIBI, so using Arista's default which is 6040.
+// IANA assigns 9339 for gNxI, 9559 for P4RT and 9340 for gRIBI.  
 var (
 	gnmiPort    = flag.Int("gnmi_port", 9339, "default gNMI port")
 	gnoiPort    = flag.Int("gnoi_port", 9339, "default gNOI port")
 	gnsiPort    = flag.Int("gnsi_port", 9339, "default gNSI port")
-	gribiPort   = flag.Int("gribi_port", 6040, "default gRIBI port")
+	gribiPort   = flag.Int("gribi_port", 9340, "default gRIBI port")
 	p4rtPort    = flag.Int("p4rt_port", 9559, "default P4RT part")
 	ateGNMIPort = flag.Int("ate_gnmi_port", 50051, "default ATE gNMI port")
 	ateOTGPort  = flag.Int("ate_grpc_port", 40051, "default ATE OTG port")


### PR DESCRIPTION
fix dialer to call the svc (was hardcoded to gNMI) fix gRIBI iana port to 9340
"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."