### PR TITLE
Move binary logs to google cloud object storage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.pb filter=lfs diff=lfs merge=lfs -text

--- a/feature/experimental/replay/tests/diff_command_trees/diff_command_trees_test.go
+++ b/feature/experimental/replay/tests/diff_command_trees/diff_command_trees_test.go
@@ -29,9 +29,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestReplay(t *testing.T) {
-	const logFile = "grpclog.pb"
+	const logFile = "https://storage.googleapis.com/featureprofiles-binarylogs/diff_command_trees.pb"
 	t.Logf("Parsing log file: %v", logFile)
-	rec := replayer.ParseFile(t, logFile)
+	rec := replayer.ParseURL(t, logFile)
 
 	dut := ondatra.DUT(t, "dut")
 	portMap := map[string]string{}

--- a/feature/experimental/replay/tests/diff_command_trees/grpclog.pb
+++ b/feature/experimental/replay/tests/diff_command_trees/grpclog.pb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3357e4dd91ab08a8e7ceff5b0c103152cff8c3bdc0f14e20695529d20a37cc5c
-size 183034360

--- a/feature/experimental/replay/tests/p4rt_replay/grpclog.pb
+++ b/feature/experimental/replay/tests/p4rt_replay/grpclog.pb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3fafadc255b5bcfb7b6f7dd7c648335e854972e35bc5082c9ee77e1305b1701
-size 215584820

--- a/feature/experimental/replay/tests/p4rt_replay/p4rt_replay_test.go
+++ b/feature/experimental/replay/tests/p4rt_replay/p4rt_replay_test.go
@@ -55,9 +55,9 @@ func configureDeviceID(t *testing.T, dut *ondatra.DUTDevice) {
 }
 
 func TestReplay(t *testing.T) {
-	const logFile = "grpclog.pb"
+	const logFile = "https://storage.googleapis.com/featureprofiles-binarylogs/p4rt_replay.pb"
 	t.Logf("Parsing log file: %v", logFile)
-	rec := replayer.ParseFile(t, logFile)
+	rec := replayer.ParseURL(t, logFile)
 
 	dut := ondatra.DUT(t, "dut")
 	portMap := map[string]string{}

--- a/feature/experimental/replay/tests/presession_test/grpclog.pb
+++ b/feature/experimental/replay/tests/presession_test/grpclog.pb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:26fac21959a4a89d0a68b7435a6572f65bed882d109ea5a5a40375cd40030519
-size 21831306

--- a/feature/experimental/replay/tests/presession_test/presession_test.go
+++ b/feature/experimental/replay/tests/presession_test/presession_test.go
@@ -29,9 +29,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestReplay(t *testing.T) {
-	const logFile = "grpclog.pb"
+	const logFile = "https://storage.googleapis.com/featureprofiles-binarylogs/presession_test.pb"
 	t.Logf("Parsing log file: %v", logFile)
-	rec := replayer.ParseFile(t, logFile)
+	rec := replayer.ParseURL(t, logFile)
 
 	dut := ondatra.DUT(t, "dut")
 	portMap := map[string]string{}


### PR DESCRIPTION
Storing the files in a public cloud storage bucket prevents the messiness of keeping them in the git repo while ensuring the file is accessible by the test both in open source and when running internally.