### PR TITLE
Add static_protocol_name deviation to metadata file for sflow_base_test for Arista

### DIFF
--- a/feature/sflow/otg_tests/sflow_base_test/metadata.textproto
+++ b/feature/sflow/otg_tests/sflow_base_test/metadata.textproto
@@ -33,5 +33,6 @@ platform_exceptions: {
     interface_config_vrf_before_address: true
     interface_enabled: true
     default_network_instance: "default"
+    static_protocol_name: "STATIC"
   }
 }


### PR DESCRIPTION
This change updates the `metadata.textproto` file for Arista for the `sflow_base_test` to make use of `static_protocol_name` deviation. This fixes a regression made recently due to a test code change.