### PR TITLE
RT-5.1 change from in-discards to use in-errors for drop

### DIFF
--- a/feature/interface/singleton/otg_tests/singleton_test/singleton_test.go
+++ b/feature/interface/singleton/otg_tests/singleton_test/singleton_test.go
@@ -376,7 +376,7 @@ func inCounters(tic *oc.Interface_Counters) *counters {
 	return &counters{unicast: tic.GetInUnicastPkts(),
 		multicast: tic.GetInMulticastPkts(),
 		broadcast: tic.GetInBroadcastPkts(),
-		drop:      tic.GetInDiscards()}
+		drop:      tic.GetInErrors()}
 }
 
 func outCounters(tic *oc.Interface_Counters) *counters {


### PR DESCRIPTION
Changing the counter for drop variable to use in-errors leaf instead of in-discards.
As per OC definition/rfc2863, 
in-discards packets are number of inbound packets that were chosen to be discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol

& in-errors packets are he number of inbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.

So, the for Packets with size > MTU should be increment the interface error counters.