### PR TITLE
move bgp policy tests to rt-7.x

### DIFF
--- a/feature/bgp/policybase/otg_tests/aspath_and_community_test/README.md
+++ b/feature/bgp/policybase/otg_tests/aspath_and_community_test/README.md
@@ -1,4 +1,4 @@
-# RT-2.4: BGP Policy AS Path Set and Community Set
+# RT-7.4: BGP Policy AS Path Set and Community Set
 
 ## Summary
 
@@ -6,7 +6,7 @@ BGP policy configuration for AS Paths and Community Sets
 
 ## Procedure
 
-* RT-2.4.1 - Test setup
+* RT-7.4.1 - Test setup
   * Generate config for 2 DUT ports, with DUT port 1 eBGP session to ATE port 1.
 
   * Generate config for ATE 2 ports, with ATE port 1 eBGP session to DUT port 1.
@@ -22,7 +22,7 @@ BGP policy configuration for AS Paths and Community Sets
   * Generate traffic from ATE port-2 to all prefixes
   * Validate that traffic is received on ATE port-1 for all prefixes
 
-* RT-2.4.1 - Validate single routing-policy containing as-path-set and ext-community-set
+* RT-7.4.2 - Validate single routing-policy containing as-path-set and ext-community-set
 
   * Create a as-path-set named `any_my_regex_aspath` with members
     * `{ as-path-set-member = [ "(10[0-9]]|200)" ] }`

--- a/feature/bgp/policybase/otg_tests/aspath_and_community_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/aspath_and_community_test/metadata.textproto
@@ -1,7 +1,7 @@
 # proto-file: github.com/openconfig/featureprofiles/proto/metadata.proto
 # proto-message: Metadata
 
-plan_id: "RT-2.4"
+plan_id: "RT-7.4"
 description: "BGP Policy AS Path Set and Community Set"
 testbed: TESTBED_DUT_ATE_2LINKS
 tags: TAGS_AGGREGATION, TAGS_TRANSIT, TAGS_DATACENTER_EDGE

--- a/feature/bgp/policybase/otg_tests/aspath_test/README.md
+++ b/feature/bgp/policybase/otg_tests/aspath_test/README.md
@@ -57,7 +57,7 @@ BGP policy configuration for AS Paths and Community Sets
         * conditions/bgp-conditions/match-community-set/config/match-set-options = ANY
         * actions/config/policy-result = ACCEPT_ROUTE
 
-* RT-2.2.7 - Replace /routing-policy DUT config 
+* RT-7.3.3 - Replace /routing-policy DUT config 
   * For each DUT policy-definition
     * Replace the configuration for BGP neighbor policy (`.../apply-policy/config/import-policy`) to the currently tested policy
       * Verify prefixes sent, received and installed are as expected

--- a/feature/bgp/policybase/otg_tests/aspath_test/README.md
+++ b/feature/bgp/policybase/otg_tests/aspath_test/README.md
@@ -1,4 +1,4 @@
-# RT-2.2: BGP Policy AS Path Set
+# RT-7.3: BGP Policy AS Path Set
 
 ## Summary
 
@@ -6,7 +6,7 @@ BGP policy configuration for AS Paths and Community Sets
 
 ## Procedure
 
-* RT-2.2.1 - Test setup
+* RT-7.3.1 - Test setup
   * Generate config for 2 DUT ports, with DUT port 1 eBGP session to ATE port 1
 
   * Generate config for ATE 2 ports, with ATE port 1 eBGP session to DUT port 1
@@ -23,7 +23,7 @@ BGP policy configuration for AS Paths and Community Sets
   * Generate traffic from ATE port-2 to all prefixes
   * Validate that traffic is received on ATE port-1 for all installed prefixes
 
-* RT-2.2.2 - Configure as-path-sets
+* RT-7.3.2 - Configure as-path-sets
   * Configure DUT with the following routing policies
     * Create the following /routing-policy/defined-sets/bgp-defined-sets/as-path-sets/as-path-set/
       * Create as-path-set-name = "my_3_aspaths" with members

--- a/feature/bgp/policybase/otg_tests/aspath_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/aspath_test/metadata.textproto
@@ -1,7 +1,7 @@
 # proto-file: github.com/openconfig/featureprofiles/proto/metadata.proto
 # proto-message: Metadata
 
-plan_id: "RT-2.2"
+plan_id: "RT-7.3"
 description: "BGP Policy AS Path Set"
 testbed: TESTBED_DUT_ATE_2LINKS
 tags: TAGS_AGGREGATION, TAGS_TRANSIT, TAGS_DATACENTER_EDGE

--- a/feature/bgp/policybase/otg_tests/community_test/README.md
+++ b/feature/bgp/policybase/otg_tests/community_test/README.md
@@ -1,4 +1,4 @@
-# RT-2.3: BGP Policy Community Set
+# RT-7.2: BGP Policy Community Set
 
 ## Summary
 
@@ -6,7 +6,7 @@ BGP policy configuration for AS Paths and Community Sets
 
 ## Subtests
 
-* RT-2.3.1 - Setup BGP sessions
+* RT-7.2.1 - Setup BGP sessions
   * Generate config for 2 DUT ports, with DUT port 1 eBGP session to ATE port 1.
   * Generate config for ATE 2 ports, with ATE port 1 eBGP session to DUT port 1.
   * Configure ATE port 1 to advertise ipv4 and ipv6 prefixes to DUT port 1 using the following communities:
@@ -21,7 +21,7 @@ BGP policy configuration for AS Paths and Community Sets
   * Validate that traffic can be received on ATE port-1 for all installed
         routes.
 
-* RT-2.3.2 - Validate community-set
+* RT-7.2.2 - Validate community-set
   * Configure the following community sets on the DUT.
     * Create a community-set named `any_my_3_comms` with members as follows:
       * `{ community-member = [ "100:1", "200:2", "300:3" ] }`

--- a/feature/bgp/policybase/otg_tests/community_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/community_test/metadata.textproto
@@ -1,7 +1,7 @@
 # proto-file: github.com/openconfig/featureprofiles/proto/metadata.proto
 # proto-message: Metadata
 
-plan_id: "RT-2.3"
+plan_id: "RT-7.2"
 description: "BGP Policy Community Set"
 testbed: TESTBED_DUT_ATE_2LINKS
 tags: TAGS_AGGREGATION, TAGS_TRANSIT, TAGS_DATACENTER_EDGE

--- a/feature/bgp/policybase/otg_tests/default_policies_test/README.md
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/README.md
@@ -1,4 +1,4 @@
-# RT-7: BGP default policies
+# RT-7.1: BGP default policies
 
 ## Summary
 
@@ -23,7 +23,7 @@ B <-- IBGP+IS-IS --> C[Port2:OTG];
 * DUT:Port2 has IBGP peering with ATE:Port2 using its loopback interface. The loopback interface is reachable only via IS-IS. Ensure ATE:Port2 advertises IPv4-prefix4, IPv4-prefix5, IPv4-prefix6, IPv6-prefix4, IPv6-prefix5 and IPv6-prefix6 over IBGP. Please also configure IPv4-prefix8 and IPv6-prefix8 on ATE:Port2 but these shouldnt be advertised over IBGP to the DUT
 * Conduct following test procedures by applying policies at the Peer-group and Neighbor AFI-SAFI levels.
 
-### RT-7.1 : Policy definition in policy chain is not satisfied and Default Policy has REJECT_ROUTE action
+### RT-7.1.1 : Policy definition in policy chain is not satisfied and Default Policy has REJECT_ROUTE action
   * Create a default-policy REJECT-ALL with action as REJECT_ROUTE and apply the same to both IPV4-unicast and IPV6-unicast AFI-SAFI
   * Create policy EBGP-IMPORT-IPV4 that only accepts IPv4-prefix1 and IPv4-prefix2 and then terminates
   * Create policy EBGP-IMPORT-IPV6 that only accepts IPv6-prefix1 and IPv6-prefix2 and then terminates
@@ -44,7 +44,7 @@ B <-- IBGP+IS-IS --> C[Port2:OTG];
     * DUT:Port2 should reject export of IPv4-prefix2 and IPv6-prefix2
     * IS-IS and static routes shouldn't be advertised to the EBGP and IBGP peers.
 
-### RT-7.2 : Policy definition in policy chain is not satisfied and Default Policy has ACCEPT_ROUTE action  
+### RT-7.1.2 : Policy definition in policy chain is not satisfied and Default Policy has ACCEPT_ROUTE action  
   * Continue with the same configuration as RT-7.1
   * Replace the default-policy REJECT-ALL with default-policy ACCEPT-ALL which has action ACCEPT_ROUTE.
   * Ensure ACCEPT-ALL default-policy is applied to both IPv4-unicast and IPv6-unicast AFI-SAFI of both IBGP and EBGP peers
@@ -55,7 +55,7 @@ B <-- IBGP+IS-IS --> C[Port2:OTG];
     * DUT:Port2 should allow export of IPv4-prefix1, IPv4-prefix2, IPv4-prefix3, IPv6-prefix1, IPv6-prefix2 and IPv6-prefix3
     * IS-IS and static routes shouldn't be advertised to the EBGP and IBGP peers.
       
-### RT-7.3 : No policy attached either at the Peer-group or at the neighbor level and Default Policy has ACCEPT_ROUTE action
+### RT-7.1.3 : No policy attached either at the Peer-group or at the neighbor level and Default Policy has ACCEPT_ROUTE action
   * Continue with the same configuration as RT-7.2. However, do not attach any non-default import/export policies to the peers at either the peer-group or neighbor levels.
   * Ensure that the ACCEPT-ALL default-policy with default action of ACCEPT_ROUTE is appled to both IPv4-unicast and IPv6-unicast AFI-SAFI of both IBGP and EBGP peers
   * Following test expectations. If expectations not met, the test should fail.
@@ -65,7 +65,7 @@ B <-- IBGP+IS-IS --> C[Port2:OTG];
     * DUT:Port2 should allow export of IPv4-prefix1, IPv4-prefix2, IPv4-prefix3, IPv6-prefix1, IPv6-prefix2 and IPv6-prefix3
     * IS-IS and static routes shouldn't be advertised to the EBGP and IBGP peers.
 
-### RT-7.4 : No policy attached either at the Peer-group or at the neighbor level and Default Policy has REJECT_ROUTE action
+### RT-7.1.4 : No policy attached either at the Peer-group or at the neighbor level and Default Policy has REJECT_ROUTE action
   * Continue with the same configuration as RT-7.3. Ensure no non-default import/export policies are applied to the peers at either the peer-group or neighbor levels.
   * Ensure that only the REJECT-ALL default-policy with default action of REJECT_ROUTE is appled to both IPv4-unicast and IPv6-unicast AFI-SAFI of both IBGP and EBGP peers
   * Following test expectations. If expectations not met, the test should fail.
@@ -75,7 +75,7 @@ B <-- IBGP+IS-IS --> C[Port2:OTG];
     * DUT:Port2 should reject export of IPv4-prefix1, IPv4-prefix2, IPv4-prefix3, IPv6-prefix1, IPv6-prefix2 and IPv6-prefix3
     * IS-IS and static routes shouldn't be advertised to the EBGP and IBGP peers.
 
-### RT-7.5 : No policy, including the default-policy is attached either at the Peer-group or at the neighbor level for only IBGP peer
+### RT-7.1.5 : No policy, including the default-policy is attached either at the Peer-group or at the neighbor level for only IBGP peer
 #### TODO: RT-7.5 should be automated only after the expected behavior is confirmed in https://github.com/openconfig/public/issues/981
   * Continue with the same configuration as RT-7.4. However, do not attach any non-default OR default import/export policies to the IBGP peer at the peer-group or neighbor levels. This is true for both IPv4-unicast and IPv6-unicast AFI-SAFI.
   * Ensure that only the ACCEPT-ALL IMPORT/EXPORT default-policy with default action of ACCEPT_ROUTE is appled to the EBGP peer on both IPv4-unicast and IPv6-unicast AFI-SAFI
@@ -86,8 +86,8 @@ B <-- IBGP+IS-IS --> C[Port2:OTG];
     * DUT:Port2 should allow export of IPv4-prefix1, IPv4-prefix2, IPv4-prefix3, IPv6-prefix1, IPv6-prefix2 and IPv6-prefix3
     * IS-IS and static routes shouldn't be advertised to the EBGP and IBGP peers.
    
-### RT-7.6 : No policy, including the default-policy is attached either at the Peer-group or at the neighbor level for both EBGP and IBGP peers
-#### TODO: RT-7.6 should be automated only after the expected behavior is confirmed in https://github.com/openconfig/public/issues/981
+### RT-7.1.6 : No policy, including the default-policy is attached either at the Peer-group or at the neighbor level for both EBGP and IBGP peers
+#### TODO: RT-7.1.6 should be automated only after the expected behavior is confirmed in https://github.com/openconfig/public/issues/981
   * Continue with the same configuration as RT-7.5. However, do not attach any non-default OR default import/export policies to the IBGP and EBGP peers at the peer-group or neighbor levels. This is true for both IPv4-unicast and IPv6-unicast AFI-SAFI.
   * Following test expectations. If expectations not met, the test should fail.
     * DUT:Port1 should reject import of IPv4-prefix1, IPv4-prefix2, IPv4-prefix3, IPv6-prefix1, IPv6-prefix2 and IPv6-prefix3

--- a/feature/bgp/policybase/otg_tests/default_policies_test/bgp_default_policies_test.go
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/bgp_default_policies_test.go
@@ -822,25 +822,25 @@ func TestBGPDefaultPolicies(t *testing.T) {
 		funcName func()
 		skipMsg  string
 	}{{
-		desc:     "RT-7.1: Policy definition in policy chain is not satisfied and Default Policy has REJECT_ROUTE action",
+		desc:     "RT-7.1.1: Policy definition in policy chain is not satisfied and Default Policy has REJECT_ROUTE action",
 		funcName: func() { testDefaultPolicyRejectRouteAction(t, dut) },
 	}, {
-		desc:     "RT-7.2 : Policy definition in policy chain is not satisfied and Default Policy has ACCEPT_ROUTE action",
+		desc:     "RT-7.1.2 : Policy definition in policy chain is not satisfied and Default Policy has ACCEPT_ROUTE action",
 		funcName: func() { testDefaultPolicyAcceptRouteAction(t, dut) },
 	}, {
-		desc:     "RT-7.3 : No policy attached either at the Peer-group or at the neighbor level and Default Policy has ACCEPT_ROUTE action",
+		desc:     "RT-7.1.3 : No policy attached either at the Peer-group or at the neighbor level and Default Policy has ACCEPT_ROUTE action",
 		funcName: func() { testDefaultPolicyAcceptRouteActionOnly(t, dut) },
 	}, {
-		desc:     "RT-7.4 : No policy attached either at the Peer-group or at the neighbor level and Default Policy has REJECT_ROUTE action",
+		desc:     "RT-7.1.4 : No policy attached either at the Peer-group or at the neighbor level and Default Policy has REJECT_ROUTE action",
 		funcName: func() { testDefaultPolicyRejectRouteActionOnly(t, dut) },
 	}, {
-		desc:     "RT-7.5 : No policy including the default-policy is attached either at the Peer-group or at the neighbor level for only IBGP peer",
+		desc:     "RT-7.1.5 : No policy including the default-policy is attached either at the Peer-group or at the neighbor level for only IBGP peer",
 		funcName: func() { testNoPolicyConfiguredIBGPPeer(t, dut) },
-		skipMsg:  "TODO: RT-7.5 should be automated only after the expected behavior is confirmed in issue num 981",
+		skipMsg:  "TODO: RT-7.1.5 should be automated only after the expected behavior is confirmed in issue num 981",
 	}, {
-		desc:     "RT-7.6 : No policy including the default-policy is attached either at the Peer-group or at the neighbor level for both EBGP and IBGP peers",
+		desc:     "RT-7.1.6 : No policy including the default-policy is attached either at the Peer-group or at the neighbor level for both EBGP and IBGP peers",
 		funcName: func() { testNoPolicyConfigured(t, dut) },
-		skipMsg:  "TODO: RT-7.5 should be automated only after the expected behavior is confirmed in issue num 981",
+		skipMsg:  "TODO: RT-7.1.6 should be automated only after the expected behavior is confirmed in issue num 981",
 	}}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/feature/bgp/policybase/otg_tests/default_policies_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/metadata.textproto
@@ -2,7 +2,7 @@
 # proto-message: Metadata
 
 uuid:  "1d21e3cf-25c0-4e44-8988-582188e37452"
-plan_id:  "RT-7"
+plan_id:  "RT-7.1"
 description:  "BGP default policies"
 testbed:  TESTBED_DUT_ATE_2LINKS
 platform_exceptions:  {

--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -206,24 +206,6 @@ test: {
   exec: " "
 }
 test: {
-  id: "RT-1.17"
-  description: "RT-1.17: BGP Link Bandwidth Community Forwarding"
-  readme: ""
-  exec: " "
-}
-test: {
-  id: "RT-1.18"
-  description: "RT-1.18: BGP Link Bandwidth Community - Aggregation"
-  readme: ""
-  exec: " "
-}
-test: {
-  id: "RT-1.19"
-  description: "RT-1.19: BGP Link Bandwidth Community - Set Bandwidth"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/experimental/bgp/ate_tests/bgp_2byte_4byte_asn/README.md"
-  exec: " "
-}
-test: {
   id: "RT-1.2"
   description: "BGP Policy & Route Installation"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/route_installation_test/README.md"
@@ -350,25 +332,6 @@ test: {
   readme: ""
   exec: " "
 }
-test: {
-  id: "RT-2.2"
-  description: "BGP Policy AS Path Set"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/aspath_test/README.md"
-  exec: " "
-}
-test: {
-  id: "RT-2.3"
-  description: "BGP Policy Community Set"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/community_test/README.md"
-  exec: " "
-}
-test: {
-  id: "RT-2.4"
-  description: "BGP Policy AS Path Set and Community Set"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/aspath_and_community_test/README.md"
-  exec: " "
-}
-
 test: {
   id: "RT-2.6"
   description: "IS-IS Hello-Padding  enabled at interface level"
@@ -502,9 +465,57 @@ test: {
   exec: " "
 }
 test: {
-  id: "RT-7"
+  id: "RT-7.1"
   description: "BGP default policies"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/default_policies_test/README.md"
+  exec: " "
+}
+test: {
+  id: "RT-7.2"
+  description: "BGP Policy Community Set"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/community_test/README.md"
+  exec: " "
+}
+test: {
+  id: "RT-7.3"
+  description: "BGP Policy AS Path Set"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/aspath_test/README.md"
+  exec: " "
+}
+test: {
+  id: "RT-7.4"
+  description: "BGP Policy AS Path Set and Community Set"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/aspath_and_community_test/README.md"
+  exec: " "
+}
+test: {
+  id: "RT-7.5"
+  description: "RT-7.5: BGP Link Bandwidth Community Forwarding"
+  readme: ""
+  exec: " "
+}
+test: {
+  id: "RT-7.6"
+  description: "RT-7.6: BGP Link Bandwidth Community - Aggregation"
+  readme: ""
+  exec: " "
+}
+test: {
+  id: "RT-7.7"
+  description: "RT-7.7: BGP Link Bandwidth Community - Set Bandwidth"
+  readme: " "
+  exec: " "
+}
+test: {
+  id: "RT-7.8"
+  description: "RT-7.8: BGP Policy - Ext Community Matching"
+  readme: " "
+  exec: " "
+}
+test: {
+  id: "RT-7.9"
+  description: "RT-7.9: BGP Policy - Import/Export Policy Action Using Communities "
+  readme: " "
   exec: " "
 }
 test: {


### PR DESCRIPTION
* Renumbered existing readmes (and two test automations) to  move BGP policy related tests into RT-7.x numbering.
* Updated metadata.textproto where present to match
* Added testregistry entry for RT-7.9: BGP Policy - Import/Export Policy Action Using Communities
  * RT-7.9 README will appear in a future PR 
