### PR TITLE
Update ci-trigger service account formatting

### DIFF
--- a/tools/ci-trigger/cloudbuild.go
+++ b/tools/ci-trigger/cloudbuild.go
@@ -72,7 +72,7 @@ func (c *cloudBuild) submitBuild(objPath string) (string, string, error) {
 			Object: objPath,
 		},
 	}
-	build.ServiceAccount = gcpCloudBuildServiceAccount
+	build.ServiceAccount = "projects/" + gcpProjectID + "/serviceAccounts/" + gcpCloudBuildServiceAccount
 
 	resp, err := c.buildClient.Projects.Locations.Builds.Create("projects/"+gcpProjectID+"/locations/us-west1", build).Do()
 	if err != nil {


### PR DESCRIPTION
Previous change #2647 got the formatting of the service account field wrong; the Cloud Build API wants it in the format `projects/[ACCOUNT]/serviceAccounts/[USER_NAME]` instead of simply the username string.