### PR TITLE
Simplify and improve binding dimension logic

### DIFF
--- a/topologies/binding/binding_test.go
+++ b/topologies/binding/binding_test.go
@@ -209,11 +209,9 @@ func TestReservation_Error(t *testing.T) {
 
 	wants := []string{
 		`missing binding for DUT "dut.tb"`,
-		`error binding DUT "dut.both"`,
-		`binding DUT "dut.b" not found in testbed`,
+		`missing binding for port "port1" on "dut.both"`,
 		`missing binding for ATE "ate.tb"`,
-		`error binding ATE "ate.both"`,
-		`testbed port "port1" is missing in binding`,
+		`missing binding for port "port1" on "ate.both"`,
 	}
 	errText := err.Error()
 

--- a/topologies/binding/binding_test.go
+++ b/topologies/binding/binding_test.go
@@ -191,7 +191,7 @@ func TestReservation_Error(t *testing.T) {
 		Ates: []*bindpb.Device{{
 			Id:   "ate.both",
 			Name: "ate.name",
-			Ports: []*bindpb.Port{{ // port1 missing, port3 extra
+			Ports: []*bindpb.Port{{ // port2 missing, port3 extra
 				Id:   "port1",
 				Name: "1/1",
 			}, {

--- a/topologies/binding/binding_test.go
+++ b/topologies/binding/binding_test.go
@@ -192,8 +192,8 @@ func TestReservation_Error(t *testing.T) {
 			Id:   "ate.both",
 			Name: "ate.name",
 			Ports: []*bindpb.Port{{ // port1 missing, port3 extra
-				Id:   "port2",
-				Name: "1/2",
+				Id:   "port1",
+				Name: "1/1",
 			}, {
 				Id:   "port3",
 				Name: "1/3",
@@ -211,7 +211,7 @@ func TestReservation_Error(t *testing.T) {
 		`missing binding for DUT "dut.tb"`,
 		`missing binding for port "port1" on "dut.both"`,
 		`missing binding for ATE "ate.tb"`,
-		`missing binding for port "port1" on "ate.both"`,
+		`missing binding for port "port2" on "ate.both"`,
 	}
 	errText := err.Error()
 

--- a/topologies/binding/options.go
+++ b/topologies/binding/options.go
@@ -88,26 +88,6 @@ type resolver struct {
 	*bindpb.Binding
 }
 
-// dutByID looks up the *bindpb.Device with the given dutID.
-func (r *resolver) dutByID(dutID string) *bindpb.Device {
-	for _, dut := range r.Duts {
-		if dut.Id == dutID {
-			return dut
-		}
-	}
-	return nil
-}
-
-// ateByID looks up the *bindpb.Device with the given ateID.
-func (r *resolver) ateByID(ateID string) *bindpb.Device {
-	for _, ate := range r.Ates {
-		if ate.Id == ateID {
-			return ate
-		}
-	}
-	return nil
-}
-
 func (r *resolver) grpc(dev *bindpb.Device, params *svcParams) *bindpb.Options {
 	targetOpts := &bindpb.Options{Target: fmt.Sprintf("%s:%d", dev.Name, params.port)}
 	return merge(targetOpts, r.Options, dev.Options, params.optsFn(dev))

--- a/topologies/binding/options_test.go
+++ b/topologies/binding/options_test.go
@@ -152,66 +152,6 @@ var resolverBinding = resolver{&bindpb.Binding{
 	}},
 }}
 
-func TestResolver_ByID(t *testing.T) {
-	r := resolverBinding
-	cases := []struct {
-		test string
-		id   string
-		fn   func(name string) *bindpb.Device
-		want bool
-	}{{
-		test: "dutByID(dut)",
-		id:   "dut",
-		fn:   r.dutByID,
-		want: true,
-	}, {
-		test: "dutByID(anotherdut)",
-		id:   "anotherdut",
-		fn:   r.dutByID,
-		want: true,
-	}, {
-		test: "ateByID(ate)",
-		id:   "ate",
-		fn:   r.ateByID,
-		want: true,
-	}, {
-		test: "ateByID(anotherate)",
-		id:   "anotherate",
-		fn:   r.ateByID,
-		want: true,
-	}, {
-		test: "dutByID(no.such.dut)",
-		id:   "no.such.dut",
-		fn:   r.dutByID,
-		want: false,
-	}, {
-		test: "ateByID(no.such.ate)",
-		id:   "no.such.ate",
-		fn:   r.ateByID,
-		want: false,
-	}, {
-		test: "ateByID(dut)",
-		id:   "dut",
-		fn:   r.ateByID,
-		want: false,
-	}, {
-		test: "dutByID(ate)",
-		id:   "ate",
-		fn:   r.dutByID,
-		want: false,
-	}}
-
-	for _, c := range cases {
-		t.Run(c.test, func(t *testing.T) {
-			d := c.fn(c.id)
-			got := d != nil
-			if got != c.want {
-				t.Errorf("Lookup by ID got %v, want %v", got, c.want)
-			}
-		})
-	}
-}
-
 func TestResolver_Options(t *testing.T) {
 	r := resolverBinding
 	cases := []struct {


### PR DESCRIPTION
* Make the logic more easy to read and straightforward as to what dimensions its matching
* Reduce use of the ambiguously named "resolver" type
* Add TODOs to remove the copying of testbed values to bound values