### PR TITLE
Stop copying testbed dimensions to bound dimensions

### DIFF
--- a/topologies/binding/binding.go
+++ b/topologies/binding/binding.go
@@ -329,27 +329,14 @@ func dims(td *opb.Device, bd *bindpb.Device) (*binding.Dims, []error) {
 	var errs []error
 
 	// Check that the bound device matches the testbed device.
-	// TODO(greg-dennis): Stop copying the testbed device dimensions into the bound dimensions.
 	if tdVendor := td.GetVendor(); tdVendor != opb.Device_VENDOR_UNSPECIFIED && bd.Vendor != tdVendor {
-		if bd.Vendor == opb.Device_VENDOR_UNSPECIFIED {
-			bd.Vendor = tdVendor
-		} else {
-			errs = append(errs, fmt.Errorf("binding vendor %v and testbed vendor %v do not match", bd.Vendor, tdVendor))
-		}
+		errs = append(errs, fmt.Errorf("binding vendor %v and testbed vendor %v do not match", bd.Vendor, tdVendor))
 	}
 	if tdHardwareModel := td.GetHardwareModel(); tdHardwareModel != "" && bd.HardwareModel != tdHardwareModel {
-		if bd.HardwareModel == "" {
-			bd.HardwareModel = td.GetHardwareModel()
-		} else {
-			errs = append(errs, fmt.Errorf("binding hardware model %v and testbed hardware model %v do not match", bd.HardwareModel, tdHardwareModel))
-		}
+		errs = append(errs, fmt.Errorf("binding hardware model %v and testbed hardware model %v do not match", bd.HardwareModel, tdHardwareModel))
 	}
 	if tdSoftwareVersion := td.GetSoftwareVersion(); tdSoftwareVersion != "" && bd.SoftwareVersion != tdSoftwareVersion {
-		if bd.SoftwareVersion == "" {
-			bd.SoftwareVersion = td.GetSoftwareVersion()
-		} else {
-			errs = append(errs, fmt.Errorf("binding software version %v and testbed software version %v do not match", bd.SoftwareVersion, tdSoftwareVersion))
-		}
+		errs = append(errs, fmt.Errorf("binding software version %v and testbed software version %v do not match", bd.SoftwareVersion, tdSoftwareVersion))
 	}
 
 	portmap, portErrs := ports(td.Ports, bd)
@@ -379,20 +366,11 @@ func ports(tports []*opb.Port, bd *bindpb.Device) (map[string]*binding.Port, []e
 			errs = append(errs, fmt.Errorf("missing binding for port %q on %q", tport.Id, bd.Id))
 			continue
 		}
-		// TODO(greg-dennis): Stop copying the testbed port dimensions into the bound dimensions.
 		if tport.Speed != opb.Port_SPEED_UNSPECIFIED && tport.Speed != bport.Speed {
-			if bport.Speed == opb.Port_SPEED_UNSPECIFIED {
-				bport.Speed = tport.Speed
-			} else {
-				errs = append(errs, fmt.Errorf("binding port speed %v and testbed port speed %v do not match", bport.Speed, tport.Speed))
-			}
+			errs = append(errs, fmt.Errorf("binding port speed %v and testbed port speed %v do not match", bport.Speed, tport.Speed))
 		}
 		if tport.GetPmd() != opb.Port_PMD_UNSPECIFIED && tport.GetPmd() != bport.Pmd {
-			if bport.Pmd == opb.Port_PMD_UNSPECIFIED {
-				bport.Pmd = tport.GetPmd()
-			} else {
-				errs = append(errs, fmt.Errorf("binding port PMD %v and testbed port PMD %v do not match", bport.Pmd, tport.GetPmd()))
-			}
+			errs = append(errs, fmt.Errorf("binding port PMD %v and testbed port PMD %v do not match", bport.Pmd, tport.GetPmd()))
 		}
 		portmap[tport.Id] = &binding.Port{
 			Name:  bport.Name,

--- a/topologies/binding/binding_test.go
+++ b/topologies/binding/binding_test.go
@@ -220,8 +220,10 @@ func TestReservation_Error(t *testing.T) {
 
 	wants := []string{
 		`missing binding for DUT "dut.tb"`,
+		`binding vendor`,
 		`binding hardware model`,
 		`missing binding for port "port1" on "dut.both"`,
+		`binding port speed`,
 		`binding port PMD`,
 		`missing binding for ATE "ate.tb"`,
 		`missing binding for port "port2" on "ate.both"`,


### PR DESCRIPTION
DO NOT SUBMIT until 2/26/24.

This is a necessary step to unblock dynamic reservation for the static FP binding.