### PR TITLE
Adding applicable deviations for Arista to os_install test metadata.textproto file

### DIFF
--- a/feature/gnoi/os/tests/osinstall/metadata.textproto
+++ b/feature/gnoi/os/tests/osinstall/metadata.textproto
@@ -22,3 +22,12 @@ platform_exceptions: {
     interface_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: ARISTA
+  }
+  deviations: {
+    default_network_instance: "default"
+    interface_enabled: true
+  }
+}


### PR DESCRIPTION
The test still fails due to some recently added strict expectations in the test but, the deviations are needed nevertheless. There is an open discussion about the other test issues causing the test to fail.