### PR TITLE
Update IP assignment guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -339,9 +339,9 @@ a1v4.Protocol, _ = a1v4.To_Acl_AclSet_AclEntry_Ipv4_Protocol_Union(6)
 ## IP Addresses Assignment
 
 > **Warning:** Though we are trying to use RFC defined non-globally routable
-> space, there might be tests that are still using public routable ranges. Users
-> who runs the tests owns the responsibility of not letting test traffic leaked
-> to the internet.
+> space in the test, there might be tests (e.g. scaling tests) that are still
+> using public routable ranges. Users who run the tests own the responsibility
+> of not leaking test traffic to internet.
 
 ### IPv4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -339,9 +339,9 @@ a1v4.Protocol, _ = a1v4.To_Acl_AclSet_AclEntry_Ipv4_Protocol_Union(6)
 ## IP Addresses Assignment
 
 > **Warning:** Though we are trying to use RFC defined non-globally routable
-> space in the test, there might be tests (e.g. scaling tests) that are still
-> using public routable ranges. Users who run the tests own the responsibility
-> of not leaking test traffic to internet.
+> space in tests, there might be tests (e.g. scaling tests) that are still using
+> public routable ranges. Users who run the tests own the responsibility of not
+> leaking test traffic to internet.
 
 ### IPv4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,8 +123,8 @@ in the [project](https://github.com/orgs/openconfig/projects/2/views/1) item.
 
 Each test must also be accompanied by a `metadata.textproto` file that supplies
 the metadata for annotating the JUnit XML test results. This file can be
-generated or updated using the command: `go run ./tools/addrundata --fix`.
-See [addrundata](/tools/addrundata/README.md) for more info.
+generated or updated using the command: `go run ./tools/addrundata --fix`. See
+[addrundata](/tools/addrundata/README.md) for more info.
 
 For example:
 
@@ -338,55 +338,29 @@ a1v4.Protocol, _ = a1v4.To_Acl_AclSet_AclEntry_Ipv4_Protocol_Union(6)
 
 ## IP Addresses Assignment
 
-Netblocks used in the test topology should follow IPv4 Address Blocks Reserved
-for Documentation ([RFC 5737]), IPv4 reserved for Benchmarking Methodology
-([RFC 2544]), and IPv6 Address Prefix Reserved for Documentation ([RFC 3849]).
-In particular:
-
-[RFC 5737]: https://datatracker.ietf.org/doc/html/rfc5737
-[RFC 2544]: https://datatracker.ietf.org/doc/html/rfc2544
-[RFC 3849]: https://datatracker.ietf.org/doc/html/rfc3849
-
-For IPv6, link local addresses (FE80::/10) addresses are allowed in contexts
-where link local is being tested.
+> **Warning:** Though we are trying to use RFC defined non-globally routable
+> space, there might be tests that are still using public routable ranges. Users
+> who runs the tests owns the responsibility of not letting test traffic leaked
+> to the internet.
 
 ### IPv4
 
-*   `TEST-NET-1`: (192.0.2.0/24): control plane addresses split into /30 subnets
-    for each ATE/DUT port pair.
-*   `TEST-NET-2`: (198.51.100.0/24): data plane source network addresses used
-    for traffic testing; split as needed.
-*   `TEST-NET-3`: (203.0.113.0/24): data plane destination network addresses
-    used for traffic testing; split as needed.
-*   `BMWG`: (198.18.0.0/15): additional data plane networks.
-
-*   20.0.0.1/15: data plane source network addresses used for scale testing.
-
-*   30.0.0.1/15: data plane source network addresses used for scale testing.
-
-*   100.0.0.0/12: data plane source network addresses used for scale testing.
-
-*   138.0.11.0/24: data plane source network addresses used for traffic testing; split as needed.
-
-*   192.51.100.1/24: data plane source network addresses used for traffic testing; split as needed.
-
-*   192.51.129.0/22: data plane source network addresses used for traffic testing; split as needed.
-
-*   192.55.200.3/32: data plane source network addresses used for traffic testing; split as needed.
-
-*   198.100.200.123/24: data plane source network addresses used for traffic testing; split as needed.
-
-*   203.10.113.1/24: data plane source network addresses used for traffic testing; split as needed.
-
-*   192.58.200.1/24:  data plane source network addresses used for traffic testing; split as needed.
-
-*   192.168.10.0/24:  network addresses used for bgp policy testing; split as needed.
-
-*   192.168.20.0/24:  network addresses used for bgp policy testing; split as needed.
+*   192.0.2.0/24 ([TEST-NET-1](https://www.iana.org/go/rfc5737)): control plane
+    addresses split into /30 subnets for each ATE/DUT port pair.
+*   198.51.100.0/24 ([TEST-NET-2](https://www.iana.org/go/rfc5737)): data plane
+    source network addresses used for traffic testing; split as needed.
+*   203.0.113.0/24 ([TEST-NET-3](https://www.iana.org/go/rfc5737)): data plane
+    destination network addresses used for traffic testing; split as needed.
+*   100.64.0.0/10 ([CGN Shared Space](https://www.iana.org/go/rfc6598)):
+    additional network address; split as needed.
+*   198.18.0.0/15 ([Device Benchmark Testing](https://www.iana.org/go/rfc2544)):
+    additional network address; split as needed.
 
 ### IPv6
 
-2001:DB8::/32 is a very large space, so we divide them as follows.
+2001:DB8::/32
+([Reserved for Documentation](https://datatracker.ietf.org/doc/html/rfc3849)) is
+a very large space, so we divide them as follows.
 
 *   2001:DB8:0::/64: control plane addresses split into /126 subnets for each
     ATE/DUT port pair.
@@ -394,6 +368,9 @@ where link local is being tested.
     address; split as needed.
 *   2001:DB8:2::/64: data plane addresses used for traffic testing as the
     destination address; split as needed.
+
+Link local addresses (FE80::/10) addresses are allowed in contexts where link
+local is being tested.
 
 ### Rationale
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ or by opening a GitHub
 # Running Tests on Virtual Devices
 
 > **Warning:** Though we are trying to use RFC defined non-globally routable
-> space in the test, there might be tests (e.g. scaling tests) that are still
-> using public routable ranges. Users who run the tests own the responsibility
-> of not leaking test traffic to internet.
+> space in tests, there might be tests (e.g. scaling tests) that are still using
+> public routable ranges. Users who run the tests own the responsibility of not
+> leaking test traffic to internet.
 
 Tests may be run on virtual devices using the
 [Kubernetes Network Emulation](https://github.com/openconfig/kne) binding.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ or by opening a GitHub
 
 # Running Tests on Virtual Devices
 
+> **Warning:** Though we are trying to use RFC defined non-globally routable
+> space, there might be tests that are still using public routable ranges. Users
+> who runs the tests owns the responsibility of not letting test traffic leaked
+> to the internet.
+
 Tests may be run on virtual devices using the
 [Kubernetes Network Emulation](https://github.com/openconfig/kne) binding.
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ or by opening a GitHub
 # Running Tests on Virtual Devices
 
 > **Warning:** Though we are trying to use RFC defined non-globally routable
-> space, there might be tests that are still using public routable ranges. Users
-> who runs the tests owns the responsibility of not letting test traffic leaked
-> to the internet.
+> space in the test, there might be tests (e.g. scaling tests) that are still
+> using public routable ranges. Users who run the tests own the responsibility
+> of not leaking test traffic to internet.
 
 Tests may be run on virtual devices using the
 [Kubernetes Network Emulation](https://github.com/openconfig/kne) binding.

--- a/feature/bgp/policybase/otg_tests/actions-MED_LocPref_prepend_flow-control/actions_MED_LocPref_prepend_flow_control_test.go
+++ b/feature/bgp/policybase/otg_tests/actions-MED_LocPref_prepend_flow-control/actions_MED_LocPref_prepend_flow_control_test.go
@@ -55,6 +55,8 @@ const (
 	initialMEDValue             = 50
 	setMEDPolicy                = "med-policy"
 	matchStatement1             = "match-statement-1"
+	setPrependPolicy            = "prepend-policy"
+	testASN                     = 23456
 	defRejectRoute              = oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE
 	defAcceptRoute              = oc.RoutingPolicy_DefaultPolicyType_ACCEPT_ROUTE
 	peerGrpName1v4              = "iBGP-PEER-GROUP1-V4"
@@ -203,7 +205,7 @@ func VerifyBgpState(t *testing.T, dut *ondatra.DUTDevice) {
 }
 
 // configureMEDLocalPrefPolicy configures MED, Local Pref, AS prepend etc
-func configureMEDLocalPrefPolicy(t *testing.T, dut *ondatra.DUTDevice, policyType, policyValue, statement string) {
+func configureMEDLocalPrefPolicy(t *testing.T, dut *ondatra.DUTDevice, policyType, policyValue, statement string, ASN uint32) {
 	t.Helper()
 	dutOcRoot := &oc.Root{}
 	batchConfig := &gnmi.SetBatch{}
@@ -226,6 +228,12 @@ func configureMEDLocalPrefPolicy(t *testing.T, dut *ondatra.DUTDevice, policyTyp
 			metric, _ := strconv.Atoi(policyValue)
 			actions.GetOrCreateBgpActions().SetMed = oc.UnionUint32(uint32(metric))
 		}
+		actions.PolicyResult = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+	case setPrependPolicy:
+		metric, _ := strconv.Atoi(policyValue)
+		asPrepend := actions.GetOrCreateBgpActions().GetOrCreateSetAsPathPrepend()
+		asPrepend.Asn = ygot.Uint32(ASN)
+		asPrepend.RepeatN = ygot.Uint8(uint8(metric))
 		actions.PolicyResult = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
 	default:
 		rp = nil
@@ -403,8 +411,8 @@ func configureOTG(t *testing.T, otg *otg.OTG) gosnappi.Config {
 	return config
 }
 
-// validateOTGBgpPrefixV4AndMED verifies that the IPv4 prefix is received on OTG.
-func validateOTGBgpPrefixV4AndMED(t *testing.T, otg *otg.OTG, config gosnappi.Config, peerName, ipAddr string, prefixLen uint32, isMEDCheck bool, med uint32) {
+// validateOTGBgpPrefixV4AndASLocalPrefMED verifies that the IPv4 prefix is received on OTG.
+func validateOTGBgpPrefixV4AndASLocalPrefMED(t *testing.T, otg *otg.OTG, config gosnappi.Config, peerName, ipAddr string, prefixLen uint32, pathAttr string, metric uint32) {
 	t.Helper()
 	_, ok := gnmi.WatchAll(t,
 		otg,
@@ -414,29 +422,47 @@ func validateOTGBgpPrefixV4AndMED(t *testing.T, otg *otg.OTG, config gosnappi.Co
 			_, present := v.Val()
 			return present
 		}).Await(t)
-
+	var foundPrefix = false
 	if ok {
 		bgpPrefixes := gnmi.GetAll(t, otg, gnmi.OTG().BgpPeer(peerName).UnicastIpv4PrefixAny().State())
 		for _, bgpPrefix := range bgpPrefixes {
 			if bgpPrefix.Address != nil && bgpPrefix.GetAddress() == ipAddr &&
 				bgpPrefix.PrefixLength != nil && bgpPrefix.GetPrefixLength() == prefixLen {
+				foundPrefix = true
 				t.Logf("Prefix recevied on OTG is correct, got prefix %v, want prefix %v", bgpPrefix, ipAddr)
-				if isMEDCheck {
-					if bgpPrefix.GetMultiExitDiscriminator() != med {
-						t.Errorf("For Prefix %v, got MED %d want MED %d", bgpPrefix.GetAddress(), bgpPrefix.GetMultiExitDiscriminator(), med)
+				switch pathAttr {
+				case setMEDPolicy:
+					if bgpPrefix.GetMultiExitDiscriminator() != metric {
+						t.Errorf("For Prefix %v, got MED %d want MED %d", bgpPrefix.GetAddress(), bgpPrefix.GetMultiExitDiscriminator(), metric)
 					} else {
-						t.Logf("For Prefix %v, got MED %d want MED %d", bgpPrefix.GetAddress(), bgpPrefix.GetMultiExitDiscriminator(), med)
+						t.Logf("For Prefix %v, got MED %d want MED %d", bgpPrefix.GetAddress(), bgpPrefix.GetMultiExitDiscriminator(), metric)
 					}
+				case setLocalPrefPolicy:
+					if bgpPrefix.GetLocalPreference() != metric {
+						t.Errorf("For Prefix %v, got Local Preference %d want Local Preference %d", bgpPrefix.GetAddress(), bgpPrefix.GetLocalPreference(), metric)
+					} else {
+						t.Logf("For Prefix %v, got Local Preference %d want Local Preference %d", bgpPrefix.GetAddress(), bgpPrefix.GetLocalPreference(), metric)
+					}
+				case setPrependPolicy:
+					if len(bgpPrefix.AsPath) != int(metric) {
+						t.Errorf("For Prefix %v, got AS Path Prepend %d want AS Path Prepend %d", bgpPrefix.GetAddress(), len(bgpPrefix.AsPath), int(metric))
+					} else {
+						t.Logf("For Prefix %v, got AS Path Prepend %d want AS Path Prepend %d", bgpPrefix.GetAddress(), len(bgpPrefix.AsPath), int(metric))
+					}
+				default:
+					t.Errorf("Incorrect BGP Path Attribute. Expected MED, Local Pref or AS Path Prepend!!!!")
 				}
 				break
 			}
 		}
-		t.Logf("Prefix %v not received on OTG", ipAddr)
+	}
+	if !foundPrefix {
+		t.Errorf("Prefix %v not received on OTG", ipAddr)
 	}
 }
 
-// validateOTGBgpPrefixV6AndMED verifies that the IPv6 prefix is received on OTG.
-func validateOTGBgpPrefixV6AndMED(t *testing.T, otg *otg.OTG, config gosnappi.Config, peerName, ipAddr string, prefixLen uint32, isMEDCheck bool, med uint32) {
+// validateOTGBgpPrefixV6AndASLocalPrefMED verifies that the IPv6 prefix is received on OTG.
+func validateOTGBgpPrefixV6AndASLocalPrefMED(t *testing.T, otg *otg.OTG, config gosnappi.Config, peerName, ipAddr string, prefixLen uint32, pathAttr string, metric uint32) {
 	t.Helper()
 	_, ok := gnmi.WatchAll(t,
 		otg,
@@ -446,24 +472,42 @@ func validateOTGBgpPrefixV6AndMED(t *testing.T, otg *otg.OTG, config gosnappi.Co
 			_, present := v.Val()
 			return present
 		}).Await(t)
-
+	var foundPrefix = false
 	if ok {
 		bgpPrefixes := gnmi.GetAll(t, otg, gnmi.OTG().BgpPeer(peerName).UnicastIpv6PrefixAny().State())
 		for _, bgpPrefix := range bgpPrefixes {
 			if bgpPrefix.Address != nil && bgpPrefix.GetAddress() == ipAddr &&
 				bgpPrefix.PrefixLength != nil && bgpPrefix.GetPrefixLength() == prefixLen {
+				foundPrefix = true
 				t.Logf("Prefix recevied on OTG is correct, got prefix %v, want prefix %v", bgpPrefix, ipAddr)
-				if isMEDCheck {
-					if bgpPrefix.GetMultiExitDiscriminator() != med {
-						t.Errorf("For Prefix %v, got MED %d want MED %d", bgpPrefix.GetAddress(), bgpPrefix.GetMultiExitDiscriminator(), med)
+				switch pathAttr {
+				case setMEDPolicy:
+					if bgpPrefix.GetMultiExitDiscriminator() != metric {
+						t.Errorf("For Prefix %v, got MED %d want MED %d", bgpPrefix.GetAddress(), bgpPrefix.GetMultiExitDiscriminator(), metric)
 					} else {
-						t.Logf("For Prefix %v, got MED %d want MED %d", bgpPrefix.GetAddress(), bgpPrefix.GetMultiExitDiscriminator(), med)
+						t.Logf("For Prefix %v, got MED %d want MED %d", bgpPrefix.GetAddress(), bgpPrefix.GetMultiExitDiscriminator(), metric)
 					}
+				case setLocalPrefPolicy:
+					if bgpPrefix.GetLocalPreference() != metric {
+						t.Errorf("For Prefix %v, got Local Preference %d want Local Preference %d", bgpPrefix.GetAddress(), bgpPrefix.GetLocalPreference(), metric)
+					} else {
+						t.Logf("For Prefix %v, got Local Preference %d want Local Preference %d", bgpPrefix.GetAddress(), bgpPrefix.GetLocalPreference(), metric)
+					}
+				case setPrependPolicy:
+					if len(bgpPrefix.AsPath) != int(metric) {
+						t.Errorf("For Prefix %v, got AS Path Prepend %d want AS Path Prepend %d", bgpPrefix.GetAddress(), len(bgpPrefix.AsPath), int(metric))
+					} else {
+						t.Logf("For Prefix %v, got AS Path Prepend %d want AS Path Prepend %d", bgpPrefix.GetAddress(), len(bgpPrefix.AsPath), int(metric))
+					}
+				default:
+					t.Errorf("Incorrect Routing Policy. Expected MED, Local Pref or AS Path Prepend!!!!")
 				}
 				break
 			}
 		}
-		t.Logf("Prefix %v not received on OTG", ipAddr)
+	}
+	if !foundPrefix {
+		t.Errorf("Prefix %v not received on OTG", ipAddr)
 	}
 }
 
@@ -509,8 +553,8 @@ func TestBGPPolicy(t *testing.T) {
 		defPolicyPort1, defPolicyPort2                              oc.E_RoutingPolicy_DefaultPolicyType
 		policyValue                                                 string
 		port1v4Prefix, port1v6Prefix, port2v4Prefix, port2v6Prefix  string
-		isMEDCheck, isDeletePolicy                                  bool
-		metricValue                                                 uint32
+		isDeletePolicy                                              bool
+		metricValue, asn                                            uint32
 		deleteNbrv4, deleteNbrv6                                    string
 		polNbrv4, polNbrv6                                          string
 	}{{
@@ -526,13 +570,13 @@ func TestBGPPolicy(t *testing.T) {
 		port1v6Prefix:   advertisedRoutesv6Net2,
 		port2v4Prefix:   advertisedRoutesv4Net1,
 		port2v6Prefix:   advertisedRoutesv6Net1,
-		isMEDCheck:      true,
 		metricValue:     100,
 		polNbrv4:        atePort1.IPv4,
 		polNbrv6:        atePort1.IPv6,
 		isDeletePolicy:  false,
 		deleteNbrv4:     "",
 		deleteNbrv6:     "",
+		asn:             dutAS,
 	}, {
 		desc:            "Configure eBGP set MED Import Export Policy",
 		rpPolicy:        setMEDPolicy,
@@ -546,13 +590,13 @@ func TestBGPPolicy(t *testing.T) {
 		port1v6Prefix:   advertisedRoutesv6Net2,
 		port2v4Prefix:   advertisedRoutesv4Net1,
 		port2v6Prefix:   advertisedRoutesv6Net1,
-		isMEDCheck:      true,
 		metricValue:     100,
 		polNbrv4:        atePort2.IPv4,
 		polNbrv6:        atePort2.IPv6,
 		isDeletePolicy:  true,
 		deleteNbrv4:     atePort1.IPv4,
 		deleteNbrv6:     atePort1.IPv6,
+		asn:             dutAS,
 	}, {
 		desc:            "Configure iBGP increase MED Import Export Policy",
 		rpPolicy:        setMEDPolicy,
@@ -566,13 +610,13 @@ func TestBGPPolicy(t *testing.T) {
 		port1v6Prefix:   advertisedRoutesv6Net1,
 		port2v4Prefix:   advertisedRoutesv4Net2,
 		port2v6Prefix:   advertisedRoutesv6Net2,
-		isMEDCheck:      true,
 		metricValue:     150,
 		polNbrv4:        atePort1.IPv4,
 		polNbrv6:        atePort1.IPv6,
 		isDeletePolicy:  true,
 		deleteNbrv4:     atePort2.IPv4,
 		deleteNbrv6:     atePort2.IPv6,
+		asn:             dutAS,
 	}, {
 		desc:            "Configure eBGP increase MED Import Export Policy",
 		rpPolicy:        setMEDPolicy,
@@ -586,13 +630,13 @@ func TestBGPPolicy(t *testing.T) {
 		port1v6Prefix:   advertisedRoutesv6Net2,
 		port2v4Prefix:   advertisedRoutesv4Net1,
 		port2v6Prefix:   advertisedRoutesv6Net1,
-		isMEDCheck:      true,
 		metricValue:     150,
 		polNbrv4:        atePort2.IPv4,
 		polNbrv6:        atePort2.IPv6,
 		isDeletePolicy:  true,
 		deleteNbrv4:     atePort1.IPv4,
 		deleteNbrv6:     atePort1.IPv6,
+		asn:             dutAS,
 	}, {
 		desc:            "Configure iBGP set Local Preference Import Export Policy",
 		rpPolicy:        setLocalPrefPolicy,
@@ -606,13 +650,13 @@ func TestBGPPolicy(t *testing.T) {
 		port1v6Prefix:   advertisedRoutesv6Net2,
 		port2v4Prefix:   advertisedRoutesv4Net1,
 		port2v6Prefix:   advertisedRoutesv6Net1,
-		isMEDCheck:      false,
 		metricValue:     100,
 		polNbrv4:        atePort1.IPv4,
 		polNbrv6:        atePort1.IPv6,
 		isDeletePolicy:  true,
 		deleteNbrv4:     atePort2.IPv4,
 		deleteNbrv6:     atePort2.IPv6,
+		asn:             dutAS,
 	}, {
 		desc:            "Configure eBGP set Local Preference Import Export Policy",
 		rpPolicy:        setLocalPrefPolicy,
@@ -626,19 +670,99 @@ func TestBGPPolicy(t *testing.T) {
 		port1v6Prefix:   advertisedRoutesv6Net2,
 		port2v4Prefix:   advertisedRoutesv4Net1,
 		port2v6Prefix:   advertisedRoutesv6Net1,
-		isMEDCheck:      false,
 		metricValue:     100,
 		polNbrv4:        atePort2.IPv4,
 		polNbrv6:        atePort2.IPv6,
 		isDeletePolicy:  true,
 		deleteNbrv4:     atePort1.IPv4,
 		deleteNbrv6:     atePort1.IPv6,
+		asn:             dutAS,
+	}, {
+		desc:            "Configure iBGP  prepend 10 x local ASN Import Export Policy",
+		rpPolicy:        setPrependPolicy,
+		policyTypePort1: setPrependPolicy,
+		policyValue:     "10",
+		policyStatement: matchStatement1,
+		defPolicyPort1:  defRejectRoute,
+		defPolicyPort2:  defAcceptRoute,
+		policyTypePort2: "",
+		port1v4Prefix:   advertisedRoutesv4Net2,
+		port1v6Prefix:   advertisedRoutesv6Net2,
+		port2v4Prefix:   advertisedRoutesv4Net1,
+		port2v6Prefix:   advertisedRoutesv6Net1,
+		metricValue:     11,
+		polNbrv4:        atePort1.IPv4,
+		polNbrv6:        atePort1.IPv6,
+		isDeletePolicy:  true,
+		deleteNbrv4:     atePort2.IPv4,
+		deleteNbrv6:     atePort2.IPv6,
+		asn:             dutAS,
+	}, {
+		desc:            "Configure eBGP  prepend 10 x local ASN Import Export Policy",
+		rpPolicy:        setPrependPolicy,
+		policyTypePort1: "",
+		policyValue:     "10",
+		policyStatement: matchStatement1,
+		defPolicyPort1:  defRejectRoute,
+		defPolicyPort2:  defAcceptRoute,
+		policyTypePort2: setPrependPolicy,
+		port1v4Prefix:   advertisedRoutesv4Net2,
+		port1v6Prefix:   advertisedRoutesv6Net2,
+		port2v4Prefix:   advertisedRoutesv4Net1,
+		port2v6Prefix:   advertisedRoutesv6Net1,
+		metricValue:     11,
+		polNbrv4:        atePort2.IPv4,
+		polNbrv6:        atePort2.IPv6,
+		isDeletePolicy:  true,
+		deleteNbrv4:     atePort1.IPv4,
+		deleteNbrv6:     atePort1.IPv6,
+		asn:             dutAS,
+	}, {
+		desc:            "Configure iBGP  prepend 10 x ASN Import Export Policy",
+		rpPolicy:        setPrependPolicy,
+		policyTypePort1: setPrependPolicy,
+		policyValue:     "10",
+		policyStatement: matchStatement1,
+		defPolicyPort1:  defRejectRoute,
+		defPolicyPort2:  defAcceptRoute,
+		policyTypePort2: "",
+		port1v4Prefix:   advertisedRoutesv4Net2,
+		port1v6Prefix:   advertisedRoutesv6Net2,
+		port2v4Prefix:   advertisedRoutesv4Net1,
+		port2v6Prefix:   advertisedRoutesv6Net1,
+		metricValue:     11,
+		polNbrv4:        atePort1.IPv4,
+		polNbrv6:        atePort1.IPv6,
+		isDeletePolicy:  true,
+		deleteNbrv4:     atePort2.IPv4,
+		deleteNbrv6:     atePort2.IPv6,
+		asn:             23456,
+	}, {
+		desc:            "Configure eBGP  prepend 10 x ASN Import Export Policy",
+		rpPolicy:        setPrependPolicy,
+		policyTypePort1: "",
+		policyValue:     "10",
+		policyStatement: matchStatement1,
+		defPolicyPort1:  defRejectRoute,
+		defPolicyPort2:  defAcceptRoute,
+		policyTypePort2: setPrependPolicy,
+		port1v4Prefix:   advertisedRoutesv4Net2,
+		port1v6Prefix:   advertisedRoutesv6Net2,
+		port2v4Prefix:   advertisedRoutesv4Net1,
+		port2v6Prefix:   advertisedRoutesv6Net1,
+		metricValue:     11,
+		polNbrv4:        atePort2.IPv4,
+		polNbrv6:        atePort2.IPv6,
+		isDeletePolicy:  true,
+		deleteNbrv4:     atePort1.IPv4,
+		deleteNbrv6:     atePort1.IPv6,
+		asn:             23456,
 	}}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 
 			// Configure Routing Policy on the DUT.
-			configureMEDLocalPrefPolicy(t, dut, tc.rpPolicy, tc.policyValue, tc.policyStatement)
+			configureMEDLocalPrefPolicy(t, dut, tc.rpPolicy, tc.policyValue, tc.policyStatement, tc.asn)
 			// Configure BGP default import export policy on Port1
 			configureBGPDefaultImportExportPolicy(t, dut, atePort1.IPv4, atePort1.IPv6, tc.defPolicyPort1)
 			// Configure BGP default import export policy on Port1
@@ -655,10 +779,10 @@ func TestBGPPolicy(t *testing.T) {
 			verifyBgpPolicyTelemetry(t, dut, atePort2.IPv4, tc.defPolicyPort2, tc.policyTypePort2, true)
 			verifyBgpPolicyTelemetry(t, dut, atePort2.IPv6, tc.defPolicyPort2, tc.policyTypePort2, false)
 			// Validate Prefixes
-			validateOTGBgpPrefixV4AndMED(t, otg, otgConfig, atePort1.Name+".BGP4.Route", tc.port1v4Prefix, advertisedRoutesv4PrefixLen, tc.isMEDCheck, tc.metricValue)
-			validateOTGBgpPrefixV6AndMED(t, otg, otgConfig, atePort1.Name+".BGP6.Route", tc.port1v6Prefix, advertisedRoutesv6PrefixLen, tc.isMEDCheck, tc.metricValue)
-			validateOTGBgpPrefixV4AndMED(t, otg, otgConfig, atePort2.Name+".BGP4.Route", tc.port2v4Prefix, advertisedRoutesv4PrefixLen, tc.isMEDCheck, tc.metricValue)
-			validateOTGBgpPrefixV6AndMED(t, otg, otgConfig, atePort2.Name+".BGP6.Route", tc.port2v6Prefix, advertisedRoutesv6PrefixLen, tc.isMEDCheck, tc.metricValue)
+			validateOTGBgpPrefixV4AndASLocalPrefMED(t, otg, otgConfig, atePort1.Name+".BGP4.Route", tc.port1v4Prefix, advertisedRoutesv4PrefixLen, tc.rpPolicy, tc.metricValue)
+			validateOTGBgpPrefixV6AndASLocalPrefMED(t, otg, otgConfig, atePort1.Name+".BGP6.Route", tc.port1v6Prefix, advertisedRoutesv6PrefixLen, tc.rpPolicy, tc.metricValue)
+			validateOTGBgpPrefixV4AndASLocalPrefMED(t, otg, otgConfig, atePort2.Name+".BGP4.Route", tc.port2v4Prefix, advertisedRoutesv4PrefixLen, tc.rpPolicy, tc.metricValue)
+			validateOTGBgpPrefixV6AndASLocalPrefMED(t, otg, otgConfig, atePort2.Name+".BGP6.Route", tc.port2v6Prefix, advertisedRoutesv6PrefixLen, tc.rpPolicy, tc.metricValue)
 		})
 	}
 }

--- a/tools/check_ip_addresses.pl
+++ b/tools/check_ip_addresses.pl
@@ -43,7 +43,11 @@ if (/\b(\d{1,3}(\.\d{1,3}){3,})(\/\d+)?\b/) {
   next if $ip =~ /192\.0\.2\./;         # TEST-NET-1 (RFC 5737)
   next if $ip =~ /198\.51\.100\./;      # TEST-NET-2 (RFC 5737)
   next if $ip =~ /203\.0\.113\./;       # TEST-NET-3 (RFC 5737)
-  next if $ip =~ /198\.(18|19)\./;      # BMWG (RFC 2544)
+  next if $ip =~ /100\.(6[4-9])\./;       # 64-69, CGN Shared Space (RFC 6598)
+  next if $ip =~ /100\.([789][0-9])\./;       # 70-99, CGN Shared Space (RFC 6598)
+  next if $ip =~ /100\.(1[01][0-9])\./;       # 100 - 119, CGN Shared Space (RFC 6598)
+  next if $ip =~ /100\.(12[0-7])\./;       # 120 - 127, CGN Shared Space (RFC 6598)
+  next if $ip =~ /198\.(18|19)\./;      # Device Benchmark Testing (RFC 2544)
   next if $ip =~ /20\.0\./;             # 20.0.0.1/15
   next if $ip =~ /30\.0\./;             # 30.0.0.1/15
   next if $ip =~ /100\.0\./;            # 100.0.0.1/12


### PR DESCRIPTION
* Add a WARNING that users who run the test own the responsibility of not leaking test traffic to internet.
* Add `100.64.0.0/10`, a non-globally routable CGN range, which usually is used inside service providers. https://www.iana.org/go/rfc6598.
* Correct the name of `198.18.0.0/15` to `Device Benchmark Testing` (RFC 2544).
* Removed other "arbitrary" IP ranages, we'd like to deprecate them from the tests.
* Update IP check script accordingly.

Formatting:
* Simplify the wording in the `IP Addresses Assignment` section.