### PR TITLE
Update virtual device testing CI SSH key

### DIFF
--- a/cloudbuild/virtual.yaml
+++ b/cloudbuild/virtual.yaml
@@ -1,10 +1,15 @@
 steps:
+  - id: fetch-secrets
+    name: gcr.io/cloud-builders/gcloud
+    script: |
+      gcloud secrets versions access latest --secret=featureprofiles-ci-ssh > builder-key
+      gcloud secrets versions access latest --secret=featureprofiles-ci-ssh-pub > builder-key.pub
   - id: fp-presubmit
     name: gcr.io/${PROJECT_ID}/remote-builder
     waitFor: ["-"]
     env:
       - USERNAME=user
-      - SSH_ARGS=--internal-ip --ssh-key-expire-after=1d
+      - SSH_ARGS=--internal-ip
       - INSTANCE_NAME=fp-presubmit-${BUILD_ID}
       - INSTANCE_ARGS=--network cloudbuild-workers --image-project gep-kne --image-family kne --machine-type ${_MACHINE_TYPE} ${_MACHINE_ARGS} --boot-disk-size 200GB --service-account=fp-kne@disco-idea-817.iam.gserviceaccount.com --scopes=default,compute-rw
       - ZONE=us-west1-a


### PR DESCRIPTION
Virtual device tests will sometimes hang on the "setup" phase.  An example can be seen in #2731 - the logs will show the following when trying to connect to the KNE instance:

```
ERROR: (gcloud.compute.ssh) INVALID_ARGUMENT: Login profile size exceeds 32 KiB. Delete profile values to make additional space.
```

This is because the remote-builder container generates a new SSH key each time which gets cached into the cloud build service account profile (related to OS Login enforcement).  This was previously mitigated by #298 by adding key expiration, however this is still a problem if too many tests run in a 24-hour window.  Very short timeouts did not work well because `gcloud compute scp...` would not refresh the keys similar to how `gcloud compute ssh...` would.

This change eliminates the issue by fetching a SSH key stored in Secret Manager for each execution.  The remote-builder container will use an existing builder-key if one exists instead of creating a new key.