### PR TITLE
Fix incorrect textproto syntax in metadata.

### DIFF
--- a/feature/bgp/policybase/otg_tests/comm_match_action_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/comm_match_action_test/metadata.textproto
@@ -4,4 +4,4 @@
 plan_id: "RT-7.8"
 description: "BGP Policy Match Standard Community and Add Community Import/Export Policy"
 testbed: TESTBED_DUT_ATE_2LINKS
-tags: TAGS_AGGREGATION, TAGS_TRANSIT, TAGS_DATACENTER_EDGE
+tags: [TAGS_AGGREGATION, TAGS_TRANSIT, TAGS_DATACENTER_EDGE]

--- a/feature/bgp/policybase/otg_tests/extcomm_action_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/extcomm_action_test/metadata.textproto
@@ -4,4 +4,4 @@
 plan_id: "RT-7.9"
 description: "BGP Policy - Import/Export Policy Action Using Communities"
 testbed: TESTBED_DUT_ATE_2LINKS
-tags: TAGS_AGGREGATION, TAGS_TRANSIT, TAGS_DATACENTER_EDGE
+tags: [TAGS_AGGREGATION, TAGS_TRANSIT, TAGS_DATACENTER_EDGE]

--- a/tools/wikidoc/wikidoc.go
+++ b/tools/wikidoc/wikidoc.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -143,7 +144,7 @@ func fetchTestDocs(rootPath string) ([]testDoc, error) {
 			}
 			md := new(mpb.Metadata)
 			if err := prototext.Unmarshal(bytes, md); err != nil {
-				return err
+				return fmt.Errorf("cannot unmarshal %s: %v", path, err)
 			}
 			docMap[md.GetUuid()] = testDoc{
 				Name:  filepath.Base(filepath.Dir(path)),


### PR DESCRIPTION
```
 * (M) tools/wikidoc/wikidoc.go
   - Make wikidoc report what file it failed to parse.
 * (M) feature/bgp/policybase/otg_tests/comm_match_action_test/metadata.textproto
 * (M) feature/bgp/policybase/otg_tests/extcomm_action_test/metadata.textproto
   - Fix missing [] to indicate a list of tags.
```
