### PR TITLE
Remove restore-keys from Github Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,6 @@ jobs:
           ~/go/pkg/mod
           ~/.cache/go-build
         key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
     - name: Build
       run: go build -v ./...
   test:
@@ -41,7 +40,6 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
           key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
       # Dependency for Go module github.com/google/gopacket
       - name: Install libpcap-dev
         run: sudo apt-get -y install libpcap-dev
@@ -75,7 +73,6 @@ jobs:
           ~/.cache/go-build
           ~/.cache/staticcheck
         key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
     # Dependency for Go module github.com/google/gopacket
     - name: Install libpcap-dev
       run: sudo apt-get -y install libpcap-dev

--- a/.github/workflows/protobufs.yml
+++ b/.github/workflows/protobufs.yml
@@ -25,7 +25,6 @@ jobs:
           ~/go/pkg/mod
           ~/.cache/go-build
         key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
     - name: Install protobuf
       uses: arduino/setup-protoc@v1
       with:
@@ -104,7 +103,6 @@ jobs:
           ~/go/pkg/mod
           ~/.cache/go-build
         key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
     - name: Fetch Openconfig Models
       run: make openconfig_public
     - name: Validate Paths

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -28,7 +28,6 @@ jobs:
           ~/go/pkg/mod
           ~/.cache/go-build
         key: ${{ github.job }}-${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ github.job }}-${{ runner.os }}-go-build-
     - name: Build Wiki
       run: |
         pushd featureprofiles.wiki


### PR DESCRIPTION
staticcheck was failing with container disk full in [some PRs](https://github.com/openconfig/featureprofiles/actions/runs/8169538025/job/22333812800):

```
Run GOGC=30 staticcheck ./...
-: # github.com/openconfig/featureprofiles/feature/qos/tests/qos_ecn_config_test_test [github.com/openconfig/featureprofiles/feature/qos/tests/qos_ecn_config_test.test]
compile: writing output: write $WORK/b1526/_pkg_.a: no space left on device (compile)
-: # github.com/openconfig/featureprofiles/feature/qos/tests/qos_policy_config_test_test [github.com/openconfig/featureprofiles/feature/qos/tests/qos_policy_config_test.test]
compile: writing output: write $WORK/b1528/_pkg_.a: no space left on device (compile)
...
```

In the run log for the last time [go.sum changed](https://github.com/openconfig/featureprofiles/actions/runs/8150357957/job/22276494131), the cache was restored from an old key to a new key:

```
...
Cache restored from key: static_analysis-Linux-go-build-2dbbc6a937382829013c5be87501984699d6d6a97c28b08f632befe06801a8fe.
...
Cache saved with key: static_analysis-Linux-go-build-1c13e07f9ed5e8b76b1440facd258e17b8f7e6c6611cb0323e925c2b391c804e
...
```

This change removes the loose key matching. I believe as dependencies change the cache can grow indefinitely. The cache size for staticcheck went from 1.9GB to 1.5GB when regenerating it from a miss. The downside to this change is any PRs changing go.mod will take a while to run because they can't reuse a cache (~5m vs ~30m).

The cache size change doesn't sound like much, but it uncompresses to ~20GB which is a good chunk of the space available for Github Actions.