### PR TITLE
staticcheck CI: Move cache directory to scratch disk partition

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,6 +63,8 @@ jobs:
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo mv "${HOME}/.cache" /mnt/cache
+        ln -s /mnt/cache "${HOME}/.cache"
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Cache


### PR DESCRIPTION
Some PRs were still having issues with staticcheck and disk usage (#2202 ([link](https://github.com/openconfig/featureprofiles/actions/runs/8196457547/job/22416721843)), #2718 ([link](https://github.com/openconfig/featureprofiles/actions/runs/8205704582/job/22443163513?pr=2718))).  This change moves the cache directory to the sdb1 partition at /mnt. Previously everything would go into / and the disk would fill up.

Disk usage after staticcheck runs on an example large run:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   39G   34G  54% /
tmpfs           7.9G  172K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda15      105M  6.1M   99M   6% /boot/efi
/dev/sdb1        74G   30G   40G  44% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

/mnt usually just holds a 4GB swap file, so there is 26GB of cache data in this example.