### PR TITLE
Fix references to community-set in RT-7.2

### DIFF
--- a/feature/bgp/policybase/otg_tests/community_test/README.md
+++ b/feature/bgp/policybase/otg_tests/community_test/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-BGP policy configuration for AS Paths and Community Sets
+BGP policy configuration for Community Sets
 
 ## Subtests
 
@@ -38,16 +38,16 @@ BGP policy configuration for AS Paths and Community Sets
       * conditions/bgp-conditions/match-community-set/config/match-set-options = ANY
       * actions/config/policy-result = ACCEPT_ROUTE
     * statement[name='accept_all_3_comms']/
-      * conditions/bgp-conditions/match-as-path-set/config/as-path-set = 'all_3_comms'
-      * conditions/bgp-conditions/match-as-path-set/config/match-set-options = ALL
+      * conditions/bgp-conditions/match-community-set/config/community-set = 'all_3_comms'
+      * conditions/bgp-conditions/match-community-set/config/match-set-options = ALL
       * actions/config/policy-result = ACCEPT_ROUTE
     * statement[name='accept_no_3_comms']/
-      * conditions/bgp-conditions/match-as-path-set/config/as-path-set = 'no_3_comms'
-      * conditions/bgp-conditions/match-as-path-set/config/match-set-options = INVERT
+      * conditions/bgp-conditions/match-community-set/config/community-set = 'no_3_comms'
+      * conditions/bgp-conditions/match-community-set/config/match-set-options = INVERT
       * actions/config/policy-result = ACCEPT_ROUTE
     * statement[name='accept_any_my_regex_comms']/
-      * conditions/bgp-conditions/match-as-path-set/config/as-path-set = 'all_3_comms'
-      * conditions/bgp-conditions/match-as-path-set/config/match-set-options = ANY
+      * conditions/bgp-conditions/match-community-set/config/community-set = 'all_3_comms'
+      * conditions/bgp-conditions/match-community-set/config/match-set-options = ANY
       * actions/config/policy-result = ACCEPT_ROUTE
 
   * Send traffic from ATE port-2 to all prefix-sets.

--- a/feature/bgp/policybase/otg_tests/community_test/README.md
+++ b/feature/bgp/policybase/otg_tests/community_test/README.md
@@ -63,8 +63,6 @@ BGP policy configuration for Community Sets
 | prefix-set-3 | reject         | reject      | accept     | accept             |
 | prefix-set-4 | reject         | reject      | accept     | reject             |
 
-* TODO: add coverage for link-bandwidth community in separate test.
-
 ## Config Parameter Coverage
 
 ### Policy definition
@@ -77,7 +75,9 @@ BGP policy configuration for Community Sets
 * /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set/config/community-set-name
 * /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set/config/community-member
 * /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set/config/match-set-options
-* /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/bgp-conditions/config/community-set
+* /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/bgp-conditions/match-community-set/config/community-set
+* /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/bgp-conditions/match-community-set/config/match-set-options
+* /routing-policy/policy-definitions/policy-definition/statements/statement/actions/config/policy-result
 * /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/
 import-policy
 


### PR DESCRIPTION
This is documentation clean up and brings the readme in sync with the test code