### PR TITLE
gNMI-1.4 | change parent type validation to use lookup

### DIFF
--- a/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
+++ b/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
@@ -745,8 +745,9 @@ func ValidateComponentState(t *testing.T, dut *ondatra.DUTDevice, cards []*oc.Co
 						t.Errorf("Component %s Parent: Chassis component NOT found in the hierarchy tree of component", cName)
 						break
 					}
-					parentType := gnmi.Get(t, dut, gnmi.OC().Component(parent).Type().State())
-					if parentType == componentType["Chassis"] {
+					pLoookup := gnmi.Lookup(t, dut, gnmi.OC().Component(parent).Type().State())
+					parentType, present := pLoookup.Val()
+					if present && parentType == componentType["Chassis"] {
 						t.Logf("Component %s Parent: Found chassis component in the hierarchy tree of component", cName)
 						break
 					}


### PR DESCRIPTION
Changed parent type validation to use lookup instead of get.

Some of the parent component may not map to any of identity types defined under OPENCONFIG_HARDWARE_COMPONENT, for those components type leaf would not be returned .