### PR TITLE
TE-16.1 | Changed testbed metadata field to use 8 link testbed

### DIFF
--- a/feature/gribi/otg_tests/basic_encap_test/metadata.textproto
+++ b/feature/gribi/otg_tests/basic_encap_test/metadata.textproto
@@ -4,7 +4,7 @@
 uuid:  "36cc79b5-3766-4cb4-b83b-1baea1464de8"
 plan_id:  "TE-16.1"
 description:  "basic encapsulation tests"
-testbed:  TESTBED_DUT_ATE_2LINKS
+testbed:  TESTBED_DUT_ATE_8LINKS
 platform_exceptions:  {
   platform:  {
     vendor:  CISCO


### PR DESCRIPTION
TE-16.1 requires 5 DUT-TGEN ports, so changed testbed metadata field to use TESTBED_DUT_ATE_8LINKS