### PR TITLE
backup_nhg_test - Adding 30s sleep in the validateAftTelemetry func before checking for next-hop entry count

### DIFF
--- a/feature/experimental/backup_nhg/otg_tests/backup_nhg_test/backup_nhg_test.go
+++ b/feature/experimental/backup_nhg/otg_tests/backup_nhg_test/backup_nhg_test.go
@@ -397,7 +397,7 @@ func (a *testArgs) validateAftTelemetry(t *testing.T, vrfName, prefix, ipAddress
 		t.Fatalf("Could not find prefix %s in telemetry AFT", prefix+"/"+mask)
 	}
 	aftPfx, _ := aftPfxVal.Val()
-
+	time.Sleep(30 * time.Second)
 	aftNHG := gnmi.Get(t, a.dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(a.dut)).Afts().NextHopGroup(aftPfx.GetNextHopGroup()).State())
 	if got := len(aftNHG.NextHop); got != 1 {
 		t.Fatalf("Prefix %s next-hop entry count: got %d, want 1", prefix+"/"+mask, got)


### PR DESCRIPTION
This change adds a 30s sleep before polling the AFT entry info from gNMI streaming on the DUT. The test prematurely checks for the AFT entries via gNMI. Need a little time for the streaming to settle down.