### PR TITLE
gNOI-3.3: add new subtests for configuration convergence

### DIFF
--- a/feature/gnoi/system/tests/supervisor_switchover_test/README.md
+++ b/feature/gnoi/system/tests/supervisor_switchover_test/README.md
@@ -6,12 +6,23 @@ Validate that the active supervisor can be switched.
 
 ## Procedure
 
-*   Issue gnoi.SwitchControlProcessor to the chassis with dual supervisor,
-    specifying the path to choose the standby RE/SUP.
-*   Ensure the SwitchControlProcessorResponse has the new active supervisor as
-    the one specified in the request.
-*   Validate the standby RE/SUP becomes the active after switchover
-*   Validate that all connected ports are re-enabled.
+*   Basic Switchover
+    *   Issue gnoi.SwitchControlProcessor to the chassis with dual supervisor,
+        specifying the path to choose the standby RE/SUP.
+    *   Ensure the SwitchControlProcessorResponse has the new active supervisor as
+        the one specified in the request.
+    *   Validate the standby RE/SUP becomes the active after switchover
+    *   Validate that all connected ports are re-enabled.
+
+*   Configuration consistent after switchover
+    *   Get the configuration before switchover.
+    *   Perform and validate switchover using the process outlined above.
+    *   Get configuration after switchover and validate that it matches the pre-switchover configuration.
+
+*  Configuration convergence after switchover
+    *   Perform and validate switchover using the process outlined above.
+    *   Push a large configuration
+    *   Get the configuration and validate that it is accepted whithin 60 seconds.
 
 ## Config Parameter Coverage
 

--- a/feature/gnoi/system/tests/supervisor_switchover_test/setup_test.go
+++ b/feature/gnoi/system/tests/supervisor_switchover_test/setup_test.go
@@ -1,0 +1,249 @@
+package supervisor_switchover_test
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+const (
+	// ISISInstance is ISIS instance name.
+	ISISInstance = "DEFAULT"
+	// PeerGrpName is BGP peer group name.
+	PeerGrpName = "BGP-PEER-GROUP"
+
+	// DUTAs is DUT AS.
+	DUTAs = 64500
+	// ATEAs is ATE AS.
+	ATEAs = 64501
+	// ATEAs2 is ATE source port AS
+	ATEAs2 = 64502
+	// ISISMetric is Metric for ISIS
+	ISISMetric = 100
+	// RouteCount for both BGP and ISIS
+	RouteCount = 200
+	// AdvertiseBGPRoutesv4 is the starting IPv4 address advertised by ATE Port 1.
+	AdvertiseBGPRoutesv4 = "203.0.113.1"
+
+	dutAreaAddress        = "49.0001"
+	dutSysID              = "1920.0000.2001"
+	dutStartIPAddr        = "192.0.2.1"
+	ateStartIPAddr        = "192.0.2.2"
+	plenIPv4              = 30
+	authPassword          = "ISISAuthPassword"
+	advertiseISISRoutesv4 = "198.18.0.0"
+	setALLOWPolicy        = "ALLOW"
+)
+
+// DUTIPList, ATEIPList are lists of DUT and ATE interface ip addresses.
+// ISISMetricList, ISISSetBitList are ISIS metric and setbit lists.
+var (
+	DUTIPList      = make(map[string]net.IP)
+	ATEIPList      = make(map[string]net.IP)
+	ISISMetricList []uint32
+	ISISSetBitList []bool
+)
+
+// buildPortIPs generates ip addresses for the ports in binding file.
+// (Both DUT and ATE ports).
+func buildPortIPs(dut *ondatra.DUTDevice) {
+	var dutIPIndex, ipSubnet, ateIPIndex int = 1, 2, 2
+	var endSubnetIndex = 253
+	for _, dp := range dut.Ports() {
+		dutNextIP := nextIP(net.ParseIP(dutStartIPAddr), dutIPIndex, ipSubnet)
+		ateNextIP := nextIP(net.ParseIP(ateStartIPAddr), ateIPIndex, ipSubnet)
+		DUTIPList[dp.ID()] = dutNextIP
+		ATEIPList[dp.ID()] = ateNextIP
+
+		// Increment DUT and ATE host ip index by 4.
+		dutIPIndex = dutIPIndex + 4
+		ateIPIndex = ateIPIndex + 4
+
+		// Reset DUT and ATE ip indexes when it is greater than endSubnetIndex.
+		if dutIPIndex > int(endSubnetIndex) {
+			ipSubnet = ipSubnet + 1
+			dutIPIndex = 1
+			ateIPIndex = 2
+		}
+	}
+}
+
+// nextIP returns ip address based on hostIndex and subnetIndex provided.
+func nextIP(ip net.IP, hostIndex int, subnetIndex int) net.IP {
+	s := ip.String()
+	sa := strings.Split(s, ".")
+	sa[2] = strconv.Itoa(subnetIndex)
+	sa[3] = strconv.Itoa(hostIndex)
+	s = strings.Join(sa, ".")
+	return net.ParseIP(s)
+}
+
+func BuildConfig(t *testing.T) *oc.Root {
+	dut := ondatra.DUT(t, "dut")
+	d := &oc.Root{}
+
+	// Generate ip addresses to configure DUT and ATE ports.
+	buildPortIPs(dut)
+
+	// Network instance and BGP configs.
+	netInstance := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
+
+	bgp := netInstance.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
+	global := bgp.GetOrCreateGlobal()
+	global.As = ygot.Uint32(DUTAs)
+	global.RouterId = ygot.String(dutStartIPAddr)
+
+	afi := global.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
+	afi.Enabled = ygot.Bool(true)
+
+	pg := bgp.GetOrCreatePeerGroup(PeerGrpName)
+	pg.PeerAs = ygot.Uint32(ATEAs)
+	pg.PeerGroupName = ygot.String(PeerGrpName)
+	afipg := pg.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
+	afipg.Enabled = ygot.Bool(true)
+	rp := d.GetOrCreateRoutingPolicy()
+	pdef := rp.GetOrCreatePolicyDefinition(setALLOWPolicy)
+	stmt, err := pdef.AppendNewStatement("id-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stmt.GetOrCreateActions().PolicyResult = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+	if deviations.RoutePolicyUnderAFIUnsupported(dut) {
+		rpl := pg.GetOrCreateApplyPolicy()
+		rpl.SetExportPolicy([]string{setALLOWPolicy})
+		rpl.SetImportPolicy([]string{setALLOWPolicy})
+	} else {
+		rpl := afipg.GetOrCreateApplyPolicy()
+		rpl.SetExportPolicy([]string{setALLOWPolicy})
+		rpl.SetImportPolicy([]string{setALLOWPolicy})
+	}
+
+	// ISIS configs.
+	prot := netInstance.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, ISISInstance)
+	prot.Enabled = ygot.Bool(true)
+	isis := prot.GetOrCreateIsis()
+
+	globalISIS := isis.GetOrCreateGlobal()
+	if deviations.ISISInstanceEnabledRequired(dut) {
+		globalISIS.Instance = ygot.String(ISISInstance)
+	}
+	globalISIS.LevelCapability = oc.Isis_LevelType_LEVEL_2
+	globalISIS.AuthenticationCheck = ygot.Bool(true)
+	if deviations.ISISGlobalAuthenticationNotRequired(dut) {
+		globalISIS.AuthenticationCheck = nil
+	}
+	globalISIS.Net = []string{fmt.Sprintf("%v.%v.00", dutAreaAddress, dutSysID)}
+	globalISIS.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled = ygot.Bool(true)
+	lspBit := globalISIS.GetOrCreateLspBit().GetOrCreateOverloadBit()
+	lspBit.SetBit = ygot.Bool(false)
+	isisTimers := globalISIS.GetOrCreateTimers()
+	isisTimers.LspLifetimeInterval = ygot.Uint16(600)
+	isisTimers.LspRefreshInterval = ygot.Uint16(250)
+	spfTimers := isisTimers.GetOrCreateSpf()
+	spfTimers.SpfHoldInterval = ygot.Uint64(5000)
+	spfTimers.SpfFirstInterval = ygot.Uint64(600)
+
+	isisLevel2 := isis.GetOrCreateLevel(2)
+	isisLevel2.MetricStyle = oc.Isis_MetricStyle_WIDE_METRIC
+
+	if deviations.ISISLevelEnabled(dut) {
+		isisLevel2.Enabled = ygot.Bool(true)
+	}
+	isisLevel2Auth := isisLevel2.GetOrCreateAuthentication()
+	isisLevel2Auth.Enabled = ygot.Bool(true)
+	if deviations.ISISExplicitLevelAuthenticationConfig(dut) {
+		isisLevel2Auth.DisableCsnp = ygot.Bool(false)
+		isisLevel2Auth.DisableLsp = ygot.Bool(false)
+		isisLevel2Auth.DisablePsnp = ygot.Bool(false)
+	}
+	isisLevel2Auth.AuthPassword = ygot.String(authPassword)
+	isisLevel2Auth.AuthMode = oc.IsisTypes_AUTH_MODE_MD5
+	isisLevel2Auth.AuthType = oc.KeychainTypes_AUTH_TYPE_SIMPLE_KEY
+
+	for _, dp := range dut.Ports() {
+		// Interfaces config.
+		i := d.GetOrCreateInterface(dp.Name())
+		i.Type = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
+		if deviations.InterfaceEnabled(dut) {
+			i.Enabled = ygot.Bool(true)
+		}
+		i.Description = ygot.String("from oc")
+		i.Name = ygot.String(dp.Name())
+
+		s := i.GetOrCreateSubinterface(0)
+		s4 := s.GetOrCreateIpv4()
+		if deviations.InterfaceEnabled(dut) {
+			s4.Enabled = ygot.Bool(true)
+		}
+		a4 := s4.GetOrCreateAddress(DUTIPList[dp.ID()].String())
+		a4.Type = oc.IfIp_Ipv4AddressType_SECONDARY
+		a4.PrefixLength = ygot.Uint8(plenIPv4)
+
+		if deviations.ExplicitPortSpeed(dut) {
+			i.GetOrCreateEthernet().PortSpeed = fptest.GetIfSpeed(t, dp)
+		}
+
+		// BGP neighbor configs.
+		nv4 := bgp.GetOrCreateNeighbor(ATEIPList[dp.ID()].String())
+		nv4.PeerGroup = ygot.String(PeerGrpName)
+		if dp.ID() == "port1" {
+			nv4.PeerAs = ygot.Uint32(ATEAs2)
+		} else {
+			nv4.PeerAs = ygot.Uint32(ATEAs)
+		}
+		nv4.Enabled = ygot.Bool(true)
+
+		// ISIS configs.
+		intfName := dp.Name()
+		if deviations.ExplicitInterfaceInDefaultVRF(dut) {
+			intfName = dp.Name() + ".0"
+		}
+		isisIntf := isis.GetOrCreateInterface(intfName)
+		isisIntf.Enabled = ygot.Bool(true)
+		isisIntf.HelloPadding = oc.Isis_HelloPaddingType_ADAPTIVE
+		isisIntf.CircuitType = oc.Isis_CircuitType_POINT_TO_POINT
+		isisIntfAfi := isisIntf.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST)
+		isisIntfAfi.Enabled = ygot.Bool(true)
+		if deviations.ISISInterfaceAfiUnsupported(dut) {
+			isisIntf.Af = nil
+		}
+
+		isisIntfLevel := isisIntf.GetOrCreateLevel(2)
+		isisIntfLevel.Enabled = ygot.Bool(true)
+
+		isisIntfLevelTimers := isisIntfLevel.GetOrCreateTimers()
+		isisIntfLevelTimers.HelloInterval = ygot.Uint32(1)
+		isisIntfLevelTimers.HelloMultiplier = ygot.Uint8(5)
+
+		isisIntfLevelAfi := isisIntfLevel.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST)
+		isisIntfLevelAfi.Metric = ygot.Uint32(200)
+		isisIntfLevelAfi.Enabled = ygot.Bool(true)
+
+		// Configure ISIS AfiSafi enable flag at the global level
+		if deviations.MissingIsisInterfaceAfiSafiEnable(dut) {
+			isisIntfLevelAfi.Enabled = nil
+		}
+	}
+	p := gnmi.OC()
+	fptest.LogQuery(t, "DUT", p.Config(), d)
+
+	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
+		for _, dp := range dut.Ports() {
+			ni := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
+			niIntf, _ := ni.NewInterface(dp.Name())
+			niIntf.Interface = ygot.String(dp.Name())
+			niIntf.Subinterface = ygot.Uint32(0)
+			niIntf.Id = ygot.String(dp.Name() + ".0")
+		}
+	}
+	return d
+}

--- a/internal/diffutils/diffcollector.go
+++ b/internal/diffutils/diffcollector.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package diffutils provides helper functions for performing diff operations on ygot structs.
+package diffutils
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// DiffEntry represents a single path with different values
+type DiffEntry struct {
+	Path string
+	Vx   *reflect.Value
+	Vy   *reflect.Value
+}
+
+// DiffCollector is a reporter that collects all diff values
+type DiffCollector struct {
+	path  cmp.Path
+	diffs []*DiffEntry
+}
+
+func (r *DiffCollector) PushStep(ps cmp.PathStep) {
+	r.path = append(r.path, ps)
+}
+
+func (r *DiffCollector) Report(rs cmp.Result) {
+	if !rs.Equal() {
+		vx, vy := r.path.Last().Values()
+		r.diffs = append(r.diffs, &DiffEntry{fmt.Sprintf("%#v", r.path), &vx, &vy})
+	}
+}
+
+func (r *DiffCollector) PopStep() {
+	r.path = r.path[:len(r.path)-1]
+}
+
+func (r *DiffCollector) String() string {
+	str := ""
+	for _, df := range r.diffs {
+		str += df.String()
+	}
+	return str
+}
+
+// Diff returns all the diff entries
+func (r *DiffCollector) Diff() []*DiffEntry {
+	return r.diffs
+}
+
+func (e *DiffEntry) String() string {
+	return fmt.Sprintf("%s:\n\t-: %+v\n\t+: %+v\n", e.Path, *e.Vx, *e.Vy)
+}


### PR DESCRIPTION
Add the following subtests:
1- TestConfigurationUnchanged checks that the configuration is unchanged after switchover
2- TestConfigurationConvergence checks that a large configuration is accepted within 60 seconds after switchover

Also adds a [Reporter](https://pkg.go.dev/github.com/google/go-cmp/cmp#Reporter) to collect diff entries from cmp.Diff. This allows the test to examine the each diff to decide whether, for e.g., the configuration match. In this enhanced switchover test, this is used to ignore leaves that are not explicitly configured (i.e., fields with nil value) when comparing against the configuration returned from the device.