### PR TITLE
Fix basic_encap_test failure due to unexpected traffic distribution ratio

### DIFF
--- a/feature/gribi/otg_tests/basic_encap_test/basic_encap_test.go
+++ b/feature/gribi/otg_tests/basic_encap_test/basic_encap_test.go
@@ -873,7 +873,7 @@ func clearCapture(t *testing.T, otg *otg.OTG, topo gosnappi.Config) {
 }
 
 func randRange(max int, count int) []uint32 {
-	rand.Seed(time.Now().UnixNano())
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 	var result []uint32
 	for len(result) < count {
 		result = append(result, uint32(rand.Intn(max)))

--- a/feature/gribi/otg_tests/basic_encap_test/basic_encap_test.go
+++ b/feature/gribi/otg_tests/basic_encap_test/basic_encap_test.go
@@ -18,6 +18,7 @@ package basic_encap_test
 import (
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"strconv"
 	"strings"
@@ -871,6 +872,15 @@ func clearCapture(t *testing.T, otg *otg.OTG, topo gosnappi.Config) {
 	otg.PushConfig(t, topo)
 }
 
+func randRange(max int, count int) []uint32 {
+	rand.Seed(time.Now().UnixNano())
+	var result []uint32
+	for len(result) < count {
+		result = append(result, uint32(rand.Intn(max)))
+	}
+	return result
+}
+
 // getFlow returns a flow of type ipv4, ipv4in4, ipv6in4 or ipv6 with dscp value passed in args.
 func (fa *flowAttr) getFlow(flowType string, name string, dscp uint32) gosnappi.Flow {
 	flow := fa.topo.Flows().Add().SetName(name)
@@ -887,8 +897,8 @@ func (fa *flowAttr) getFlow(flowType string, name string, dscp uint32) gosnappi.
 		v4.TimeToLive().SetValue(ttl)
 		v4.Priority().Dscp().Phb().SetValue(dscp)
 		udp := flow.Packet().Add().Udp()
-		udp.SrcPort().Increment().SetStart(50001).SetCount(1000)
-		udp.DstPort().Increment().SetStart(50001).SetCount(1000)
+		udp.SrcPort().SetValues(randRange(50001, 10000))
+		udp.DstPort().SetValues(randRange(50001, 10000))
 
 		// add inner ipv4 headers
 		if flowType == "ipv4in4" {
@@ -910,8 +920,8 @@ func (fa *flowAttr) getFlow(flowType string, name string, dscp uint32) gosnappi.
 		v6.HopLimit().SetValue(ttl)
 		v6.TrafficClass().SetValue(dscp << 2)
 		udp := flow.Packet().Add().Udp()
-		udp.SrcPort().Increment().SetStart(50001).SetCount(1000)
-		udp.DstPort().Increment().SetStart(50001).SetCount(1000)
+		udp.SrcPort().SetValues(randRange(50001, 10000))
+		udp.DstPort().SetValues(randRange(50001, 10000))
 	}
 
 	return flow


### PR DESCRIPTION
The test is passing now the following changes
- Increase the number of flows from 1000 to 10000
- Randomize the source/dst port set in the UDP header of the pacKet flows
- Enable the extended hashing feature in EOS by setting the right TCAM profile configuration in startup configuration