### PR TITLE
Add Arista specific deviation for TE-17.1 (VRF selection policy driven TE)

### DIFF
--- a/feature/experimental/gribi/otg_tests/vrf_policy_driven_te/metadata.textproto
+++ b/feature/experimental/gribi/otg_tests/vrf_policy_driven_te/metadata.textproto
@@ -44,6 +44,7 @@ platform_exceptions:  {
     deprecated_vlan_id:  true
     interface_enabled:  true
     default_network_instance:  "default"
+    gribi_mac_override_static_arp_static_route: true
     missing_isis_interface_afi_safi_enable: true
     isis_interface_afi_unsupported: true
     isis_instance_enabled_required: true


### PR DESCRIPTION


- Add static route to a special fictitious IP address pointing to all TE egress interfaces
- Add static arp entries to the fictitious IP address pointing to the magic mac address
- Publish GRIBI AFT entries with fictitious IP address in the nexthop AFT entry