### PR TITLE
Remove stray metadata.textproto

### DIFF
--- a/feature/system/management/metadata.textproto
+++ b/feature/system/management/metadata.textproto
@@ -1,7 +1,0 @@
-# proto-file: github.com/openconfig/featureprofiles/proto/metadata.proto
-# proto-message: Metadata
-
-plan_id: "MGT-1"
-description: "Management HA test"
-testbed: TESTBED_DUT_ATE_4LINKS
-tags: [TAGS_AGGREGATION, TAGS_TRANSIT, TAGS_DATACENTER_EDGE]


### PR DESCRIPTION
This file looks like it was moved to `feature/system/management/otg_tests/management_ha_test/metadata.textproto` but the old file was not removed.