### PR TITLE
Remove the deletion of vrf selection policy parent OC path in the API…

### DIFF
--- a/internal/vrfpolicy/vrfpolicy.go
+++ b/internal/vrfpolicy/vrfpolicy.go
@@ -197,9 +197,6 @@ func BuildVRFSelectionPolicyW(t *testing.T, dut *ondatra.DUTDevice, niName strin
 func ConfigureVRFSelectionPolicyW(t *testing.T, dut *ondatra.DUTDevice) {
 	t.Helper()
 
-	t.Log("Delete existing vrf selection policy and Apply vrf selectioin policy W")
-	gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Config())
-
 	port1 := dut.Port(t, "port1")
 	interfaceID := port1.Name()
 	if deviations.InterfaceRefInterfaceIDFormat(dut) {


### PR DESCRIPTION
… used

for creating dcGate policies
- 'configureVRFSelectionPolicyW' currently deletes '/network-instances/network-instance[name=default]/policy-forwarding/' when attempting to clean the old policies, before creating the new policies for a given test. But given that the function does a gNMI.replace() the deletion of the old policy is not required. Also a replace without the delete represents the realistic production scenario where the entire config for a device will be pushed.