### PR TITLE
fixing duplicate test id issue for mpls forwarding static lsp test

### DIFF
--- a/feature/gribi/otg_tests/static_lsp/README.md
+++ b/feature/gribi/otg_tests/static_lsp/README.md
@@ -1,4 +1,4 @@
-# TE-9.1: MPLS based forwarding Static LSP
+# TE-9.2: MPLS based forwarding Static LSP
 
 ## Summary
 

--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -1035,14 +1035,14 @@ test: {
   exec: " "
 }
 test: {
-  id: "TE-9"
-  description: "MPLS based forwarding Static LSP"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/otg_tests/mpls_compliance/README.md"
-}
-test: {
   id: "TE-9.1"
   description: "Base gRIBI MPLS Compliance"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/otg_tests/static_lsp/README.md"
+}
+test: {
+  id: "TE-9.2"
+  description: "MPLS based forwarding Static LSP"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/otg_tests/mpls_compliance/README.md"
 }
 test: {
   id: "TE-10"


### PR DESCRIPTION
fixing duplicate test id issue for mpls forwarding static lsp test TE-9.1 -> TE-9.2