### PR TITLE
Add yaml for OCPaths/RPC to test README

### DIFF
--- a/doc/test-requirements-template.md
+++ b/doc/test-requirements-template.md
@@ -45,16 +45,20 @@ Write a few sentences or paragraphs describing the purpose and scope of the test
 This example yaml defines the OC paths intended to be covered by this test.  OC paths used for test environment setup are not required to be listed here.
 
 ```yaml
-OCPaths:
-    # Configuration of policy
-  - name: /interfaces/interface/config/description
-  - name: /components/component/state/name
-    constraint: CHASSIS
+paths:
+  # interface configuration
+  /interfaces/interface/config/description:
+  /interfaces/interface/config/enabled:
+  # name of chassis component
+  /components/component/state/name:
+    platform_type: "CHASSIS"
 
-OCRPCs:
-  - gnmi
-    method_name: gnmi.gNMI.Set.SetRequest.Update.union_replace
-    method_name: gnmi.gNMI.Subscribe
+rpcs:
+  gnmi:
+    gNMI.Set:
+      union_replace: true
+    gNMI.Subscribe:
+      on_change: true
 ```
 
 ## Required DUT platform

--- a/doc/test-requirements-template.md
+++ b/doc/test-requirements-template.md
@@ -4,7 +4,6 @@ about: Use this template to document the requirements for a new test to be imple
 title: ''
 labels: enhancement
 assignees: ''
-
 ---
 
 # Instructions for this template
@@ -28,40 +27,34 @@ Write a few sentences or paragraphs describing the purpose and scope of the test
 
 ## Procedure
 
-* TestID-x.y.z - Name of subtest
-  * Step 1
-  * Step 2
-  * Validation and pass fail criteria
+* Test environment setup
+  * Description of procedure to configure ATE and DUT with pre-requisites making it possible to cover the intended paths and RPC's.
 
 * TestID-x.y.z - Name of subtest
   * Step 1
   * Step 2
-  * Validation and pass fail criteria
+  * Validation and pass/fail criteria
 
-## Config Parameter Coverage
+* TestID-x.y.z - Name of subtest
+  * Step 1
+  * Step 2
+  * Validation and pass/fail criteria
 
-Add list of OpenConfig 'config' paths used in this test, if any.
+## OpenConfig Path and RPC Coverage
 
-## Telemetry Parameter Coverage
+This example yaml defines the OC paths intended to be covered by this test.  OC paths used for test environment setup are not required to be listed here.
 
-Add list of OpenConfig 'state' paths used in this test, if any.
+```yaml
+- OCPaths
+    # Configuration of policy
+    ocpath: [ name: /routing-policy/policy-definitions/policy-definition/config/name ]
+    ocpath: [ name: /routing-policy/policy-definitions/policy-definition/statements/statement/config/name ]
 
-## Protocol/RPC Parameter Coverage
-
-Add list of OpenConfig RPC's (gNMI, gNOI, gNSI, gRIBI) used in the list, if any.
-
-For example:
-
-* gNMI
-  * Set
-  * Subscribe
-* gNOI
-  * System
-    * KillProcess
-  * Healthz
-    * Get
-    * Check
-    * Artifact
+- OCRPCs
+    - gnmi
+        method_name: gnmi.gNMI.Set.SetRequest.Update.union_replace
+        method_name: gnmi.gNMI.Subscribe
+```
 
 ## Required DUT platform
 

--- a/doc/test-requirements-template.md
+++ b/doc/test-requirements-template.md
@@ -45,15 +45,16 @@ Write a few sentences or paragraphs describing the purpose and scope of the test
 This example yaml defines the OC paths intended to be covered by this test.  OC paths used for test environment setup are not required to be listed here.
 
 ```yaml
-- OCPaths
+OCPaths:
     # Configuration of policy
-    ocpath: [ name: /routing-policy/policy-definitions/policy-definition/config/name ]
-    ocpath: [ name: /routing-policy/policy-definitions/policy-definition/statements/statement/config/name ]
+  - name: /interfaces/interface/config/description
+  - name: /components/component/state/name
+    constraint: CHASSIS
 
-- OCRPCs
-    - gnmi
-        method_name: gnmi.gNMI.Set.SetRequest.Update.union_replace
-        method_name: gnmi.gNMI.Subscribe
+OCRPCs:
+  - gnmi
+    method_name: gnmi.gNMI.Set.SetRequest.Update.union_replace
+    method_name: gnmi.gNMI.Subscribe
 ```
 
 ## Required DUT platform


### PR DESCRIPTION
This changes the requirement for featureprofiles test READMEs to format OC path and RPCs from plain text to a structured format (yaml).

This format is intended to be easy for humans who are writing README's for test requirements and may not be a developer.  It is also more simple to maintain the path list with the test which is using the paths versus today's practice where the path is listed in a readme and in feature.textproto files.  To keep feature.textproto files accurate, they must be manually kept in sync with README's from multiple tests across potentially many child folders with multiple levels.  In addition the feature.textproto files lack the ability to indicate which tests are intended to cover a path.  It is useful to know which test(s) a path is intended to cover.

The structured list of paths/rpc can be used for static analysis of tests for invalid OC paths, detecting tests which would break due to breaking OC model changes and building an OCPath/RPC to test relationship, showing all the intended test requirements for any given path/RPC.

