### PR TITLE
sampled_backplane_capacity_counters_test - Added 90s sleep for Linecards to be properly up post power disable/enable in TestOnChangeBackplaneCapacityCounters and a check to skip validation on unused FAPs

### DIFF
--- a/feature/platform/fabric/otg_tests/sampled_backplane_capacity_counters_test/sampled_backplane_capacity_counters_test.go
+++ b/feature/platform/fabric/otg_tests/sampled_backplane_capacity_counters_test/sampled_backplane_capacity_counters_test.go
@@ -129,7 +129,8 @@ func TestOnChangeBackplaneCapacityCounters(t *testing.T) {
 		gnmi.Replace(t, dut, gnmi.OC().Component(f).Fabric().PowerAdminState().Config(), oc.Platform_ComponentPowerType_POWER_DISABLED)
 		gnmi.Await(t, dut, gnmi.OC().Component(f).Fabric().PowerAdminState().State(), time.Minute, oc.Platform_ComponentPowerType_POWER_DISABLED)
 	}
-
+	t.Logf("Waiting for 90s after power disable...")
+	time.Sleep(90 * time.Second)
 	ts2, tocs2, apct2 := getBackplaneCapacityCounters(t, dut, ics)
 
 	for _, f := range fabrics[:fc] {
@@ -145,7 +146,8 @@ func TestOnChangeBackplaneCapacityCounters(t *testing.T) {
 			t.Errorf("Component %s oper-status after POWER_ENABLED, got: %v, want: %v", f, oper, oc.PlatformTypes_COMPONENT_OPER_STATUS_ACTIVE)
 		}
 	}
-
+	t.Logf("Waiting for 90s after power enable...")
+	time.Sleep(90 * time.Second)
 	ts3, tocs3, apct3 := getBackplaneCapacityCounters(t, dut, ics)
 
 	for _, ic := range ics {
@@ -184,7 +186,7 @@ func TestOnChangeBackplaneCapacityCounters(t *testing.T) {
 			switch {
 			case !ok1 || !ok2 || !ok3:
 				t.Errorf("BackplaneFacingCapacity AvailablePct not present: ok1 %t, ok2 %t, ok3 %t", ok1, ok2, ok3)
-			case v1 <= v2 || v1 != v3:
+			case v1 != 0 && (v1 <= v2 || v1 != v3):
 				t.Errorf("BackplaneFacingCapacity AvailablePct are not valid: v1 %d, v2 %d, v3 %d", v1, v2, v3)
 			}
 		})


### PR DESCRIPTION
- Added a 90s sleep after power disable/enable to wait for Linuecards to be properly up before validating the BackplaneFacingCapacity parameters
- Added a check to skip validation of AvailablePct when value is 0 indicating that no up interface is present in that particular FAPs