### PR TITLE
Issue telemetry bugs

### DIFF
--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -862,11 +862,11 @@ func TestIntfCounterUpdate(t *testing.T) {
 	dutInPktsAfterTraffic, dutOutPktsAfterTraffic := fetchInAndOutPkts(t, dut, dp1, dp2)
 	t.Log("inPkts and outPkts counters after traffic: ", dutInPktsAfterTraffic, dutOutPktsAfterTraffic)
 
-	if dutInPktsAfterTraffic-dutInPktsBeforeTraffic < uint64(ateInPkts) {
+	if dutInPktsAfterTraffic-dutInPktsBeforeTraffic < uint64(ateOutPkts) {
 		t.Errorf("Get less inPkts from telemetry: got %v, want >= %v", dutInPktsAfterTraffic-dutInPktsBeforeTraffic, ateOutPkts)
 	}
-	if dutOutPktsAfterTraffic-dutOutPktsBeforeTraffic < uint64(ateOutPkts) {
-		t.Errorf("Get less outPkts from telemetry: got %v, want >= %v", dutOutPktsAfterTraffic-dutOutPktsBeforeTraffic, ateOutPkts)
+	if dutOutPktsAfterTraffic-dutOutPktsBeforeTraffic < uint64(ateInPkts) {
+		t.Errorf("Get less outPkts from telemetry: got %v, want >= %v", dutOutPktsAfterTraffic-dutOutPktsBeforeTraffic, ateInPkts)
 	}
 }
 

--- a/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -382,10 +382,10 @@ func TestIntfCounterUpdate(t *testing.T) {
 
 	t.Logf("inPkts: %v and outPkts: %v after traffic: ", dutInPktsAfterTraffic, dutOutPktsAfterTraffic)
 	for k := range dutInPktsAfterTraffic {
-		if got, want := dutInPktsAfterTraffic[k]-dutInPktsBeforeTraffic[k], ateInPkts[k]; got < want {
+		if got, want := dutInPktsAfterTraffic[k]-dutInPktsBeforeTraffic[k], ateOutPkts[k]; got < want {
 			t.Errorf("Get less inPkts from telemetry: got %v, want >= %v", got, want)
 		}
-		if got, want := dutOutPktsAfterTraffic[k]-dutOutPktsBeforeTraffic[k], ateOutPkts[k]; got < want {
+		if got, want := dutOutPktsAfterTraffic[k]-dutOutPktsBeforeTraffic[k], ateInPkts[k]; got < want {
 			t.Errorf("Get less outPkts from telemetry: got %v, want >= %v", got, want)
 		}
 	}

--- a/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -286,7 +286,7 @@ func TestIntfCounterUpdate(t *testing.T) {
 		SetTxNames([]string{intf1.Name() + ".IPv4"}).
 		SetRxNames([]string{intf2.Name() + ".IPv4"})
 	flowipv4.Size().SetFixed(100)
-	flowipv4.Rate().SetPps(15)
+	flowipv4.Rate().SetPps(50)
 	e1 := flowipv4.Packet().Add().Ethernet()
 	e1.Src().SetValue(eth1.Mac())
 	v4 := flowipv4.Packet().Add().Ipv4()
@@ -299,7 +299,7 @@ func TestIntfCounterUpdate(t *testing.T) {
 		SetTxNames([]string{intf1.Name() + ".IPv6"}).
 		SetRxNames([]string{intf2.Name() + ".IPv6"})
 	flowipv6.Size().SetFixed(100)
-	flowipv6.Rate().SetPps(15)
+	flowipv6.Rate().SetPps(50)
 	e2 := flowipv6.Packet().Add().Ethernet()
 	e2.Src().SetValue(eth1.Mac())
 	v6 := flowipv6.Packet().Add().Ipv6()


### PR DESCRIPTION
This PR fixes:
1. issues in gNMI-1.10 and gNMI-1.11 wherein the DUT Out was being compared with ATE Out, whereas the wiring is ATE Out <-> DUT IN. There was a symmetrical problem with DUT In and ATE In. 
1. An issue where the configured PPS was lower than the UHD could support.

Issue #1 could have been missed in a virtual environment where ATE OUT == ATE In, but in a real hardware environment this is not the case.

Issue #2 was unique to the UHD, but other OTG implementations should have no trouble generating the 40kps instead of 6kbps PPS for the original test.