### PR TITLE
Updates to Transceiver-9: zr_laser_bias_current_test

### DIFF
--- a/feature/platform/transceiver/tests/zr_laser_bias_current_test/zr_laser_bias_current_test.go
+++ b/feature/platform/transceiver/tests/zr_laser_bias_current_test/zr_laser_bias_current_test.go
@@ -201,18 +201,27 @@ func opticalChannelComponentFromPort(t *testing.T, dut *ondatra.DUTDevice, p *on
 			t.Fatal("Manual Optical channel name required when deviation missing_port_to_optical_channel_component_mapping applied.")
 		}
 	}
-	compName := gnmi.Get(t, dut, gnmi.OC().Interface(p.Name()).HardwarePort().State())
+	comps := gnmi.LookupAll(t, dut, gnmi.OC().ComponentAny().State())
+	hardwarePortCompName := gnmi.Get(t, dut, gnmi.OC().Interface(p.Name()).HardwarePort().State())
+	for _, comp := range comps {
+		comp, ok := comp.Val()
+
+		if ok && comp.GetType() == oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_OPTICAL_CHANNEL && isSubCompOfHardwarePort(t, dut, hardwarePortCompName, comp) {
+			return comp.GetName()
+		}
+	}
+	t.Fatalf("No interface to optical-channel mapping found for interface = %v", p.Name())
+	return ""
+}
+
+func isSubCompOfHardwarePort(t *testing.T, dut *ondatra.DUTDevice, parentHardwarePortName string, comp *oc.Component) bool {
 	for {
-		comp, ok := gnmi.Lookup(t, dut, gnmi.OC().Component(compName).State()).Val()
-		if !ok {
-			t.Fatalf("Recursive optical channel lookup failed for port: %s, component %s not found.", p.Name(), compName)
+		if comp.GetName() == parentHardwarePortName {
+			return true
 		}
-		if comp.GetType() == oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_OPTICAL_CHANNEL {
-			return compName
+		if comp.GetType() == oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_PORT {
+			return false
 		}
-		if comp.GetParent() == "" {
-			t.Fatalf("Recursive optical channel lookup failed for port: %s, parent of component %s not found.", p.Name(), compName)
-		}
-		compName = comp.GetParent()
+		comp = gnmi.Get(t, dut, gnmi.OC().Component(comp.GetParent()).State())
 	}
 }


### PR DESCRIPTION
- Corrected the logic to get the opticalComponentName, in accordance with the YANG documentation.
- In the previous logic the code was to get the optical component name by traversing through the parents of the PORT component, this would lead to no results. Hence changed it to, find the OPTICAL_CHANNEL comp first and match its parent against HARDWARE_PORT of the interface.
- Current flow : PORT <-- TRANSCIEVER <-- OPTICAL_CHANNEL