### PR TITLE
Remove AGGREGATION tag from MGT-1

### DIFF
--- a/feature/system/management/otg_tests/management_ha_test/metadata.textproto
+++ b/feature/system/management/otg_tests/management_ha_test/metadata.textproto
@@ -20,6 +20,5 @@ platform_exceptions:  {
     set_metric_as_preference:  true
   }
 }
-tags:  TAGS_AGGREGATION
 tags:  TAGS_TRANSIT
 tags:  TAGS_DATACENTER_EDGE


### PR DESCRIPTION
This test won't be used for aggregation at this time