### PR TITLE
Updates to Transceiver-12: zr_supply_voltage_test

### DIFF
--- a/feature/platform/transceiver/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
+++ b/feature/platform/transceiver/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
@@ -20,11 +20,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/featureprofiles/internal/samplestream"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/ygot/ygot"
 )
 
 const (
@@ -36,6 +38,19 @@ const (
 
 func TestMain(m *testing.M) {
 	fptest.RunTests(m)
+}
+
+func configureInterface(t *testing.T, dut1 *ondatra.DUTDevice, dp *ondatra.Port) {
+	d := &oc.Root{}
+	i := d.GetOrCreateInterface(dp.Name())
+	i.Enabled = ygot.Bool(true)
+	i.Type = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
+	gnmi.Replace(t, dut1, gnmi.OC().Interface(dp.Name()).Config(), i)
+	OCcomponent := opticalChannelComponentFromPort(t, dut1, dp)
+	gnmi.Replace(t, dut1, gnmi.OC().Component(OCcomponent).OpticalChannel().Config(), &oc.Component_OpticalChannel{
+		TargetOutputPower: ygot.Float64(targetOutputPowerdBm),
+		Frequency:         ygot.Uint64(targetFrequencyHz),
+	})
 }
 
 func verifyVoltageValue(t *testing.T, pStream *samplestream.SampleStream[float64], path string) float64 {
@@ -55,9 +70,46 @@ func verifyVoltageValue(t *testing.T, pStream *samplestream.SampleStream[float64
 	return voltageVal
 }
 
+func opticalChannelComponentFromPort(t *testing.T, dut *ondatra.DUTDevice, p *ondatra.Port) string {
+	t.Helper()
+	if deviations.MissingPortToOpticalChannelMapping(dut) {
+		switch dut.Vendor() {
+		case ondatra.ARISTA:
+			transceiverName := gnmi.Get(t, dut, gnmi.OC().Interface(p.Name()).Transceiver().State())
+			return fmt.Sprintf("%s-Optical0", transceiverName)
+		default:
+			t.Fatal("Manual Optical channel name required when deviation missing_port_to_optical_channel_component_mapping applied.")
+		}
+	}
+	comps := gnmi.LookupAll(t, dut, gnmi.OC().ComponentAny().State())
+	hardwarePortCompName := gnmi.Get(t, dut, gnmi.OC().Interface(p.Name()).HardwarePort().State())
+	for _, comp := range comps {
+		comp, ok := comp.Val()
+
+		if ok && comp.GetType() == oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_OPTICAL_CHANNEL && isSubCompOfHardwarePort(t, dut, hardwarePortCompName, comp) {
+			return comp.GetName()
+		}
+	}
+	t.Fatalf("No interface to optical-channel mapping found for interface = %v", p.Name())
+	return ""
+}
+
+func isSubCompOfHardwarePort(t *testing.T, dut *ondatra.DUTDevice, parentHardwarePortName string, comp *oc.Component) bool {
+	for {
+		if comp.GetName() == parentHardwarePortName {
+			return true
+		}
+		if comp.GetType() == oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_PORT {
+			return false
+		}
+		comp = gnmi.Get(t, dut, gnmi.OC().Component(comp.GetParent()).State())
+	}
+}
+
 func TestZrSupplyVoltage(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
-
+	configureInterface(t, dut, dut.Port(t, "port1"))
+	configureInterface(t, dut, dut.Port(t, "port2"))
 	for _, port := range []string{"port1", "port2"} {
 		t.Run(fmt.Sprintf("Port:%s", port), func(t *testing.T) {
 			dp := dut.Port(t, port)
@@ -66,14 +118,16 @@ func TestZrSupplyVoltage(t *testing.T) {
 
 			// Derive transceiver names from ports.
 			tr := gnmi.Get(t, dut, gnmi.OC().Interface(dp.Name()).Transceiver().State())
+			opticalCompName := opticalChannelComponentFromPort(t, dut, dp)
+			opticalComp := gnmi.OC().Component(opticalCompName)
 			component := gnmi.OC().Component(tr)
 
-			outputPower := gnmi.Get(t, dut, component.OpticalChannel().TargetOutputPower().State())
+			outputPower := gnmi.Get(t, dut, opticalComp.OpticalChannel().TargetOutputPower().State())
 			if outputPower != targetOutputPowerdBm {
 				t.Fatalf("Output power does not match target output power, got: %v want :%v", outputPower, targetOutputPowerdBm)
 			}
 
-			frequency := gnmi.Get(t, dut, component.OpticalChannel().Frequency().State())
+			frequency := gnmi.Get(t, dut, opticalComp.OpticalChannel().Frequency().State())
 			if frequency != targetFrequencyHz {
 				t.Fatalf("Frequency does not match target frequency, got: %v want :%v", frequency, targetFrequencyHz)
 			}
@@ -102,7 +156,7 @@ func TestZrSupplyVoltage(t *testing.T) {
 				t.Fatalf("The average is not between the maximum and minimum values, Avg:%v Max:%v Min:%v", volAvg, volMax, volMin)
 			}
 
-			// Wait for the cooling off period
+			gnmi.Replace(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config(), *ygot.Bool(false))
 			gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_DOWN)
 
 			volInstNew := verifyVoltageValue(t, streamInst, "Instant")
@@ -119,6 +173,8 @@ func TestZrSupplyVoltage(t *testing.T) {
 			} else {
 				t.Fatalf("The average voltage after port down is not between the maximum and minimum values, Avg:%v Max:%v Min:%v", volAvgNew, volMaxNew, volMinNew)
 			}
+
+			gnmi.Replace(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config(), *ygot.Bool(true))
 		})
 	}
 

--- a/feature/platform/transceiver/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
+++ b/feature/platform/transceiver/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
 	"github.com/openconfig/ygot/ygot"
+	"github.com/openconfig/featureprofiles/internal/cfgplugins"
 )
 
 const (

--- a/feature/platform/transceiver/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
+++ b/feature/platform/transceiver/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openconfig/featureprofiles/internal/cfgplugins"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/featureprofiles/internal/samplestream"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
 	"github.com/openconfig/ygot/ygot"
-	"github.com/openconfig/featureprofiles/internal/cfgplugins"
 )
 
 const (
@@ -62,11 +62,11 @@ func TestZrSupplyVoltage(t *testing.T) {
 	p1 := dut.Port(t, "port1")
 	p2 := dut.Port(t, "port2")
 
-	cfgplugins.configureInterface(t, dut, p1)
-	cfgplugins.configureTargetOutputPowerAndFrequency(t, dut, p1, targetOutputPowerdBm, targetFrequencyHz)
+	cfgplugins.ConfigureInterface(t, dut, p1)
+	cfgplugins.ConfigureTargetOutputPowerAndFrequency(t, dut, p1, targetOutputPowerdBm, targetFrequencyHz)
 
-	cfgplugins.configureInterface(t, dut, p2)
-	cfgplugins.configureTargetOutputPowerAndFrequency(t, dut, p2, targetOutputPowerdBm, targetFrequencyHz)
+	cfgplugins.ConfigureInterface(t, dut, p2)
+	cfgplugins.ConfigureTargetOutputPowerAndFrequency(t, dut, p2, targetOutputPowerdBm, targetFrequencyHz)
 
 	for _, port := range []string{"port1", "port2"} {
 		t.Run(fmt.Sprintf("Port:%s", port), func(t *testing.T) {
@@ -76,7 +76,7 @@ func TestZrSupplyVoltage(t *testing.T) {
 
 			// Derive transceiver names from ports.
 			tr := gnmi.Get(t, dut, gnmi.OC().Interface(dp.Name()).Transceiver().State())
-			opticalCompName := cfgplugins.opticalChannelComponentFromPort(t, dut, dp)
+			opticalCompName := cfgplugins.OpticalChannelComponentFromPort(t, dut, dp)
 			opticalComp := gnmi.OC().Component(opticalCompName)
 			component := gnmi.OC().Component(tr)
 

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openconfig/ygot/ygot"
 )
 
+// isSubCompOfHardwarePort is a helper function to check if the given component is a subComponent of the given hardwarePort.
 func isSubCompOfHardwarePort(t *testing.T, dut *ondatra.DUTDevice, parentHardwarePortName string, comp *oc.Component) bool {
 	for {
 		if comp.GetName() == parentHardwarePortName {
@@ -23,6 +24,7 @@ func isSubCompOfHardwarePort(t *testing.T, dut *ondatra.DUTDevice, parentHardwar
 	}
 }
 
+// OpticalChannelComponentFromPort returns the OpticalChannelComponent name for the provided  port.
 func OpticalChannelComponentFromPort(t *testing.T, dut *ondatra.DUTDevice, p *ondatra.Port) string {
 	t.Helper()
 	if deviations.MissingPortToOpticalChannelMapping(dut) {
@@ -47,6 +49,7 @@ func OpticalChannelComponentFromPort(t *testing.T, dut *ondatra.DUTDevice, p *on
 	return ""
 }
 
+// ConfigureInterface configures the interface with portName and interfaceType.
 func ConfigureInterface(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port) {
 	d := &oc.Root{}
 	i := d.GetOrCreateInterface(dp.Name())
@@ -55,6 +58,7 @@ func ConfigureInterface(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port) 
 	gnmi.Replace(t, dut, gnmi.OC().Interface(dp.Name()).Config(), i)
 }
 
+// ConfigureTargetOutputPowerAndFrequency configures TargetOutputPower and Frequency for the given transceiver port.
 func ConfigureTargetOutputPowerAndFrequency(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port, targetOutputPower float64, frequency uint64) {
 	OCcomponent := OpticalChannelComponentFromPort(t, dut, dp)
 	gnmi.Replace(t, dut, gnmi.OC().Component(OCcomponent).OpticalChannel().Config(), &oc.Component_OpticalChannel{

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -23,7 +23,7 @@ func isSubCompOfHardwarePort(t *testing.T, dut *ondatra.DUTDevice, parentHardwar
 	}
 }
 
-func opticalChannelComponentFromPort(t *testing.T, dut *ondatra.DUTDevice, p *ondatra.Port) string {
+func OpticalChannelComponentFromPort(t *testing.T, dut *ondatra.DUTDevice, p *ondatra.Port) string {
 	t.Helper()
 	if deviations.MissingPortToOpticalChannelMapping(dut) {
 		switch dut.Vendor() {
@@ -47,7 +47,7 @@ func opticalChannelComponentFromPort(t *testing.T, dut *ondatra.DUTDevice, p *on
 	return ""
 }
 
-func configureInterface(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port) {
+func ConfigureInterface(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port) {
 	d := &oc.Root{}
 	i := d.GetOrCreateInterface(dp.Name())
 	i.Enabled = ygot.Bool(true)
@@ -55,8 +55,8 @@ func configureInterface(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port) 
 	gnmi.Replace(t, dut, gnmi.OC().Interface(dp.Name()).Config(), i)
 }
 
-func configureTargetOutputPowerAndFrequency(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port, frequency uint64, targetOutputPower float64) {
-	OCcomponent := opticalChannelComponentFromPort(t, dut, dp)
+func ConfigureTargetOutputPowerAndFrequency(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port, targetOutputPower float64, frequency uint64) {
+	OCcomponent := OpticalChannelComponentFromPort(t, dut, dp)
 	gnmi.Replace(t, dut, gnmi.OC().Component(OCcomponent).OpticalChannel().Config(), &oc.Component_OpticalChannel{
 		TargetOutputPower: ygot.Float64(targetOutputPower),
 		Frequency:         ygot.Uint64(frequency),

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -1,0 +1,64 @@
+package cfgplugins
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+func isSubCompOfHardwarePort(t *testing.T, dut *ondatra.DUTDevice, parentHardwarePortName string, comp *oc.Component) bool {
+	for {
+		if comp.GetName() == parentHardwarePortName {
+			return true
+		}
+		if comp.GetType() == oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_PORT {
+			return false
+		}
+		comp = gnmi.Get(t, dut, gnmi.OC().Component(comp.GetParent()).State())
+	}
+}
+
+func opticalChannelComponentFromPort(t *testing.T, dut *ondatra.DUTDevice, p *ondatra.Port) string {
+	t.Helper()
+	if deviations.MissingPortToOpticalChannelMapping(dut) {
+		switch dut.Vendor() {
+		case ondatra.ARISTA:
+			transceiverName := gnmi.Get(t, dut, gnmi.OC().Interface(p.Name()).Transceiver().State())
+			return fmt.Sprintf("%s-Optical0", transceiverName)
+		default:
+			t.Fatal("Manual Optical channel name required when deviation missing_port_to_optical_channel_component_mapping applied.")
+		}
+	}
+	comps := gnmi.LookupAll(t, dut, gnmi.OC().ComponentAny().State())
+	hardwarePortCompName := gnmi.Get(t, dut, gnmi.OC().Interface(p.Name()).HardwarePort().State())
+	for _, comp := range comps {
+		comp, ok := comp.Val()
+
+		if ok && comp.GetType() == oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_OPTICAL_CHANNEL && isSubCompOfHardwarePort(t, dut, hardwarePortCompName, comp) {
+			return comp.GetName()
+		}
+	}
+	t.Fatalf("No interface to optical-channel mapping found for interface = %v", p.Name())
+	return ""
+}
+
+func configureInterface(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port) {
+	d := &oc.Root{}
+	i := d.GetOrCreateInterface(dp.Name())
+	i.Enabled = ygot.Bool(true)
+	i.Type = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
+	gnmi.Replace(t, dut, gnmi.OC().Interface(dp.Name()).Config(), i)
+}
+
+func configureTargetOutputPowerAndFrequency(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port, frequency uint64, targetOutputPower float64) {
+	OCcomponent := opticalChannelComponentFromPort(t, dut, dp)
+	gnmi.Replace(t, dut, gnmi.OC().Component(OCcomponent).OpticalChannel().Config(), &oc.Component_OpticalChannel{
+		TargetOutputPower: ygot.Float64(targetOutputPower),
+		Frequency:         ygot.Uint64(frequency),
+	})
+}


### PR DESCRIPTION
- Added the function configureInterface to configure the interface with required  targetOutputPower and frequency.
- Added functions opticalChannelComponentFromPort and isSubCompOfHardwarePort to get optical_comp name from port.
- Changed the path to opticalComp to verify frequency and targetOutputPower , as they come under OpticalChannel , optical comp name has to be passed
- Added the code to flap the interface as it was missing and code was waiting for interface to go down without any changes.