### PR TITLE
   Fix static configuration and vrf selection policy configuration failure in TE-17.1 VRF selection policy driven TE

### DIFF
--- a/feature/experimental/gribi/otg_tests/vrf_policy_driven_te/metadata.textproto
+++ b/feature/experimental/gribi/otg_tests/vrf_policy_driven_te/metadata.textproto
@@ -43,6 +43,7 @@ platform_exceptions:  {
     gnoi_subcomponent_path:  true
     deprecated_vlan_id:  true
     interface_enabled:  true
+    static_protocol_name: "STATIC"
     default_network_instance:  "default"
     gribi_mac_override_static_arp_static_route: true
     missing_isis_interface_afi_safi_enable: true

--- a/feature/experimental/gribi/otg_tests/vrf_policy_driven_te/vrf_policy_driven_te_test.go
+++ b/feature/experimental/gribi/otg_tests/vrf_policy_driven_te/vrf_policy_driven_te_test.go
@@ -366,11 +366,6 @@ func configureVrfSelectionPolicyW(t *testing.T, dut *ondatra.DUTDevice) {
 	gnmi.Replace(t, dut, dutPolFwdPath.Config(), niP)
 }
 
-func deleteVrfSelectionPolicy(t *testing.T, dut *ondatra.DUTDevice) {
-	t.Helper()
-	gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Config())
-}
-
 func configureVrfSelectionPolicyC(t *testing.T, dut *ondatra.DUTDevice) {
 	t.Helper()
 	d := &oc.Root{}
@@ -2075,7 +2070,6 @@ func TestGribiDecap(t *testing.T) {
 	})
 
 	t.Log("Delete vrf selection policy W and Apply vrf selectioin policy C.")
-	deleteVrfSelectionPolicy(t, dut)
 	configureVrfSelectionPolicyC(t, dut)
 
 	t.Run("Test-4: Tunneled traffic with no decap", func(t *testing.T) {
@@ -2083,7 +2077,6 @@ func TestGribiDecap(t *testing.T) {
 	})
 
 	t.Log("Delete vrf selection policy C and Apply vrf selectioin policy W.")
-	deleteVrfSelectionPolicy(t, dut)
 	configureVrfSelectionPolicyW(t, dut)
 
 	t.Run("Test-5: Match on default term and send to default VRF", func(t *testing.T) {


### PR DESCRIPTION
The fix adds
- Arista deviation for static protocol name required for static route configuration
- Remove deletion of the policy forwarding parent path and instead do a replace when replacing cluster vrf selection policy with wan vrf selection policy