### PR TITLE
gnmi-1.13: Optics Power And Bias Current Test Deviation removal

### DIFF
--- a/feature/platform/tests/optics_power_and_bias_current_test/metadata.textproto
+++ b/feature/platform/tests/optics_power_and_bias_current_test/metadata.textproto
@@ -14,14 +14,7 @@ platform_exceptions:  {
     transceiver_thresholds_unsupported:  true
   }
 }
-platform_exceptions:  {
-  platform:  {
-    vendor:  JUNIPER
-  }
-  deviations:  {
-    transceiver_thresholds_unsupported:  true
-  }
-}
+
 platform_exceptions:  {
   platform:  {
     vendor:  ARISTA


### PR DESCRIPTION
Since Transceiver thresholds are now supported on Juniper platform, removing the transceiver_thresholds_unsupported deviation for Juniper.