### PR TITLE
Increase grpc and gnmi timeout for otg-hw

### DIFF
--- a/topologies/otgdut_2.binding
+++ b/topologies/otgdut_2.binding
@@ -52,13 +52,13 @@ ates {
   otg {
     target: "ixia-c-hostname:40051" # Change this to the Ixia-c-grpc server endpoint.
     insecure: true
-    timeout: 30
+    timeout: 60
   }
 
   gnmi {
     target: "ixia-c-hostname:50051"  # Change this to the Ixia-c-gnmi server endpoint.
     skip_verify: true
-    timeout: 30
+    timeout: 60
   }
 
   # Before this binding can be used with a topology, add ports mapping

--- a/topologies/otgdut_4.binding
+++ b/topologies/otgdut_4.binding
@@ -60,13 +60,13 @@ ates {
   otg {
     target: "ixia-c-hostname:40051" # Change this to the Ixia-c-grpc server endpoint.
     insecure: true
-    timeout: 30
+    timeout: 60
   }
 
   gnmi {
     target: "ixia-c-hostname:50051"  # Change this to the Ixia-c-gnmi server endpoint.
     skip_verify: true
-    timeout: 30    
+    timeout: 60   
   }
 
   # Before this binding can be used with a topology, add ports mapping


### PR DESCRIPTION
Few tests are failing because of grpc and gnmi timeouts, increasing the timeout from 30 to 60.