### PR TITLE
[gNMI-1.5]: Update telemetry_port_speed_test

### DIFF
--- a/feature/bgp/multipath/otg_tests/bgp_multipath_wecmp_lbw_community_test/bgp_multipath_wecmp_test.go
+++ b/feature/bgp/multipath/otg_tests/bgp_multipath_wecmp_lbw_community_test/bgp_multipath_wecmp_test.go
@@ -69,7 +69,7 @@ func configureOTG(t *testing.T, bs *cfgplugins.BGPSession) {
 		routeAddress.SetPrefix(prefixP4Len)
 		routeAddress.SetCount(prefixesCount)
 		bgp4PeerRoute.AddPath().SetPathId(pathID)
-		bgp4PeerRoute.ExtendedCommunities().Items()[0].NonTransitive2OctetAsType().LinkBandwidthSubtype().SetBandwidth(float32(linkBw[i-2] * 1000))
+		bgp4PeerRoute.ExtendedCommunities().Add().NonTransitive2OctetAsType().LinkBandwidthSubtype().SetBandwidth(float32(linkBw[i-2] * 1000))
 	}
 
 	configureFlow(bs)

--- a/feature/gnmi/otg_tests/telemetry_port_speed_test/telemetry_port_speed_test.go
+++ b/feature/gnmi/otg_tests/telemetry_port_speed_test/telemetry_port_speed_test.go
@@ -352,9 +352,10 @@ func TestGNMIPortDown(t *testing.T) {
 	portStateAction.Port().Link().SetPortNames([]string{atePort.ID()}).SetState(gosnappi.StatePortLinkState.DOWN)
 	ate.OTG().SetControlState(t, portStateAction)
 
+	want := oc.Interface_OperStatus_DOWN
+	gnmi.Await(t, dut, gnmi.OC().Interface(dutPort.Name()).OperStatus().State(), 1*time.Minute, want)
 	dutPortStatus := gnmi.Get(t, dut, gnmi.OC().Interface(dutPort.Name()).OperStatus().State())
-
-	if want := oc.Interface_OperStatus_DOWN; dutPortStatus != want {
+	if dutPortStatus != want {
 		t.Errorf("Get(DUT port1 status): got %v, want %v", dutPortStatus, want)
 	}
 


### PR DESCRIPTION
There could be a timing issue where OperStatus state is not updated yet, update the test to use `gnmi.Await()` and print out the received value if the value doesn't match the expected value.