### PR TITLE
Deviation removal from gNMI-1.10, gNOI-4.1, gNOI-2.1

### DIFF
--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/metadata.textproto
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/metadata.textproto
@@ -42,7 +42,6 @@ platform_exceptions: {
     vendor: JUNIPER
   }
   deviations: {
-    sw_version_unsupported: true
     qos_dropped_octets: true
   }
 }

--- a/feature/gnoi/os/tests/osinstall/metadata.textproto
+++ b/feature/gnoi/os/tests/osinstall/metadata.textproto
@@ -7,14 +7,6 @@ description: "Software Upgrade"
 testbed: TESTBED_DUT_ATE_2LINKS
 platform_exceptions: {
   platform: {
-    vendor: JUNIPER
-  }
-  deviations: {
-    sw_version_unsupported: true
-  }
-}
-platform_exceptions: {
-  platform: {
     vendor: NOKIA
   }
   deviations: {

--- a/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/metadata.textproto
+++ b/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/metadata.textproto
@@ -7,14 +7,6 @@ description: "Packet-based Link Qualification"
 testbed: TESTBED_DUT_DUT_4LINKS
 platform_exceptions: {
   platform: {
-    vendor: JUNIPER
-  }
-  deviations: {
-    skip_plq_interface_oper_status_check: true
-  }
-}
-platform_exceptions: {
-  platform: {
     vendor: ARISTA
   }
   deviations: {


### PR DESCRIPTION
Removing following deviations from scripts for Juniper, as these features are now supported on Juniper Devices

- gNMI-1.10: telemetry_basic_check_test.go -> sw_version_unsupported
- gNOI-4.1 : os_install_test.go -> sw_version_unsupported
- gNOI-2.1: packet_link_qualification_test.go -> skip_plq_interface_oper_status_check