### PR TITLE
RT-1.33: Fixing value for deviation flag

### DIFF
--- a/feature/bgp/policybase/otg_tests/prefix_set_test/bgp_prefix_set_test.go
+++ b/feature/bgp/policybase/otg_tests/prefix_set_test/bgp_prefix_set_test.go
@@ -256,7 +256,7 @@ func bgpCreateNbr(localAs, peerAs uint32, dut *ondatra.DUTDevice) *oc.NetworkIns
 	global.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).Enabled = ygot.Bool(true)
 
 	pg := bgp.GetOrCreatePeerGroup(peerGrpName)
-	pg.PeerAs = ygot.Uint32(ateAS)
+	pg.PeerAs = ygot.Uint32(peerAs)
 	pg.PeerGroupName = ygot.String(peerGrpName)
 
 	for _, nbr := range ebgpNbrs {
@@ -429,7 +429,7 @@ func testPrefixSet(t *testing.T, dut *ondatra.DUTDevice) {
 	t.Run("Validate acceptance based on prefix-set policy - import policy on neighbor", func(t *testing.T) {
 		applyPrefixSetPolicy(t, dut, []*prefixSetPolicy{prefixSet1V4, prefixSet2V4}, bgpImportIPv4, *ebgp1NbrV4, importPolicy)
 		applyPrefixSetPolicy(t, dut, []*prefixSetPolicy{prefixSet1V6, prefixSet2V6}, bgpImportIPv6, *ebgp1NbrV6, importPolicy)
-		if !deviations.DefaultImportExportPolicy(dut) {
+		if deviations.DefaultImportExportPolicy(dut) {
 			t.Logf("Validate for neighbour %v", ebgp1NbrV4)
 			validatePrefixCount(t, dut, *ebgp1NbrV4, 3, 5, 0)
 			validatePrefixCount(t, dut, *ebgp1NbrV6, 1, 5, 0)
@@ -476,7 +476,7 @@ func TestBGPPrefixSet(t *testing.T) {
 		verifyBgpState(t, dut)
 	})
 
-	if !deviations.DefaultImportExportPolicy(dut) {
+	if deviations.DefaultImportExportPolicy(dut) {
 		t.Run("Validate initial prefix count", func(t *testing.T) {
 			validatePrefixCount(t, dut, *ebgp1NbrV4, 5, 5, 0)
 			validatePrefixCount(t, dut, *ebgp1NbrV6, 5, 5, 0)
@@ -485,7 +485,7 @@ func TestBGPPrefixSet(t *testing.T) {
 		})
 	} else {
 		t.Run("Validate initial prefix count", func(t *testing.T) {
-			validatePrefixCount(t, dut, *ebgp1NbrV4, 0, 1, 0)
+			validatePrefixCount(t, dut, *ebgp1NbrV4, 0, 5, 0)
 			validatePrefixCount(t, dut, *ebgp1NbrV6, 0, 5, 0)
 			validatePrefixCount(t, dut, *ebgp2NbrV4, 0, 0, 0)
 			validatePrefixCount(t, dut, *ebgp2NbrV6, 0, 0, 0)

--- a/feature/bgp/policybase/otg_tests/prefix_set_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/prefix_set_test/metadata.textproto
@@ -27,7 +27,7 @@ platform_exceptions:  {
     default_network_instance: "default"
     missing_value_for_defaults: true
     skip_set_rp_match_set_options: true
-    default_import_export_policy: false
+    default_import_export_policy: true
 
   }
 }


### PR DESCRIPTION
Value for deviation flag `default_import_export_policy` is set to `false` in the metadata file, and default value for vendor not using this deviation is also `false`.

Due to this `else` part of the code which does not need this deviation never gets executed. Also restoring the original prefix count value applicable for non-deviation scenario.

“This code is a Contribution to the OpenConfig Feature Profiles project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an “as is” basis without any warranties of any kind.”