### PR TITLE
Helper CLI tool initially for listing all OC RPCs for easy browsing

### DIFF
--- a/tools/fpcli/cmd/root.go
+++ b/tools/fpcli/cmd/root.go
@@ -28,13 +28,20 @@ var cfgFile string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "fpcli",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
+	Short: "fpcli is an OpenConfig helper CLI for featureprofile-related use cases",
+	Long: `fpcli is an OpenConfig helper CLI for featureprofile-related use cases.
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+For example, you can use it to show what RPCs exist for a particular OpenConfig protocol:
+
+Example:
+$ fpcli show rpcs gnoi -d tmp
+
+gnoi.bgp.BGP.ClearBGPNeighbor
+gnoi.bootconfig.BootConfig.GetBootConfig
+gnoi.bootconfig.BootConfig.SetBootConfig
+gnoi.certificate.CertificateManagement.CanGenerateCSR
+gnoi.certificate.CertificateManagement.GenerateCSR
+...`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },

--- a/tools/fpcli/cmd/root.go
+++ b/tools/fpcli/cmd/root.go
@@ -1,0 +1,88 @@
+// Copyright © 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmd implements fpcli
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cfgFile string
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "fpcli",
+	Short: "A brief description of your application",
+	Long: `A longer description that spans multiple lines and likely contains
+examples and usage of using your application. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	// Run: func(cmd *cobra.Command, args []string) { },
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
+
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.fpcli.yaml)")
+
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := os.UserHomeDir()
+		cobra.CheckErr(err)
+
+		// Search config in home directory with name ".fpcli" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigType("yaml")
+		viper.SetConfigName(".fpcli")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+	}
+}

--- a/tools/fpcli/cmd/rpc.go
+++ b/tools/fpcli/cmd/rpc.go
@@ -1,0 +1,73 @@
+// Copyright © 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/openconfig/featureprofiles/tools/internal/ocrpcs"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"golang.org/x/exp/maps"
+)
+
+// rpcCmd represents the rpc command
+var rpcCmd = &cobra.Command{
+	Use:   "rpc",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		downloadPath := viper.GetString("download-dir")
+		if err := os.MkdirAll(downloadPath, 0750); err != nil {
+			fmt.Fprintf(os.Stderr, "cannot create download path directory: %v", downloadPath)
+			os.Exit(1)
+		}
+		for _, protocol := range args {
+			ps, err := ocrpcs.Read(downloadPath, protocol)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to read OC protocol %q: %v", protocol, err)
+				os.Exit(1)
+			}
+			rpcs := maps.Keys(ps)
+			sort.Strings(rpcs)
+			fmt.Println(strings.Join(rpcs, "\n"))
+		}
+	},
+}
+
+func init() {
+	showCmd.AddCommand(rpcCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// rpcCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// rpcCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rpcCmd.Flags().StringP("download-dir", "d", "", "Directory to download OC repositories. If already downloaded, then won't download again.")
+	rpcCmd.MarkFlagRequired("download-dir")
+	viper.BindPFlag("download-dir", rpcCmd.Flags().Lookup("download-dir"))
+}

--- a/tools/fpcli/cmd/rpcs.go
+++ b/tools/fpcli/cmd/rpcs.go
@@ -26,16 +26,21 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-// rpcCmd represents the rpc command
-var rpcCmd = &cobra.Command{
-	Use:   "rpc",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+// rpcsCmd represents the rpcs command
+var rpcsCmd = &cobra.Command{
+	Use:   "rpcs",
+	Short: "rpcs is used to show all RPCs belonging to one or more OpenConfig interfaces (e.g. gnmi, gnoi)",
+	Long: `rpcs is used to show all RPCs belonging to one or more OpenConfig interfaces (e.g. gnmi, gnoi)
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+Example:
+$ fpcli show rpcs gnoi -d tmp
+
+gnoi.bgp.BGP.ClearBGPNeighbor
+gnoi.bootconfig.BootConfig.GetBootConfig
+gnoi.bootconfig.BootConfig.SetBootConfig
+gnoi.certificate.CertificateManagement.CanGenerateCSR
+gnoi.certificate.CertificateManagement.GenerateCSR
+...`,
 	Run: func(cmd *cobra.Command, args []string) {
 		downloadPath := viper.GetString("download-dir")
 		if err := os.MkdirAll(downloadPath, 0750); err != nil {
@@ -56,18 +61,18 @@ to quickly create a Cobra application.`,
 }
 
 func init() {
-	showCmd.AddCommand(rpcCmd)
+	showCmd.AddCommand(rpcsCmd)
 
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
-	// rpcCmd.PersistentFlags().String("foo", "", "A help for foo")
+	// rpcsCmd.PersistentFlags().String("foo", "", "A help for foo")
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// rpcCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	rpcCmd.Flags().StringP("download-dir", "d", "", "Directory to download OC repositories. If already downloaded, then won't download again.")
-	rpcCmd.MarkFlagRequired("download-dir")
-	viper.BindPFlag("download-dir", rpcCmd.Flags().Lookup("download-dir"))
+	// rpcsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rpcsCmd.Flags().StringP("download-dir", "d", "", "Directory to download OC repositories. If already downloaded, then won't download again.")
+	rpcsCmd.MarkFlagRequired("download-dir")
+	viper.BindPFlag("download-dir", rpcsCmd.Flags().Lookup("download-dir"))
 }

--- a/tools/fpcli/cmd/show.go
+++ b/tools/fpcli/cmd/show.go
@@ -21,13 +21,20 @@ import (
 // showCmd represents the show command
 var showCmd = &cobra.Command{
 	Use:   "show",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+	Short: "show is used to show information related to OpenConfig featureprofiles",
+	Long: `show is used to show information related to OpenConfig featureprofiles.
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+For example, you can use it to show what RPCs exist for a particular OpenConfig protocol:
+
+Example:
+$ fpcli show rpcs gnoi -d tmp
+
+gnoi.bgp.BGP.ClearBGPNeighbor
+gnoi.bootconfig.BootConfig.GetBootConfig
+gnoi.bootconfig.BootConfig.SetBootConfig
+gnoi.certificate.CertificateManagement.CanGenerateCSR
+gnoi.certificate.CertificateManagement.GenerateCSR
+...`,
 	// Uncomment the following line if "show"
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },

--- a/tools/fpcli/cmd/show.go
+++ b/tools/fpcli/cmd/show.go
@@ -1,0 +1,48 @@
+// Copyright © 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// showCmd represents the show command
+var showCmd = &cobra.Command{
+	Use:   "show",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	// Uncomment the following line if "show"
+	// has an action associated with it:
+	// Run: func(cmd *cobra.Command, args []string) { },
+}
+
+func init() {
+	rootCmd.AddCommand(showCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// showCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// showCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/tools/fpcli/main.go
+++ b/tools/fpcli/main.go
@@ -1,0 +1,22 @@
+// Copyright © 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// fpcli is a helper CLI for FP-related tooling
+package main
+
+import "github.com/openconfig/featureprofiles/tools/fpcli/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/tools/internal/ocrpcs/ocrpcs.go
+++ b/tools/internal/ocrpcs/ocrpcs.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package ocrpcs contains utilities related to ocrpcs.proto.
 package ocrpcs
 
@@ -46,7 +60,7 @@ func cloneAPIRepo(downloadPath, api string) (string, error) {
 	return repoPath, nil
 }
 
-func readAllRPCs(downloadPath, api string) (map[string]struct{}, error) {
+func Read(downloadPath, api string) (map[string]struct{}, error) {
 	repoPath, err := cloneAPIRepo(downloadPath, api)
 	if err != nil {
 		return nil, err
@@ -97,7 +111,7 @@ func ValidateRPCs(downloadPath string, protocols map[string]*rpb.OCProtocol) (ui
 	var errs errlist.List
 	errs.Separator = "\n"
 	for api, protocol := range protocols {
-		rpcs, err := readAllRPCs(downloadPath, api)
+		rpcs, err := Read(downloadPath, api)
 		if err != nil {
 			return 0, err
 		}

--- a/tools/internal/ocrpcs/ocrpcs.go
+++ b/tools/internal/ocrpcs/ocrpcs.go
@@ -60,6 +60,10 @@ func cloneAPIRepo(downloadPath, api string) (string, error) {
 	return repoPath, nil
 }
 
+// Read returns all RPCs for the given OpenConfig API.
+//
+//   - downloadPath specifies the folder to download the associated OpenConfig
+//     repo in order to allow for proto file parsing.
 func Read(downloadPath, api string) (map[string]struct{}, error) {
 	repoPath, err := cloneAPIRepo(downloadPath, api)
 	if err != nil {


### PR DESCRIPTION
Example:
```bash
go install ./tools/fpcli

fpcli show rpcs gnoi -d tmp
```

output:
```
gnoi.bgp.BGP.ClearBGPNeighbor
gnoi.bootconfig.BootConfig.GetBootConfig
gnoi.bootconfig.BootConfig.SetBootConfig
gnoi.certificate.CertificateManagement.CanGenerateCSR
gnoi.certificate.CertificateManagement.GenerateCSR
gnoi.certificate.CertificateManagement.GetCertificates
gnoi.certificate.CertificateManagement.Install
...
...
...
```