### PR TITLE
Health-1.2 - Healthz component status paths README

### DIFF
--- a/feature/platform/healthz/tests/status/README.md
+++ b/feature/platform/healthz/tests/status/README.md
@@ -41,7 +41,6 @@ The DUT should have a HEALTHY state for all the above components.
   * Validate the following paths return a valid value:
     * /components/component/healthz/state/last-unhealthy
     * /components/component/healthz/state/unhealthy-count
-1
 
 * Healthz-1.2.3: Reboot DUT and validate status converges to healthy
   * Use gnoi.System.Reboot to reboot the DUT
@@ -88,8 +87,6 @@ paths:
             "POWER_SUPPLY",
             "INTEGRATED_CIRCUIT"
         ]
-    /components/component/healthz/state/last-unhealthy:
-    /components/component/healthz/state/unhealthy-count:
 
 rpcs:
     gnmi:

--- a/feature/platform/healthz/tests/status/README.md
+++ b/feature/platform/healthz/tests/status/README.md
@@ -94,7 +94,7 @@ rpcs:
             ON_CHANGE: true
 
     gnoi:
-        gNOI.System:
+        System.Reboot:
 
 ```
 

--- a/feature/platform/healthz/tests/status/README.md
+++ b/feature/platform/healthz/tests/status/README.md
@@ -29,7 +29,7 @@ The DUT should have a HEALTHY state for all the above components.
 
 ## Procedure
 
-* Healthz-1.2.1:
+* Healthz-1.2.1: Validate healthz status
   * gNMI Subscribe to the /components tree using ON_CHANGE option.
   * Validate `/components/component/healthz/state/status` returns `HEALTHY`
     for each of the following component types:
@@ -38,8 +38,12 @@ The DUT should have a HEALTHY state for all the above components.
         "FABRIC",
         "POWER_SUPPLY",
         "INTEGRATED_CIRCUIT"
+  * Validate the following paths return a valid value:
+    * /components/component/healthz/state/last-unhealthy
+    * /components/component/healthz/state/unhealthy-count
+1
 
-* Healthz-1.2.2: Reboot DUT and validate status converges to healthy
+* Healthz-1.2.3: Reboot DUT and validate status converges to healthy
   * Use gnoi.System.Reboot to reboot the DUT
   * Repeatedly attempt to open a gNMI subscribe request to the DUT
   * Upon success, subscribe to the /components tree using ON_CHANGE option.
@@ -84,6 +88,8 @@ paths:
             "POWER_SUPPLY",
             "INTEGRATED_CIRCUIT"
         ]
+    /components/component/healthz/state/last-unhealthy:
+    /components/component/healthz/state/unhealthy-count:
 
 rpcs:
     gnmi:

--- a/feature/platform/healthz/tests/status/README.md
+++ b/feature/platform/healthz/tests/status/README.md
@@ -1,0 +1,100 @@
+# Health-1.2: Healthz component status paths
+
+## Summary
+
+Validate healthz status paths exist for select OC component types.  There
+are two operational use cases for this test.
+
+1. As a network operator, I want to know if a device is healthy.  If the
+   device is unhealthy, I may choose to execute a mitigation or repair action.
+   The choice of action is influenced by which component(s) are not healthy.
+2. As a SDN controller, I want to know if a device is ready to be programmed
+   for traffic forwarding.
+
+## Testbed type
+
+* [Single DUT](https://github.com/openconfig/featureprofiles/blob/main/topologies/dut.testbed)
+
+## Testbed prerequisites
+
+There are no DUT configuration pre-requisites for this test.  The DUT must
+contain the following component types:
+        "CONTROLLER_CARD",
+        "LINECARD",
+        "FABRIC",
+        "POWER_SUPPLY",
+        "INTEGRATED_CIRCUIT"
+
+The DUT should have a HEALTHY state for all the above components.
+
+## Procedure
+
+* Healthz-1.2.1:
+  * gNMI Subscribe to the /components tree using ON_CHANGE option.
+  * Validate `/components/component/healthz/state/status` returns `HEALTHY`
+    for each of the following component types:
+        "CONTROLLER_CARD",
+        "LINECARD",
+        "FABRIC",
+        "POWER_SUPPLY",
+        "INTEGRATED_CIRCUIT"
+
+* Healthz-1.2.2: Reboot DUT and validate status converges to healthy
+  * Use gnoi.System.Reboot to reboot the DUT
+  * Repeatedly attempt to open a gNMI subscribe request to the DUT
+  * Upon success, subscribe to the /components tree using ON_CHANGE option.
+  * Validate `/components/component/healthz/state/status` exists for each of
+    the following component types:
+        "CONTROLLER_CARD",
+        "LINECARD",
+        "FABRIC",
+        "POWER_SUPPLY",
+        "INTEGRATED_CIRCUIT"
+  * Validate status transitions to `HEALTHY` within a timeout of 15 minutes
+    from the reboot start time.
+
+## OpenConfig Path and RPC Coverage
+
+The below yaml defines the OC paths and RPC intended to be covered by this test.
+
+```yaml
+paths:
+  ## State Paths ##
+    /components/component/healthz/state/status:
+        platform_type: [
+            "CONTROLLER_CARD",
+            "LINECARD",
+            "FABRIC",
+            "POWER_SUPPLY",
+            "INTEGRATED_CIRCUIT"
+        ]
+    /components/component/healthz/state/last-unhealthy:
+        platform_type: [
+            "CONTROLLER_CARD",
+            "LINECARD",
+            "FABRIC",
+            "POWER_SUPPLY",
+            "INTEGRATED_CIRCUIT"
+        ]
+    /components/component/healthz/state/unhealthy-count:
+        platform_type: [
+            "CONTROLLER_CARD",
+            "LINECARD",
+            "FABRIC",
+            "POWER_SUPPLY",
+            "INTEGRATED_CIRCUIT"
+        ]
+
+rpcs:
+    gnmi:
+        gNMI.Subscribe:
+            ON_CHANGE: true
+
+    gnoi:
+        gNOI.System:
+
+```
+
+## Minimum DUT platform requirement
+
+MFF - Modular form factor is specified to ensure coverage for `CONTROLLER_CARD` and `FABRIC` platform_types.

--- a/feature/platform/healthz/tests/status/README.md
+++ b/feature/platform/healthz/tests/status/README.md
@@ -94,7 +94,7 @@ rpcs:
             ON_CHANGE: true
 
     gnoi:
-        System.Reboot:
+        system.System.Reboot:
 
 ```
 

--- a/feature/platform/healthz/tests/status/metadata.textproto
+++ b/feature/platform/healthz/tests/status/metadata.textproto
@@ -1,0 +1,12 @@
+# proto-file: github.com/openconfig/featureprofiles/proto/metadata.proto
+# proto-message: Metadata
+
+plan_id: "Health-1.2"
+description: "Healthz component status paths"
+uuid: "6935156f-d42f-4bb0-9926-79235859c029"
+
+testbed: TESTBED_DUT
+
+tags:  TAGS_AGGREGATION
+tags:  TAGS_TRANSIT
+tags:  TAGS_DATACENTER_EDGE

--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -318,6 +318,12 @@ test: {
   exec: " "
 }
 test: {
+  id: "Health-1.1"
+  description: "Healthz component status paths"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/platform/healthz/tests/status/README.md"
+  exec: " "
+}
+test: {
   id: "IC-1"
   description: "Integrated Circuit Utilization and Thresholds"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/platform/integrated_circuit/otg_tests/utilization/README.md"


### PR DESCRIPTION
Adds README for test requirements covering the OC paths related to healthz