### PR TITLE
RT-2.6: Fix multiple issues with isis_interface_hello_padding_enable_…

### DIFF
--- a/feature/experimental/isis/otg_tests/isis_interface_hello_padding_enable_test/metadata.textproto
+++ b/feature/experimental/isis/otg_tests/isis_interface_hello_padding_enable_test/metadata.textproto
@@ -41,6 +41,7 @@ platform_exceptions: {
     isis_timers_csnp_interval_unsupported: true
     isis_counter_manual_address_drop_from_areas_unsupported: true
     isis_counter_part_changes_unsupported: true
+    isis_interface_afi_unsupported: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
- Make use of `ISISInterfaceAfiUnsupported` when configuring
- Add isis_interface_afi_unsupported to metadata for arista
- Check for `ISISCounterManualAddressDropFromAreasUnsupported`, `ISISCounterPartChangesUnsupported` deviations
- Use await/watch for lsdb and aft telemetry validation