### PR TITLE
RT-5.8: Update configureDUTLinkLocalInterface()

### DIFF
--- a/feature/interface/ip/ipv6_link_local/otg_tests/ipv6_link_local_test/README.md
+++ b/feature/interface/ip/ipv6_link_local/otg_tests/ipv6_link_local_test/README.md
@@ -46,9 +46,14 @@ Configure an IPv6 address which is in link local scope. Verify the link local IP
 /interfaces/interface/subinterfaces/subinterface/ipv6/addresses/address/state/type
 ```
 
-## Protocol/RPC Parameter Coverage
-
-None
+## OpenConfig Path and RPC Coverage
+```yaml
+rpcs:
+  gnmi:
+    gNMI.Get:
+    gNMI.Set:
+    gNMI.Subscribe:
+```
 
 ## Required DUT platform
 

--- a/feature/interface/ip/ipv6_link_local/otg_tests/ipv6_link_local_test/ipv6_link_local_test.go
+++ b/feature/interface/ip/ipv6_link_local/otg_tests/ipv6_link_local_test/ipv6_link_local_test.go
@@ -177,6 +177,10 @@ func configureDUTLinkLocalInterface(t *testing.T, dut *ondatra.DUTDevice) {
 	p1 := dut.Port(t, "port1")
 	srcIntf := dutSrc.NewOCInterface(p1.Name(), dut)
 	subInt := srcIntf.GetOrCreateSubinterface(0)
+	subInt4 := subInt.GetOrCreateIpv4()
+	if deviations.InterfaceEnabled(dut) && !deviations.IPv4MissingEnabled(dut) {
+		subInt4.Enabled = ygot.Bool(true)
+	}
 	subInt.GetOrCreateIpv6().Enabled = ygot.Bool(true)
 	subInt.GetOrCreateIpv6().GetOrCreateAddress(dutSrc.IPv6).SetType(oc.IfIp_Ipv6AddressType_LINK_LOCAL_UNICAST)
 	gnmi.Replace(t, dut, gnmi.OC().Interface(p1.Name()).Config(), srcIntf)
@@ -184,7 +188,11 @@ func configureDUTLinkLocalInterface(t *testing.T, dut *ondatra.DUTDevice) {
 	p2 := dut.Port(t, "port2")
 	dstIntf := dutDst.NewOCInterface(p2.Name(), dut)
 	dstSubInt := dstIntf.GetOrCreateSubinterface(0)
+	dstSubInt4 := dstSubInt.GetOrCreateIpv4()
 	dstSubInt.GetOrCreateIpv6().Enabled = ygot.Bool(true)
+	if deviations.InterfaceEnabled(dut) && !deviations.IPv4MissingEnabled(dut) {
+		dstSubInt4.Enabled = ygot.Bool(true)
+	}
 	dstSubInt.GetOrCreateIpv6().GetOrCreateAddress(dutDst.IPv6).SetType(oc.IfIp_Ipv6AddressType_LINK_LOCAL_UNICAST)
 	gnmi.Replace(t, dut, gnmi.OC().Interface(p2.Name()).Config(), dstIntf)
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {


### PR DESCRIPTION
Update configureDUTLinkLocalInterface() to enable ipv4 if InterfaceEnabled deviation exists and ipv4 is not enabled,