### PR TITLE
RT-2.2 | Remove isis_interface_level1_disable_required deviation

### DIFF
--- a/feature/experimental/isis/otg_tests/lsp_updates_test/metadata.textproto
+++ b/feature/experimental/isis/otg_tests/lsp_updates_test/metadata.textproto
@@ -24,7 +24,6 @@ platform_exceptions: {
   }
   deviations: {
     ipv4_missing_enabled: true
-    isis_interface_level1_disable_required: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
Remove isis_interface_level1_disable_required deviation for RT-2.2 is-is test