### PR TITLE
add cancellable context in ssh CLI

### DIFF
--- a/topologies/binding/binding.go
+++ b/topologies/binding/binding.go
@@ -205,6 +205,7 @@ func (d *staticDUT) DialCLI(context.Context) (binding.CLIClient, error) {
 			ssh.Password(sshOpts.Password),
 			ssh.KeyboardInteractive(sshInteractive(sshOpts.Password)),
 		},
+		Timeout: time.Duration(time.Second.Nanoseconds() * int64(sshOpts.Timeout)),
 	}
 	if sshOpts.SkipVerify {
 		c.HostKeyCallback = ssh.InsecureIgnoreHostKey()


### PR DESCRIPTION
When using the RunCommand function, there is a case where if an SSH connection is stopped from the server side without closing the connection, the program calling it will halt and be unable to resume. This may occur when a router is restarted, after which the severed ssh session will not be reestablished.

To illustrate, this line will cause deadlock 

```go
cliClient.RunCommand(context.Background(), "run killall -STOP sshd")
``` 
*note*: this will also block incoming ssh until `killall -CONT sshd` is executed. For testing, try instead `run killall -STOP sshd; sleep 10s; killall -CONT sshd`

with the proposed changes, it can be handled using a context with a timeout/deadline (or otherwise cancelled)

```go
ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
defer cancel()
cliClient.RunCommand(ctx, "run killall -STOP sshd")
``` 

Have also added the sshConfig timeout to DialCLI's ClientConfig. 