### PR TITLE
RT-1.33 changes

### DIFF
--- a/feature/bgp/policybase/otg_tests/prefix_set_test/README.md
+++ b/feature/bgp/policybase/otg_tests/prefix_set_test/README.md
@@ -62,20 +62,14 @@ paths:
   /routing-policy/defined-sets/prefix-sets/prefix-set/config/name:
   /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/ip-prefix:
   /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/masklength-range:
-
-  /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/state/ip-prefix:
-  /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/state/masklength-range:
-  /routing-policy/defined-sets/prefix-sets/prefix-set/state/mode:
-  /routing-policy/defined-sets/prefix-sets/prefix-set/state/name:
-
   /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/match-set-options:
   /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/prefix-set:
 
   ## State paths
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/session-state:
-  /network-instances/network-instance[name=DEFAULT]/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/installed:
-  /network-instances/network-instance[name=DEFAULT]/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received-pre-policy:
-  /network-instances/network-instance[name=DEFAULT]/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/sent:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/installed:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received-pre-policy:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/sent:
   /routing-policy/policy-definitions/policy-definition/statements/statement/state/name:
 
 rpcs:

--- a/feature/bgp/policybase/otg_tests/prefix_set_test/README.md
+++ b/feature/bgp/policybase/otg_tests/prefix_set_test/README.md
@@ -72,7 +72,6 @@ paths:
   /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/prefix-set:
 
   ## State paths
-  ### Policy definition state
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/session-state:
   /network-instances/network-instance[name=DEFAULT]/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/installed:
   /network-instances/network-instance[name=DEFAULT]/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received-pre-policy:

--- a/feature/bgp/policybase/otg_tests/prefix_set_test/README.md
+++ b/feature/bgp/policybase/otg_tests/prefix_set_test/README.md
@@ -49,3 +49,38 @@ Protocol/RPC Parameter coverage
 N/A
 Minimum DUT platform requirement
 vRX
+
+## OpenConfig Path and RPC Coverage
+
+The below yaml defines the OC paths intended to be covered by this test. OC
+paths used for test setup are not listed here.
+
+```yaml 
+paths:
+  ## Config paths
+  /routing-policy/defined-sets/prefix-sets/prefix-set/config/mode:
+  /routing-policy/defined-sets/prefix-sets/prefix-set/config/name:
+  /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/ip-prefix:
+  /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/masklength-range:
+
+  /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/state/ip-prefix:
+  /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/state/masklength-range:
+  /routing-policy/defined-sets/prefix-sets/prefix-set/state/mode:
+  /routing-policy/defined-sets/prefix-sets/prefix-set/state/name:
+
+  /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/match-set-options:
+  /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/prefix-set:
+
+  ## State paths
+  ### Policy definition state
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/session-state:
+  /network-instances/network-instance[name=DEFAULT]/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/installed:
+  /network-instances/network-instance[name=DEFAULT]/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received-pre-policy:
+  /network-instances/network-instance[name=DEFAULT]/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/sent:
+  /routing-policy/policy-definitions/policy-definition/statements/statement/state/name:
+
+rpcs:
+  gnmi:
+    gNMI.Set:
+    gNMI.Subscribe:
+```

--- a/feature/bgp/policybase/otg_tests/prefix_set_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/prefix_set_test/metadata.textproto
@@ -31,6 +31,14 @@ platform_exceptions:  {
 
   }
 }
+platform_exceptions:  {
+  platform:  {
+    vendor:  CISCO
+  }
+  deviations:  {
+    prepolicy_received_routes: true
+  }
+}
 tags: TAGS_AGGREGATION
 tags: TAGS_TRANSIT
 tags: TAGS_DATACENTER_EDGE

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -16,6 +16,7 @@
 package helpers
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -120,4 +121,36 @@ func GNMINotifString(n *gpb.Notification) string {
 		build.WriteString(fmt.Sprintf("update %s: %v\n", path, u.GetVal()))
 	}
 	return build.String()
+}
+
+// GnmiCLIConfig sets config built with buildCliConfigRequest.
+func GnmiCLIConfig(t testing.TB, dut *ondatra.DUTDevice, config string) {
+	gnmiClient := dut.RawAPIs().GNMI(t)
+	gpbSetRequest, err := buildCliConfigRequest(config)
+	if err != nil {
+		t.Fatalf("Cannot build a gNMI SetRequest: %v", err)
+	}
+
+	t.Log("gnmiClient Set CLI config")
+	if _, err = gnmiClient.Set(context.Background(), gpbSetRequest); err != nil {
+		t.Fatalf("gnmiClient.Set() with unexpected error: %v", err)
+	}
+}
+
+// buildCliConfigRequest Build config with Origin set to cli and Ascii encoded config.
+func buildCliConfigRequest(config string) (*gpb.SetRequest, error) {
+	gpbSetRequest := &gpb.SetRequest{
+		Update: []*gpb.Update{{
+			Path: &gpb.Path{
+				Origin: "cli",
+				Elem:   []*gpb.PathElem{},
+			},
+			Val: &gpb.TypedValue{
+				Value: &gpb.TypedValue_AsciiVal{
+					AsciiVal: config,
+				},
+			},
+		}},
+	}
+	return gpbSetRequest, nil
 }


### PR DESCRIPTION
Made below changes to the test

- Change AS# for Port2 DUT-ATE BGP sessions for routes to be advertised to that eBGP Peer , same AS wont work due to AS PATH loop prevention.
- Added soft reconfiguration inbound CLI with MissingPrePolicyReceivedRoutes deviation for pre-policy routes
- Increase timeouts in watch in validatePrefixCount to account for default sample interval with gnmi target-defined sub