### PR TITLE
[gNMI-1.14]: Check metadata2 after the 2nd large config set

### DIFF
--- a/feature/system/gnmi/metadata/tests/large_set_consistency_test/large_set_consistency_test.go
+++ b/feature/system/gnmi/metadata/tests/large_set_consistency_test/large_set_consistency_test.go
@@ -316,7 +316,7 @@ func TestLargeSetConsistency(t *testing.T) {
 				default:
 					t.Logf("[%d - running] checking config protobuf-metadata", i)
 					time.Sleep(5 * time.Millisecond)
-					checkMetadata1(t, gnmiClient, dut, done)
+					checkMetadata2(t, gnmiClient, dut)
 				}
 			}
 		}(i)


### PR DESCRIPTION
After gnmiClient set 2nd large configuration, the test should be calling checkMetadata2() instead of checkMetadata1().