### PR TITLE
RT-7.1 : Fixed receive prefix count

### DIFF
--- a/feature/bgp/policybase/otg_tests/default_policies_test/README.md
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/README.md
@@ -137,3 +137,13 @@ B <-- IBGP+IS-IS --> C[Port2:OTG];
     * afi-safis/afi-safi/state/prefixes/received
     * afi-safis/afi-safi/state/prefixes/received-pre-policy
     * afi-safis/afi-safi/state/prefixes/sent
+
+## OpenConfig Path and RPC Coverage
+
+```yaml
+rpcs:
+  gnmi:
+    gNMI.Get:
+    gNMI.Set:
+    gNMI.Subscribe:
+```

--- a/feature/bgp/policybase/otg_tests/default_policies_test/bgp_default_policies_test.go
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/bgp_default_policies_test.go
@@ -649,16 +649,16 @@ func testDefaultPolicyRejectRouteAction(t *testing.T, dut *ondatra.DUTDevice) {
 
 	verifyPostPolicyPrefixTelemetry(t, dut, &peerDetails{ipAddr: atePort1.IPv4, defExportPol: rejectRoute,
 		defImportPol: rejectRoute, exportPol: []string{ebgpExportIPv4}, importPol: []string{ebgpImportIPv4},
-		wantInstalled: 2, wantRx: 2, wantRxPrePolicy: 3, wantSent: 1, isV4: true})
+		wantInstalled: 2, wantRx: 3, wantRxPrePolicy: 3, wantSent: 1, isV4: true})
 	verifyPostPolicyPrefixTelemetry(t, dut, &peerDetails{ipAddr: atePort1.IPv6, defExportPol: rejectRoute,
 		defImportPol: rejectRoute, exportPol: []string{ebgpExportIPv6}, importPol: []string{ebgpImportIPv6},
-		wantInstalled: 2, wantRx: 2, wantRxPrePolicy: 3, wantSent: 1, isV4: false})
+		wantInstalled: 2, wantRx: 3, wantRxPrePolicy: 3, wantSent: 1, isV4: false})
 	verifyPostPolicyPrefixTelemetry(t, dut, &peerDetails{ipAddr: otgIsisPort2LoopV4, defExportPol: rejectRoute,
 		defImportPol: rejectRoute, exportPol: []string{ibgpExportIPv4}, importPol: []string{ibgpImportIPv4},
-		wantInstalled: 2, wantRx: 2, wantRxPrePolicy: 3, wantSent: 1, isV4: true})
+		wantInstalled: 2, wantRx: 3, wantRxPrePolicy: 3, wantSent: 1, isV4: true})
 	verifyPostPolicyPrefixTelemetry(t, dut, &peerDetails{ipAddr: otgIsisPort2LoopV6, defExportPol: rejectRoute,
 		defImportPol: rejectRoute, exportPol: []string{ibgpExportIPv6}, importPol: []string{ibgpImportIPv6},
-		wantInstalled: 2, wantRx: 2, wantRxPrePolicy: 3, wantSent: 1, isV4: false})
+		wantInstalled: 2, wantRx: 3, wantRxPrePolicy: 3, wantSent: 1, isV4: false})
 }
 
 func testDefaultPolicyAcceptRouteAction(t *testing.T, dut *ondatra.DUTDevice) {
@@ -738,16 +738,16 @@ func testDefaultPolicyRejectRouteActionOnly(t *testing.T, dut *ondatra.DUTDevice
 
 	verifyPostPolicyPrefixTelemetry(t, dut, &peerDetails{ipAddr: atePort1.IPv4, defExportPol: rejectRoute,
 		defImportPol: rejectRoute, exportPol: []string{}, importPol: []string{},
-		wantInstalled: 0, wantRx: 0, wantRxPrePolicy: 3, wantSent: 0, isV4: true})
+		wantInstalled: 0, wantRx: 3, wantRxPrePolicy: 3, wantSent: 0, isV4: true})
 	verifyPostPolicyPrefixTelemetry(t, dut, &peerDetails{ipAddr: atePort1.IPv6, defExportPol: rejectRoute,
 		defImportPol: rejectRoute, exportPol: []string{}, importPol: []string{},
-		wantInstalled: 0, wantRx: 0, wantRxPrePolicy: 3, wantSent: 0, isV4: false})
+		wantInstalled: 0, wantRx: 3, wantRxPrePolicy: 3, wantSent: 0, isV4: false})
 	verifyPostPolicyPrefixTelemetry(t, dut, &peerDetails{ipAddr: otgIsisPort2LoopV4, defExportPol: rejectRoute,
 		defImportPol: rejectRoute, exportPol: []string{}, importPol: []string{},
-		wantInstalled: 0, wantRx: 0, wantRxPrePolicy: 3, wantSent: 0, isV4: true})
+		wantInstalled: 0, wantRx: 3, wantRxPrePolicy: 3, wantSent: 0, isV4: true})
 	verifyPostPolicyPrefixTelemetry(t, dut, &peerDetails{ipAddr: otgIsisPort2LoopV6, defExportPol: rejectRoute,
 		defImportPol: rejectRoute, exportPol: []string{}, importPol: []string{},
-		wantInstalled: 0, wantRx: 0, wantRxPrePolicy: 3, wantSent: 0, isV4: false})
+		wantInstalled: 0, wantRx: 3, wantRxPrePolicy: 3, wantSent: 0, isV4: false})
 }
 
 func configureRoutePolicies(t *testing.T, dut *ondatra.DUTDevice) {


### PR DESCRIPTION
Hi,

Recent pull request for this script modified received prefix count, which is causing issue.
Received prefix count will be always equal to number of prefixes sent from ixia. 
Post policy count varies based on policy applied but not the prefixes received from peer.

Thanks,
Prabha
