### PR TITLE
   Fix RT-7.1: BGP default policies test for Arista

### DIFF
--- a/feature/bgp/policybase/otg_tests/default_policies_test/README.md
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/README.md
@@ -109,16 +109,12 @@ paths:
   /routing-policy/policy-definitions/policy-definition/statements/statement/config/name:
   /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/prefix-set:
   /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/match-set-options:
-  /routing-policy/policy-definitions/policy-definition/statements/statement/actions/config/policy-result:
-  # Path to Neighbor or Peer-Group level
-  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor:
-  /network-instances/network-instance/protocols/protocol/bgp/neighbors/peer-group:  
+  /routing-policy/policy-definitions/policy-definition/statements/statement/actions/config/policy-result:  
   # Apply Policy at Neighbor or Peer-Group level
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/import-policy:
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/export-policy:
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/default-import-policy:
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/default-export-policy:
-  # Telemetry Parameter Coverage
   # Path to Neighbor or Peer-Group level
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor:
   /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group:

--- a/feature/bgp/policybase/otg_tests/default_policies_test/README.md
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/README.md
@@ -103,7 +103,7 @@ paths:
   # Defined Sets
   - /routing-policy/defined-sets/prefix-sets/prefix-set:
   - /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/ip-prefix:
-  - /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/masklength-range/exact:
+  - /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/masklength-range:
   # Policy-Definition
   - /routing-policy/policy-definitions/policy-definition/config/name:
   - /routing-policy/policy-definitions/policy-definition/statements/statement/config/name:

--- a/feature/bgp/policybase/otg_tests/default_policies_test/README.md
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/README.md
@@ -101,7 +101,6 @@ B <-- IBGP+IS-IS --> C[Port2:OTG];
 ```yaml
 paths:
   # Defined Sets
-  /routing-policy/defined-sets/prefix-sets/prefix-set:
   /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/ip-prefix:
   /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/masklength-range:
   # Policy-Definition
@@ -115,9 +114,6 @@ paths:
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/export-policy:
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/default-import-policy:
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/default-export-policy:
-  # Path to Neighbor or Peer-Group level
-  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor:
-  /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group:
   # Paths under Neighbor and Peer-Group level
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/state/export-policy:
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/state/import-policy:

--- a/feature/bgp/policybase/otg_tests/default_policies_test/README.md
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/README.md
@@ -119,10 +119,10 @@ paths:
   - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/default-import-policy:
   - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/default-export-policy:
   # Telemetry Parameter Coverage
-  # Path to Neighbor or Peer-Group level:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor
-  - /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group
-  # Paths under Neighbor and Peer-Group level:
+  # Path to Neighbor or Peer-Group level
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor:
+  - /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group:
+  # Paths under Neighbor and Peer-Group level
   - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/state/export-policy:
   - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/state/import-policy:
   - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/installed:

--- a/feature/bgp/policybase/otg_tests/default_policies_test/README.md
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/README.md
@@ -100,45 +100,35 @@ B <-- IBGP+IS-IS --> C[Port2:OTG];
 ## OpenConfig Path and RPC Coverage
 ```yaml
 paths:
-  * Defined Sets
-    * /routing-policy/defined-sets/prefix-sets/prefix-set/
-    * /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/ip-prefix
-    * /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/masklength-range/exact
-
-  * Policy-Definition
-    * /routing-policy/policy-definitions/policy-definition/config/name
-    * /routing-policy/policy-definitions/policy-definition/statements/statement/config/name
-    * /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/prefix-set
-    * /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/match-set-options
-    * /routing-policy/policy-definitions/policy-definition/statements/statement/actions/config/policy-result/ACCEPT_ROUTE
-    * /routing-policy/policy-definitions/policy-definition/statements/statement/actions/config/policy-result/REJECT_ROUTE
-
-  * Path to Neighbor or Peer-Group level
-    * /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/
-    * /network-instances/network-instance/protocols/protocol/bgp/neighbors/peer-group/
-      
-  * Apply Policy at Neighbor or Peer-Group level
-    * afi-safis/afi-safi/apply-policy/config/import-policy
-    * afi-safis/afi-safi/apply-policy/config/export-policy
-    * afi-safis/afi-safi/apply-policy/config/default-import-policy/ACCEPT-ALL
-    * afi-safis/afi-safi/apply-policy/config/default-export-policy/ACCEPT-ALL
-    * afi-safis/afi-safi/apply-policy/config/default-import-policy/REJECT-ALL
-    * afi-safis/afi-safi/apply-policy/config/default-export-policy/REJECT-ALL
-
-
+  # Defined Sets
+  - /routing-policy/defined-sets/prefix-sets/prefix-set:
+  - /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/ip-prefix:
+  - /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/masklength-range/exact:
+  # Policy-Definition
+  - /routing-policy/policy-definitions/policy-definition/config/name:
+  - /routing-policy/policy-definitions/policy-definition/statements/statement/config/name:
+  - /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/prefix-set:
+  - /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/match-set-options:
+  - /routing-policy/policy-definitions/policy-definition/statements/statement/actions/config/policy-result:
+  # Path to Neighbor or Peer-Group level
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/peer-group:  
+  # Apply Policy at Neighbor or Peer-Group level
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/import-policy:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/export-policy:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/default-import-policy:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/default-export-policy:
   # Telemetry Parameter Coverage
-
-  * Path to Neighbor or Peer-Group level:
-    * /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor
-    * /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group
-
-  * Paths under Neighbor and Peer-Group level:
-    * afi-safis/afi-safi/apply-policy/state/export-policy
-    * afi-safis/afi-safi/apply-policy/state/import-policy
-    * afi-safis/afi-safi/state/prefixes/installed
-    * afi-safis/afi-safi/state/prefixes/received
-    * afi-safis/afi-safi/state/prefixes/received-pre-policy
-    * afi-safis/afi-safi/state/prefixes/sent
+  # Path to Neighbor or Peer-Group level:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor
+  - /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group
+  # Paths under Neighbor and Peer-Group level:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/state/export-policy:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/state/import-policy:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/installed:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received-pre-policy:
+  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/sent:
 rpcs:
   gnmi:
     gNMI.Get:

--- a/feature/bgp/policybase/otg_tests/default_policies_test/README.md
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/README.md
@@ -101,34 +101,34 @@ B <-- IBGP+IS-IS --> C[Port2:OTG];
 ```yaml
 paths:
   # Defined Sets
-  - /routing-policy/defined-sets/prefix-sets/prefix-set:
-  - /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/ip-prefix:
-  - /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/masklength-range:
+  /routing-policy/defined-sets/prefix-sets/prefix-set:
+  /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/ip-prefix:
+  /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/masklength-range:
   # Policy-Definition
-  - /routing-policy/policy-definitions/policy-definition/config/name:
-  - /routing-policy/policy-definitions/policy-definition/statements/statement/config/name:
-  - /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/prefix-set:
-  - /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/match-set-options:
-  - /routing-policy/policy-definitions/policy-definition/statements/statement/actions/config/policy-result:
+  /routing-policy/policy-definitions/policy-definition/config/name:
+  /routing-policy/policy-definitions/policy-definition/statements/statement/config/name:
+  /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/prefix-set:
+  /routing-policy/policy-definitions/policy-definition/statements/statement/conditions/match-prefix-set/config/match-set-options:
+  /routing-policy/policy-definitions/policy-definition/statements/statement/actions/config/policy-result:
   # Path to Neighbor or Peer-Group level
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/peer-group:  
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/peer-group:  
   # Apply Policy at Neighbor or Peer-Group level
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/import-policy:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/export-policy:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/default-import-policy:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/default-export-policy:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/import-policy:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/export-policy:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/default-import-policy:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/config/default-export-policy:
   # Telemetry Parameter Coverage
   # Path to Neighbor or Peer-Group level
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor:
-  - /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor:
+  /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group:
   # Paths under Neighbor and Peer-Group level
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/state/export-policy:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/state/import-policy:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/installed:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received-pre-policy:
-  - /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/sent:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/state/export-policy:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/apply-policy/state/import-policy:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/installed:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/received-pre-policy:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/state/prefixes/sent:
 rpcs:
   gnmi:
     gNMI.Get:

--- a/feature/bgp/policybase/otg_tests/default_policies_test/README.md
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/README.md
@@ -96,8 +96,10 @@ B <-- IBGP+IS-IS --> C[Port2:OTG];
     * DUT:Port2 wouldn't export routes to IPv4-prefix1, IPv4-prefix2, IPv4-prefix3, IPv6-prefix1, IPv6-prefix2 and IPv6-prefix3 since they are missing from the DUT's forwarding table.
     * IS-IS and static routes shouldn't be advertised to the EBGP and IBGP peers.
    
-### Config Parameter Coverage
 
+## OpenConfig Path and RPC Coverage
+```yaml
+paths:
   * Defined Sets
     * /routing-policy/defined-sets/prefix-sets/prefix-set/
     * /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/ip-prefix
@@ -124,7 +126,7 @@ B <-- IBGP+IS-IS --> C[Port2:OTG];
     * afi-safis/afi-safi/apply-policy/config/default-export-policy/REJECT-ALL
 
 
-### Telemetry Parameter Coverage
+  # Telemetry Parameter Coverage
 
   * Path to Neighbor or Peer-Group level:
     * /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor
@@ -137,3 +139,9 @@ B <-- IBGP+IS-IS --> C[Port2:OTG];
     * afi-safis/afi-safi/state/prefixes/received
     * afi-safis/afi-safi/state/prefixes/received-pre-policy
     * afi-safis/afi-safi/state/prefixes/sent
+rpcs:
+  gnmi:
+    gNMI.Get:
+    gNMI.Set:
+    gNMI.Subscribe:
+```

--- a/feature/bgp/policybase/otg_tests/default_policies_test/bgp_default_policies_test.go
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/bgp_default_policies_test.go
@@ -196,7 +196,9 @@ func configurePrefixMatchPolicy(t *testing.T, dut *ondatra.DUTDevice, prefixSet,
 		if maskLen == maskLen128 {
 			mode = oc.PrefixSet_Mode_IPV6
 		}
-		pset.SetMode(mode)
+		if !deviations.SkipPrefixSetMode(dut) {
+			pset.SetMode(mode)
+		}
 	}
 
 	pdef := rp.GetOrCreatePolicyDefinition(prefixSet)

--- a/feature/bgp/policybase/otg_tests/default_policies_test/bgp_default_policies_test.go
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/bgp_default_policies_test.go
@@ -601,7 +601,11 @@ func configureRoutingPolicyDefaultAction(t *testing.T, dut *ondatra.DUTDevice, a
 			stmt.GetOrCreateActions().PolicyResult = oc.RoutingPolicy_PolicyResultType_REJECT_ROUTE
 		}
 	}
-	gnmi.Update(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
+	if replace {
+		gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
+	} else {
+		gnmi.Update(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
+	}
 	time.Sleep(5 * time.Second)
 }
 
@@ -659,7 +663,6 @@ func testDefaultPolicyAcceptRouteActionOnly(t *testing.T, dut *ondatra.DUTDevice
 
 	t.Run("Create and apply default-policy ACCEPT-ALL with action as ACCEPT_ROUTE", func(t *testing.T) {
 		if deviations.BgpDefaultPolicyUnsupported(dut) {
-			gnmi.Delete(t, dut, gnmi.OC().RoutingPolicy().Config())
 			configureRoutingPolicyDefaultAction(t, dut, "accept", replacePolicy)
 		} else {
 			configureBGPDefaultPolicy(t, dut, acceptRoute)
@@ -700,7 +703,6 @@ func testDefaultPolicyRejectRouteActionOnly(t *testing.T, dut *ondatra.DUTDevice
 
 	t.Run("Create and apply default-policy REJECT-ALL with action as REJECT_ROUTE", func(t *testing.T) {
 		if deviations.BgpDefaultPolicyUnsupported(dut) {
-			gnmi.Delete(t, dut, gnmi.OC().RoutingPolicy().Config())
 			configureRoutingPolicyDefaultAction(t, dut, "reject", replacePolicy)
 		} else {
 			configureBGPDefaultPolicy(t, dut, rejectRoute)

--- a/feature/bgp/policybase/otg_tests/default_policies_test/bgp_default_policies_test.go
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/bgp_default_policies_test.go
@@ -15,8 +15,6 @@
 package bgp_default_policies_test
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -26,7 +24,6 @@ import (
 	"github.com/openconfig/featureprofiles/internal/attrs"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
@@ -195,6 +192,11 @@ func configurePrefixMatchPolicy(t *testing.T, dut *ondatra.DUTDevice, prefixSet,
 	pset := rp.GetOrCreateDefinedSets().GetOrCreatePrefixSet(prefixSet)
 	for _, pref := range ipPrefixSet {
 		pset.GetOrCreatePrefix(pref+"/"+maskLen, prefixSubnetRange)
+		mode := oc.PrefixSet_Mode_IPV4
+		if maskLen == maskLen128 {
+			mode = oc.PrefixSet_Mode_IPV6
+		}
+		pset.SetMode(mode)
 	}
 
 	pdef := rp.GetOrCreatePolicyDefinition(prefixSet)
@@ -584,55 +586,20 @@ func deleteBGPPolicy(t *testing.T, dut *ondatra.DUTDevice, nbrList []*bgpNbrList
 }
 
 func configureRoutingPolicyDefaultAction(t *testing.T, dut *ondatra.DUTDevice, action string, replace bool) {
-
-	var routingPolicyDefaultAction = []any{
-		map[string]any{
-			"default-action": map[string]any{
-				"policy-result": action,
-			},
-		},
-	}
-	defaultAction, err := json.Marshal(routingPolicyDefaultAction)
-	if err != nil {
-		t.Fatalf("Error with json Marshal: %v", err)
-	}
-
-	var updates []*gpb.Update
+	d := &oc.Root{}
+	rp := d.GetOrCreateRoutingPolicy()
 	for _, policy := range []string{ebgpExportIPv4, ebgpExportIPv6, ibgpExportIPv4, ibgpExportIPv6, ebgpImportIPv4, ebgpImportIPv6, ibgpImportIPv4, ibgpImportIPv6} {
-		update := gpb.Update{
-			Path: &gpb.Path{
-				Elem: []*gpb.PathElem{
-					{Name: "routing-policy"},
-					{Name: "policy", Key: map[string]string{"name": policy}},
-				},
-			},
-			Val: &gpb.TypedValue{
-				Value: &gpb.TypedValue_JsonIetfVal{
-					JsonIetfVal: defaultAction,
-				},
-			},
+		pdef := rp.GetOrCreatePolicyDefinition(policy)
+		stmt, err := pdef.AppendNewStatement("50")
+		if err != nil {
+			t.Fatal(err)
 		}
-		updates = append(updates, &update)
-	}
-	gpbSetRequest := &gpb.SetRequest{
-		Prefix: &gpb.Path{
-			Origin: "native",
-		},
-		Update: updates,
-	}
-	if replace {
-		gpbSetRequest = &gpb.SetRequest{
-			Prefix: &gpb.Path{
-				Origin: "native",
-			},
-			Replace: updates,
+		stmt.GetOrCreateActions().PolicyResult = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+		if action == "reject" {
+			stmt.GetOrCreateActions().PolicyResult = oc.RoutingPolicy_PolicyResultType_REJECT_ROUTE
 		}
 	}
-
-	gnmiClient := dut.RawAPIs().GNMI(t)
-	if _, err := gnmiClient.Set(context.Background(), gpbSetRequest); err != nil {
-		t.Fatalf("Unexpected error updating SRL routing-policy default-action: %v", err)
-	}
+	gnmi.Update(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
 	time.Sleep(5 * time.Second)
 }
 
@@ -690,6 +657,7 @@ func testDefaultPolicyAcceptRouteActionOnly(t *testing.T, dut *ondatra.DUTDevice
 
 	t.Run("Create and apply default-policy ACCEPT-ALL with action as ACCEPT_ROUTE", func(t *testing.T) {
 		if deviations.BgpDefaultPolicyUnsupported(dut) {
+			gnmi.Delete(t, dut, gnmi.OC().RoutingPolicy().Config())
 			configureRoutingPolicyDefaultAction(t, dut, "accept", replacePolicy)
 		} else {
 			configureBGPDefaultPolicy(t, dut, acceptRoute)
@@ -730,6 +698,7 @@ func testDefaultPolicyRejectRouteActionOnly(t *testing.T, dut *ondatra.DUTDevice
 
 	t.Run("Create and apply default-policy REJECT-ALL with action as REJECT_ROUTE", func(t *testing.T) {
 		if deviations.BgpDefaultPolicyUnsupported(dut) {
+			gnmi.Delete(t, dut, gnmi.OC().RoutingPolicy().Config())
 			configureRoutingPolicyDefaultAction(t, dut, "reject", replacePolicy)
 		} else {
 			configureBGPDefaultPolicy(t, dut, rejectRoute)

--- a/feature/bgp/policybase/otg_tests/default_policies_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/metadata.textproto
@@ -26,6 +26,7 @@ platform_exceptions:  {
     isis_interface_afi_unsupported: true
     isis_instance_enabled_required: true
     default_import_export_policy: true
+    bgp_default_policy_unsupported: true
   }
 }
 platform_exceptions:  {


### PR DESCRIPTION
   the diff contains the following changes to make the test pass for
   Arista
   - Add "bgp_default_policy_unsupported" deviation for Arista since default bgp policy action will not be applied for prefixes that do not match on any condition in an inbound/outbound policy applied for a given neighbor.
   - Fix the "configureRoutingPolicyDefaultAction()" to not create raw json object to create the default accept/reject rule in the policy when "bgp_default_policy_unsupported" is present.
   - set mode if the prefix-set definition ( which is a requirement for arista ) for the prefix-set to be applied on a policy
   - Fix another issue for 7.1.3 and 7.1.4 case to make sure the prefix-set match condition is deleted before applying the default accept/deny rule