### PR TITLE
TE_1.1 static arp test

### DIFF
--- a/feature/interface/staticarp/otg_tests/static_arp_test/README.md
+++ b/feature/interface/staticarp/otg_tests/static_arp_test/README.md
@@ -37,3 +37,14 @@ are the destination MAC addresses of the packets seen by the OTG.
 *   /interfaces/interface/subinterfaces/subinterface/ipv6/addresses/address/config/prefix-length
 *   /interfaces/interface/subinterfaces/subinterface/ipv6/neighbors/neighbor/config/ip
 *   /interfaces/interface/subinterfaces/subinterface/ipv6/neighbors/neighbor/config/link-layer-address
+
+## OpenConfig Path and RPC Coverage
+
+```yaml
+paths:
+  
+rpcs:
+  gnmi:
+    gNMI.Set:
+    gNMI.Subscribe:
+```

--- a/feature/interface/staticarp/otg_tests/static_arp_test/static_arp_test.go
+++ b/feature/interface/staticarp/otg_tests/static_arp_test/static_arp_test.go
@@ -296,13 +296,12 @@ func testFlow(
 }
 
 func TestStaticARP(t *testing.T) {
-	// Configure the ATE
-	ate := ondatra.ATE(t, "ate")
-	config := configureATE(t)
-
 	// Configure the DUT with dynamic ARP.
 	configureDUT(t, noStaticMAC)
 
+	// Configure the ATE
+	ate := ondatra.ATE(t, "ate")
+	config := configureATE(t)
 	ate.OTG().StartProtocols(t)
 	otgutils.WaitForARP(t, ate.OTG(), config, "IPv4")
 	dstMac := gnmi.Get(t, ate.OTG(), gnmi.OTG().Interface(ateSrc.Name+".Eth").Ipv4Neighbor(dutSrc.IPv4).LinkLayerAddress().State())


### PR DESCRIPTION
Hi,

As per ixia moving configure DUT function prior to configuring ATE.

