### PR TITLE
FDix zr_supply_voltage_test

### DIFF
--- a/feature/platform/transceiver/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
+++ b/feature/platform/transceiver/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
@@ -88,6 +88,12 @@ func TestZrSupplyVoltage(t *testing.T) {
 
 			volInstNew := verifyVoltageValue(t, streamInst, "Instant")
 			t.Logf("Port %s instant voltage after port down: %v", dp.Name(), volInstNew)
+
+			// Enable interface again.
+			i.Enabled = ygot.Bool(true)
+			gnmi.Replace(t, dut, gnmi.OC().Interface(dp.Name()).Config(), i)
+			// Wait for the cooling off period
+			gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
 		})
 	}
 }


### PR DESCRIPTION
Bring interface back up at the end of the port test