### PR TITLE
OC-26.1 | remove deviation and fix verification 

### DIFF
--- a/feature/system/ntp/tests/system_ntp_test/metadata.textproto
+++ b/feature/system/ntp/tests/system_ntp_test/metadata.textproto
@@ -7,14 +7,6 @@ description: "Network Time Protocol (NTP)"
 testbed: TESTBED_DUT
 platform_exceptions: {
   platform: {
-    vendor: CISCO
-  }
-  deviations: {
-    ntp_non_default_vrf_unsupported: true
-  }
-}
-platform_exceptions: {
-  platform: {
     vendor: JUNIPER
   }
   deviations: {

--- a/feature/system/ntp/tests/system_ntp_test/system_ntp_test.go
+++ b/feature/system/ntp/tests/system_ntp_test/system_ntp_test.go
@@ -99,7 +99,7 @@ func TestNtpServerConfigurability(t *testing.T) {
 				if ntpServer == nil {
 					t.Errorf("Missing NTP server from NTP state: %s", address)
 				}
-				if got, want := testCase.vrf, ntpServer.GetNetworkInstance(); want != "" && got != want {
+				if got, want := ntpServer.GetNetworkInstance(), testCase.vrf; want != "" && got != want {
 					t.Errorf("Incorrect NTP Server network instance for address %s: got %s, want %s", address, got, want)
 				}
 			}


### PR DESCRIPTION
Made below changes:

- Remove deviation 
- In verification for ntpServer NI , right now got and want are switched, so fixed it.