### PR TITLE
Changed TESTBED_DUT_ATE_2LINKS to TESTBED_DUT_DUT_4LINKS as per README Requirement

### DIFF
--- a/feature/platform/transceiver/tests/zr_input_output_power_test/metadata.textproto
+++ b/feature/platform/transceiver/tests/zr_input_output_power_test/metadata.textproto
@@ -4,4 +4,4 @@
 uuid:  "67be4256-6965-4a6d-bc68-322c878cbc73"
 plan_id:  "TRANSCEIVER-4"
 description:  "Telemetry: 400ZR RX input and TX output power telemetry values streaming."
-testbed:  TESTBED_DUT_ATE_2LINKS
+testbed:  TESTBED_DUT_DUT_4LINKS


### PR DESCRIPTION
This test cases needs 2 outs one for TX & one for RX. Changed the metadata to pick up the correct testbed file. 