### PR TITLE
RT-7.8: Configure send-community-type

### DIFF
--- a/feature/bgp/policybase/otg_tests/comm_match_action_test/bgp_comm_match_action_test.go
+++ b/feature/bgp/policybase/otg_tests/comm_match_action_test/bgp_comm_match_action_test.go
@@ -197,6 +197,7 @@ func bgpCreateNbr(localAs, peerAs uint32, dut *ondatra.DUTDevice) *oc.NetworkIns
 	pg := bgp.GetOrCreatePeerGroup(peerGrpName)
 	pg.PeerAs = ygot.Uint32(ateAS)
 	pg.PeerGroupName = ygot.String(peerGrpName)
+	pg.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
 	as4 := pg.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
 	as4.Enabled = ygot.Bool(true)
 	as6 := pg.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST)


### PR DESCRIPTION
send-community-type is missing in the configuration