### PR TITLE
fix link bandwidth with deviations

### DIFF
--- a/feature/bgp/multipath/otg_tests/bgp_multipath_wecmp_lbw_community_test/bgp_multipath_wecmp_test.go
+++ b/feature/bgp/multipath/otg_tests/bgp_multipath_wecmp_lbw_community_test/bgp_multipath_wecmp_test.go
@@ -187,8 +187,6 @@ func TestBGPSetup(t *testing.T) {
 	t.Logf("Verify OTG BGP sessions up")
 	cfgplugins.VerifyOTGBGPEstablished(t, bs.ATE)
 
-	t.Logf("Verify Configuration on DUT")
-	time.Sleep(time.Second * 120)
 	aftsPath := gnmi.OC().NetworkInstance(dni).Afts()
 	prefix := prefixesStart + "/" + strconv.Itoa(prefixP4Len)
 	ipv4Entry := gnmi.Get[*oc.NetworkInstance_Afts_Ipv4Entry](t, bs.DUT, aftsPath.Ipv4Entry(prefix).State())

--- a/feature/bgp/multipath/otg_tests/bgp_multipath_wecmp_lbw_community_test/bgp_multipath_wecmp_test.go
+++ b/feature/bgp/multipath/otg_tests/bgp_multipath_wecmp_lbw_community_test/bgp_multipath_wecmp_test.go
@@ -15,6 +15,7 @@
 package bgp_multipath_wecmp_test
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"testing"
@@ -24,6 +25,7 @@ import (
 	"github.com/openconfig/featureprofiles/internal/cfgplugins"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/featureprofiles/internal/helpers"
 	"github.com/openconfig/featureprofiles/internal/otgutils"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
@@ -147,15 +149,34 @@ func TestBGPSetup(t *testing.T) {
 	dni := deviations.DefaultNetworkInstance(bs.DUT)
 	bgp := bs.DUTConf.GetOrCreateNetworkInstance(dni).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
 	if deviations.MultipathUnsupportedNeighborOrAfisafi(bs.DUT) {
+		t.Logf("MultipathUnsupportedNeighborOrAfisafi is supported")
 		bgp.GetOrCreatePeerGroup(cfgplugins.BGPPeerGroup1).GetOrCreateUseMultiplePaths().Enabled = ygot.Bool(true)
 		bgp.GetOrCreatePeerGroup(cfgplugins.BGPPeerGroup1).GetOrCreateUseMultiplePaths().GetOrCreateEbgp().AllowMultipleAs = ygot.Bool(true)
 	}
-	gEBGP := bgp.GetOrCreateGlobal().GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).GetOrCreateUseMultiplePaths().GetOrCreateEbgp()
-	bgp.GetOrCreatePeerGroup(cfgplugins.BGPPeerGroup1).GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).GetOrCreateUseMultiplePaths().Enabled = ygot.Bool(true)
-
-	if !deviations.SkipSettingAllowMultipleAS(bs.DUT) {
-		gEBGP.AllowMultipleAs = ygot.Bool(true)
+	if deviations.SkipAfiSafiPathForBgpMultipleAs(bs.DUT) {
+		var communitySetCLIConfig string
+		t.Log("AfiSafi Path For BgpMultipleAs is not supported")
+		gEBGP := bgp.GetOrCreateGlobal().GetOrCreateUseMultiplePaths().GetOrCreateEbgp()
+		gEBGPMP := bgp.GetOrCreateGlobal().GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).GetOrCreateUseMultiplePaths().GetOrCreateEbgp()
+		gEBGPMP.MaximumPaths = ygot.Uint32(maxPaths)
+		if deviations.SkipSettingAllowMultipleAS(bs.DUT) {
+			gEBGP.AllowMultipleAs = ygot.Bool(false)
+			switch bs.DUT.Vendor() {
+			case ondatra.CISCO:
+				communitySetCLIConfig = fmt.Sprintf("router bgp %v instance BGP neighbor-group %v \n ebgp-recv-extcommunity-dmz \n ebgp-send-extcommunity-dmz\n", cfgplugins.DutAS, cfgplugins.BGPPeerGroup1)
+			default:
+				t.Fatalf("Unsupported vendor %s for deviation 'CommunityMemberRegexUnsupported'", bs.DUT.Vendor())
+			}
+			helpers.GnmiCLIConfig(t, bs.DUT, communitySetCLIConfig)
+		}
+	} else {
+		t.Logf("AfiSafi Path For BgpMultipleAs is supported")
+		gEBGP := bgp.GetOrCreateGlobal().GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).GetOrCreateUseMultiplePaths().GetOrCreateEbgp()
+		if !deviations.SkipSettingAllowMultipleAS(bs.DUT) {
+			gEBGP.AllowMultipleAs = ygot.Bool(true)
+		}
 	}
+	bgp.GetOrCreatePeerGroup(cfgplugins.BGPPeerGroup1).GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).GetOrCreateUseMultiplePaths().Enabled = ygot.Bool(true)
 
 	configureOTG(t, bs)
 	bs.PushAndStart(t)
@@ -166,12 +187,16 @@ func TestBGPSetup(t *testing.T) {
 	t.Logf("Verify OTG BGP sessions up")
 	cfgplugins.VerifyOTGBGPEstablished(t, bs.ATE)
 
+	t.Logf("Verify Configuration on DUT")
+	time.Sleep(time.Second * 120)
 	aftsPath := gnmi.OC().NetworkInstance(dni).Afts()
 	prefix := prefixesStart + "/" + strconv.Itoa(prefixP4Len)
 	ipv4Entry := gnmi.Get[*oc.NetworkInstance_Afts_Ipv4Entry](t, bs.DUT, aftsPath.Ipv4Entry(prefix).State())
 	hopGroup := gnmi.Get[*oc.NetworkInstance_Afts_NextHopGroup](t, bs.DUT, aftsPath.NextHopGroup(ipv4Entry.GetNextHopGroup()).State())
 	if got, want := len(hopGroup.NextHop), 2; got != want {
 		t.Errorf("prefix: %s, found %d hops, want %d", ipv4Entry.GetPrefix(), got, want)
+	} else {
+		t.Logf("prefix: %s, found %d hops, want %d", ipv4Entry.GetPrefix(), got, want)
 	}
 
 	sleepTime := time.Duration(totalPackets/trafficPps) + 5

--- a/feature/bgp/multipath/otg_tests/bgp_multipath_wecmp_lbw_community_test/metadata.textproto
+++ b/feature/bgp/multipath/otg_tests/bgp_multipath_wecmp_lbw_community_test/metadata.textproto
@@ -11,6 +11,8 @@ platform_exceptions: {
   }
   deviations: {
     ipv4_missing_enabled: true
+    skip_setting_allow_multiple_as: true
+    skip_afi_safi_path_for_bgp_multiple_as: true
   }
 }
 platform_exceptions: {
@@ -45,3 +47,4 @@ platform_exceptions: {
   }
 }
 tags: TAGS_DATACENTER_EDGE
+


### PR DESCRIPTION
1. Added below deviations as the OC path for MultipleAS is not supported under the AFI_SAFI_Path.
    'skip_setting_allow_multiple_as'
    'skip_afi_safi_path_for_bgp_multiple_as'

2. Added dmz related command for the peer-group
        'ebgp-recv-extcommunity-dmz'
        'ebgp-send-extcommunity-dmz'
4. Enabled "maximum-paths ebgp" under the BGP neighbor AFI/SAFI address-family