### PR TITLE
Changes to remove the 'deprecated_vlan_id' deviation from metadata.proto

### DIFF
--- a/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/metadata.textproto
+++ b/feature/experimental/gribi/otg_tests/route_addition_during_failover_test/metadata.textproto
@@ -29,7 +29,6 @@ platform_exceptions: {
   }
   deviations: {
     gnoi_subcomponent_path: true
-    deprecated_vlan_id: true
     interface_enabled: true
     default_network_instance: "default"
   }

--- a/feature/experimental/gribi/otg_tests/route_removal_during_failover_test/metadata.textproto
+++ b/feature/experimental/gribi/otg_tests/route_removal_during_failover_test/metadata.textproto
@@ -38,7 +38,6 @@ platform_exceptions: {
   }
   deviations: {
     gnoi_subcomponent_path: true
-    deprecated_vlan_id: true
     interface_enabled: true
     default_network_instance: "default"
   }

--- a/feature/experimental/gribi/otg_tests/vrf_policy_driven_te/metadata.textproto
+++ b/feature/experimental/gribi/otg_tests/vrf_policy_driven_te/metadata.textproto
@@ -44,7 +44,6 @@ platform_exceptions:  {
   }
   deviations:  {
     gnoi_subcomponent_path:  true
-    deprecated_vlan_id:  true
     interface_enabled:  true
     static_protocol_name: "STATIC"
     default_network_instance:  "default"

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/README.md
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/README.md
@@ -93,3 +93,12 @@ Test different VRF selection policies.
 *   Native IPv6
 
         *   Flow#10: Native IPv6 flow with any source address and destination as ATE-DEST-IPv6-VLAN20
+
+## OpenConfig Path and RPC Coverage
+```yaml
+rpcs:
+  gnmi:
+    gNMI.Get:
+    gNMI.Set:
+    gNMI.Subscribe:
+```

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/metadata.textproto
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/base_vrf_selection/metadata.textproto
@@ -32,7 +32,6 @@ platform_exceptions: {
   deviations: {
     static_protocol_name: "STATIC"
     interface_config_vrf_before_address: true
-    deprecated_vlan_id: true
     interface_enabled: true
     default_network_instance: "default"
   }

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/README.md
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/README.md
@@ -50,21 +50,21 @@ It's ok that some NOS does not support this config (duplicated matching conditio
 
 Ensure that unspecified fields are wildcard and IPinIP packets are only received at VLAN 10 subinterface. 
 
-## Config Parameter Coverage
- *  /openconfig-network-instance/network-instances/network-instance/policy-forwarding/policies/policy/config/type
- *  /openconfig-network-instance/network-instances/network-instance/policy-forwarding/policies/policy/policy-id
- *  /openconfig-network-instance/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/sequence-id
- *  /openconfig-network-instance/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/ipv4/config/dscp-set
- *  /openconfig-network-instance/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/ipv4/config/protocol
- *  /openconfig-network-instance/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/config/network-instance
- *  /openconfig-network-instance/network-instances/network-instance/policy-forwarding/interfaces/interface/interface-id
- *  /openconfig-network-instance/network-instances/network-instance/policy-forwarding/interfaces/interface/config/apply-vrf-selection-policy
-
-## Paths
-
-* /openconfig-network-instance/network-instances/network-instance/policy-forwarding
-* /openconfig-network-instance/network-instances/network-instance/policy-forwarding/policies/policy
-* /openconfig-network-instance/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule
-* /openconfig-network-instance/network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/ipv4
-* /openconfig-network-instance/network-instances/network-instance/policy-forwarding/interfaces/interface/config/apply-vrf-selection-policy 
+## OpenConfig Path and RPC Coverage
+```yaml
+paths:
+  /network-instances/network-instance/policy-forwarding/policies/policy/config/type:
+  /network-instances/network-instance/policy-forwarding/policies/policy/policy-id:
+  /network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/sequence-id:
+  /network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/ipv4/config/dscp-set:
+  /network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/ipv4/config/protocol:
+  /network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/config/network-instance:
+  /network-instances/network-instance/policy-forwarding/interfaces/interface/interface-id:
+  /network-instances/network-instance/policy-forwarding/interfaces/interface/config/apply-vrf-selection-policy:
+rpcs:
+  gnmi:
+    gNMI.Get:
+    gNMI.Set:
+    gNMI.Subscribe:
+```
 

--- a/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/metadata.textproto
+++ b/feature/experimental/policy/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/metadata.textproto
@@ -39,7 +39,6 @@ platform_exceptions: {
     vendor: ARISTA
   }
   deviations: {
-    deprecated_vlan_id: true
     interface_enabled: true
     default_network_instance: "default"
   }

--- a/feature/gribi/otg_tests/encap_decap_scale/metadata.textproto
+++ b/feature/gribi/otg_tests/encap_decap_scale/metadata.textproto
@@ -41,7 +41,6 @@ platform_exceptions:  {
     vendor:  ARISTA
   }
   deviations:  {
-    deprecated_vlan_id:  true
     interface_enabled:  true
     default_network_instance:  "default"
     omit_l2_mtu: true

--- a/feature/gribi/otg_tests/gribi_scaling/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_scaling/metadata.textproto
@@ -40,7 +40,6 @@ platform_exceptions: {
     vendor: ARISTA
   }
   deviations: {
-    deprecated_vlan_id: true
     interface_enabled: true
     default_network_instance: "default"
     omit_l2_mtu: true

--- a/feature/gribi/otg_tests/hierarchical_weight_resolution_pbf_test/metadata.textproto
+++ b/feature/gribi/otg_tests/hierarchical_weight_resolution_pbf_test/metadata.textproto
@@ -43,7 +43,6 @@ platform_exceptions: {
   }
   deviations: {
     omit_l2_mtu: true
-    deprecated_vlan_id: true
     interface_enabled: true
     default_network_instance: "default"
   }

--- a/feature/gribi/otg_tests/hierarchical_weight_resolution_test/README.md
+++ b/feature/gribi/otg_tests/hierarchical_weight_resolution_test/README.md
@@ -126,15 +126,18 @@ N/A
 TODO:
 /network-instances/network-instance/afts/next-hop-groups/next-hop-group/next-hops/next-hop/state/weight
 
-## Protocol/RPC Parameter coverage
-
-*   gRIBI:
-    *   Modify()
-        *   ModifyRequest:
-            *   AFTOperation:
-                *   next_hop_group
-                    *   NextHopGroupKey: id
-                    *   NextHopGroup: weight
+## OpenConfig Path and RPC Coverage
+```yaml
+rpcs:
+  gnmi:
+    gNMI.Get:
+    gNMI.Set:
+    gNMI.Subscribe:
+  gribi:
+    gRIBI.Get:
+    gRIBI.Modify:
+    gRIBI.Flush:
+```
 
 ## Minimum DUT platform requirement
 

--- a/feature/gribi/otg_tests/hierarchical_weight_resolution_test/metadata.textproto
+++ b/feature/gribi/otg_tests/hierarchical_weight_resolution_test/metadata.textproto
@@ -41,7 +41,6 @@ platform_exceptions: {
   }
   deviations: {
     omit_l2_mtu: true
-    deprecated_vlan_id: true
     interface_enabled: true
     default_network_instance: "default"
   }


### PR DESCRIPTION
Changes to remove the 'deprecated_vlan_id' deviation from metadata.proto as it is no longer required now