### PR TITLE
Update gNMI-1.4 to validate subcomponents paths.

### DIFF
--- a/feature/platform/tests/telemetry_inventory_test/README.md
+++ b/feature/platform/tests/telemetry_inventory_test/README.md
@@ -69,9 +69,9 @@ paths:
     /components/component/state/temperature/max-time:
        platform_type: ["SENSOR"]
     /components/component/subcomponents/subcomponent/name:
-       platform_type: ["INTEGRATED_CIRCUIT"]
+       platform_type: ["CHASSIS", "CONTROLLER_CARD", "CPU", "FABRIC", "FAN", "FAN_TRAY", "INTEGRATED_CIRCUIT", "LINECARD", "POWER_SUPPLY", "SENSOR", "STORAGE", "TRANSCEIVER"]
     /components/component/subcomponents/subcomponent/state/name:
-       platform_type: ["INTEGRATED_CIRCUIT"]
+       platform_type: ["CHASSIS", "CONTROLLER_CARD", "CPU", "FABRIC", "FAN", "FAN_TRAY", "INTEGRATED_CIRCUIT", "LINECARD", "POWER_SUPPLY", "SENSOR", "STORAGE", "TRANSCEIVER"]
     /components/component/integrated-circuit/backplane-facing-capacity/state/available-pct:
        platform_type: ["INTEGRATED_CIRCUIT"]
     /components/component/integrated-circuit/backplane-facing-capacity/state/consumed-capacity:

--- a/feature/platform/tests/telemetry_inventory_test/README.md
+++ b/feature/platform/tests/telemetry_inventory_test/README.md
@@ -68,6 +68,10 @@ paths:
        platform_type: ["SENSOR"]
     /components/component/state/temperature/max-time:
        platform_type: ["SENSOR"]
+    /components/component/subcomponents/subcomponent/name:
+       platform_type: ["INTEGRATED_CIRCUIT"]
+    /components/component/subcomponents/subcomponent/state/name:
+       platform_type: ["INTEGRATED_CIRCUIT"]
     /components/component/integrated-circuit/backplane-facing-capacity/state/available-pct:
        platform_type: ["INTEGRATED_CIRCUIT"]
     /components/component/integrated-circuit/backplane-facing-capacity/state/consumed-capacity:

--- a/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
+++ b/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
@@ -584,7 +584,7 @@ func TestControllerCardEmpty(t *testing.T) {
 func verifySubcomponentNameExists(c *oc.Component, components []*oc.Component, t *testing.T) {
 	// Note that this will get the subcomponents regardless of whether they are stored in
 	// subcomponent/name or subcomponent/state/name.
-	for _, s := range c.GetOrCreateSubcomponentMap() {
+	for _, s := range c.Subcomponent {
 		sName := s.GetName()
 		if sName != "" {
 			for _, component := range components {

--- a/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
+++ b/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
@@ -582,16 +582,18 @@ func TestControllerCardEmpty(t *testing.T) {
 // If the component has a leafref for a subcomponent, that leaf must exist in the list of
 // components.
 func verifySubcomponentNameExists(c *oc.Component, components []*oc.Component, t *testing.T) {
-	// Note that this will get the subcomponent regardless of whether it is stored in
+	// Note that this will get the subcomponents regardless of whether they are stored in
 	// subcomponent/name or subcomponent/state/name.
-	subcomponentName := c.GetSubcomponent(c.GetName()).GetName()
-	if subcomponentName != "" {
-		for _, component := range components {
-			if component.GetName() == subcomponentName {
-				return
+	for _, subcomponent := range c.GetOrCreateSubcomponentMap() {
+		sName := subcomponent.GetName()
+		if sName != "" {
+			for _, component := range components {
+				if component.GetName() == sName {
+					continue
+				}
 			}
+			t.Errorf("Subcomponent %s not found in list of components", sName)
 		}
-		t.Errorf("Subcomponent %s not found in list of components", subcomponentName)
 	}
 }
 

--- a/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
+++ b/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
@@ -584,8 +584,8 @@ func TestControllerCardEmpty(t *testing.T) {
 func verifySubcomponentNameExists(c *oc.Component, components []*oc.Component, t *testing.T) {
 	// Note that this will get the subcomponents regardless of whether they are stored in
 	// subcomponent/name or subcomponent/state/name.
-	for _, subcomponent := range c.GetOrCreateSubcomponentMap() {
-		sName := subcomponent.GetName()
+	for _, s := range c.GetOrCreateSubcomponentMap() {
+		sName := s.GetName()
 		if sName != "" {
 			for _, component := range components {
 				if component.GetName() == sName {

--- a/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
+++ b/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
@@ -579,9 +579,9 @@ func TestControllerCardEmpty(t *testing.T) {
 	}
 }
 
-// If the component has a leafref for a subcomponent, that leaf must exist in the list of
-// components.
-func verifySubcomponentNameExists(c *oc.Component, components []*oc.Component, t *testing.T) {
+// validateSubcomponentsExistAsComponents checks that if the given component has subcomponents, that
+// those subcomponents exist as components on the device (i.e. the leafref is valid).
+func validateSubcomponentsExistAsComponents(c *oc.Component, components []*oc.Component, t *testing.T) {
 	// Note that this will get the subcomponents regardless of whether they are stored in
 	// subcomponent/name or subcomponent/state/name.
 	for _, s := range c.Subcomponent {
@@ -623,7 +623,7 @@ func ValidateComponentState(t *testing.T, dut *ondatra.DUTDevice, cards []*oc.Co
 		}
 		cName := card.GetName()
 		t.Run(cName, func(t *testing.T) {
-			verifySubcomponentNameExists(card, validCards, t)
+			validateSubcomponentsExistAsComponents(card, validCards, t)
 			if p.descriptionValidation {
 				t.Logf("Component %s Description: %s", cName, card.GetDescription())
 				if card.GetDescription() == "" {

--- a/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
+++ b/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
@@ -593,6 +593,8 @@ func verifySubcomponentNameExists(c *oc.Component, components []*oc.Component, t
 				}
 			}
 			t.Errorf("Subcomponent %s not found in list of components", sName)
+		} else {
+			t.Errorf("Component %s has empty subcomponent name", c.GetName())
 		}
 	}
 }


### PR DESCRIPTION
If a component has either `components/component/subcomponents/subcomponent/name` or `components/component/subcomponents/subcomponent/state/name`, then the leafref value of this path should be for a component that exists on that device.