### PR TITLE
gNMI-1.21 - Remove threshold state validation for /components OC path

### DIFF
--- a/feature/platform/integrated_circuit/otg_tests/utilization_test/README.md
+++ b/feature/platform/integrated_circuit/otg_tests/utilization_test/README.md
@@ -31,17 +31,29 @@ Test `used-threshold-upper` configuration and telemetry for hardware resources.
 
 *   Get utilization percentages again and validate decrease in utilization.
 
-## Config Parameter coverage
+## OpenConfig Path and RPC Coverage
 
-*   /system/utilization/resources/resource/config/name
-*   /system/utilization/resources/resource/config/used-threshold-upper
-*   /system/utilization/resources/resource/config/used-threshold-upper-clear
+This example yaml defines the OC paths intended to be covered by this test.  OC paths used for test environment setup are not required to be listed here.
+```yaml
+paths:
+  ## Config parameter coverage
+  /system/utilization/resources/resource/config/name:
+  /system/utilization/resources/resource/config/used-threshold-upper:
+  /system/utilization/resources/resource/config/used-threshold-upper-clear:
 
-## Telemetry Parameter coverage
-
-*   /system/utilization/resources/resource/state/name
-*   /system/utilization/resources/resource/state/used-threshold-upper
-*   /system/utilization/resources/resource/state/used-threshold-upper-clear
-*   /components/component/integrated_circuit/utilization/resources/resource/state/name
-*   /components/component/integrated_circuit/utilization/resources/resource/state/used
-*   /components/component/integrated_circuit/utilization/resources/resource/state/free
+  ## Telemetry parameter coverage
+  /system/utilization/resources/resource/state/name:
+  /system/utilization/resources/resource/state/used-threshold-upper:
+  /system/utilization/resources/resource/state/used-threshold-upper-clear:
+  /components/component/integrated_circuit/utilization/resources/resource/state/name:
+    platform_type: ["INTEGRATED_CIRCUIT"]
+  /components/component/integrated_circuit/utilization/resources/resource/state/used:
+    platform_type: ["INTEGRATED_CIRCUIT"]
+  /components/component/integrated_circuit/utilization/resources/resource/state/free:
+    platform_type: ["INTEGRATED_CIRCUIT"]
+rpcs:
+  gnmi:
+    gNMI.Set:
+    gNMI.Subscribe:
+          Mode: [ "ON_CHANGE", "SAMPLE" ]
+```

--- a/feature/platform/integrated_circuit/otg_tests/utilization_test/README.md
+++ b/feature/platform/integrated_circuit/otg_tests/utilization_test/README.md
@@ -45,11 +45,11 @@ paths:
   /system/utilization/resources/resource/state/name:
   /system/utilization/resources/resource/state/used-threshold-upper:
   /system/utilization/resources/resource/state/used-threshold-upper-clear:
-  /components/component/integrated_circuit/utilization/resources/resource/state/name:
+  /components/component/integrated-circuit/utilization/resources/resource/state/name:
     platform_type: ["INTEGRATED_CIRCUIT"]
-  /components/component/integrated_circuit/utilization/resources/resource/state/used:
+  /components/component/integrated-circuit/utilization/resources/resource/state/used:
     platform_type: ["INTEGRATED_CIRCUIT"]
-  /components/component/integrated_circuit/utilization/resources/resource/state/free:
+  /components/component/integrated-circuit/utilization/resources/resource/state/free:
     platform_type: ["INTEGRATED_CIRCUIT"]
 rpcs:
   gnmi:

--- a/feature/platform/integrated_circuit/otg_tests/utilization_test/README.md
+++ b/feature/platform/integrated_circuit/otg_tests/utilization_test/README.md
@@ -45,5 +45,3 @@ Test `used-threshold-upper` configuration and telemetry for hardware resources.
 *   /components/component/integrated_circuit/utilization/resources/resource/state/name
 *   /components/component/integrated_circuit/utilization/resources/resource/state/used
 *   /components/component/integrated_circuit/utilization/resources/resource/state/free
-*   /components/component/integrated_circuit/utilization/resources/resource/state/used-threshold-upper
-*   /components/component/integrated_circuit/utilization/resources/resource/state/used-threshold-upper-clear

--- a/feature/platform/integrated_circuit/otg_tests/utilization_test/utilization_test.go
+++ b/feature/platform/integrated_circuit/otg_tests/utilization_test/utilization_test.go
@@ -139,18 +139,6 @@ func TestResourceUtilization(t *testing.T) {
 	if len(beforeUtzs) != len(comps) {
 		t.Fatalf("Couldn't retrieve Utilization information for all Components in active-component-list")
 	}
-	t.Run("Utilization Thresholds per Component", func(t *testing.T) {
-		for _, c := range comps {
-			t.Run(c, func(t *testing.T) {
-				if got, want := beforeUtzs[c].upperThreshold, usedThresholdUpper; got != want {
-					t.Errorf("used-upper-threshold mismatch for component: %s, got: %d, want: %d", c, got, want)
-				}
-				if got, want := beforeUtzs[c].upperThresholdClear, usedThresholdUpperClear; got != want {
-					t.Errorf("used-upper-threshold-clear mismatch for component: %s, got: %d, want: %d", c, got, want)
-				}
-			})
-		}
-	})
 
 	injectBGPRoutes(t, otg, otgV6Peer, otgPort1, otgConfig)
 


### PR DESCRIPTION
As discussed in internal bug b/281931161#comment37, removing 

* /components/component/integrated_circuit/utilization/resources/resource/state/used-threshold-upper
* /components/component/integrated_circuit/utilization/resources/resource/state/used-threshold-upper-clear