### PR TITLE
gNMI-1.4: Skip subcomponent check if subcomponent doesn't exist

### DIFF
--- a/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
+++ b/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
@@ -586,14 +586,13 @@ func validateSubcomponentsExistAsComponents(c *oc.Component, components []*oc.Co
 	subcomponentsValue := gnmi.Lookup(t, dut, gnmi.OC().Component(cName).SubcomponentMap().State())
 	subcomponents, ok := subcomponentsValue.Val()
 	if !ok {
-		t.Errorf("Error getting subcomponents for component %s", cName)
+		// Not all components have subcomponents
+		// If the component doesn't have subcomponent, skip the check and return early
+		return
 	}
 	for _, subc := range subcomponents {
-		if !ok {
-			t.Errorf("Error getting subcomponent for component %s", cName)
-		}
 		subcName := subc.GetName()
-		subComponent := gnmi.Lookup[*oc.Component](t, dut, gnmi.OC().Component(subcName).State())
+		subComponent := gnmi.Lookup(t, dut, gnmi.OC().Component(subcName).State())
 		if !subComponent.IsPresent() {
 			t.Errorf("Subcomponent %s does not exist as a component on the device", subcName)
 		}


### PR DESCRIPTION
For some components, they don't have subcomponents such as 'Storage' and some 'SENSOR'.
In the existing validations, it always assumes the subcomponent exists for all the components.
Therefore, skip validating the subcomponent's existance and  name if component doesn't have it.