### PR TITLE
TE-8.2 fix telemetry fetching for standby

### DIFF
--- a/feature/gribi/otg_tests/supervisor_failure_test/supervisor_failure_test.go
+++ b/feature/gribi/otg_tests/supervisor_failure_test/supervisor_failure_test.go
@@ -246,13 +246,13 @@ func validateTelemetry(t *testing.T, dut *ondatra.DUTDevice, primaryAfterSwitch,
 	}
 
 	if !gnmi.Lookup(t, dut, secondary.LastRebootTime().State()).IsPresent() {
-		t.Errorf("primary.LastRebootTime.().Lookup(t).IsPresent(): got false, want true")
+		t.Errorf("secondary.LastRebootTime.().Lookup(t).IsPresent(): got false, want true")
 	} else {
 		lastrebootTime := gnmi.Get(t, dut, secondary.LastRebootTime().State())
 		t.Logf("Found lastRebootTime.GetDetails(): %v", lastrebootTime)
 	}
 	if !gnmi.Lookup(t, dut, secondary.LastRebootReason().State()).IsPresent() {
-		t.Errorf("primary.LastRebootReason.().Lookup(t).IsPresent(): got false, want true")
+		t.Errorf("secondary.LastRebootReason.().Lookup(t).IsPresent(): got false, want true")
 	} else {
 		lastrebootReason := gnmi.Get(t, dut, secondary.LastRebootReason().State())
 		t.Logf("Found lastRebootReason.GetDetails(): %v", lastrebootReason)

--- a/feature/gribi/otg_tests/supervisor_failure_test/supervisor_failure_test.go
+++ b/feature/gribi/otg_tests/supervisor_failure_test/supervisor_failure_test.go
@@ -220,9 +220,10 @@ func findSecondaryController(t *testing.T, dut *ondatra.DUTDevice, controllers [
 }
 
 // validateTelemetry validates telemetry sensors
-func validateTelemetry(t *testing.T, dut *ondatra.DUTDevice, primaryAfterSwitch string) {
+func validateTelemetry(t *testing.T, dut *ondatra.DUTDevice, primaryAfterSwitch, secondaryAfterSwitch string) {
 	t.Log("Validate OC Switchover time/reason.")
 	primary := gnmi.OC().Component(primaryAfterSwitch)
+	secondary := gnmi.OC().Component(secondaryAfterSwitch)
 	if !gnmi.Lookup(t, dut, primary.LastSwitchoverTime().State()).IsPresent() {
 		t.Errorf("primary.LastSwitchoverTime().Lookup(t).IsPresent(): got false, want true")
 	} else {
@@ -244,16 +245,16 @@ func validateTelemetry(t *testing.T, dut *ondatra.DUTDevice, primaryAfterSwitch 
 		t.Errorf("primary.GetLastSwitchoverReason().GetTrigger(): got %s, want %s.", got, want)
 	}
 
-	if !gnmi.Lookup(t, dut, primary.LastRebootTime().State()).IsPresent() {
+	if !gnmi.Lookup(t, dut, secondary.LastRebootTime().State()).IsPresent() {
 		t.Errorf("primary.LastRebootTime.().Lookup(t).IsPresent(): got false, want true")
 	} else {
-		lastrebootTime := gnmi.Get(t, dut, primary.LastRebootTime().State())
+		lastrebootTime := gnmi.Get(t, dut, secondary.LastRebootTime().State())
 		t.Logf("Found lastRebootTime.GetDetails(): %v", lastrebootTime)
 	}
-	if !gnmi.Lookup(t, dut, primary.LastRebootReason().State()).IsPresent() {
+	if !gnmi.Lookup(t, dut, secondary.LastRebootReason().State()).IsPresent() {
 		t.Errorf("primary.LastRebootReason.().Lookup(t).IsPresent(): got false, want true")
 	} else {
-		lastrebootReason := gnmi.Get(t, dut, primary.LastRebootReason().State())
+		lastrebootReason := gnmi.Get(t, dut, secondary.LastRebootReason().State())
 		t.Logf("Found lastRebootReason.GetDetails(): %v", lastrebootReason)
 	}
 }
@@ -354,8 +355,8 @@ func TestSupFailure(t *testing.T) {
 
 	// Old secondary controller becomes primary after switchover.
 	primaryAfterSwitch := secondaryBeforeSwitch
-
-	validateTelemetry(t, dut, primaryAfterSwitch)
+	secondaryAfterSwitch := secondaryBeforeSwitch
+	validateTelemetry(t, dut, primaryAfterSwitch, secondaryAfterSwitch)
 	// Assume Controller Switchover happened, ensure traffic flows without loss.
 	// Verify the entry for 203.0.113.0/24 is active through AFT Telemetry.
 	// Try starting the gribi client twice as switchover may reset the connection.


### PR DESCRIPTION
`validateTelemetry()` was incorrectly assuming the newly active had a last-reboot-reason. Fetching the reboot-related queries from new-standby. 
ref: b/352496075

---
<sub>This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.</sub>