### PR TITLE
Update testregistry.textproto for BGP route-refresh test

### DIFF
--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -382,6 +382,12 @@ test: {
   exec: " "
 }
 test: {
+  id: "RT-1.17"
+  description: "RT-1.17: BGP route-refresh capability"
+  readme: ""
+  exec: " "
+}
+test: {
   id: "RT-1.2"
   description: "BGP Policy & Route Installation"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/route_installation_test/README.md"

--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -388,6 +388,12 @@ test: {
   exec: " "
 }
 test: {
+  id: "RT-1.18"
+  description: "RT-1.18: Support for MP-BGP w/ Multiple AFI-SAFI Tuples on a single neighborship"
+  readme: ""
+  exec: " "
+}
+test: {
   id: "RT-1.2"
   description: "BGP Policy & Route Installation"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/route_installation_test/README.md"


### PR DESCRIPTION
Add Test# for:
 
1. BGP route-refresh capability
2. Support for MP-BGP w/ Multiple AFI-SAFI Tuples on a single neighborship