### PR TITLE
System-1: Added Type Config to gnmi get request to avoid get request error

### DIFF
--- a/feature/system/tests/system_base_test/g_protocol_test.go
+++ b/feature/system/tests/system_base_test/g_protocol_test.go
@@ -58,7 +58,7 @@ func TestGNMIClient(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	conn := dialConn(t, dut, introspect.GNMI, 9339)
 	c := gpb.NewGNMIClient(conn)
-	if _, err := c.Get(context.Background(), &gpb.GetRequest{Encoding: gpb.Encoding_JSON_IETF, Path: []*gpb.Path{{Elem: []*gpb.PathElem{}}}}); err != nil {
+	if _, err := c.Get(context.Background(), &gpb.GetRequest{Encoding: gpb.Encoding_JSON_IETF, Path: []*gpb.Path{{Elem: []*gpb.PathElem{}}}, Type: gpb.GetRequest_CONFIG}); err != nil {
 		t.Fatalf("gnmi.Get failed: %v", err)
 	}
 }


### PR DESCRIPTION
System-1: Added Type Config to gnmi get request to avoid get request error: code = Unimplemented desc = Unsupported 'type' for /gnmi.gNMI/Get request. Valid options are ['CONFIG']