### PR TITLE
Fix encap_frr tests to add the network instance for REPAIR_VRF

### DIFF
--- a/internal/vrfpolicy/vrfpolicy.go
+++ b/internal/vrfpolicy/vrfpolicy.go
@@ -36,6 +36,7 @@ const (
 	niEncapTeVrfB           = "ENCAP_TE_VRF_B"
 	niEncapTeVrfC           = "ENCAP_TE_VRF_C"
 	niEncapTeVrfD           = "ENCAP_TE_VRF_D"
+	niRepairVrf             = "REPAIR_VRF"
 	niDefault               = "DEFAULT"
 	dscpEncapA1             = 10
 	dscpEncapA2             = 18
@@ -74,7 +75,7 @@ type policyFwRule struct {
 func configNonDefaultNetworkInstance(t *testing.T, dut *ondatra.DUTDevice) {
 	t.Helper()
 	c := &oc.Root{}
-	vrfs := []string{niDecapTeVrf, niEncapTeVrfA, niEncapTeVrfB, niEncapTeVrfC, niEncapTeVrfD, niTeVrf111, niTeVrf222}
+	vrfs := []string{niDecapTeVrf, niEncapTeVrfA, niEncapTeVrfB, niEncapTeVrfC, niEncapTeVrfD, niTeVrf111, niTeVrf222, niRepairVrf}
 	for _, vrf := range vrfs {
 		ni := c.GetOrCreateNetworkInstance(vrf)
 		ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF


### PR DESCRIPTION
Please note that the test is still continuing to fail at a later point in our internal testbed with the following error
    encap_frr_test.go:1122: SetControlState(t) on ATE{Dims:Dims{Name:google-ondatra-keng:40051 Vendor:VENDOR_UNSPECIFIED HardwareModel: SoftwareVersion: Ports:map[port1:Port{Name:ixas120/89 Speed:SPEED_UNSPECIFIED CardModel: PMD:PMD_UNSPECIFIED} port2:Port{Name:ixas120/90 Speed:SPEED_UNSPECIFIED CardModel: PMD:PMD_UNSPECIFIED} port3:Port{Name:ixas120/91 Speed:SPEED_UNSPECIFIED CardModel: PMD:PMD_UNSPECIFIED} port4:Port{Name:ixas120/92 Speed:SPEED_UNSPECIFIED CardModel: PMD:PMD_UNSPECIFIED} port5:Port{Name:ixas120/93 Speed:SPEED_UNSPECIFIED CardModel: PMD:PMD_UNSPECIFIED} port6:Port{Name:ixas120/94 Speed:SPEED_UNSPECIFIED CardModel: PMD:PMD_UNSPECIFIED} port7:Port{Name:ixas120/95 Speed:SPEED_UNSPECIFIED CardModel: PMD:PMD_UNSPECIFIED} port8:Port{Name:ixas120/96 Speed:SPEED_UNSPECIFIED CardModel: PMD:PMD_UNSPECIFIED} port9:Port{Name:ixas120/97 Speed:SPEED_UNSPECIFIED CardModel: PMD:PMD_UNSPECIFIED}]}}: {
          "code":  3,
          "errors":  [
            "error on request {\ncontrol_state:  {\n  choice:  port\n  port:  {\n    choice:  capture\n    capture:  {\n      state:  start\n    }\n  }\n}\n}: {\n  \"code\": 3,\n  \"kind\": \"validation\",\n  \"errors\": [\n    \"Capture is not enabled on any configured ports\"\n  ]\n}"
          ]
        }

I am not sure if this is an arista ixia hardware specific issue. But I would like to merge the obvious fix of missing REPAIR_VRF network instance configuration in the test
