### PR TITLE
corrected deviation usage and  isis await timeout

### DIFF
--- a/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/aggregate_all_not_forwarding_viable_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/aggregate_all_not_forwarding_viable_test.go
@@ -176,13 +176,15 @@ func TestAggregateAllNotForwardingViable(t *testing.T) {
 	changeMetric(t, dut, aggIDs[2], 30)
 	top := configureATE(t, ate)
 	installGRIBIRoutes(t, dut, ate, top)
-	flows := createFlows(t, dut, top, aggIDs)
 	ate.OTG().PushConfig(t, top)
 	ate.OTG().StartProtocols(t)
 	for _, aggID := range aggIDs {
-		gnmi.Await(t, dut, gnmi.OC().Interface(aggID).OperStatus().State(), 30*time.Second, oc.Interface_OperStatus_UP)
+		gnmi.Await(t, dut, gnmi.OC().Interface(aggID).OperStatus().State(), 60*time.Second, oc.Interface_OperStatus_UP)
 	}
 
+	flows := createFlows(t, ate, top)
+	ate.OTG().PushConfig(t, top)
+	ate.OTG().StartProtocols(t)
 	for _, agg := range []*aggPortData{agg1, agg2, agg3} {
 		bgpPath := ocpath.Root().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 		gnmi.Await(t, dut, bgpPath.Neighbor(agg.ateIPv4).SessionState().State(), time.Minute, oc.Bgp_Neighbor_SessionState_ESTABLISHED)
@@ -809,9 +811,9 @@ func incrementMAC(mac string, i int) (string, error) {
 	return newMac.String(), nil
 }
 
-func createFlows(t *testing.T, dut *ondatra.DUTDevice, top gosnappi.Config, aggIDs []string) []gosnappi.Flow {
-	for _, aggID := range aggIDs {
-		dutAggMac = append(dutAggMac, gnmi.Get(t, dut, gnmi.OC().Interface(aggID).Ethernet().MacAddress().State()))
+func createFlows(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config) []gosnappi.Flow {
+	for _, aggID := range []*aggPortData{agg1, agg2, agg3} {
+		dutAggMac = append(dutAggMac, gnmi.Get(t, ate.OTG(), gnmi.OTG().Interface(aggID.ateAggName+".Eth").Ipv4Neighbor(aggID.dutIPv4).LinkLayerAddress().State()))
 	}
 	f1V4 := configureFlows(t, top, pfx1AdvV4, pfx2AdvV4, "pfx1ToPfx2_3", agg1, []*aggPortData{agg2, agg3}, dutAggMac[0], ipRange[1])
 	f2V4 := configureFlows(t, top, pfx1AdvV4, pfx4AdvV4, "pfx1ToPfx4", agg1, []*aggPortData{agg2, agg3}, dutAggMac[0], ipRange[0])

--- a/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/aggregate_all_not_forwarding_viable_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/aggregate_all_not_forwarding_viable_test.go
@@ -215,7 +215,9 @@ func TestAggregateAllNotForwardingViable(t *testing.T) {
 		// Ensure ISIS Adjacency is Down on LAG_2
 
 		if ok := awaitAdjacency(t, dut, aggIDs[1], oc.Isis_IsisInterfaceAdjState_DOWN); !ok {
-			t.Fatal("ISIS Adjacency is Established on LAG_2")
+			if presence := gnmi.LookupAll(t, dut, ocpath.Root().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, isisInstance).Isis().Interface(aggIDs[1]).LevelAny().AdjacencyAny().AdjacencyState().State()); len(presence) > 0 {
+				t.Fatalf("ISIS Adjacency is Established on LAG_2 ")
+			}
 		}
 		startTraffic(t, dut, ate, top)
 		if err := confirmNonViableForwardingTraffic(t, dut, ate, atePortList[1:agg2.ateLagCount+1], dutPortList[1:agg2.ateLagCount+1]); err != nil {
@@ -292,7 +294,9 @@ func TestAggregateAllNotForwardingViable(t *testing.T) {
 		configForwardingViable(t, dut, dutPortList[1:2], false)
 		// Ensure ISIS Adjacency is Down on LAG_2
 		if ok := awaitAdjacency(t, dut, aggIDs[1], oc.Isis_IsisInterfaceAdjState_DOWN); !ok {
-			t.Fatal("ISIS Adjacency is Established on LAG_2")
+			if presence := gnmi.LookupAll(t, dut, ocpath.Root().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, isisInstance).Isis().Interface(aggIDs[1]).LevelAny().AdjacencyAny().AdjacencyState().State()); len(presence) > 0 {
+				t.Fatalf("ISIS Adjacency is Established on LAG_2")
+			}
 		}
 		startTraffic(t, dut, ate, top)
 		if err := confirmNonViableForwardingTraffic(t, dut, ate, atePortList[1:(agg2.ateLagCount+1)], dutPortList[1:(agg2.ateLagCount+1)]); err != nil {
@@ -394,7 +398,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) []string {
 	configureRoutingPolicy(t, dut)
 	configureDUTISIS(t, dut, aggIDs)
 
-	if deviations.MaxEcmpPaths(dut) {
+	if !deviations.MaxEcmpPaths(dut) {
 		isisPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, isisInstance).Isis()
 		gnmi.Update(t, dut, isisPath.Global().MaxEcmpPaths().Config(), 2)
 	}
@@ -807,7 +811,7 @@ func incrementMAC(mac string, i int) (string, error) {
 
 func createFlows(t *testing.T, dut *ondatra.DUTDevice, top gosnappi.Config, aggIDs []string) []gosnappi.Flow {
 	for _, aggID := range aggIDs {
-		dutAggMac = append(dutAggMac, gnmi.Get(t, dut, gnmi.OC().Lacp().Interface(aggID).SystemIdMac().State()))
+		dutAggMac = append(dutAggMac, gnmi.Get(t, dut, gnmi.OC().Interface(aggID).Ethernet().MacAddress().State()))
 	}
 	f1V4 := configureFlows(t, top, pfx1AdvV4, pfx2AdvV4, "pfx1ToPfx2_3", agg1, []*aggPortData{agg2, agg3}, dutAggMac[0], ipRange[1])
 	f2V4 := configureFlows(t, top, pfx1AdvV4, pfx4AdvV4, "pfx1ToPfx4", agg1, []*aggPortData{agg2, agg3}, dutAggMac[0], ipRange[0])
@@ -958,7 +962,7 @@ func awaitAdjacency(t *testing.T, dut *ondatra.DUTDevice, intfName string, state
 	isisPath := ocpath.Root().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, isisInstance).Isis()
 	intf := isisPath.Interface(intfName)
 	query := intf.LevelAny().AdjacencyAny().AdjacencyState().State()
-	_, ok := gnmi.WatchAll(t, dut, query, time.Minute, func(val *ygnmi.Value[oc.E_Isis_IsisInterfaceAdjState]) bool {
+	_, ok := gnmi.WatchAll(t, dut, query, 90*time.Second, func(val *ygnmi.Value[oc.E_Isis_IsisInterfaceAdjState]) bool {
 		v, ok := val.Val()
 		return v == state && ok
 	}).Await(t)

--- a/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/metadata.textproto
+++ b/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/metadata.textproto
@@ -36,7 +36,7 @@ platform_exceptions: {
     static_protocol_name: "STATIC"
     aggregate_atomic_update: true
     missing_value_for_defaults: true
-    max_ecmp_paths: false
+    max_ecmp_paths: true
     explicit_interface_in_default_vrf: false
   }
 }


### PR DESCRIPTION
1. Corrected use of deviation as per PR-2953 , i.e deviation is need to skip ecmp config . 
2. Modified gnmi Await timeout to 90 seconds to verify ISIS session state , this to accommodated 3 hello packets drop interval 
3. Using LACP System ID as destination MAC in flow creation is not reliable  so changed to get interface MAC  while creating traffic flow. 
4. Added additional check to verify either session DOWN or no adjacencies presence.  
 

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."