### PR TITLE
Update testregistry.textproto

### DIFF
--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -340,6 +340,49 @@ test: {
   exec: " "
 }
 test: {
+  id: "RT-1.2"
+  description: "BGP Policy & Route Installation"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/route_installation_test/README.md"
+  exec: " "
+}
+test: {
+  id: "RT-1.3"
+  description: "BGP Route Propagation"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/addpath/ate_tests/route_propagation_test/README.md"
+  exec: " "
+}
+test: {
+  id: "RT-1.4"
+  description: "BGP Graceful Restart"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/gracefulrestart/ate_tests/bgp_graceful_restart_test/README.md"
+  exec: " "
+}
+test: {
+  id: "RT-1.5"
+  description: "BGP Prefix Limit"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/README.md"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/prefixlimit/ate_tests/bgp_prefix_limit_test/README.md"
+  exec: " "
+}
+test: {
+  id: "RT-1.7"
+  description: "Local BGP Test"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/tests/local_bgp_test/README.md"
+  exec: " "
+}
+test: {
+  id: "RT-1.8"
+  description: "BGP Route Reflector test at scale"
+  readme: ""
+  exec: " "
+}
+test: {
+  id: "RT-1.9"
+  description: "BGP Transport Parameters test"
+  readme: ""
+  exec: " "
+}
+test: {
   id: "RT-1.10"
   description: "RT-1.10: BGP Keepalive and Holdtimer configuration"
   readme: ""
@@ -400,12 +443,6 @@ test: {
   exec: " "
 }
 test: {
-  id: "RT-1.2"
-  description: "BGP Policy & Route Installation"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/route_installation_test/README.md"
-  exec: " "
-}
-test: {
   id: "RT-1.21"
   description: "BGP TCP MSS and PMTUD"
   readme: ""
@@ -460,12 +497,6 @@ test: {
   exec: " "
 }
 test: {
-  id: "RT-1.3"
-  description: "BGP Route Propagation"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/addpath/ate_tests/route_propagation_test/README.md"
-  exec: " "
-}
-test: {
   id: "RT-1.30"
   description: "BGP nested import/export policy attachment"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/nested_policies/README.md"
@@ -494,19 +525,6 @@ test: {
   exec: " "
 }
 test: {
-  id: "RT-1.4"
-  description: "BGP Graceful Restart"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/gracefulrestart/ate_tests/bgp_graceful_restart_test/README.md"
-  exec: " "
-}
-test: {
-  id: "RT-1.5"
-  description: "BGP Prefix Limit"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/README.md"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/prefixlimit/ate_tests/bgp_prefix_limit_test/README.md"
-  exec: " "
-}
-test: {
   id: "RT-1.51"
   description: "BGP multipath ECMP"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/multipath/otg_tests/bgp_multipath_ecmp_test/README.md"
@@ -531,21 +549,45 @@ test: {
   exec: " "
 }
 test: {
-  id: "RT-1.7"
-  description: "Local BGP Test"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/tests/local_bgp_test/README.md"
+  id: "RT-1.56"
+  description: "BGP extended Next-hop support (RFC 5549)"
+  readme: " "
   exec: " "
 }
 test: {
-  id: "RT-1.8"
-  description: "BGP Route Reflector test at scale"
-  readme: ""
+  id: "RT-1.57"
+  description: "Support [E|I]BGP updates for IPv6 NLRI (including ULA/64 address space) with IPv4 Next-hop."
+  readme: " "
   exec: " "
 }
 test: {
-  id: "RT-1.9"
-  description: "BGP Transport Parameters test"
-  readme: ""
+  id: "RT-1.58"
+  description: "Support for learning IPv6 ULA/64 address space over [E|I]BGP sessions"
+  readme: " "
+  exec: " "
+}
+test: {
+  id: "RT-1.59"
+  description: "Support for configuring static IPv6 ULA/64 routes with higher administrative distance"
+  readme: " "
+  exec: " "
+}
+test: {
+  id: "RT-1.60"
+  description: "ECMP hashing support for [E|I]BGP learnt ULA/64 address space"
+  readme: " "
+  exec: " "
+}
+test: {
+  id: "RT-1.61"
+  description: "ECMP hashing support for statically confifgured ULA/64 address space"
+  readme: " "
+  exec: " "
+}
+test: {
+  id: "RT-1.62"
+  description: "ECMP hash testing for [E|I]BGP learnt IPv6 NLRI (including ULA/64 address space) with IPv4 Next-hop."
+  readme: " "
   exec: " "
 }
 test: {


### PR DESCRIPTION
Add FNTs denominations for
1. RFC 5549
2. IPv6 NLRI with IPv4 next-hops
3. ULA address space
4. ECMP coverage for above flows.