### PR TITLE
healthz parameters for CISCO

### DIFF
--- a/feature/gnoi/system/tests/copying_debug_files_test/copying_debug_files_test.go
+++ b/feature/gnoi/system/tests/copying_debug_files_test/copying_debug_files_test.go
@@ -31,10 +31,11 @@ var (
 		ondatra.NOKIA:   "sr_bgp_mgr",
 		ondatra.ARISTA:  "IpRib",
 		ondatra.JUNIPER: "rpd",
+		ondatra.CISCO:   "bgp",
 	}
 	components = map[ondatra.Vendor]string{
 		ondatra.ARISTA:  "Chassis",
-		ondatra.CISCO:   "Chassis",
+		ondatra.CISCO:   "Rack 0",
 		ondatra.JUNIPER: "CHASSIS0",
 		ondatra.NOKIA:   "Chassis",
 	}
@@ -85,6 +86,7 @@ func TestCopyingDebugFiles(t *testing.T) {
 	componentName := map[string]string{"name": components[dut.Vendor()]}
 	req := &hpb.GetRequest{
 		Path: &tpb.Path{
+			Origin: "openconfig",
 			Elem: []*tpb.PathElem{
 				{
 					Name: "components",
@@ -129,6 +131,7 @@ func TestChassisComponentArtifacts(t *testing.T) {
 	// Execute Healthz Check RPC for the chassis component.
 	chkReq := &hpb.CheckRequest{
 		Path: &tpb.Path{
+			Origin: "openconfig",
 			Elem: []*tpb.PathElem{
 				{
 					Name: "components",


### PR DESCRIPTION
1. added bgp process "bgp" and chassis component name "Rack 0"
2. Origin as "openconfig" for healthz RPCs