### PR TITLE
RT-1.53 fix

### DIFF
--- a/feature/experimental/policy/otg_tests/prefix_set_test/metadata.textproto
+++ b/feature/experimental/policy/otg_tests/prefix_set_test/metadata.textproto
@@ -5,3 +5,11 @@ uuid: "619040ac-21a0-403f-b38e-6d5d0aed433a"
 plan_id: "RT-1.53"
 description: "prefix-list test"
 testbed: TESTBED_DUT
+platform_exceptions: {
+    platform: {
+      vendor: NOKIA
+    }
+    deviations: {
+      skip_prefix_set_mode: true
+    }
+  }

--- a/feature/experimental/policy/otg_tests/prefix_set_test/prefix_set_test.go
+++ b/feature/experimental/policy/otg_tests/prefix_set_test/prefix_set_test.go
@@ -17,6 +17,7 @@ package prefix_set_test
 import (
 	"testing"
 
+	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
@@ -45,7 +46,9 @@ func TestPrefixSet(t *testing.T) {
 
 	// create a prefix-set with 2 prefixes
 	v4PrefixSet := ds.GetOrCreatePrefixSet(prefixSetA)
-	v4PrefixSet.SetMode(oc.PrefixSet_Mode_IPV4)
+	if !deviations.SkipPrefixSetMode(dut) {
+		v4PrefixSet.SetMode(oc.PrefixSet_Mode_IPV4)
+	}
 	v4PrefixSet.GetOrCreatePrefix(pfx1, mskLen)
 	v4PrefixSet.GetOrCreatePrefix(pfx2, mskLen)
 
@@ -62,9 +65,12 @@ func TestPrefixSet(t *testing.T) {
 
 	// replace the prefix-set by replacing an existing prefix with new prefix
 	v4PrefixSet = ds.GetOrCreatePrefixSet(prefixSetA)
-	v4PrefixSet.SetMode(oc.PrefixSet_Mode_IPV4)
+	if !deviations.SkipPrefixSetMode(dut) {
+		v4PrefixSet.SetMode(oc.PrefixSet_Mode_IPV4)
+	}
 	v4PrefixSet.GetOrCreatePrefix(pfx1, mskLen)
 	v4PrefixSet.GetOrCreatePrefix(pfx3, mskLen)
+	v4PrefixSet.DeletePrefix(pfx2, mskLen)
 
 	gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().DefinedSets().PrefixSet(prefixSetA).Config(), v4PrefixSet)
 	prefixSet = gnmi.Get[*oc.RoutingPolicy_DefinedSets_PrefixSet](t, dut, gnmi.OC().RoutingPolicy().DefinedSets().PrefixSet(prefixSetA).State())
@@ -79,10 +85,13 @@ func TestPrefixSet(t *testing.T) {
 
 	// replace the prefix-set with 2 existing and a new prefix
 	v4PrefixSet = ds.GetOrCreatePrefixSet(prefixSetA)
-	v4PrefixSet.SetMode(oc.PrefixSet_Mode_IPV4)
+	if !deviations.SkipPrefixSetMode(dut) {
+		v4PrefixSet.SetMode(oc.PrefixSet_Mode_IPV4)
+	}
 	v4PrefixSet.GetOrCreatePrefix(pfx1, mskLen)
 	v4PrefixSet.GetOrCreatePrefix(pfx3, mskLen)
 	v4PrefixSet.GetOrCreatePrefix(pfx4, mskLen)
+	v4PrefixSet.DeletePrefix(pfx2, mskLen)
 
 	gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().DefinedSets().PrefixSet(prefixSetA).Config(), v4PrefixSet)
 	prefixSet = gnmi.Get[*oc.RoutingPolicy_DefinedSets_PrefixSet](t, dut, gnmi.OC().RoutingPolicy().DefinedSets().PrefixSet(prefixSetA).State())


### PR DESCRIPTION
- delete pfx2 from var as it was never "replaced" - see below
Before the change, we can see that the var was never replaced and always carried pfx2 which seems to not be the intended behavior by the author.
```
    prefix_set_test.go:65: Printing the value after re-assignment, &{out-of-range E_PrefixSet_Mode enum value: 0 0xc001e93e80 map[{10.240.31.48/28 exact}:0xc001e93eb0 {173.36.128.0/20 exact}:0xc001e93ee0]}
    prefix_set_test.go:69: Printing the value after L68, &{out-of-range E_PrefixSet_Mode enum value: 0 0xc001e93e80 map[{10.240.31.48/28 exact}:0xc001e93eb0 {173.36.128.0/20 exact}:0xc001e93ee0 {173.36.144.0/20 exact}:0xc002171a90]}
```
- add deviation 
---
<sub>This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.</sub>