### PR TITLE
Fix P4RT-5.2: Traceroute Packetout regression

### DIFF
--- a/feature/experimental/p4rt/otg_tests/traceroute_packetout_test/traceroute_packetout_test.go
+++ b/feature/experimental/p4rt/otg_tests/traceroute_packetout_test/traceroute_packetout_test.go
@@ -238,9 +238,9 @@ func TestPacketOut(t *testing.T) {
 
 	otg := ate.OTG()
 	otg.PushConfig(t, top)
+	otg.StartProtocols(t)
 	otgutils.WaitForARP(t, ate.OTG(), top, "IPv4")
 	otgutils.WaitForARP(t, ate.OTG(), top, "IPv6")
-	otg.StartProtocols(t)
 
 	configureDeviceID(ctx, t, dut)
 


### PR DESCRIPTION
The test started failing with the following commit https://github.com/openconfig/featureprofiles/commit/e8db60afb7a6e044e5d7f63318f59d55ccdde43f

The problem with the change was that the test was waiting for ARP on the OTG side even before the call to otg.StartProtocols() and as a result the ip address was not configured on the OTG interfaces and the neighbor entry was missing.