### PR TITLE
gNMI-1.4 deviation addition

### DIFF
--- a/feature/platform/tests/telemetry_inventory_test/metadata.textproto
+++ b/feature/platform/tests/telemetry_inventory_test/metadata.textproto
@@ -43,5 +43,6 @@ platform_exceptions: {
     backplane_facing_capacity_unsupported: true
     install_position_and_install_component_unsupported: true
     model_name_unsupported: true
+    skip_controller_card_power_admin: true
   }
 }

--- a/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
+++ b/feature/platform/tests/telemetry_inventory_test/telemetry_inventory_test.go
@@ -1069,12 +1069,13 @@ func TestDefaultPowerAdminState(t *testing.T) {
 			t.Errorf("Component %s PowerAdminState is unset", linecards[0].GetName())
 		}
 	}
-
-	if len(supervisors) != 0 {
-		pas := gnmi.Get(t, dut, gnmi.OC().Component(supervisors[0].GetName()).ControllerCard().PowerAdminState().Config())
-		t.Logf("Component %s PowerAdminState: %v", supervisors[0].GetName(), pas)
-		if pas == oc.Platform_ComponentPowerType_UNSET {
-			t.Errorf("Component %s PowerAdminState is unset", supervisors[0].GetName())
+	if !deviations.SkipControllerCardPowerAdmin(dut) {
+		if len(supervisors) != 0 {
+			pas := gnmi.Get(t, dut, gnmi.OC().Component(supervisors[0].GetName()).ControllerCard().PowerAdminState().Config())
+			t.Logf("Component %s PowerAdminState: %v", supervisors[0].GetName(), pas)
+			if pas == oc.Platform_ComponentPowerType_UNSET {
+				t.Errorf("Component %s PowerAdminState is unset", supervisors[0].GetName())
+			}
 		}
 	}
 }


### PR DESCRIPTION

adding deviation to skip power-admin-state for controllers

---
<sub>This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.</sub>