### PR TITLE
DP-1.16: Remove MFF as a requirement

### DIFF
--- a/feature/qos/otg_tests/ingress_traffic_classification_and_rewrite_test/README.md
+++ b/feature/qos/otg_tests/ingress_traffic_classification_and_rewrite_test/README.md
@@ -150,5 +150,4 @@ rpcs:
 
 ## Minimum DUT platform requirement
 
-* MFF - A modular form factor device containing LINECARDs, FABRIC and redundant CONTROLLER_CARD components
 * FFF - fixed form factor


### PR DESCRIPTION
These qos features are not inherently dependent on FFF vs. MFF devices.  So the minimum platform to be used is FFF.