### PR TITLE
RT-6.1 Fix

### DIFF
--- a/feature/lldp/ate_tests/core_lldp_tlv_population_test/README.md
+++ b/feature/lldp/ate_tests/core_lldp_tlv_population_test/README.md
@@ -17,29 +17,33 @@ Determine LLDP advertisement and reception operates correctly.
         configuration of lldp/interfaces/interface/config/enabled (TRUE or
         FALSE) on any interface.
 
-## Config Parameter coverage
+## OpenConfig Path and RPC Coverage
 
-*   /lldp/config/enabled
-*   /lldp/interfaces/interface/config/enabled
+The below yaml defines the OC paths intended to be covered by this test.  OC paths used for test setup are not listed here.
 
-## Telemetry Parameter coverage
+```yaml
+paths:
+  ## Config Paths ##
+  /lldp/config/enabled:
+  /lldp/interfaces/interface/config/enabled:
 
-*   /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id
-*   /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id-subtype
-*   /lldp/interfaces/interface/neighbors/neighbor/state/port-id
-*   /lldp/interfaces/interface/neighbors/neighbor/state/port-id-subtype
-*   /lldp/interfaces/interface/neighbors/neighbor/state/system-name
-*   /lldp/interfaces/interface/state/name
-*   /lldp/state/chassis-id
-*   /lldp/state/chassis-id-type
-*   /lldp/state/system-name
+  ## State Paths ##
+  /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id:
+  /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id-subtype:
+  /lldp/interfaces/interface/neighbors/neighbor/state/port-id:
+  /lldp/interfaces/interface/neighbors/neighbor/state/port-id-subtype:
+  /lldp/interfaces/interface/neighbors/neighbor/state/system-name:
+  /lldp/interfaces/interface/state/name:
+  /lldp/state/chassis-id:
+  /lldp/state/chassis-id-type:
+  /lldp/state/system-name:
 
-## Protocol/RPC Parameter coverage
+rpcs:
+  gnmi:
+    gNMI.Get:
+    gNMI.Set:
 
-LLDP:
-
-*   /lldp/config/enabled = true
-*   /lldp/interfaces/interface/config/enabled = true
+```
 
 ## Minimum DUT platform requirement
 

--- a/feature/lldp/ate_tests/core_lldp_tlv_population_test/README.md
+++ b/feature/lldp/ate_tests/core_lldp_tlv_population_test/README.md
@@ -29,9 +29,7 @@ paths:
 
   ## State Paths ##
   /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id:
-  /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id-subtype:
   /lldp/interfaces/interface/neighbors/neighbor/state/port-id:
-  /lldp/interfaces/interface/neighbors/neighbor/state/port-id-subtype:
   /lldp/interfaces/interface/neighbors/neighbor/state/system-name:
   /lldp/interfaces/interface/state/name:
   /lldp/state/chassis-id:

--- a/feature/lldp/ate_tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
+++ b/feature/lldp/ate_tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
@@ -94,19 +94,21 @@ func TestCoreLLDPTLVPopulation(t *testing.T) {
 func configureNode(t *testing.T, name string, lldpEnabled bool) (*ondatra.DUTDevice, *oc.Lldp) {
 	node := ondatra.DUT(t, name)
 	p := node.Port(t, portName)
-	lldp := gnmi.OC().Lldp()
+	d := &oc.Root{}
+	lldp := d.GetOrCreateLldp()
+	llint := lldp.GetOrCreateInterface(p.Name())
 
-	gnmi.Replace(t, node, lldp.Enabled().Config(), lldpEnabled)
+	gnmi.Replace(t, node, gnmi.OC().Lldp().Enabled().Config(), lldpEnabled)
 
 	if lldpEnabled {
-		gnmi.Replace(t, node, lldp.Interface(p.Name()).Enabled().Config(), lldpEnabled)
+		gnmi.Replace(t, node, gnmi.OC().Lldp().Interface(p.Name()).Config(), llint)
 	}
 
 	if deviations.InterfaceEnabled(node) {
 		gnmi.Replace(t, node, gnmi.OC().Interface(p.Name()).Enabled().Config(), true)
 	}
 
-	return node, gnmi.Get(t, node, lldp.Config())
+	return node, gnmi.Get(t, node, gnmi.OC().Lldp().Config())
 }
 
 // verifyNodeConfig verifies the config by comparing against the telemetry state object.

--- a/feature/lldp/otg_tests/core_lldp_tlv_population_test/README.md
+++ b/feature/lldp/otg_tests/core_lldp_tlv_population_test/README.md
@@ -17,29 +17,33 @@ Determine LLDP advertisement and reception operates correctly.
         configuration of lldp/interfaces/interface/config/enabled (TRUE or
         FALSE) on any interface.
 
-## Config Parameter coverage
+## OpenConfig Path and RPC Coverage
 
-*   /lldp/config/enabled
-*   /lldp/interfaces/interface/config/enabled
+The below yaml defines the OC paths intended to be covered by this test.  OC paths used for test setup are not listed here.
 
-## Telemetry Parameter coverage
+```yaml
+paths:
+  ## Config Paths ##
+  /lldp/config/enabled:
+  /lldp/interfaces/interface/config/enabled:
 
-*   /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id
-*   /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id-subtype
-*   /lldp/interfaces/interface/neighbors/neighbor/state/port-id
-*   /lldp/interfaces/interface/neighbors/neighbor/state/port-id-subtype
-*   /lldp/interfaces/interface/neighbors/neighbor/state/system-name
-*   /lldp/interfaces/interface/state/name
-*   /lldp/state/chassis-id
-*   /lldp/state/chassis-id-type
-*   /lldp/state/system-name
+  ## State Paths ##
+  /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id:
+  /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id-subtype:
+  /lldp/interfaces/interface/neighbors/neighbor/state/port-id:
+  /lldp/interfaces/interface/neighbors/neighbor/state/port-id-subtype:
+  /lldp/interfaces/interface/neighbors/neighbor/state/system-name:
+  /lldp/interfaces/interface/state/name:
+  /lldp/state/chassis-id:
+  /lldp/state/chassis-id-type:
+  /lldp/state/system-name:
 
-## Protocol/RPC Parameter coverage
+rpcs:
+  gnmi:
+    gNMI.Get:
+    gNMI.Set:
 
-LLDP:
-
-*   /lldp/config/enabled = true
-*   /lldp/interfaces/interface/config/enabled = true
+```
 
 ## Minimum DUT platform requirement
 

--- a/feature/lldp/otg_tests/core_lldp_tlv_population_test/README.md
+++ b/feature/lldp/otg_tests/core_lldp_tlv_population_test/README.md
@@ -29,9 +29,7 @@ paths:
 
   ## State Paths ##
   /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id:
-  /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id-subtype:
   /lldp/interfaces/interface/neighbors/neighbor/state/port-id:
-  /lldp/interfaces/interface/neighbors/neighbor/state/port-id-subtype:
   /lldp/interfaces/interface/neighbors/neighbor/state/system-name:
   /lldp/interfaces/interface/state/name:
   /lldp/state/chassis-id:

--- a/feature/lldp/otg_tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
+++ b/feature/lldp/otg_tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
@@ -138,18 +138,21 @@ func TestLLDPDisabled(t *testing.T) {
 func configureDUT(t *testing.T, name string, lldpEnabled bool) (*ondatra.DUTDevice, *oc.Lldp) {
 	node := ondatra.DUT(t, name)
 	p := node.Port(t, portName)
-	lldp := gnmi.OC().Lldp()
+	d := &oc.Root{}
+	lldp := d.GetOrCreateLldp()
+	llint := lldp.GetOrCreateInterface(p.Name())
 
-	gnmi.Replace(t, node, lldp.Enabled().Config(), lldpEnabled)
+	gnmi.Replace(t, node, gnmi.OC().Lldp().Enabled().Config(), lldpEnabled)
 
 	if lldpEnabled {
-		gnmi.Replace(t, node, lldp.Interface(p.Name()).Enabled().Config(), lldpEnabled)
+		gnmi.Replace(t, node, gnmi.OC().Lldp().Interface(p.Name()).Config(), llint)
 	}
+
 	if deviations.InterfaceEnabled(node) {
 		gnmi.Replace(t, node, gnmi.OC().Interface(p.Name()).Enabled().Config(), true)
 	}
 
-	return node, gnmi.Get(t, node, lldp.Config())
+	return node, gnmi.Get(t, node, gnmi.OC().Lldp().Config())
 }
 
 func configureATE(t *testing.T, otg *otg.OTG) gosnappi.Config {


### PR DESCRIPTION
use `GetOrCreate()` for lldp interface configs
ref b/358044619

---
<sub>This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.</sub>