### PR TITLE
Fixed error in NH addition

### DIFF
--- a/feature/gribi/otg_tests/gribigo_compliance_test/gribigo_compliance_test.go
+++ b/feature/gribi/otg_tests/gribigo_compliance_test/gribigo_compliance_test.go
@@ -331,7 +331,7 @@ func addNHGReferencingToDownPort(tcArgs *testArgs, wantACK fluent.ProgrammingRes
 
 	tcArgs.client.Modify().AddEntry(t,
 		fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(tcArgs.dut)).
-			WithIndex(2000).WithInterfaceRef(p.Name()).WithIPAddress(atePort2.IPv4),
+			WithIndex(2000).WithIPAddress(atePort2.IPv4),
 		fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(tcArgs.dut)).
 			WithID(2000).AddNextHop(2000, 1),
 		fluent.IPv4Entry().WithNetworkInstance(deviations.DefaultNetworkInstance(tcArgs.dut)).


### PR DESCRIPTION
Next-hop needs to be either interface-ref + MAC or IP , it cant be interface-ref+IP

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."