### PR TITLE
gnmi-1.4: fix deviations for nokia

### DIFF
--- a/feature/platform/tests/telemetry_inventory_test/metadata.textproto
+++ b/feature/platform/tests/telemetry_inventory_test/metadata.textproto
@@ -40,7 +40,6 @@ platform_exceptions: {
     vendor: NOKIA
   }
   deviations: {
-    backplane_facing_capacity_unsupported: true
     install_position_and_install_component_unsupported: true
     model_name_unsupported: true
     skip_controller_card_power_admin: true


### PR DESCRIPTION
This deviation was added in #3046 likely by mistake, hence removing it once again. 

---
<sup>
This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.</sup>