### PR TITLE
fixed the failure that was introduced by PR-3376

### DIFF
--- a/feature/experimental/bgp/ate_tests/bgp_long_lived_graceful_restart/bgp_long_lived_graceful_restart_test.go
+++ b/feature/experimental/bgp/ate_tests/bgp_long_lived_graceful_restart/bgp_long_lived_graceful_restart_test.go
@@ -885,7 +885,7 @@ func TestTrafficWithGracefulRestartLLGR(t *testing.T) {
 		})
 
 		t.Run("Restart routing", func(t *testing.T) {
-			gnoi.KillProcess(t, dut, gnoi.ROUTING, gnoi.SIG_TERM, true, true)
+			gnoi.KillProcess(t, dut, gnoi.ROUTING, gnoi.SigTerm, true, true)
 		})
 
 		var bgpIxPeer []*ixnet.BGP

--- a/feature/experimental/bgp/ate_tests/bgp_long_lived_graceful_restart/bgp_long_lived_graceful_restart_test.go
+++ b/feature/experimental/bgp/ate_tests/bgp_long_lived_graceful_restart/bgp_long_lived_graceful_restart_test.go
@@ -885,7 +885,7 @@ func TestTrafficWithGracefulRestartLLGR(t *testing.T) {
 		})
 
 		t.Run("Restart routing", func(t *testing.T) {
-			gnoi.KillProcess(t, dut, gnoi.ROUTING, true)
+			gnoi.KillProcess(t, dut, gnoi.ROUTING, gnoi.SIG_TERM, true, true)
 		})
 
 		var bgpIxPeer []*ixnet.BGP

--- a/feature/experimental/gribi/otg_tests/dut_daemon_failure/dut_daemon_failure_test.go
+++ b/feature/experimental/gribi/otg_tests/dut_daemon_failure/dut_daemon_failure_test.go
@@ -310,7 +310,7 @@ func TestDUTDaemonFailure(t *testing.T) {
 	})
 
 	t.Run("KillGRIBIDaemon", func(t *testing.T) {
-		gnoi.KillProcess(t, dut, gnoi.GRIBI, true)
+		gnoi.KillProcess(t, dut, gnoi.GRIBI, gnoi.SIG_TERM, true, true)
 
 		t.Logf("Time check: %s", time.Since(start))
 

--- a/feature/experimental/gribi/otg_tests/dut_daemon_failure/dut_daemon_failure_test.go
+++ b/feature/experimental/gribi/otg_tests/dut_daemon_failure/dut_daemon_failure_test.go
@@ -310,7 +310,7 @@ func TestDUTDaemonFailure(t *testing.T) {
 	})
 
 	t.Run("KillGRIBIDaemon", func(t *testing.T) {
-		gnoi.KillProcess(t, dut, gnoi.GRIBI, gnoi.SIG_TERM, true, true)
+		gnoi.KillProcess(t, dut, gnoi.GRIBI, gnoi.SigTerm, true, true)
 
 		t.Logf("Time check: %s", time.Since(start))
 

--- a/feature/experimental/policy/otg_tests/prefix_set_test/prefix_set_test.go
+++ b/feature/experimental/policy/otg_tests/prefix_set_test/prefix_set_test.go
@@ -133,7 +133,7 @@ func TestPrefixSetWithOCAgentRestart(t *testing.T) {
 		t.Errorf("Prefix set has %v prefixes, want %v", got, want)
 	}
 
-	gnoi.KillProcess(t, dut, gnoi.OCAGENT, gnoi.SIG_TERM, true, true)
+	gnoi.KillProcess(t, dut, gnoi.OCAGENT, gnoi.SigTerm, true, true)
 
 	v4PrefixSet = ds.GetOrCreatePrefixSet(tag3IPv4)
 	if !deviations.SkipPrefixSetMode(dut) {

--- a/feature/experimental/policy/otg_tests/prefix_set_test/prefix_set_test.go
+++ b/feature/experimental/policy/otg_tests/prefix_set_test/prefix_set_test.go
@@ -133,7 +133,7 @@ func TestPrefixSetWithOCAgentRestart(t *testing.T) {
 		t.Errorf("Prefix set has %v prefixes, want %v", got, want)
 	}
 
-	gnoi.KillProcess(t, dut, gnoi.OCAGENT, true)
+	gnoi.KillProcess(t, dut, gnoi.OCAGENT, gnoi.SIG_TERM, true, true)
 
 	v4PrefixSet = ds.GetOrCreatePrefixSet(tag3IPv4)
 	if !deviations.SkipPrefixSetMode(dut) {

--- a/feature/p4rt/otg_tests/p4rt_daemon_failure_test/p4rt_daemon_failure_test.go
+++ b/feature/p4rt/otg_tests/p4rt_daemon_failure_test/p4rt_daemon_failure_test.go
@@ -309,7 +309,7 @@ func TestP4RTDaemonFailure(t *testing.T) {
 
 	flow := startTraffic(t, ate, top)
 
-	gnoi.KillProcess(t, dut, gnoi.P4RT, gnoi.SIG_TERM, true, true)
+	gnoi.KillProcess(t, dut, gnoi.P4RT, gnoi.SigTerm, true, true)
 
 	// let traffic keep running for another 10 seconds.
 	time.Sleep(10 * time.Second)

--- a/feature/p4rt/otg_tests/p4rt_daemon_failure_test/p4rt_daemon_failure_test.go
+++ b/feature/p4rt/otg_tests/p4rt_daemon_failure_test/p4rt_daemon_failure_test.go
@@ -309,7 +309,7 @@ func TestP4RTDaemonFailure(t *testing.T) {
 
 	flow := startTraffic(t, ate, top)
 
-	gnoi.KillProcess(t, dut, gnoi.P4RT, false)
+	gnoi.KillProcess(t, dut, gnoi.P4RT, gnoi.SIG_TERM, true, true)
 
 	// let traffic keep running for another 10 seconds.
 	time.Sleep(10 * time.Second)

--- a/internal/gnoi/gnoi.go
+++ b/internal/gnoi/gnoi.go
@@ -71,8 +71,17 @@ const (
 	ROUTING Daemon = "ROUTING"
 )
 
+// signal type of termination request
+const (
+	SIG_TERM       = spb.KillProcessRequest_SIGNAL_TERM
+	SIG_KILL       = spb.KillProcessRequest_SIGNAL_KILL
+	SIG_HUP        = spb.KillProcessRequest_SIGNAL_HUP
+	SIG_ABORT      = spb.KillProcessRequest_SIGNAL_ABRT
+	SIG_UNSPECIFED = spb.KillProcessRequest_SIGNAL_UNSPECIFIED
+)
+
 // KillProcess terminates the daemon on the DUT.
-func KillProcess(t *testing.T, dut *ondatra.DUTDevice, daemon Daemon, waitForRestart bool) {
+func KillProcess(t *testing.T, dut *ondatra.DUTDevice, daemon Daemon, signal spb.KillProcessRequest_Signal, restart bool, waitForRestart bool) {
 	t.Helper()
 
 	daemonName, err := FetchProcessName(dut, daemon)
@@ -86,10 +95,10 @@ func KillProcess(t *testing.T, dut *ondatra.DUTDevice, daemon Daemon, waitForRes
 
 	gnoiClient := dut.RawAPIs().GNOI(t)
 	killProcessRequest := &spb.KillProcessRequest{
-		Signal:  spb.KillProcessRequest_SIGNAL_KILL,
+		Signal:  signal,
 		Name:    daemonName,
 		Pid:     uint32(pid),
-		Restart: true,
+		Restart: restart,
 	}
 	gnoiClient.System().KillProcess(context.Background(), killProcessRequest)
 

--- a/internal/gnoi/gnoi.go
+++ b/internal/gnoi/gnoi.go
@@ -73,11 +73,11 @@ const (
 
 // signal type of termination request
 const (
-	SIG_TERM       = spb.KillProcessRequest_SIGNAL_TERM
-	SIG_KILL       = spb.KillProcessRequest_SIGNAL_KILL
-	SIG_HUP        = spb.KillProcessRequest_SIGNAL_HUP
-	SIG_ABORT      = spb.KillProcessRequest_SIGNAL_ABRT
-	SIG_UNSPECIFED = spb.KillProcessRequest_SIGNAL_UNSPECIFIED
+	SigTerm        = spb.KillProcessRequest_SIGNAL_TERM
+	SigKill        = spb.KillProcessRequest_SIGNAL_KILL
+	SigHup         = spb.KillProcessRequest_SIGNAL_HUP
+	SigAbort       = spb.KillProcessRequest_SIGNAL_ABRT
+	SigUnspecified = spb.KillProcessRequest_SIGNAL_UNSPECIFIED
 )
 
 // KillProcess terminates the daemon on the DUT.


### PR DESCRIPTION
1. PR- 3376 changes changed the signal type to KILL instead of TERM  that resulted to non graceful application restart , fixed by adding that as an parameter to the  KillProces() function.
2. Also, added parameter option for restart after kill to have more flexibility  

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."