### PR TITLE
adding 400gzr testbed file to tb mapping

### DIFF
--- a/internal/fptest/runtests.go
+++ b/internal/fptest/runtests.go
@@ -75,6 +75,7 @@ func testbedPathFromMetadata() (string, error) {
 		mpb.Metadata_TESTBED_DUT_ATE_9LINKS_LAG: "atedut_9_lag.testbed",
 		mpb.Metadata_TESTBED_DUT_DUT_ATE_2LINKS: "dutdutate.testbed",
 		mpb.Metadata_TESTBED_DUT_ATE_8LINKS:     "atedut_8.testbed",
+		mpb.Metadata_TESTBED_DUT_400ZR:          "dut_400zr.testbed",
 	}
 	testbedFile, ok := testbedToFile[testbed]
 	if !ok {


### PR DESCRIPTION
adding 400g zr testbed file to mapping for automatic allocation

---
<sub>This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind.</sub>