### PR TITLE
TE-16.3 - fix for transport and subtest-8

### DIFF
--- a/feature/gribi/otg_tests/encap_frr_with_reencap_vrf_test/metadata.textproto
+++ b/feature/gribi/otg_tests/encap_frr_with_reencap_vrf_test/metadata.textproto
@@ -15,7 +15,7 @@ platform_exceptions:  {
     gribi_mac_override_with_static_arp: true
     interface_ref_interface_id_format: true
     pf_require_match_default_rule: true
-    pf_require_sequential_order_pbr_rules: true   
+    pf_require_sequential_order_pbr_rules: true
   }
 }
 platform_exceptions:  {


### PR DESCRIPTION
1. Added changes to add loopback address as transport address for vendor=cisco

2. Deleted code from TC-8 which is not correct as per readme. Added code to delete tunnel prefixes from niTEVRF222 such that traffic falls to backup path that leads to decap and lookup.