### PR TITLE
Fixing policyforwarding rule using the /afts tree, instead should be …

### DIFF
--- a/feature/gribi/otg_tests/mpls_in_udp/README.md
+++ b/feature/gribi/otg_tests/mpls_in_udp/README.md
@@ -248,7 +248,6 @@ decapsulate MPLS in UDP.  # TODO: Move to dedicated README
 openconfig-network-instance:
   network-instances:
     - network-instance: "DEFAULT"
-      afts:
         policy-forwarding:
           policies:
             policy: "default decap rule"


### PR DESCRIPTION
…in the /policy-forwarding tree.