### PR TITLE
added changes to .github/CODEOWNERS to remove ownership for policy_forwarding

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,6 @@
 /feature/mtu/          @swetha-haridasula
 /feature/networkinstance/    @swetha-haridasula
 /feature/platform/           @amrindrr
-/feature/policy_forwarding/  @swetha-haridasula
 /feature/qos                 @sezhang2
 /feature/routing_policy/     @swetha-haridasula
 /feature/sampling/           @sudhinj


### PR DESCRIPTION
Removing ownership for Policy_forwarding for swetha-haridasula.