### PR TITLE
adding waitForARP to fix flakiness

### DIFF
--- a/feature/interface/aggregate/otg_tests/aggregate_forwarding_viable_test/aggregate_forwarding_viable_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_forwarding_viable_test/aggregate_forwarding_viable_test.go
@@ -552,6 +552,7 @@ func (tc *testArgs) testAggregateForwardingFlow(t *testing.T, forwardingViable b
 	tc.ate.OTG().PushConfig(t, tc.top)
 	tc.ate.OTG().StartProtocols(t)
 
+	otgutils.WaitForARP(t, tc.ate.OTG(), tc.top, "IPv4")
 	beforeTrafficCounters := tc.getCounters(t, "before")
 
 	tc.ate.OTG().StartTraffic(t)


### PR DESCRIPTION
Traffic is sent without waiting for ARP and that is causing for flakiness in result , this change will make sure ARP is resolved

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."