### PR TITLE
Issue #3525: Increase test_data and documentation.

### DIFF
--- a/feature/security/gnsi/certz/client_certificates/README.md
+++ b/feature/security/gnsi/certz/client_certificates/README.md
@@ -42,8 +42,8 @@ gRPC service.
 
 Perform this for both RSA and ECDSA signed CA bundles and
 certificates.
-Perform this for the permutations of 1, 2, 10, 1000 CA
-trust_bundle configurations: (## indicates the 1, 2, 10, 1000 CA testdata)
+Perform this for the permutations of 1, 2, 10, 1000, 20000 CA
+trust_bundle configurations: (## indicates the 1, 2, 10, 1000, 20000 CA testdata)
 
    1) Load the correct key-type trust bundle onto the device and client system:
         ca-##/trust_bundle_##_rsa.pem

--- a/feature/security/gnsi/certz/test_data/README.md
+++ b/feature/security/gnsi/certz/test_data/README.md
@@ -10,6 +10,7 @@ Creation of test data for use in TLS tests.
    * ca-02 - a set of two CAs where signatures are RSA or ECDSA.
    * ca-10 - a set of ten CAs where signatures are RSA or ECDSA.
    * ca-1000 - a set of one thousand CAs where signatures are RSA or ECDSA.
+   * ca-20000 - a set of twenty thousand CAs where signatures are RSA or ECDSA.
    * server_cert.cnf/server_cert_ext.cnf - server openssl profile configuration
    * client_cert.cnf/client_cert_ext.cnf - client openssl profile configuration
 

--- a/feature/security/gnsi/certz/test_data/cleanup.sh
+++ b/feature/security/gnsi/certz/test_data/cleanup.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
-for d in 01 02 10 1000; do
-  rm -f ca-${d}/*
+for d in 01 02 10 1000 20000; do
+  find ca-${d}/ -type f -exec /usr/bin/rm -f {} \;
+  /usr/bin/rm -rf ca-${d}/
 done

--- a/feature/security/gnsi/certz/test_data/mk_cas.sh
+++ b/feature/security/gnsi/certz/test_data/mk_cas.sh
@@ -5,7 +5,7 @@
 #
 # The list of directories of CA contents, also the count of CAs built
 # in each directory.
-DIRS=(01 02 10 1000)
+DIRS=(01 02 10 1000 20000)
 
 # The types of signatures to support for the CA Certs.
 TYPES=(rsa ecdsa)
@@ -20,14 +20,14 @@ RSAKEYLEN=2048
 LIFETIME=3650
 
 # Create RSA and ECDSA CA keys, and associated certificates.
-for d in ${DIRS[@]} ; do 
+for d in ${DIRS[@]} ; do
   if [ ! -d ca-${d} ] ; then
     mkdir ca-${d}
   fi
   # Create a CA key and certificate for each of the DIRS count of
   # keys / certs. Do this for each of the TYPES key types.
   for k in $(seq 1 ${d}); do
-    OFFSET=$(printf  "%04i" ${k})
+    OFFSET=$(printf  "%05i" ${k})
     for t in ${TYPES[@]}; do
       # Generate the appropriate key type keys.
       case ${t} in
@@ -53,6 +53,11 @@ done
 for d in ${DIRS[@]}; do
   for t in ${TYPES[@]}; do
     cat ca-${d}/ca-*-${t}-cert.pem > ca-${d}/trust_bundle_${d}_${t}.pem
+    CERTS=""
+    for cf in ca-${d}/ca-*-${t}-cert.pem; do
+      CERTS="${CERTS} -certfile ${cf}"
+    done
+    openssl crl2pkcs7 -nocrl ${CERTS} -out ca-${d}/trust_bundle_${d}_${t}.p7b
   done
 done
 
@@ -67,7 +72,7 @@ for  d in ${DIRS[@]}; do
     mkdir ca-${d}
   fi
   for t in ${TYPES[@]}; do
-    OFFSET=$(printf "%04i" ${d})
+    OFFSET=$(printf "%05i" ${d})
     # Create both client and server cert keys for each type.
     # use a/b here to signal the required 2 client or server certs/keys.
     for g in a b; do

--- a/feature/security/gnsi/certz/trust_bundle/README.md
+++ b/feature/security/gnsi/certz/trust_bundle/README.md
@@ -62,6 +62,7 @@ Load the server certificate and key from each of the following CA sets:
    * ca-02
    * ca-10
    * ca-1000
+   * ca-20000
 
 Each service must be configured to use the appropriate certificate and validate
 that certificate using the included trust_bundle.


### PR DESCRIPTION
Update test_data creation and destruction.
Account for the new requirement to handle 20000 certificates.

Additionally, create a p7b form of the trust-bundle, this will be used in the certz interactions instead of the pem file.