### PR TITLE
Added defer function to cleanup fib table

### DIFF
--- a/feature/gribi/otg_tests/fib_failed_due_to_hw_res_exhaust_test/fib_failed_due_to_hw_res_exhaust_test.go
+++ b/feature/gribi/otg_tests/fib_failed_due_to_hw_res_exhaust_test/fib_failed_due_to_hw_res_exhaust_test.go
@@ -303,7 +303,7 @@ func TestFibFailDueToHwResExhaust(t *testing.T) {
 		WithFIBACK().WithRedundancyMode(fluent.ElectedPrimaryClient)
 	client.Start(ctx, t)
 	defer client.Stop(t)
-
+	gribi.FlushAll(client)
 	defer func() {
 		// Flush all entries after test.
 		if err := gribi.FlushAll(client); err != nil {
@@ -334,6 +334,12 @@ func TestFibFailDueToHwResExhaust(t *testing.T) {
 		otg:           otg,
 	}
 	start := time.Now()
+	// cleanup fib table
+	defer func() {
+		ate.OTG().StopProtocols(t)
+		time.Sleep(5 * time.Minute)
+	}()
+
 	injectEntry(ctx, t, args, dstIPList, vipList)
 	t.Logf("Main Function: Time elapsed %.2f seconds since start", time.Since(start).Seconds())
 


### PR DESCRIPTION
currently after test is complete OTG retains its config and due to which following tests are failing as fib is full and not able to install any more routes.  added defer function to stop BGP protocol that will clear all routes injecected .

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."