### PR TITLE
Rename Packages in features/security.

### DIFF
--- a/feature/security/gnsi/acctz/tests/record_subscribe_full/record_subscribe_full_test.go
+++ b/feature/security/gnsi/acctz/tests/record_subscribe_full/record_subscribe_full_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package recordsubscribefull
+package recordsubscribefull_test
 
 import (
 	"context"

--- a/feature/security/gnsi/acctz/tests/record_subscribe_non_grpc/record_subscribe_non_grpc_test.go
+++ b/feature/security/gnsi/acctz/tests/record_subscribe_non_grpc/record_subscribe_non_grpc_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package recordsubscribenongrpc
+package recordsubscribenongrpc_test
 
 import (
 	"context"

--- a/feature/security/gnsi/acctz/tests/record_subscribe_partial/record_subscribe_partial_test.go
+++ b/feature/security/gnsi/acctz/tests/record_subscribe_partial/record_subscribe_partial_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package recordsubscribepartial
+package recordsubscribepartial_test
 
 import (
 	"context"

--- a/feature/security/gnsi/credentialz/tests/hiba_authentication/hiba_authentication_test.go
+++ b/feature/security/gnsi/credentialz/tests/hiba_authentication/hiba_authentication_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package hibaauthentication
+package hibaauthentication_test
 
 import (
 	"fmt"

--- a/feature/security/gnsi/credentialz/tests/host_certificates/host_certificates_test.go
+++ b/feature/security/gnsi/credentialz/tests/host_certificates/host_certificates_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package hostcertificates
+package hostcertificates_test
 
 import (
 	"fmt"

--- a/feature/security/gnsi/credentialz/tests/password_console_login/password_console_login_test.go
+++ b/feature/security/gnsi/credentialz/tests/password_console_login/password_console_login_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package passwordconsolelogin
+package passwordconsolelogin_test
 
 import (
 	"testing"

--- a/feature/security/gnsi/credentialz/tests/ssh_password_login_disallowed/ssh_password_login_disallowed_test.go
+++ b/feature/security/gnsi/credentialz/tests/ssh_password_login_disallowed/ssh_password_login_disallowed_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sshpasswordlogindisallowed
+package sshpasswordlogindisallowed_test
 
 import (
 	"context"

--- a/feature/security/gnsi/credentialz/tests/ssh_public_key_authentication/ssh_public_key_authentication_test.go
+++ b/feature/security/gnsi/credentialz/tests/ssh_public_key_authentication/ssh_public_key_authentication_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sshpublickeyauthentication
+package sshpublickeyauthentication_test
 
 import (
 	"os"


### PR DESCRIPTION
The package name config for each golang test package could have been more specified.

Supposedly this might fix the copy action into google's internal  repository?