### PR TITLE
AcctzPB fix - there were 2 definitions for 'acctz', that's bad.

### DIFF
--- a/feature/security/gnsi/acctz/tests/record_history_truncation/record_history_truncation_test.go
+++ b/feature/security/gnsi/acctz/tests/record_history_truncation/record_history_truncation_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/openconfig/featureprofiles/internal/fptest"
+	acctzpb "github.com/openconfig/gnsi/acctz"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -46,7 +47,7 @@ func TestAccountzRecordHistoryTruncation(t *testing.T) {
 		t.Fatalf("Failed getting accountz record subscribe client, error: %s", err)
 	}
 
-	err = acctzSubClient.Send(&acctz.RecordRequest{
+	err = acctzSubClient.Send(&acctzpb.RecordRequest{
 		Timestamp: timestamppb.New(recordStartTime),
 	})
 	if err != nil {

--- a/feature/security/gnsi/acctz/tests/record_history_truncation/record_history_truncation_test.go
+++ b/feature/security/gnsi/acctz/tests/record_history_truncation/record_history_truncation_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/openconfig/featureprofiles/internal/fptest"
-	"github.com/openconfig/gnsi/acctz"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/feature/security/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
+++ b/feature/security/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/openconfig/featureprofiles/internal/fptest"
-	"github.com/openconfig/gnsi/acctz"
+	acctzpb "github.com/openconfig/gnsi/acctz"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
@@ -33,7 +33,7 @@ func TestMain(m *testing.M) {
 }
 
 type recordRequestResult struct {
-	record *acctz.RecordResponse
+	record *acctzpb.RecordResponse
 	err    error
 }
 
@@ -66,7 +66,7 @@ func TestAccountzRecordPayloadTruncation(t *testing.T) {
 		t.Fatalf("Failed getting accountz record subscribe client, error: %s", err)
 	}
 
-	err = acctzSubClient.Send(&acctz.RecordRequest{
+	err = acctzSubClient.Send(&acctzpb.RecordRequest{
 		Timestamp: timestamppb.New(startTime),
 	})
 	if err != nil {
@@ -77,7 +77,7 @@ func TestAccountzRecordPayloadTruncation(t *testing.T) {
 		r := make(chan recordRequestResult)
 
 		go func(r chan recordRequestResult) {
-			var response *acctz.RecordResponse
+			var response *acctzpb.RecordResponse
 			response, err = acctzSubClient.Recv()
 			r <- recordRequestResult{
 				record: response,
@@ -105,7 +105,7 @@ func TestAccountzRecordPayloadTruncation(t *testing.T) {
 
 		grpcServiceRecord := resp.record.GetGrpcService()
 
-		if grpcServiceRecord.GetServiceType() != acctz.GrpcService_GRPC_SERVICE_TYPE_GNMI {
+		if grpcServiceRecord.GetServiceType() != acctzpb.GrpcService_GRPC_SERVICE_TYPE_GNMI {
 			// Not our gnmi set, nothing to see here.
 			continue
 		}


### PR DESCRIPTION
Set the PB versions of the import to use an alias: acctzpb
Leave the featureprofile version of acctz alone.