### PR TITLE
fix linkbw_any regex

### DIFF
--- a/feature/bgp/policybase/otg_tests/link_bandwidth_test/link_bandwidth_test.go
+++ b/feature/bgp/policybase/otg_tests/link_bandwidth_test/link_bandwidth_test.go
@@ -114,13 +114,13 @@ var (
 	extCommunitySet = map[string]string{
 		"linkbw_1M":  "link-bandwidth:23456:1M",
 		"linkbw_2G":  "link-bandwidth:23456:2G",
-		"linkbw_any": "^link-bandwidth:.*:.$",
+		"linkbw_any": "^link-bandwidth:.*:.*$",
 	}
 
 	extCommunitySetCisco = map[string]string{
 		"linkbw_1M":  "23456:1000000",
 		"linkbw_2G":  "23456:2000000000",
-		"linkbw_any": "^.*:.$",
+		"linkbw_any": "^.*:.*$",
 	}
 
 	CommunitySet = map[string]string{


### PR DESCRIPTION
earlier regex matches only single char for bandwidth.  Now it will match any number of chars in the bandwidth portion of the community