### PR TITLE
updated metadata for nokia with deviations

### DIFF
--- a/feature/gribi/otg_tests/basic_encap_test/basic_encap_test.go
+++ b/feature/gribi/otg_tests/basic_encap_test/basic_encap_test.go
@@ -578,8 +578,6 @@ func getPbrRules(dut *ondatra.DUTDevice, clusterFacing bool) []pbrRule {
 		pbrRules = append(pbrRules, encapRules...)
 	}
 
-	pbrRules = append(pbrRules, splitDefaultClassRules...)
-
 	if deviations.PfRequireMatchDefaultRule(dut) {
 		pbrRules = append(pbrRules, splitDefaultClassRules...)
 	} else {
@@ -803,6 +801,13 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	// configure base PBF policies and network-instances
 	configureBaseconfig(t, dut)
 
+	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
+		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p3.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p4.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p5.Name(), deviations.DefaultNetworkInstance(dut), 0)
+	}
 	// apply PBF to src interface.
 	applyForwardingPolicy(t, dut, p1.Name())
 	if deviations.GRIBIMACOverrideWithStaticARP(dut) {

--- a/feature/gribi/otg_tests/basic_encap_test/metadata.textproto
+++ b/feature/gribi/otg_tests/basic_encap_test/metadata.textproto
@@ -38,4 +38,15 @@ platform_exceptions:  {
     omit_l2_mtu: true
   }
 }
+platform_exceptions:  {
+  platform:  {
+    vendor: NOKIA
+  }
+  deviations:  {
+    interface_enabled: true
+    explicit_interface_in_default_vrf: true
+    static_protocol_name: "static"
+    ttl_copy_unsupported: true
+  }
+}
 tags:  TAGS_DATACENTER_EDGE


### PR DESCRIPTION
updated metadata with deviations for nokia
added code to add itnerfaces into default vrf with deviation removed the duplicate append in pbf rules

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."