### PR TITLE
RT-1.54 bgp_override_as_path_split_horizon_test.go

### DIFF
--- a/feature/bgp/otg_tests/bgp_override_as_path_split_horizon_test/bgp_override_as_path_split_horizon_test.go
+++ b/feature/bgp/otg_tests/bgp_override_as_path_split_horizon_test/bgp_override_as_path_split_horizon_test.go
@@ -242,7 +242,7 @@ func configureRoutePolicy(t *testing.T, dut *ondatra.DUTDevice, name string, pr 
 		t.Fatalf("AppendNewStatement(%s) failed: %v", name, err)
 	}
 	stmt.GetOrCreateActions().PolicyResult = pr
-	// stmt.GetOrCreateConditions().InstallProtocolEq = oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP
+	stmt.GetOrCreateConditions().InstallProtocolEq = oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP
 	gnmi.Update(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
 
 }


### PR DESCRIPTION
Hi,


Fixing issue with route policy, it was commented out in previous git pull.
If we dont add condition install protocol eq to BGP, all direct routes will be installed and sent prefixes does not match.

Thanks,
Prabha