### PR TITLE
🧹: Clean up `CODEOWNERS` to reflect approvers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,9 +6,9 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @openconfig/featureprofiles-maintainers will be requested for
+# @openconfig/featureprofiles-approvers will be requested for
 # review when someone opens a pull request.
-*       @openconfig/featureprofiles-maintainers
+*       @openconfig/featureprofiles-approvers
 
 # /feature folders each have owners who are auto requested for review and may merge PR's
 /feature/acl/          @alokmtri-g

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 /feature/qos                 @sezhang2
 /feature/routing_policy/     @swetha-haridasula
 /feature/sampling/           @sudhinj
-/feature/security            @mihirpitale-googler
+/feature/security            @mihirpitale-googler @morrowc
 /feature/staticroute/        @swetha-haridasula
 /feature/stp/                @alokmtri-g
 /feature/system              @swetha-haridasula


### PR DESCRIPTION
```
commit e7aa0b4e6e5baf2b3312d92ad733e0b879b0b452
Author: Rob Shakir <robjs@google.com>
Date:   Tue Dec 17 12:06:46 2024 -0800

    Add @morrowc as a security codeowner.
    
     * (M) .github/CODEOWNERS
      - annoint @morrowc as a security codeowner.

commit ea2f92bd745fb9170267a5c52c269069309f8d7e
Author: Rob Shakir <robjs@google.com>
Date:   Tue Dec 17 12:04:39 2024 -0800

    🧹: housekeeping to ensure well-scoped CODEOWNERS.
    
     * (M) .github/CODEOWNERS
      - `s/featureprofiles-maintainers/featureprofiles-approvers/g` to
        have a clear group of folks that are the default CODEOWNERS.
```
