### PR TITLE
Adding deviation for rate class unsupport option for the ETH channel configuration

### DIFF
--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -162,26 +162,14 @@ func ConfigETHChannel(t *testing.T, dut *ondatra.DUTDevice, interfaceName, trans
 			},
 		}
 	}
-	var channel *oc.TerminalDevice_Channel
-	if deviations.ChannelRateClassParametersUnsupported(dut) {
-		channel = &oc.TerminalDevice_Channel{
-			Description:        ygot.String("ETH Logical Channel"),
-			Index:              ygot.Uint32(ethIndex),
-			LogicalChannelType: oc.TransportTypes_LOGICAL_ELEMENT_PROTOCOL_TYPE_PROT_ETHERNET,
-			TribProtocol:       oc.TransportTypes_TRIBUTARY_PROTOCOL_TYPE_PROT_400GE,
-			Ingress:            ingress,
-			Assignment:         assignment,
-		}
-	} else {
-		channel = &oc.TerminalDevice_Channel{
-			Description:        ygot.String("ETH Logical Channel"),
-			Index:              ygot.Uint32(ethIndex),
-			LogicalChannelType: oc.TransportTypes_LOGICAL_ELEMENT_PROTOCOL_TYPE_PROT_ETHERNET,
-			TribProtocol:       oc.TransportTypes_TRIBUTARY_PROTOCOL_TYPE_PROT_400GE,
-			RateClass:          oc.TransportTypes_TRIBUTARY_RATE_CLASS_TYPE_TRIB_RATE_400G,
-			Ingress:            ingress,
-			Assignment:         assignment,
-		}
+	channel = &oc.TerminalDevice_Channel{
+		Description:        ygot.String("ETH Logical Channel"),
+		Index:              ygot.Uint32(ethIndex),
+		LogicalChannelType: oc.TransportTypes_LOGICAL_ELEMENT_PROTOCOL_TYPE_PROT_ETHERNET,
+		TribProtocol:       oc.TransportTypes_TRIBUTARY_PROTOCOL_TYPE_PROT_400GE,
+		RateClass:          oc.TransportTypes_TRIBUTARY_RATE_CLASS_TYPE_TRIB_RATE_400G,
+		Ingress:            ingress,
+		Assignment:         assignment,
 	}
 	gnmi.Replace(t, dut, gnmi.OC().TerminalDevice().Channel(ethIndex).Config(), channel)
 }

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -173,7 +173,7 @@ func ConfigETHChannel(t *testing.T, dut *ondatra.DUTDevice, interfaceName, trans
 			Assignment:         assignment,
 		}
 	} else {
-		channel := &oc.TerminalDevice_Channel{
+		channel = &oc.TerminalDevice_Channel{
 			Description:        ygot.String("ETH Logical Channel"),
 			Index:              ygot.Uint32(ethIndex),
 			LogicalChannelType: oc.TransportTypes_LOGICAL_ELEMENT_PROTOCOL_TYPE_PROT_ETHERNET,

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -162,14 +162,26 @@ func ConfigETHChannel(t *testing.T, dut *ondatra.DUTDevice, interfaceName, trans
 			},
 		}
 	}
-	channel := &oc.TerminalDevice_Channel{
-		Description:        ygot.String("ETH Logical Channel"),
-		Index:              ygot.Uint32(ethIndex),
-		LogicalChannelType: oc.TransportTypes_LOGICAL_ELEMENT_PROTOCOL_TYPE_PROT_ETHERNET,
-		TribProtocol:       oc.TransportTypes_TRIBUTARY_PROTOCOL_TYPE_PROT_400GE,
-		RateClass:          oc.TransportTypes_TRIBUTARY_RATE_CLASS_TYPE_TRIB_RATE_400G,
-		Ingress:            ingress,
-		Assignment:         assignment,
+	var channel *oc.TerminalDevice_Channel
+	if deviations.ChannelRateClassParametersUnsupported(dut) {
+		channel = &oc.TerminalDevice_Channel{
+			Description:        ygot.String("ETH Logical Channel"),
+			Index:              ygot.Uint32(ethIndex),
+			LogicalChannelType: oc.TransportTypes_LOGICAL_ELEMENT_PROTOCOL_TYPE_PROT_ETHERNET,
+			TribProtocol:       oc.TransportTypes_TRIBUTARY_PROTOCOL_TYPE_PROT_400GE,
+			Ingress:            ingress,
+			Assignment:         assignment,
+		}
+	} else {
+		channel := &oc.TerminalDevice_Channel{
+			Description:        ygot.String("ETH Logical Channel"),
+			Index:              ygot.Uint32(ethIndex),
+			LogicalChannelType: oc.TransportTypes_LOGICAL_ELEMENT_PROTOCOL_TYPE_PROT_ETHERNET,
+			TribProtocol:       oc.TransportTypes_TRIBUTARY_PROTOCOL_TYPE_PROT_400GE,
+			RateClass:          oc.TransportTypes_TRIBUTARY_RATE_CLASS_TYPE_TRIB_RATE_400G,
+			Ingress:            ingress,
+			Assignment:         assignment,
+		}
 	}
 	gnmi.Replace(t, dut, gnmi.OC().TerminalDevice().Channel(ethIndex).Config(), channel)
 }

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -162,14 +162,26 @@ func ConfigETHChannel(t *testing.T, dut *ondatra.DUTDevice, interfaceName, trans
 			},
 		}
 	}
-	channel = &oc.TerminalDevice_Channel{
-		Description:        ygot.String("ETH Logical Channel"),
-		Index:              ygot.Uint32(ethIndex),
-		LogicalChannelType: oc.TransportTypes_LOGICAL_ELEMENT_PROTOCOL_TYPE_PROT_ETHERNET,
-		TribProtocol:       oc.TransportTypes_TRIBUTARY_PROTOCOL_TYPE_PROT_400GE,
-		RateClass:          oc.TransportTypes_TRIBUTARY_RATE_CLASS_TYPE_TRIB_RATE_400G,
-		Ingress:            ingress,
-		Assignment:         assignment,
+	var channel *oc.TerminalDevice_Channel
+	if deviations.ChannelRateClassParametersUnsupported(dut) {
+		channel = &oc.TerminalDevice_Channel{
+			Description:        ygot.String("ETH Logical Channel"),
+			Index:              ygot.Uint32(ethIndex),
+			LogicalChannelType: oc.TransportTypes_LOGICAL_ELEMENT_PROTOCOL_TYPE_PROT_ETHERNET,
+			TribProtocol:       oc.TransportTypes_TRIBUTARY_PROTOCOL_TYPE_PROT_400GE,
+			Ingress:            ingress,
+			Assignment:         assignment,
+		}
+	} else {
+		channel = &oc.TerminalDevice_Channel{
+			Description:        ygot.String("ETH Logical Channel"),
+			Index:              ygot.Uint32(ethIndex),
+			LogicalChannelType: oc.TransportTypes_LOGICAL_ELEMENT_PROTOCOL_TYPE_PROT_ETHERNET,
+			TribProtocol:       oc.TransportTypes_TRIBUTARY_PROTOCOL_TYPE_PROT_400GE,
+			RateClass:          oc.TransportTypes_TRIBUTARY_RATE_CLASS_TYPE_TRIB_RATE_400G,
+			Ingress:            ingress,
+			Assignment:         assignment,
+		}
 	}
 	gnmi.Replace(t, dut, gnmi.OC().TerminalDevice().Channel(ethIndex).Config(), channel)
 }

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1243,8 +1243,3 @@ func EnableTableConnections(dut *ondatra.DUTDevice) bool {
 func NoZeroSuppression(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetNoZeroSuppression()
 }
-
-// ChannelRateClassParametersUnsupported returns true if channel rate class parameters are unsupported
-func ChannelRateClassParametersUnsupported(dut *ondatra.DUTDevice) bool {
-	return lookupDUTDeviations(dut).GetChannelAssignmentRateClassParametersUnsupported()
-}

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1243,3 +1243,8 @@ func EnableTableConnections(dut *ondatra.DUTDevice) bool {
 func NoZeroSuppression(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetNoZeroSuppression()
 }
+
+// ChannelRateClassParametersUnsupported returns true if channel rate class parameters are unsupported
+func ChannelRateClassParametersUnsupported(dut *ondatra.DUTDevice) bool {
+	return lookupDUTDeviations(dut).GetChannelAssignmentRateClassParametersUnsupported()
+}


### PR DESCRIPTION
Arista does not support rate class setting yet, hence adding a deviation in the ConfigETHChannel function in the interface.go file as well as the corresponding changes in the deviations.go file.