### PR TITLE
Bug fixes: 1) time.Duration function wrong unit; 2) transceiver disable OC path

### DIFF
--- a/feature/platform/transceiver/tests/zr_laser_bias_current_test/zr_laser_bias_current_test.go
+++ b/feature/platform/transceiver/tests/zr_laser_bias_current_test/zr_laser_bias_current_test.go
@@ -155,10 +155,11 @@ func TestZRLaserBiasCurrentStateTransceiverOnOff(t *testing.T) {
 	verifyLaserBiasCurrentAll(t, p1Stream, dut1)
 	// power off interface transceiver
 	gnmi.Update(t, dut1, gnmi.OC().Component(dp1.Name()).Name().Config(), dp1.Name())
-	gnmi.Update(t, dut1, gnmi.OC().Component(dp1.Name()).Transceiver().Enabled().Config(), false)
+	// for transceiver disable, the input needs to be the transceiver name instead of the interface name
+	gnmi.Update(t, dut1, gnmi.OC().Component(transceiverState).Transceiver().Enabled().Config(), false)
 	verifyLaserBiasCurrentAll(t, p1Stream, dut1)
 	// power on interface transceiver
-	gnmi.Update(t, dut1, gnmi.OC().Component(dp1.Name()).Transceiver().Enabled().Config(), true)
+	gnmi.Update(t, dut1, gnmi.OC().Component(transceiverState).Transceiver().Enabled().Config(), true)
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
 	verifyLaserBiasCurrentAll(t, p1Stream, dut1)
 }

--- a/feature/platform/transceiver/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
+++ b/feature/platform/transceiver/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
@@ -130,7 +130,7 @@ func TestLowPowerMode(t *testing.T) {
 
 			validateStreamOutput(t, allStream)
 			opticalChannelName := components.OpticalChannelComponentFromPort(t, dut, dp)
-			samplingInterval = time.Duration(gnmi.Get(t, dut, gnmi.OC().Component(opticalChannelName).OpticalChannel().OutputPower().Interval().State()))
+			samplingInterval = time.Duration(gnmi.Get(t, dut, gnmi.OC().Component(opticalChannelName).OpticalChannel().OutputPower().Interval().State())) * time.Second
 			opInst := samplestream.New(t, dut, gnmi.OC().Component(opticalChannelName).OpticalChannel().OutputPower().Instant().State(), samplingInterval)
 			defer opInst.Close()
 			if opInstN := opInst.Next(); opInstN != nil {


### PR DESCRIPTION
bug fixes: 1) in zr_laser_bias_current_test file, the time.Duration function returns value in nanosecond by default, needs to convert it to second; 2) in zr_low_power_mode_test file, to use the transceiver disable OC path, the input needs to be transceiver name instead of interface name.