### PR TITLE
system_base_test: run TestGNMIClient for defined path

### DIFF
--- a/feature/system/system_base_test/tests/system_g_protocol_test/metadata.textproto
+++ b/feature/system/system_base_test/tests/system_g_protocol_test/metadata.textproto
@@ -22,3 +22,11 @@ platform_exceptions: {
     gnmi_get_on_root_unsupported: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: ARISTA
+  }
+  deviations: {
+    gnmi_get_on_root_unsupported: true
+  }
+}


### PR DESCRIPTION
In PR #2855 the commit
https://github.com/openconfig/featureprofiles/commit/87f3397bc322ec35e34a470cd793b070db882e63 made a change to the path being requested when the  connection is being tested. 
Previously an empty GetRequest was being sent, which meant that the GetResponse would also be empty. 
This was changed so that now the test is requesting the root node.

However, its possible that the GetResponse for the root node is larger than the maximum response size for which the client is configured (i.e. the gRPC  default max response size of 4MiB)

To get around this we should run the request to a defined path so that we are guaranteed a small response. The response is ignored anyway, so it doesnt matter what path we request here.

Use the `gnmi_get_on_root_unsupported` introduced in https://github.com/openconfig/featureprofiles/pull/2605 to avoid performing a get on the root node