### PR TITLE
Updated go script to include new Accountz proto changes

### DIFF
--- a/feature/security/gnsi/acctz/tests/record_history_truncation/record_history_truncation_test.go
+++ b/feature/security/gnsi/acctz/tests/record_history_truncation/record_history_truncation_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 	"time"
-        "fmt"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	acctzpb "github.com/openconfig/gnsi/acctz"
 	"github.com/openconfig/ondatra"

--- a/feature/security/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
+++ b/feature/security/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
@@ -57,21 +57,19 @@ func sendOversizedPayload(t *testing.T, dut *ondatra.DUTDevice) {
 
 func TestAccountzRecordPayloadTruncation(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
-	startTime := time.Now()
 	sendOversizedPayload(t, dut)
-	acctzClient := dut.RawAPIs().GNSI(t).Acctz()
+        requestTimestamp := &timestamppb.Timestamp{
+                Seconds:  0,
+                Nanos:   0, 
+        }
 
-	acctzSubClient, err := acctzClient.RecordSubscribe(context.Background())
-	if err != nil {
-		t.Fatalf("Failed getting accountz record subscribe client, error: %s", err)
-	}
+        acctzClient := dut.RawAPIs().GNSI(t).AcctzStream()
 
-	err = acctzSubClient.Send(&acctzpb.RecordRequest{
-		Timestamp: timestamppb.New(startTime),
-	})
-	if err != nil {
-		t.Fatalf("Failed sending record request, error: %s", err)
-	}
+        acctzSubClient, err := acctzClient.RecordSubscribe(context.Background(), &acctzpb.RecordRequest{Timestamp: requestTimestamp})
+
+        if err != nil {
+                t.Fatalf("Failed getting accountz record subscribe client, error: %s", err)
+        }
 
 	for {
 		r := make(chan recordRequestResult)


### PR DESCRIPTION
Existing Accountz script for history truncation verification had deprecated proto API usage w.r.t accountz. 
Updated the APIs to use latest proto based accountz apis.