### PR TITLE
Create README for Storage-1.1: Storage File System Check

### DIFF
--- a/feature/platform/storage/README.md
+++ b/feature/platform/storage/README.md
@@ -13,11 +13,17 @@ Storage File System Check
 * For each mountpoint collect and verify if the following path returns valid values
 
   *  /components/component/storage/state/counters/soft-read-error-rate:
+     The response returned must ideally be 0, throw a warning message for any other floating point number
   *  /components/component/storage/state/counters/reallocated-sectors:
+     Check if the response is an integer 
   *  /components/component/storage/state/counters/end-to-end-error:
+     Check if the response is an integer  
   *  /components/component/storage/state/counters/offline-uncorrectable-sectors-count:
+     The value returned must ideally be 0, thorw a warning message for any other other integer
   *  /components/component/storage/state/counters/life-left:
+     Check if the response is an integer 
   *  /components/component/storage/state/counters/percentage-used:
+     The response returned must be an integer, thorw a warning message if utilization is greater than the threshold
 
   
 ## OpenConfig Path and RPC Coverage

--- a/feature/platform/storage/README.md
+++ b/feature/platform/storage/README.md
@@ -12,12 +12,12 @@ Storage File System Check
 
 * For each mountpoint collect and verify if the following path returns valid values
 
-  *  /components/component/storage/state/counters/soft-read-error-rate:
-  *  /components/component/storage/state/counters/reallocated-sectors:
-  *  /components/component/storage/state/counters/end-to-end-error:
-  *  /components/component/storage/state/counters/offline-uncorrectable-sectors-count:
-  *  /components/component/storage/state/counters/life-left:
-  *  /components/component/storage/state/counters/percentage-used:
+  *  /components/component[name=STORAGE]/state/counters/soft-read-error-rate:
+  *  /components/component[name=STORAGE]/state/counters/reallocated-sectors:
+  *  /components/component[name=STORAGE]/state/counters/end-to-end-error:
+  *  /components/component[name=STORAGE]/state/counters/offline-uncorrectable-sectors-count:
+  *  /components/component[name=STORAGE]/state/counters/life-left:
+  *  /components/component[name=STORAGE]/state/counters/percentage-used:
 
   
 ## OpenConfig Path and RPC Coverage
@@ -26,12 +26,12 @@ Storage File System Check
 
 paths:
 
-  /components/component/storage/state/counters/soft-read-error-rate:
-  /components/component/storage/state/counters/reallocated-sectors:
-  /components/component/storage/state/counters/end-to-end-error:
-  /components/component/storage/state/counters/offline-uncorrectable-sectors-count:
-  /components/component/storage/state/counters/life-left:
-  /components/component/storage/state/counters/percentage-used:
+  /components/component[name=STORAGE]/storage/state/counters/soft-read-error-rate:
+  /components/component[name=STORAGE]/storage/state/counters/reallocated-sectors:
+  /components/component[name=STORAGE]/storage/state/counters/end-to-end-error:
+  /components/component[name=STORAGE]/state/counters/offline-uncorrectable-sectors-count:
+  /components/component[name=STORAGE]/state/counters/life-left:
+  /components/component[name=STORAGE]/state/counters/percentage-used:
 
 
 rpcs:

--- a/feature/platform/storage/README.md
+++ b/feature/platform/storage/README.md
@@ -10,21 +10,20 @@ Storage File System Check
 
 ## Procedure
 
-* For each mountpoint collect and verify if the following path returns valid values
+* For each storage file system collect and verify if the following path are not empty and returns valid values. Log the values returned. 
 
   *  /components/component/storage/state/counters/soft-read-error-rate:
-     The response returned must ideally be 0, throw a warning message for any other floating point number
+     Check if the response is a counter64
   *  /components/component/storage/state/counters/reallocated-sectors:
-     Check if the response is an integer 
+     Check if the response is a counter64
   *  /components/component/storage/state/counters/end-to-end-error:
-     Check if the response is an integer  
+     Check if the response is a counter64
   *  /components/component/storage/state/counters/offline-uncorrectable-sectors-count:
-     The value returned must ideally be 0, thorw a warning message for any other other integer
+     Check if the response is a counter64
   *  /components/component/storage/state/counters/life-left:
      Check if the response is an integer 
   *  /components/component/storage/state/counters/percentage-used:
-     The response returned must be an integer, thorw a warning message if utilization is greater than the threshold
-
+     Check if the response is an integer 
   
 ## OpenConfig Path and RPC Coverage
 

--- a/feature/platform/storage/README.md
+++ b/feature/platform/storage/README.md
@@ -1,0 +1,42 @@
+# Storage-1.1: Storage File System Check
+
+## Summary
+
+Storage File System Check
+
+## Testbed type
+
+*    dut.testbed
+
+## Procedure
+
+* For each mountpoint collect and verify if the following path returns valid values
+
+  *  /components/component/storage/state/counters/soft-read-error-rate:
+  *  /components/component/storage/state/counters/reallocated-sectors:
+  *  /components/component/storage/state/counters/end-to-end-error:
+  *  /components/component/storage/state/counters/offline-uncorrectable-sectors-count:
+  *  /components/component/storage/state/counters/life-left:
+  *  /components/component/storage/state/counters/percentage-used:
+
+  
+## OpenConfig Path and RPC Coverage
+
+```yaml
+
+paths:
+
+  /components/component/storage/state/counters/soft-read-error-rate:
+  /components/component/storage/state/counters/reallocated-sectors:
+  /components/component/storage/state/counters/end-to-end-error:
+  /components/component/storage/state/counters/offline-uncorrectable-sectors-count:
+  /components/component/storage/state/counters/life-left:
+  /components/component/storage/state/counters/percentage-used:
+
+
+rpcs:
+  gnmi:
+    gNMI.Get:
+```
+## Required DUT platform
+Single DUT

--- a/feature/platform/storage/README.md
+++ b/feature/platform/storage/README.md
@@ -27,11 +27,17 @@ Storage File System Check
 paths:
 
   /components/component/storage/state/counters/soft-read-error-rate:
+   platform_type: [ "STORAGE" ]
   /components/component/storage/state/counters/reallocated-sectors:
+   platform_type: [ "STORAGE" ]
   /components/component/storage/state/counters/end-to-end-error:
+   platform_type: [ "STORAGE" ]
   /components/component/storage/state/counters/offline-uncorrectable-sectors-count:
+   platform_type: [ "STORAGE" ]
   /components/component/storage/state/counters/life-left:
+   platform_type: [ "STORAGE" ]
   /components/component/storage/state/counters/percentage-used:
+   platform_type: [ "STORAGE" ]
 
 
 rpcs:

--- a/feature/platform/storage/README.md
+++ b/feature/platform/storage/README.md
@@ -12,12 +12,12 @@ Storage File System Check
 
 * For each mountpoint collect and verify if the following path returns valid values
 
-  *  /components/component[name=STORAGE]/state/counters/soft-read-error-rate:
-  *  /components/component[name=STORAGE]/state/counters/reallocated-sectors:
-  *  /components/component[name=STORAGE]/state/counters/end-to-end-error:
-  *  /components/component[name=STORAGE]/state/counters/offline-uncorrectable-sectors-count:
-  *  /components/component[name=STORAGE]/state/counters/life-left:
-  *  /components/component[name=STORAGE]/state/counters/percentage-used:
+  *  /components/component/storage/state/counters/soft-read-error-rate:
+  *  /components/component/storage/state/counters/reallocated-sectors:
+  *  /components/component/storage/state/counters/end-to-end-error:
+  *  /components/component/storage/state/counters/offline-uncorrectable-sectors-count:
+  *  /components/component/storage/state/counters/life-left:
+  *  /components/component/storage/state/counters/percentage-used:
 
   
 ## OpenConfig Path and RPC Coverage
@@ -26,12 +26,12 @@ Storage File System Check
 
 paths:
 
-  /components/component[name=STORAGE]/storage/state/counters/soft-read-error-rate:
-  /components/component[name=STORAGE]/storage/state/counters/reallocated-sectors:
-  /components/component[name=STORAGE]/storage/state/counters/end-to-end-error:
-  /components/component[name=STORAGE]/state/counters/offline-uncorrectable-sectors-count:
-  /components/component[name=STORAGE]/state/counters/life-left:
-  /components/component[name=STORAGE]/state/counters/percentage-used:
+  /components/component/storage/state/counters/soft-read-error-rate:
+  /components/component/storage/state/counters/reallocated-sectors:
+  /components/component/storage/state/counters/end-to-end-error:
+  /components/component/storage/state/counters/offline-uncorrectable-sectors-count:
+  /components/component/storage/state/counters/life-left:
+  /components/component/storage/state/counters/percentage-used:
 
 
 rpcs:


### PR DESCRIPTION
The README is to verify the below storage OC paths. 

/components/component/storage/state/counters
/components/component/storage/state/counters/soft-read-error-rate
/components/component/storage/state/counters/reallocated-sectors
/components/component/storage/state/counters/end-to-end-error
/components/component/storage/state/counters/offline-uncorrectable-sectors-count
/components/component/storage/state/counters/life-left
/components/component/storage/state/counters/percentage-used
