### PR TITLE
RT-1.28: Invert the verification for removal testcases

### DIFF
--- a/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
+++ b/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
@@ -486,8 +486,8 @@ func verifyNonMatchingCommunityTelemetry(t *testing.T, dut *ondatra.DUTDevice, a
 	}
 
 	_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().ExtendedIpv4Reachability().Prefix(advertisedIPv4.address).State(), 30*time.Second, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_ExtendedIpv4Reachability_Prefix]) bool {
-		prefix, present := v.Val()
-		return present && prefix.GetPrefix() == advertisedIPv4.address
+		_, present := v.Val()
+		return !present
 	}).Await(t)
 	if ok {
 		t.Errorf("Prefix found, not want: %s", advertisedIPv4.address)
@@ -699,8 +699,8 @@ func verifyNonMatchingCommunityTelemetryV6(t *testing.T, dut *ondatra.DUTDevice,
 	}
 
 	_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(advertisedIPv6.address).State(), 60*time.Second, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_Ipv6Reachability_Prefix]) bool {
-		prefix, present := v.Val()
-		return present && prefix.GetPrefix() == advertisedIPv6.address
+		_, present := v.Val()
+		return !present
 	}).Await(t)
 	if ok {
 		t.Errorf("Prefix found, not want: %s", advertisedIPv6.address)


### PR DESCRIPTION
The testcase was waiting for the prefix to exist, but checking for it to NOT exist. It would fail when the prefix hasn't been removed by the time Await() function gets called. The fix is to invert the check and wait for the prefix removal.