### PR TITLE
Adding defer () function to flush all entries before exit

### DIFF
--- a/feature/gribi/otg_tests/gribigo_compliance_test/gribigo_compliance_test.go
+++ b/feature/gribi/otg_tests/gribigo_compliance_test/gribigo_compliance_test.go
@@ -224,6 +224,14 @@ func testAdditionalCompliance(tcArgs *testArgs, t *testing.T) {
 			fn:   addNHGReferencingToDownPort,
 		},
 	}
+
+	defer func() {
+		// Flush all entries after test.
+		if err := gribi.FlushAll(tcArgs.client); err != nil {
+			t.Error(err)
+		}
+	}()
+
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			if err := gribi.FlushAll(tcArgs.client); err != nil {


### PR DESCRIPTION
gribigo_compliance_test.go 
 - entries with rib fib ack were not cleaned up
 -  Adding defer () function to flush all entries before exit