### PR TITLE
AnCX tests correction

### DIFF
--- a/feature/bgp/otg_tests/bgp_override_as_path_split_horizon_test/bgp_override_as_path_split_horizon_test.go
+++ b/feature/bgp/otg_tests/bgp_override_as_path_split_horizon_test/bgp_override_as_path_split_horizon_test.go
@@ -240,7 +240,6 @@ func configureRoutePolicy(t *testing.T, dut *ondatra.DUTDevice, name string, pr 
 		t.Fatalf("AppendNewStatement(%s) failed: %v", name, err)
 	}
 	stmt.GetOrCreateActions().PolicyResult = pr
-	stmt.GetOrCreateConditions().InstallProtocolEq = oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP
 	gnmi.Update(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
 
 }

--- a/feature/isis/otg_tests/isis_interface_hello_padding_enable_test/isis_interface_hello_padding_enable_test.go
+++ b/feature/isis/otg_tests/isis_interface_hello_padding_enable_test/isis_interface_hello_padding_enable_test.go
@@ -400,7 +400,7 @@ func TestIsisInterfaceHelloPaddingEnable(t *testing.T) {
 		t.Run("Traffic checks", func(t *testing.T) {
 			t.Logf("Starting traffic")
 			otg.StartTraffic(t)
-			time.Sleep(time.Second * 15)
+			time.Sleep(time.Second * 30)
 			t.Logf("Stop traffic")
 			otg.StopTraffic(t)
 


### PR DESCRIPTION
bgp_override_as_path_split_horizon_test - Removed install-protocol-eq which is not needed
isis_interface_hello_padding_enable_test - Increasing timeout to avoid flakiness
