### PR TITLE
fix isis_interface_passive_test

### DIFF
--- a/feature/isis/otg_tests/isis_interface_passive_test/isis_interface_passive_test.go
+++ b/feature/isis/otg_tests/isis_interface_passive_test/isis_interface_passive_test.go
@@ -65,6 +65,7 @@ func configureISIS(t *testing.T, ts *isissession.TestSession) {
 
 	// Level configs.
 	level := isis.GetOrCreateLevel(2)
+	level.LevelNumber = ygot.Uint8(2)
 
 	// Authentication configs.
 	auth := level.GetOrCreateAuthentication()
@@ -95,6 +96,9 @@ func configureISIS(t *testing.T, ts *isissession.TestSession) {
 
 	// Interface level configs.
 	isisIntfLevel := intf.GetOrCreateLevel(2)
+	isisIntfLevel.LevelNumber = ygot.Uint8(2)
+	isisIntfLevel.SetEnabled(true)
+	isisIntfLevel.Enabled = ygot.Bool(true)
 	isisIntfLevel.GetOrCreateHelloAuthentication().Enabled = ygot.Bool(true)
 	isisIntfLevel.GetHelloAuthentication().AuthPassword = ygot.String(password)
 	isisIntfLevel.GetHelloAuthentication().AuthType = oc.KeychainTypes_AUTH_TYPE_SIMPLE_KEY
@@ -197,8 +201,10 @@ func TestIsisInterfacePassive(t *testing.T) {
 			}
 			// Checking dis system id.
 			if !deviations.MissingValueForDefaults(ts.DUT) {
-				if got := gnmi.Get(t, ts.DUT, adjPath.DisSystemId().State()); got != "0000.0000.0000" {
-					t.Errorf("FAIL- Expected dis system id not found, got %s, want %s", got, "0000.0000.0000")
+				if !deviations.IsisDisSysidUnsupported(ts.DUT) {
+					if got := gnmi.Get(t, ts.DUT, adjPath.DisSystemId().State()); got != "0000.0000.0000" {
+						t.Errorf("FAIL- Expected dis system id not found, got %s, want %s", got, "0000.0000.0000")
+					}
 				}
 			}
 			// Checking isis local extended circuit id.
@@ -279,8 +285,10 @@ func TestIsisInterfacePassive(t *testing.T) {
 			}
 			// Checking database_overloads counters.
 			if !deviations.MissingValueForDefaults(ts.DUT) {
-				if got := gnmi.Get(t, ts.DUT, statePath.Level(2).SystemLevelCounters().DatabaseOverloads().State()); got != 0 {
-					t.Errorf("FAIL- Not expecting non zero database_overloads, got %d, want %d", got, 0)
+				if !deviations.IsisDatabaseOverloadsUnsupported(ts.DUT) {
+					if got := gnmi.Get(t, ts.DUT, statePath.Level(2).SystemLevelCounters().DatabaseOverloads().State()); got != 0 {
+						t.Errorf("FAIL- Not expecting non zero database_overloads, got %d, want %d", got, 0)
+					}
 				}
 			}
 			// Checking execeeded maximum seq number counters").

--- a/feature/isis/otg_tests/isis_interface_passive_test/metadata.textproto
+++ b/feature/isis/otg_tests/isis_interface_passive_test/metadata.textproto
@@ -27,6 +27,9 @@ platform_exceptions: {
   deviations: {
     ipv4_missing_enabled: true
     isis_interface_level1_disable_required: true
+    isis_interface_level_passive_unsupported: true
+    isis_dis_sysid_unsupported: true
+    isis_database_overloads_unsupported: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
Fix isis enabling the level2 at the interface level and disabling level1.
 
