### PR TITLE
Remove laser-bias-current avg, min, max from README

### DIFF
--- a/feature/platform/transceiver/laser_bias_current/tests/zr_laser_bias_current_test/README.md
+++ b/feature/platform/transceiver/laser_bias_current/tests/zr_laser_bias_current_test/README.md
@@ -33,9 +33,6 @@ specified operating temperature and voltage.
     the ZR optics
 
     *   /components/component/optical-channel/state/laser-bias-current/instant
-    *   /components/component/optical-channel/state/laser-bias-current/avg
-    *   /components/component/optical-channel/state/laser-bias-current/min
-    *   /components/component/optical-channel/state/laser-bias-current/max
 
 
 ## TRANSCEIVER-9.2
@@ -45,11 +42,6 @@ specified operating temperature and voltage.
 
 *   Laser bias current values must always be of type decimal64.
     When laser is in off state 0 must be reported as a valid value.
-
-**Note:** For min, max, and avg values, 10 second sampling is preferred. If the
-          min, max average values or the 10 seconds sampling is not supported,
-          the sampling interval used must be specified and this must be
-          captured by adding a deviation to the test.
 
 ## TRANSCEIVER-9.3
 
@@ -98,12 +90,6 @@ paths:
     /interfaces/interface/config/enabled:
     ## State Paths ##
     /components/component/optical-channel/state/laser-bias-current/instant:
-        platform_type: [ "OPTICAL_CHANNEL" ]
-    /components/component/optical-channel/state/laser-bias-current/avg:
-        platform_type: [ "OPTICAL_CHANNEL" ]
-    /components/component/optical-channel/state/laser-bias-current/min:
-        platform_type: [ "OPTICAL_CHANNEL" ]
-    /components/component/optical-channel/state/laser-bias-current/max:
         platform_type: [ "OPTICAL_CHANNEL" ]
     
 rpcs:

--- a/feature/platform/transceiver/laser_bias_current/tests/zrp_laser_bias_current_test/README.md
+++ b/feature/platform/transceiver/laser_bias_current/tests/zrp_laser_bias_current_test/README.md
@@ -33,9 +33,6 @@ specified operating temperature and voltage.
     the ZR_PLUS optics
 
     *   /components/component/optical-channel/state/laser-bias-current/instant
-    *   /components/component/optical-channel/state/laser-bias-current/avg
-    *   /components/component/optical-channel/state/laser-bias-current/min
-    *   /components/component/optical-channel/state/laser-bias-current/max
 
 
 ## TRANSCEIVER-9.2
@@ -45,11 +42,6 @@ specified operating temperature and voltage.
 
 *   Laser bias current values must always be of type decimal64.
     When laser is in off state 0 must be reported as a valid value.
-
-**Note:** For min, max, and avg values, 10 second sampling is preferred. If the
-          min, max average values or the 10 seconds sampling is not supported,
-          the sampling interval used must be specified and this must be
-          captured by adding a deviation to the test.
 
 ## TRANSCEIVER-9.3
 
@@ -98,12 +90,6 @@ paths:
     /interfaces/interface/config/enabled:
     ## State Paths ##
     /components/component/optical-channel/state/laser-bias-current/instant:
-        platform_type: [ "OPTICAL_CHANNEL" ]
-    /components/component/optical-channel/state/laser-bias-current/avg:
-        platform_type: [ "OPTICAL_CHANNEL" ]
-    /components/component/optical-channel/state/laser-bias-current/min:
-        platform_type: [ "OPTICAL_CHANNEL" ]
-    /components/component/optical-channel/state/laser-bias-current/max:
         platform_type: [ "OPTICAL_CHANNEL" ]
     
 rpcs:


### PR DESCRIPTION
since they are no longer required