### PR TITLE
g_protocol_test- added type config 

### DIFF
--- a/feature/system/system_base_test/tests/system_g_protocol_test/system_g_protocol_test.go
+++ b/feature/system/system_base_test/tests/system_g_protocol_test/system_g_protocol_test.go
@@ -76,7 +76,7 @@ func TestGNMIClient(t *testing.T) {
 			Encoding: gpb.Encoding_JSON_IETF,
 		}
 	} else {
-		req = &gpb.GetRequest{Encoding: gpb.Encoding_JSON_IETF, Path: []*gpb.Path{{Elem: []*gpb.PathElem{}}}}
+		req = &gpb.GetRequest{Encoding: gpb.Encoding_JSON_IETF, Path: []*gpb.Path{{Elem: []*gpb.PathElem{}}},Type: gpb.GetRequest_CONFIG}
 	}
 
 	if _, err := c.Get(context.Background(), req); err != nil {


### PR DESCRIPTION
Script was missing type config because of that it was failing, so added type config.