### PR TITLE
fixing some of the failures for Cisco related to routing-instance

### DIFF
--- a/feature/bgp/ate_tests/bgp_long_lived_graceful_restart/bgp_long_lived_graceful_restart_test.go
+++ b/feature/bgp/ate_tests/bgp_long_lived_graceful_restart/bgp_long_lived_graceful_restart_test.go
@@ -268,8 +268,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	gnmi.Replace(t, dut, dc.Interface(i2.GetName()).Config(), i2)
 
 	t.Log("Configure/update Network Instance")
-	dutConfNIPath := dc.NetworkInstance(deviations.DefaultNetworkInstance(dut))
-	gnmi.Replace(t, dut, dutConfNIPath.Type().Config(), oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE)
+	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
 	if deviations.InterfaceConfigVRFBeforeAddress(dut) {
 		gnmi.Replace(t, dut, dc.Interface(i1.GetName()).Config(), i1)


### PR DESCRIPTION
bgp_long_lived_graceful_restart_test.go changes
1. Just replaced the utility to configure network instance "fptest.ConfigureDefaultNetworkInstance(t, dut)"

bgp_remove_private_as_test.go
1. Replaced the utility to configure network instance "fptest.ConfigureDefaultNetworkInstance(t, dut)"
2.Commenting out routing policy configuration being set to 'oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP' as it is not required for Cisco

