### PR TITLE
increase the timeout for addressing flakiness

### DIFF
--- a/feature/platform/tests/power_admin_down_up_test/power_admin_down_up_test.go
+++ b/feature/platform/tests/power_admin_down_up_test/power_admin_down_up_test.go
@@ -47,7 +47,7 @@ func TestFabricPowerAdmin(t *testing.T) {
 
 			powerDownUp(t, dut, f, oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_FABRIC, 3*time.Minute)
 
-			helpers.ValidateOperStatusUPIntfs(t, dut, before, 5*time.Minute)
+			helpers.ValidateOperStatusUPIntfs(t, dut, before, 8*time.Minute)
 		})
 	}
 }
@@ -76,7 +76,7 @@ func TestLinecardPowerAdmin(t *testing.T) {
 
 			powerDownUp(t, dut, l, oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_LINECARD, 20*time.Minute)
 
-			helpers.ValidateOperStatusUPIntfs(t, dut, before, 5*time.Minute)
+			helpers.ValidateOperStatusUPIntfs(t, dut, before, 8*time.Minute)
 		})
 	}
 }


### PR DESCRIPTION
Many times the interfaces are not coming up after the power enable/disable and the test is failing since the Interfaces are not available after a reboot.
So, increase the timeout to 8minutes vs 5minutes
