### PR TITLE
fix bgp_tcp_mss_path_mtu_test for issue with address family initialization

### DIFF
--- a/feature/bgp/otg_tests/bgp_tcp_mss_path_mtu/bgp_tcp_mss_path_mtu_test.go
+++ b/feature/bgp/otg_tests/bgp_tcp_mss_path_mtu/bgp_tcp_mss_path_mtu_test.go
@@ -118,6 +118,8 @@ func bgpCreateNbr(t *testing.T, dut *ondatra.DUTDevice, authPwd, routerID string
 	global := bgp.GetOrCreateGlobal()
 	global.RouterId = ygot.String(routerID)
 	global.As = ygot.Uint32(localAs)
+	global.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Enabled = ygot.Bool(true)
+	global.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).Enabled = ygot.Bool(true)
 
 	pg1 := bgp.GetOrCreatePeerGroup(peerGrpName1)
 	pg1.PeerAs = ygot.Uint32(ateAS1)


### PR DESCRIPTION
Fix the issue with the global AFI-SAFI family initialization for Cisco. Because of this the entire test was failing without execution. Below are the error messages


"error-path": "openconfig-network-instance//[openconfig.net/yang/bgp-types:network-instances/network-instance[name](https://www.google.com/url?q=http://openconfig.net/yang/bgp-types:network-instances/network-instance%5Bname&sa=D) = 'DEFAULT']/protocols/protocol[name = 'BGP' and identifier = 'BGP']/bgp/neighbors/neighbor[neighbor-address = '192.0.2.2']/afi-safis/afi-safi[afi-safi-name = 'ns2:IPV4_UNICAST']/config/enabled",
            "error-message": "'BGP' detected the 'warning' condition 'The address family has not been initialized'"

"error-path": "openconfig-network-instance//[openconfig.net/yang/bgp-types:network-instances/network-instance[name](https://www.google.com/url?q=http://openconfig.net/yang/bgp-types:network-instances/network-instance%5Bname&sa=D) = 'DEFAULT']/protocols/protocol[name = 'BGP' and identifier = 'BGP']/bgp/neighbors/neighbor[neighbor-address = '192.0.2.2']/afi-safis/afi-safi[afi-safi-name = 'ns2:IPV4_UNICAST']/config/enabled",
            "error-message": "'BGP' detected the 'warning' condition 'The address family has not been initialized'"
           }
