### PR TITLE
Te 14.1 remove cisco deviation

### DIFF
--- a/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
@@ -263,7 +263,6 @@ func incrementMAC(mac string, i int) (string, error) {
 
 func TestScaling(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
-	overrideScaleParams(dut)
 	ate := ondatra.ATE(t, "ate")
 
 	ctx := context.Background()
@@ -400,11 +399,3 @@ func checkTraffic(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config) {
 	}
 }
 
-// overrideScaleParams allows to override the default scale parameters based on the DUT vendor.
-func overrideScaleParams(dut *ondatra.DUTDevice) {
-	if deviations.OverrideDefaultNhScale(dut) {
-		if dut.Vendor() == ondatra.CISCO {
-			*fpargs.V4TunnelCount = 3328
-		}
-	}
-}

--- a/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
@@ -398,4 +398,3 @@ func checkTraffic(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config) {
 		t.Errorf("FAIL- Got %v%% packet loss for %s ; expected < 1%%", lossPct, "flow")
 	}
 }
-

--- a/feature/gribi/otg_tests/gribi_scaling/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_scaling/metadata.textproto
@@ -12,7 +12,6 @@ platform_exceptions: {
   deviations: {
     ipv4_missing_enabled: true
     interface_ref_interface_id_format: true
-    override_default_nh_scale: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
Removed the deviation block for overrideScaleParams as the feature is delivered. 