### PR TITLE
Update ci-trigger's Dockerfile to use newest go1.x

### DIFF
--- a/tools/ci-trigger/Dockerfile
+++ b/tools/ci-trigger/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.21 as builder
+FROM golang:1 as builder
 WORKDIR /app
 COPY . /app/
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server github.com/openconfig/featureprofiles/tools/ci-trigger
-FROM golang:1.21-alpine
+FROM golang:1-alpine
 COPY --from=builder /app/server /server
 ENTRYPOINT ["/server"]
 CMD ["-alsologtostderr"]


### PR DESCRIPTION
I missed the references to go 1.21 in #3842 for the Dockerfile - this should hopefully fix the build https://github.com/openconfig/featureprofiles/runs/37634960038

```
Step 4/8 : RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server github.com/openconfig/featureprofiles/tools/ci-trigger
193 | ---> Running in 861a72e83c78
194 | go: go.mod requires go >= 1.22.0 (running go 1.21.13; GOTOOLCHAIN=local)
195
```