### PR TITLE
RT-2.14 | Changes to isis drain test

### DIFF
--- a/feature/isis/otg_tests/isis_drain_test/isis_drain_test.go
+++ b/feature/isis/otg_tests/isis_drain_test/isis_drain_test.go
@@ -239,6 +239,10 @@ func configureISISDUT(t *testing.T, dut *ondatra.DUTDevice, intfs []string) {
 	isis := prot.GetOrCreateIsis()
 
 	globalISIS := isis.GetOrCreateGlobal()
+	//Explicit Disable the default igp-ldp-sync enabled global leaf
+	isismpls := prot.GetOrCreateIsis().GetOrCreateGlobal().GetOrCreateMpls()
+	isismplsldpsync := isismpls.GetOrCreateIgpLdpSync()
+	isismplsldpsync.Enabled = ygot.Bool(false)
 	if deviations.ISISInstanceEnabledRequired(dut) {
 		globalISIS.Instance = ygot.String(isisInstance)
 	}
@@ -257,6 +261,9 @@ func configureISISDUT(t *testing.T, dut *ondatra.DUTDevice, intfs []string) {
 	}
 	for _, intfName := range intfs {
 		isisIntf := isis.GetOrCreateInterface(intfName)
+		//Explicit Disable the default igp-ldp-sync enabled interface level leaf
+		isisintfmplsldpsync := isisIntf.GetOrCreateMpls().GetOrCreateIgpLdpSync()
+		isisintfmplsldpsync.Enabled = ygot.Bool(false)
 		isisIntf.GetOrCreateInterfaceRef().Interface = ygot.String(intfName)
 		isisIntf.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 		if deviations.InterfaceRefConfigUnsupported(dut) {

--- a/feature/isis/otg_tests/isis_drain_test/isis_drain_test.go
+++ b/feature/isis/otg_tests/isis_drain_test/isis_drain_test.go
@@ -239,7 +239,7 @@ func configureISISDUT(t *testing.T, dut *ondatra.DUTDevice, intfs []string) {
 	isis := prot.GetOrCreateIsis()
 
 	globalISIS := isis.GetOrCreateGlobal()
-	//Explicit Disable the default igp-ldp-sync enabled global leaf
+	// Explicit Disable the default igp-ldp-sync enabled global leaf
 	isismpls := prot.GetOrCreateIsis().GetOrCreateGlobal().GetOrCreateMpls()
 	isismplsldpsync := isismpls.GetOrCreateIgpLdpSync()
 	isismplsldpsync.Enabled = ygot.Bool(false)
@@ -261,7 +261,7 @@ func configureISISDUT(t *testing.T, dut *ondatra.DUTDevice, intfs []string) {
 	}
 	for _, intfName := range intfs {
 		isisIntf := isis.GetOrCreateInterface(intfName)
-		//Explicit Disable the default igp-ldp-sync enabled interface level leaf
+		// Explicit Disable the default igp-ldp-sync enabled interface level leaf
 		isisintfmplsldpsync := isisIntf.GetOrCreateMpls().GetOrCreateIgpLdpSync()
 		isisintfmplsldpsync.Enabled = ygot.Bool(false)
 		isisIntf.GetOrCreateInterfaceRef().Interface = ygot.String(intfName)

--- a/feature/isis/otg_tests/isis_drain_test/metadata.textproto
+++ b/feature/isis/otg_tests/isis_drain_test/metadata.textproto
@@ -22,7 +22,7 @@ platform_exceptions: {
   }
   deviations: {
     ipv4_missing_enabled: true
-    missing_isis_interface_afi_safi_enable: true
+    interface_ref_config_unsupported: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
Made below changes to the RT-2.14 test:

- Add deviation interface_ref_config_unsupported, remove missing_isis_interface_afi_safi_enable
- Explicitly disable igp-ldp-sync enabled leaf.
   - This is enabled by default in OC https://github.com/openconfig/public/blob/master/release/models/isis/openconfig-isis.yang#L504
   - When this config is enabled and LDP is not active on link, is-is sets max metric to the routes per https://datatracker.ietf.org/doc/html/rfc5443#section-2
   - So the metric config changes are not reflected.