### PR TITLE
RT-1.23 Cisco deviations.

### DIFF
--- a/feature/bgp/otg_tests/bgp_afi_safi_defaults/metadata.textproto
+++ b/feature/bgp/otg_tests/bgp_afi_safi_defaults/metadata.textproto
@@ -12,7 +12,9 @@ platform_exceptions: {
   deviations: {
     ipv4_missing_enabled: true
     bgp_extended_next_hop_encoding_leaf_unsupported: true
+    bgp_global_extended_next_hop_encoding_unsupported: true
     bgp_afi_safi_wildcard_not_supported: true
+    skip_bgp_session_check_without_afisafi: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
Adding pertinent deviations for the test RT-1.23 for Cisco devices:
skip_bgp_session_check_without_afisafi 
bgp_global_extended_next_hop_encoding_unsupported