### PR TITLE
added requirement to test interface/rate/load-interval

### DIFF
--- a/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/README.md
+++ b/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/README.md
@@ -9,6 +9,10 @@ Validate interfaces counters including both IPv4 and IPv6 counters.
 In the automated ondatra test, verify the presence of the telemetry paths of the
 following features:
 
+*   Configure Interface and add load-interval:
+
+    *   /interfaces/interface/rates/config/load-interval
+
 *   Configure IPv4 and IPv6 addresses under subinterface:
 
     *   /interfaces/interface/config/enabled
@@ -21,29 +25,34 @@ following features:
     *   /interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/state/enabled
     *   /interfaces/interface/subinterfaces/subinterface/ipv6/addresses/address/state/enabled
 
+*   Validate that Interface has load-interval configured:
+
+    *   /interfaces/interface/rates/state/load-interval
+
 *   For the parent interface counters in-pkts and out-pkts:
 
-    Check the presence of packet counter paths and monitor counters every 30 seconds:
+    Check the presence of packet counter paths and monitor counters every
+    30 seconds:
 
-    *   /interfaces/interface[name=<port>]/state/counters/in-pkts
-    *   /interfaces/interface[name=<port>]/state/counters/out-pkts
+    *   /interfaces/interface[name='port']/state/counters/in-pkts
+    *   /interfaces/interface[name='port']/state/counters/out-pkts
 
 *   Subinterfaces counters:
 
-    Check the presence of packet counter paths:
+    Check the presence of packet counter paths
 
     *   TODO:
-        /interfaces/interface[name=<port>]/subinterfaces/subinterface[index=<index>]/ipv4/state/counters/in-pkts
+        /interfaces/interface[name=port]/subinterfaces/subinterface[index='index']/ipv4/state/counters/in-pkts
     *   TODO:
-        /interfaces/interface[name=<port>]/subinterfaces/subinterface[index=<index>]/ipv4/state/counters/out-pkts
+        /interfaces/interface[name=port]/subinterfaces/subinterface[index='index']/ipv4/state/counters/out-pkts
     *   TODO:
-        /interfaces/interface[name=<port>]/subinterfaces/subinterface[index=<index>]/ipv6/state/counters/in-discarded-pkts
+        /interfaces/interface[name=port]/subinterfaces/subinterface[index='index']/ipv6/state/counters/in-discarded-pkts
     *   TODO:
-        /interfaces/interface[name=<port>]/subinterfaces/subinterface[index=<index>]/ipv6/state/counters/out-discarded-pkts
+        /interfaces/interface[name=port]/subinterfaces/subinterface[index='index']/ipv6/state/counters/out-discarded-pkts
 
 *   Ethernet interface counters
 
-    Check the presence of counter path including in-maxsize-exceeded:
+    Check the presence of counter path including 'in-maxsize-exceeded'
 
     *   TODO: /interfaces/interface/ethernet/state/counters/in-maxsize-exceeded
     *   /interfaces/interface/ethernet/state/counters/in-mac-pause-frames
@@ -54,14 +63,24 @@ following features:
 
 *   Interface CPU and management
 
-    Check the presence of CPU and management paths:
+    Check the presence of CPU and management paths
 
     *   TODO: /interfaces/interface/state/cpu
     *   TODO: /interfaces/interface/state/management
 
+## Testbed type
+
+* [`featureprofiles/topologies/atedut_2.testbed`](https://github.com/openconfig/featureprofiles/blob/main/topologies/atedut_2.testbed)
+
+## Test environment setup
+The test uses a 2 port ATE setup where 2 ports are used as a singleton interface
+Ports are configured with ipv4, ipv6 interfaces on DUT and ATE. Traffic is sent
+and from ATE to DUT and the counters are verified.
+
 ## OpenConfig Path and RPC Coverage
 
-The below yaml defines the OC paths intended to be covered by this test.  OC paths used for test setup are not listed here.
+The below yaml defines the OC paths intended to be covered by this test.
+OC paths used for test setup are not listed here.
 
 ```yaml
 paths:
@@ -70,10 +89,12 @@ paths:
   /interfaces/interface/subinterfaces/subinterface/config/enabled:
   /interfaces/interface/subinterfaces/subinterface/ipv4/config/enabled:
   /interfaces/interface/subinterfaces/subinterface/ipv6/config/enabled:
+  /interfaces/interface/rates/config/load-interval:
 
   ## State Paths ##
   /interfaces/interface/state/counters/in-pkts:
   /interfaces/interface/state/counters/out-pkts:
+  /interfaces/interface/rates/state/load-interval:
   /interfaces/interface/subinterfaces/subinterface/ipv4/state/counters/in-pkts:
   /interfaces/interface/subinterfaces/subinterface/ipv4/state/counters/out-pkts:
   /interfaces/interface/subinterfaces/subinterface/ipv6/state/counters/in-pkts:
@@ -95,6 +116,13 @@ rpcs:
     gNMI.Set:
 ```
 
-## Minimum DUT platform requirement
+## Required DUT platform
 
-N/A
+* Specify the minimum DUT-type
+  * FFF - fixed form factor is enough for this test. However it can run also
+  on a MFF testbed.
+    gNMI.Set:
+
+## Minimum DUT platform requirement
+  * FFF - fixed form factor
+


### PR DESCRIPTION
[interface] [interface_base] FNT development for OC Paths not covered

/interfaces/interface/rates/config/load-interval is not covered and hence adding coverage for this one.

