### PR TITLE
reverting changes in PR3852 as it was skipping bgp_session_check_without_afisafi

### DIFF
--- a/feature/bgp/otg_tests/bgp_afi_safi_defaults/metadata.textproto
+++ b/feature/bgp/otg_tests/bgp_afi_safi_defaults/metadata.textproto
@@ -14,7 +14,6 @@ platform_exceptions: {
     bgp_extended_next_hop_encoding_leaf_unsupported: true
     bgp_global_extended_next_hop_encoding_unsupported: true
     bgp_afi_safi_wildcard_not_supported: true
-    skip_bgp_session_check_without_afisafi: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
reverting changes in PR3852 as it was skipping bgp_session_check_without_afisafi
