### PR TITLE
Rt 1.23

### DIFF
--- a/feature/bgp/otg_tests/bgp_afi_safi_defaults/bgp_afi_safi_defaults_test.go
+++ b/feature/bgp/otg_tests/bgp_afi_safi_defaults/bgp_afi_safi_defaults_test.go
@@ -355,8 +355,14 @@ func verifyBgpCapabilities(t *testing.T, dut *ondatra.DUTDevice, afiSafiLevel st
 				if !nbr.isV4 && afiSafi == oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST {
 					continue
 				}
-				t.Logf("AFI-SAFI state: %v", gnmi.Get(t, dut, statePath.Neighbor(nbr.neighborip).AfiSafi(afiSafi).State()))
-				afiSafiList = append(afiSafiList, gnmi.Get(t, dut, statePath.Neighbor(nbr.neighborip).AfiSafi(afiSafi).State()))
+				t.Logf("AFI-SAFI state: %v", gnmi.Lookup(t, dut, statePath.Neighbor(nbr.neighborip).AfiSafi(afiSafi).State()))
+				res := gnmi.Lookup(t, dut, statePath.Neighbor(nbr.neighborip).AfiSafi(afiSafi).State())
+				if res != nil {
+					val, err := res.Val()
+					if !err {
+						afiSafiList = append(afiSafiList, val)
+					}
+				}
 				t.Logf("AFI-SAFI list: %v", afiSafiList)
 			}
 			for _, cap := range afiSafiList {

--- a/feature/bgp/otg_tests/bgp_afi_safi_defaults/metadata.textproto
+++ b/feature/bgp/otg_tests/bgp_afi_safi_defaults/metadata.textproto
@@ -14,7 +14,7 @@ platform_exceptions: {
     bgp_extended_next_hop_encoding_leaf_unsupported: true
     bgp_global_extended_next_hop_encoding_unsupported: true
     bgp_afi_safi_wildcard_not_supported: true
-    skip_bgp_session_check_without_afisafi: true
+
   }
 }
 platform_exceptions: {

--- a/feature/bgp/otg_tests/bgp_afi_safi_defaults/metadata.textproto
+++ b/feature/bgp/otg_tests/bgp_afi_safi_defaults/metadata.textproto
@@ -12,7 +12,9 @@ platform_exceptions: {
   deviations: {
     ipv4_missing_enabled: true
     bgp_extended_next_hop_encoding_leaf_unsupported: true
+    bgp_global_extended_next_hop_encoding_unsupported: true
     bgp_afi_safi_wildcard_not_supported: true
+    skip_bgp_session_check_without_afisafi: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
Reverted the deviation: bgp_global_extended_next_hop_encoding_unsupported
updated the get afi safi state with lookup, because of the case of enabled: false. By using lookup instead of get, ondatra is able to handle the case where the state returns null when the afi safi is disabled.