### PR TITLE
RT-1.24: Removing deviations and adding required OC configs

### DIFF
--- a/feature/bgp/otg_tests/bgp_2byte_4byte_asn_policy_test/metadata.textproto
+++ b/feature/bgp/otg_tests/bgp_2byte_4byte_asn_policy_test/metadata.textproto
@@ -19,10 +19,8 @@ platform_exceptions: {
     vendor: NOKIA
   }
   deviations: {
-    explicit_port_speed: true
     explicit_interface_in_default_vrf: true
     interface_enabled: true
-    bgp_conditions_match_community_set_unsupported: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION

 - Using `explicit_interface_in_default_vrf` to add interface to default VRF
 - Configuring regex based as-path-set using openconfig
 - Replacing `gnmi.Get` with `gnmi.Watch` for `verifyPrefixesTelemetry` function
 - Removing deviation `bgp_conditions_match_community_set_unsupported` and `explicit_port_speed`

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."