### PR TITLE
update the scrip with gNMI watch to verify recieved MED

### DIFF
--- a/feature/bgp/otg_tests/bgp_always_compare_med/bgp_always_compare_med_test.go
+++ b/feature/bgp/otg_tests/bgp_always_compare_med/bgp_always_compare_med_test.go
@@ -129,11 +129,6 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	i3 := dutDst2.NewOCInterface(dut.Port(t, "port3").Name(), dut)
 	gnmi.Replace(t, dut, dc.Interface(i3.GetName()).Config(), i3)
 
-	if deviations.ExplicitPortSpeed(dut) {
-		fptest.SetPortSpeed(t, dut.Port(t, "port1"))
-		fptest.SetPortSpeed(t, dut.Port(t, "port2"))
-		fptest.SetPortSpeed(t, dut.Port(t, "port3"))
-	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
 		fptest.AssignToNetworkInstance(t, dut, i1.GetName(), deviations.DefaultNetworkInstance(dut), 0)
 		fptest.AssignToNetworkInstance(t, dut, i2.GetName(), deviations.DefaultNetworkInstance(dut), 0)
@@ -144,7 +139,13 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 // verifyPortsUp asserts that each port on the device is operating.
 func verifyPortsUp(t *testing.T, dev *ondatra.Device) {
 	t.Helper()
-	for _, p := range dev.Ports() {
+	dutPorts := map[string]*ondatra.Port{
+		"port1": dev.Port(t, "port1"),
+		"port2": dev.Port(t, "port2"),
+		"port3": dev.Port(t, "port3"),
+	}
+
+	for _, p := range dutPorts {
 		status := gnmi.Get(t, dev, gnmi.OC().Interface(p.Name()).OperStatus().State())
 		if want := oc.Interface_OperStatus_UP; status != want {
 			t.Errorf("%s Status: got %v, want %v", p, status, want)
@@ -445,6 +446,7 @@ func configPolicy(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root) {
 		t.Fatal(err)
 	}
 	actions1 := st.GetOrCreateActions()
+	actions1.GetOrCreateBgpActions().SetMedAction = oc.BgpPolicy_BgpSetMedAction_SET
 	actions1.GetOrCreateBgpActions().SetMed = oc.UnionUint32(bgpMED100)
 	if deviations.BGPSetMedRequiresEqualOspfSetMetric(dut) {
 		actions1.GetOrCreateOspfActions().GetOrCreateSetMetric().SetMetric(bgpMED100)
@@ -457,6 +459,7 @@ func configPolicy(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root) {
 		t.Fatal(err)
 	}
 	actions2 := st.GetOrCreateActions()
+	actions2.GetOrCreateBgpActions().SetMedAction = oc.BgpPolicy_BgpSetMedAction_SET
 	actions2.GetOrCreateBgpActions().SetMed = oc.UnionUint32(bgpMED50)
 	if deviations.BGPSetMedRequiresEqualOspfSetMetric(dut) {
 		actions2.GetOrCreateOspfActions().GetOrCreateSetMetric().SetMetric(bgpMED50)
@@ -476,23 +479,30 @@ func configPolicy(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root) {
 
 // verifySetMed is used to validate MED on received prefixes at OTG Port1.
 func verifySetMed(t *testing.T, otg *otg.OTG, config gosnappi.Config, wantMEDValue uint32) {
-	t.Helper()
-
 	bgpPrefixes := gnmi.GetAll(t, otg, gnmi.OTG().BgpPeer(ateSrc.Name+".BGP4.peer").UnicastIpv4PrefixAny().State())
 	gotPrefixCount := len(bgpPrefixes)
+	var gotMEDValue uint32
 	if gotPrefixCount < routeCount {
 		t.Errorf("Received prefixes on otg are not as expected got prefixes %v, want prefixes %v", gotPrefixCount, routeCount)
 	} else {
 		t.Logf("Received prefixes on otg are matched, got prefixes %v, want prefixes %v", gotPrefixCount, routeCount)
-	}
-
-	// compare Med val with expected for each of the recieved routes.
-	for _, prefix := range bgpPrefixes {
-		if prefix.GetMultiExitDiscriminator() != wantMEDValue {
-			t.Errorf("Received Prefix Med %d Expected Med %d for Prefix %v", prefix.GetMultiExitDiscriminator(), wantMEDValue, prefix.GetAddress())
+		for _, prefix := range bgpPrefixes {
+			_, ok := gnmi.Watch(t, otg, gnmi.OTG().BgpPeer(ateSrc.Name+".BGP4.peer").UnicastIpv4Prefix(prefix.GetAddress(), prefix.GetPrefixLength(), prefix.GetOrigin(), prefix.GetPathId()).MultiExitDiscriminator().State(),
+				time.Minute, func(v *ygnmi.Value[uint32]) bool {
+					if !v.IsPresent() {
+						return false
+					}
+					if gotMEDValue, _ = v.Val(); gotMEDValue == wantMEDValue {
+						return true
+					}
+					return false
+				}).Await(t)
+			if !ok {
+				t.Errorf("Prefix: %v  MED value got: %v want: %v", prefix.GetAddress(), gotMEDValue, wantMEDValue)
+			}
 		}
+		t.Logf("Received Prefixes are verified for Proper MED value %d", wantMEDValue)
 	}
-	t.Logf("Received Prefixes are verified for Proper MED value %d", wantMEDValue)
 }
 
 // verifyBGPCapabilities is used to Verify BGP capabilities like route refresh as32 and mpbgp.
@@ -629,7 +639,6 @@ func TestAlwaysCompareMED(t *testing.T) {
 		}
 
 	})
-
 	t.Run("Verify MED on received routes at ATE Port1 after removing MED settings", func(t *testing.T) {
 		t.Log("Verify BGP prefix telemetry.")
 		verifyPrefixesTelemetry(t, dut, 0, routeCount)

--- a/feature/bgp/otg_tests/bgp_always_compare_med/metadata.textproto
+++ b/feature/bgp/otg_tests/bgp_always_compare_med/metadata.textproto
@@ -12,6 +12,7 @@ platform_exceptions: {
   deviations: {
     explicit_interface_in_default_vrf: true
     interface_enabled: true
+    default_bgp_instance_name: "BGP"
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
1. added watch to verify MED value for recieved prefixes
2. restricted the port status check to the ports that has OTG config
3. added deviation for bgp instance name
4. Removed port speed deviation

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."