### PR TITLE
gnmi_subscriptionlist enhancements to add some OC path coverage

### DIFF
--- a/feature/gnmi/subscribe/tests/gnmi_subscriptionlist_test/gnmi_subscriptionlist_test.go
+++ b/feature/gnmi/subscribe/tests/gnmi_subscriptionlist_test/gnmi_subscriptionlist_test.go
@@ -36,6 +36,10 @@ var (
 	telemetryPaths = map[gpb.SubscriptionMode][]ygnmi.PathStruct{
 		gpb.SubscriptionMode_ON_CHANGE: {
 			gnmi.OC().InterfaceAny().AdminStatus().State().PathStruct(),
+			gnmi.OC().InterfaceAny().OperStatus().State().PathStruct(),
+			gnmi.OC().InterfaceAny().LastChange().State().PathStruct(),
+			gnmi.OC().InterfaceAny().PhysicalChannel().State().PathStruct(),
+			gnmi.OC().InterfaceAny().Transceiver().State().PathStruct(),
 			gnmi.OC().Lacp().InterfaceAny().MemberAny().Interface().State().PathStruct(),
 			gnmi.OC().InterfaceAny().Ethernet().MacAddress().State().PathStruct(),
 			gnmi.OC().InterfaceAny().HardwarePort().State().PathStruct(),


### PR DESCRIPTION
Subscribe requests for the OC paths in cable audit ("batch 1") is timing out and hence adding these coverages for below OC paths in the FNT.

/interfaces/interface[name=%s]/state/oper-status
/interfaces/interface[name=%s]/state/last-change
/interfaces/interface[name=%s]/state/admin-status
/interfaces/interface[name=%s]/state/physical-channel
/interfaces/interface[name=%s]/state/transceiver
