### PR TITLE
MTU-1.3: Removed deviation in large IP packet transmission.

### DIFF
--- a/feature/mtu/largeippacket/otg_tests/large_ip_packet_transmission/large_ip_packet_transmission_test.go
+++ b/feature/mtu/largeippacket/otg_tests/large_ip_packet_transmission/large_ip_packet_transmission_test.go
@@ -446,11 +446,10 @@ func configureDUTBundle(t *testing.T, dut *ondatra.DUTDevice, lag *attrs.Attribu
 	intfAgg := agg.GetOrCreateAggregation()
 	intfAgg.LagType = oc.IfAggregate_AggregationType_STATIC
 
-	switch {
-	case deviations.OmitL2MTU(dut):
-		v4SubInterface.SetMtu(mtu)
-		v6SubInterface.SetMtu(mtu)
-	default:
+	v4SubInterface.SetMtu(mtu)
+	v6SubInterface.SetMtu(mtu)
+
+	if !deviations.OmitL2MTU(dut) {
 		agg.Mtu = ygot.Uint16(mtu + 14)
 	}
 

--- a/feature/mtu/largeippacket/otg_tests/large_ip_packet_transmission/metadata.textproto
+++ b/feature/mtu/largeippacket/otg_tests/large_ip_packet_transmission/metadata.textproto
@@ -10,11 +10,9 @@ platform_exceptions: {
     vendor: NOKIA
   }
   deviations: {
-    explicit_port_speed: true
     explicit_interface_in_default_vrf: true
     aggregate_atomic_update: true
     interface_enabled: true
-    omit_l2_mtu: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
Updated metadata.textproto
- Removed explicit_port_speed
- Removed omit_l2_mtu

Updated large_ip_packet_transmission_test.go
- Changes ensure that the omit_l2_mtu deviation applies only to L2 MTU and does not affect IP MTU configuration under the subinterface.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."