### PR TITLE
Add grpc-services constraint to ocpaths.textproto

### DIFF
--- a/proto/ocpaths.proto
+++ b/proto/ocpaths.proto
@@ -77,8 +77,11 @@ message OCPath {
 // fields for each type of constraint
 message OCPathConstraint {
   oneof constraint {
-    string platform_type = 1;  // derived from OC module oc-platform-types
-    string grpc_service = 2;   // derived from OC module oc-sys-grpc
+    // Specifies a OPENCONFIG_HARDWARE_COMPONENT or OPENCONFIG_SOFTWARE_COMPONENT
+    // identity as defined in OC module oc-platform-types 
+    string platform_type = 1;  
+    // Specifies a GRPC_SERVICE identity as defined in OC module oc-sys-grpc
+    string grpc_service = 2;
   }
 }
 

--- a/proto/ocpaths.proto
+++ b/proto/ocpaths.proto
@@ -77,7 +77,8 @@ message OCPath {
 // fields for each type of constraint
 message OCPathConstraint {
   oneof constraint {
-    string platform_type = 1;
+    string platform_type = 1;  // derived from OC module oc-platform-types
+    string grpc_service = 2;   // derived from OC module oc-sys-grpc
   }
 }
 


### PR DESCRIPTION
This allows specifying a constraint to assert OC Paths which are restricted to a specific GRPC service. (ie: the use of gnmi, gnsi, gnpsi, gribi in the /system/grpc-servers/grpc-server subtree)

The relevant identity-ref is at `/system/grpc-servers/grpc-server/config/services`