### PR TITLE
RT-7.1 & RT-1.33-Code and deviation changes

### DIFF
--- a/feature/bgp/policybase/otg_tests/default_policies_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/metadata.textproto
@@ -24,6 +24,7 @@ platform_exceptions:  {
     missing_isis_interface_afi_safi_enable: true
     isis_interface_afi_unsupported: true
     isis_instance_enabled_required: true
+    bgp_default_policy_unsupported: true
   }
 }
 platform_exceptions:  {

--- a/feature/bgp/policybase/otg_tests/prefix_set_test/bgp_prefix_set_test.go
+++ b/feature/bgp/policybase/otg_tests/prefix_set_test/bgp_prefix_set_test.go
@@ -430,20 +430,9 @@ func testPrefixSet(t *testing.T, dut *ondatra.DUTDevice) {
 	t.Run("Validate acceptance based on prefix-set policy - import policy on neighbor", func(t *testing.T) {
 		applyPrefixSetPolicy(t, dut, []*prefixSetPolicy{prefixSet1V4, prefixSet2V4}, bgpImportIPv4, *ebgp1NbrV4, importPolicy)
 		applyPrefixSetPolicy(t, dut, []*prefixSetPolicy{prefixSet1V6, prefixSet2V6}, bgpImportIPv6, *ebgp1NbrV6, importPolicy)
-		if deviations.DefaultImportExportPolicyUnsupported(dut) {
-			t.Logf("Validate for neighbour %v", ebgp1NbrV4)
-			validatePrefixCount(t, dut, *ebgp1NbrV4, 3, 5, 0)
-			validatePrefixCount(t, dut, *ebgp1NbrV6, 1, 5, 0)
-			validatePrefixCount(t, dut, *ebgp2NbrV4, 0, 0, 3)
-			validatePrefixCount(t, dut, *ebgp2NbrV6, 0, 0, 1)
-		} else {
-			t.Logf("Validate for neighbour %v", ebgp1NbrV4)
-			validatePrefixCount(t, dut, *ebgp1NbrV4, 3, 5, 0)
-			// only route6 is expected to accepted based on prefix-set
-			validatePrefixCount(t, dut, *ebgp1NbrV6, 1, 5, 0)
-			validatePrefixCount(t, dut, *ebgp2NbrV4, 0, 0, 0)
-			validatePrefixCount(t, dut, *ebgp2NbrV6, 0, 0, 0)
-		}
+		t.Logf("Validate for neighbour %v", ebgp1NbrV4)
+		validatePrefixCount(t, dut, *ebgp1NbrV4, 3, 5, 0)
+		validatePrefixCount(t, dut, *ebgp1NbrV6, 1, 5, 0)
 	})
 
 	// Associating prefix-set with the required routing-policy and applying to BGP neighbors on ATE-port-2
@@ -486,23 +475,6 @@ func TestBGPPrefixSet(t *testing.T) {
 		configureOTG(t, otg)
 		verifyBgpState(t, dut)
 	})
-
-	if deviations.DefaultImportExportPolicyUnsupported(dut) {
-		t.Run("Validate initial prefix count", func(t *testing.T) {
-			validatePrefixCount(t, dut, *ebgp1NbrV4, 5, 5, 0)
-			validatePrefixCount(t, dut, *ebgp1NbrV6, 5, 5, 0)
-			validatePrefixCount(t, dut, *ebgp2NbrV4, 0, 0, 5)
-			validatePrefixCount(t, dut, *ebgp2NbrV6, 0, 0, 5)
-		})
-	} else {
-		t.Run("Validate initial prefix count", func(t *testing.T) {
-			validatePrefixCount(t, dut, *ebgp1NbrV4, 0, 5, 0)
-			validatePrefixCount(t, dut, *ebgp1NbrV6, 0, 5, 0)
-			validatePrefixCount(t, dut, *ebgp2NbrV4, 0, 0, 0)
-			validatePrefixCount(t, dut, *ebgp2NbrV6, 0, 0, 0)
-		})
-
-	}
 
 	testPrefixSet(t, dut)
 }


### PR DESCRIPTION
RT-7.1
1. The test adds bgp_default_policy_unsupported deviation in Arista
2. The initial prefix verification only checks if all the prefixes advertised by otg port 1 is received and advertised to otg port 2 in the absence of import/export routing policies. 

RT-1.33
1. Remove initial prefix validation as it is not mentioned in the README. The test would eventually fail if there is a miss in otg prefix advertisement. 
2. Validate prefixes only on ebgp neighbor 1 after applying import policy on ebgp neighbor 1. Neigbour 2 will anyways be validated after applying the export policy. 