### PR TITLE
Update the aggregate interface counters pkg name

### DIFF
--- a/feature/gnmi/otg_tests/aggregate_interface_counters_test/aggregate_interface_counters_test.go
+++ b/feature/gnmi/otg_tests/aggregate_interface_counters_test/aggregate_interface_counters_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package telemetry_interface_packet_counters_test
+package aggregate_interface_counters_test
 
 import (
 	"bytes"


### PR DESCRIPTION
The aggregate interface counters test package was named "telemetry_interface_packet_counters_test", which is duplicated with the test at https://github.com/openconfig/featureprofiles/blob/main/feature/gnmi/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go.  This is a little confusing because this is a different test and is differently named in the metadata/directory name, just not the package name.