### PR TITLE
TRANSCEIVER-3: Fixed metadata & initialized operationalMode flag

### DIFF
--- a/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/metadata.textproto
+++ b/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/metadata.textproto
@@ -15,3 +15,12 @@ platform_exceptions: {
     missing_port_to_optical_channel_component_mapping: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+  }
+  deviations: {
+    interface_enabled: true
+    explicit_dco_config: true
+  }
+}

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -15,6 +15,7 @@
 package cfgplugins
 
 import (
+	"fmt"
 	"math"
 	"sync"
 	"testing"
@@ -47,7 +48,12 @@ func init() {
 // Initialize assigns OpMode with value received through operationalMode flag.
 func Initialize(operationalMode uint16) {
 	once.Do(func() {
-		opmode = operationalMode
+		if operationalMode != 0 {
+			opmode = operationalMode
+		} else {
+			fmt.Sprintln("Please specify the vendor-specific operational-mode flag")
+			return
+		}
 	})
 }
 


### PR DESCRIPTION
-Initialize operationalmode flag in test.go.
-Update metadata.textproto.
-Used ConfigOpticalChannel.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."