### PR TITLE
RT-1.8 Update waitTime and IPv6 address

### DIFF
--- a/feature/bgp/routereflector/otg_tests/route_reflector_scale/route_reflector_scale_test.go
+++ b/feature/bgp/routereflector/otg_tests/route_reflector_scale/route_reflector_scale_test.go
@@ -523,7 +523,7 @@ func verifyPrefixesTelemetry(t *testing.T, dut *ondatra.DUTDevice, nbr string, w
 	} else {
 		prefixPath = statePath.Neighbor(nbr).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).Prefixes()
 	}
-	if gotSent, ok := gnmi.Watch(t, dut, prefixPath.Sent().State(), 10*time.Second, func(val *ygnmi.Value[uint32]) bool {
+	if gotSent, ok := gnmi.Watch(t, dut, prefixPath.Sent().State(), 30*time.Second, func(val *ygnmi.Value[uint32]) bool {
 		gotSent, ok := val.Val()
 		return ok && gotSent == wantSent
 	}).Await(t); !ok {

--- a/internal/cfgplugins/bgp.go
+++ b/internal/cfgplugins/bgp.go
@@ -72,28 +72,28 @@ var (
 		Name:    "port1",
 		IPv4:    "192.0.2.1",
 		IPv4Len: plenIPv4,
-		IPv6:    "2001:0db8::192:0:2:1",
+		IPv6:    "2001:db8::192:0:2:1",
 		IPv6Len: plenIPv6,
 	}
 	dutPort2 = &attrs.Attributes{
 		Name:    "port2",
 		IPv4:    "192.0.2.5",
 		IPv4Len: plenIPv4,
-		IPv6:    "2001:0db8::192:0:2:5",
+		IPv6:    "2001:db8::192:0:2:5",
 		IPv6Len: plenIPv6,
 	}
 	dutPort3 = &attrs.Attributes{
 		Name:    "port3",
 		IPv4:    "192.0.2.9",
 		IPv4Len: plenIPv4,
-		IPv6:    "2001:0db8::192:0:2:9",
+		IPv6:    "2001:db8::192:0:2:9",
 		IPv6Len: plenIPv6,
 	}
 	dutPort4 = &attrs.Attributes{
 		Name:    "port4",
 		IPv4:    "192.0.2.13",
 		IPv4Len: plenIPv4,
-		IPv6:    "2001:0db8::192:0:2:d",
+		IPv6:    "2001:db8::192:0:2:d",
 		IPv6Len: plenIPv6,
 	}
 
@@ -102,7 +102,7 @@ var (
 		MAC:     "02:00:01:01:01:01",
 		IPv4:    "192.0.2.2",
 		IPv4Len: plenIPv4,
-		IPv6:    "2001:0db8::192:0:2:2",
+		IPv6:    "2001:db8::192:0:2:2",
 		IPv6Len: plenIPv6,
 	}
 	atePort2 = &attrs.Attributes{
@@ -110,7 +110,7 @@ var (
 		MAC:     "02:00:02:01:01:01",
 		IPv4:    "192.0.2.6",
 		IPv4Len: plenIPv4,
-		IPv6:    "2001:0db8::192:0:2:6",
+		IPv6:    "2001:db8::192:0:2:6",
 		IPv6Len: plenIPv6,
 	}
 	atePort3 = &attrs.Attributes{
@@ -118,7 +118,7 @@ var (
 		MAC:     "02:00:03:01:01:01",
 		IPv4:    "192.0.2.10",
 		IPv4Len: plenIPv4,
-		IPv6:    "2001:0db8::192:0:2:a",
+		IPv6:    "2001:db8::192:0:2:a",
 		IPv6Len: plenIPv6,
 	}
 	atePort4 = &attrs.Attributes{
@@ -126,7 +126,7 @@ var (
 		MAC:     "02:00:04:01:01:01",
 		IPv4:    "192.0.2.14",
 		IPv4Len: plenIPv4,
-		IPv6:    "2001:0db8::192:0:2:e",
+		IPv6:    "2001:db8::192:0:2:e",
 		IPv6Len: plenIPv6,
 	}
 


### PR DESCRIPTION
Remove prepended 0 from IPv6 address, other usage of IPv6 does not prepend the 0.
Increase wait time for sending prefixes to 30 seconds.