### PR TITLE
TRANSCEIVER-8 Fixed with operationalMode inititization

### DIFF
--- a/feature/platform/transceiver/temperature/tests/zr_temperature_test/metadata.textproto
+++ b/feature/platform/transceiver/temperature/tests/zr_temperature_test/metadata.textproto
@@ -24,3 +24,13 @@ platform_exceptions: {
     use_parent_component_for_temperature_telemetry: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+  }
+  deviations: {
+    interface_enabled: true
+    explicit_dco_config: true
+    missing_zr_optical_channel_tunable_parameters_telemetry: true
+  }
+}

--- a/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
+++ b/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
@@ -15,6 +15,7 @@
 package zr_temperature_test
 
 import (
+	"flag"
 	"reflect"
 	"testing"
 	"time"
@@ -31,6 +32,11 @@ import (
 
 const (
 	sensorType = oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_SENSOR
+)
+
+var (
+	operationalModeFlag = flag.Int("operational_mode", 1, "vendor-specific operational-mode for the channel")
+	operationalMode     uint16
 )
 
 func TestMain(m *testing.M) {
@@ -67,6 +73,8 @@ func TestZRTemperatureState(t *testing.T) {
 	t.Logf("dut1: %v", dut1)
 	t.Logf("dut1 dp1 name: %v", dp1.Name())
 	intUpdateTime := 2 * time.Minute
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(operationalMode)
 	cfgplugins.InterfaceConfig(t, dut1, dp1)
 	cfgplugins.InterfaceConfig(t, dut1, dp2)
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)


### PR DESCRIPTION
- Added operationalMode flag & initialized it.
- Using deviation `missing_zr_optical_channel_tunable_parameters_telemetry` as per  https://partnerissuetracker.corp.google.com/issues/334189916

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."