### PR TITLE
Fix P4RT-2.2 and TE-2.2 intermittent test failures for EOS

### DIFF
--- a/feature/gribi/otg_tests/encap_decap_scale/encap_decap_scale_test.go
+++ b/feature/gribi/otg_tests/encap_decap_scale/encap_decap_scale_test.go
@@ -107,7 +107,7 @@ const (
 	teVrf111TunnelCount     = 1600
 	teVrf222TunnelCount     = 1600
 	encapNhCount            = 1600
-	encapNhgcount           = 800
+	encapNhgcount           = 200
 	encapIPv4Count          = 5000
 	encapIPv6Count          = 5000
 	decapIPv4Count          = 48

--- a/feature/gribi/otg_tests/encap_decap_scale/encap_decap_scale_test.go
+++ b/feature/gribi/otg_tests/encap_decap_scale/encap_decap_scale_test.go
@@ -107,7 +107,7 @@ const (
 	teVrf111TunnelCount     = 1600
 	teVrf222TunnelCount     = 1600
 	encapNhCount            = 1600
-	encapNhgcount           = 200
+	encapNhgcount           = 800
 	encapIPv4Count          = 5000
 	encapIPv6Count          = 5000
 	decapIPv4Count          = 48

--- a/feature/gribi/otg_tests/ipv4_entry_with_aggregate_ports_test/ipv4_entry_with_aggregate_ports_test.go
+++ b/feature/gribi/otg_tests/ipv4_entry_with_aggregate_ports_test/ipv4_entry_with_aggregate_ports_test.go
@@ -151,6 +151,7 @@ func validateTrafficFlows(t *testing.T, ate *ondatra.ATEDevice, good, bad []stri
 		return
 	}
 
+	time.Sleep(15 * time.Second)
 	ate.OTG().StartTraffic(t)
 	time.Sleep(15 * time.Second)
 	ate.OTG().StopTraffic(t)

--- a/feature/gribi/otg_tests/ipv4_entry_with_aggregate_ports_test/ipv4_entry_with_aggregate_ports_test.go
+++ b/feature/gribi/otg_tests/ipv4_entry_with_aggregate_ports_test/ipv4_entry_with_aggregate_ports_test.go
@@ -151,7 +151,6 @@ func validateTrafficFlows(t *testing.T, ate *ondatra.ATEDevice, good, bad []stri
 		return
 	}
 
-	time.Sleep(15 * time.Second)
 	ate.OTG().StartTraffic(t)
 	time.Sleep(15 * time.Second)
 	ate.OTG().StopTraffic(t)

--- a/feature/p4rt/tests/metadata_validation_test/metadata.textproto
+++ b/feature/p4rt/tests/metadata_validation_test/metadata.textproto
@@ -4,7 +4,7 @@
 uuid: "c4f6b3eb-697e-4792-93c0-785c3fc61f67"
 plan_id: "P4RT-2.2"
 description: "P4RT Metadata Validation"
-testbed: TESTBED_DUT_ATE_2LINKS 
+testbed: TESTBED_DUT
 platform_exceptions: {
   platform: {
     vendor: JUNIPER

--- a/feature/p4rt/tests/metadata_validation_test/metadata.textproto
+++ b/feature/p4rt/tests/metadata_validation_test/metadata.textproto
@@ -4,7 +4,7 @@
 uuid: "c4f6b3eb-697e-4792-93c0-785c3fc61f67"
 plan_id: "P4RT-2.2"
 description: "P4RT Metadata Validation"
-testbed: TESTBED_DUT
+testbed: TESTBED_DUT_ATE_2LINKS 
 platform_exceptions: {
   platform: {
     vendor: JUNIPER

--- a/feature/p4rt/tests/metadata_validation_test/metadata.textproto
+++ b/feature/p4rt/tests/metadata_validation_test/metadata.textproto
@@ -4,7 +4,7 @@
 uuid: "c4f6b3eb-697e-4792-93c0-785c3fc61f67"
 plan_id: "P4RT-2.2"
 description: "P4RT Metadata Validation"
-testbed: TESTBED_DUT
+testbed: TESTBED_DUT_ATE_2LINKS
 platform_exceptions: {
   platform: {
     vendor: JUNIPER


### PR DESCRIPTION
P4RT-2.2 was failing because the testbedType is wrong in metadata.textproto. This is used to construct the right binding file to use for the test TE-2.2 needs a interlock between shut/unshut of the link and when the traffic is started to validate the traffic.