### PR TITLE
TRANSCEIVER-11: remove stale workaround for optical channel format

### DIFF
--- a/feature/platform/transceiver/logical_channels/tests/zr_logical_channels_test/zr_logical_channels_test.go
+++ b/feature/platform/transceiver/logical_channels/tests/zr_logical_channels_test/zr_logical_channels_test.go
@@ -2,7 +2,6 @@ package zr_logical_channels_test
 
 import (
 	"flag"
-	"strings"
 	"testing"
 	"time"
 
@@ -225,7 +224,6 @@ func validateOTNChannelTelemetry(t *testing.T, dut *ondatra.DUTDevice, otnChIdx 
 	var opticalChannelAssignmentIndexTestcases []testcase
 
 	if deviations.OTNChannelAssignmentCiscoNumbering(dut) {
-		ciscoOpticalChannelFormat := strings.ReplaceAll(opticalChannel, "/", "_") // Ex: OpticalChannel0_0_0_18
 		opticalChannelAssignmentIndexTestcases = []testcase{
 			{
 				desc: "Assignment: Index",
@@ -235,7 +233,7 @@ func validateOTNChannelTelemetry(t *testing.T, dut *ondatra.DUTDevice, otnChIdx 
 			{
 				desc: "Optical Channel Assignment: Optical Channel",
 				got:  cc.GetAssignment(1).GetOpticalChannel(),
-				want: ciscoOpticalChannelFormat,
+				want: opticalChannel,
 			},
 			{
 				desc: "Optical Channel Assignment: Description",

--- a/feature/platform/transceiver/logical_channels/tests/zrp_logical_channels_test/zrp_logical_channels_test.go
+++ b/feature/platform/transceiver/logical_channels/tests/zrp_logical_channels_test/zrp_logical_channels_test.go
@@ -2,7 +2,6 @@ package zrp_logical_channels_test
 
 import (
 	"flag"
-	"strings"
 	"testing"
 	"time"
 
@@ -205,7 +204,6 @@ func validateOTNChannelTelemetry(t *testing.T, dut *ondatra.DUTDevice, otnChIdx 
 
 	index := 0
 	if deviations.OTNChannelAssignmentCiscoNumbering(dut) {
-		opticalChannel = strings.ReplaceAll(opticalChannel, "/", "_") // Ex: ciscoOpticalChannelFormat is OpticalChannel0_0_0_18
 		index = 1
 	}
 


### PR DESCRIPTION
Cisco devices now return the correct format, meaning this workaround would cause a failure

Old e.g: `OpticalChannel0_0_0_18`

instead of : `Ex: OpticalChannel0/0/0/18`