### PR TITLE
changing the tests to handle gnmi.Get() response gracefully

### DIFF
--- a/feature/lldp/otg_tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
+++ b/feature/lldp/otg_tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
@@ -154,9 +154,9 @@ func configureDUT(t *testing.T, name string, lldpEnabled bool) (*ondatra.DUTDevi
 	}
 
 	tsState := gnmi.Lookup(t, node, gnmi.OC().Lldp().State())
-	_, isPresent := tsState.Val()
+	lldpState, isPresent := tsState.Val()
 	if isPresent {
-		return node, gnmi.Get(t, node, gnmi.OC().Lldp().State())
+		return node, lldpState
 	}
 	return node, nil
 }


### PR DESCRIPTION
Added check - for some cases gnmi.Get() query when LLDP is disabled; should be handled carefully; such that value not found exception can be handled gracefully instead of test cases ended abruptly.