### PR TITLE
RT-6.1: LLDP testcase changes for cisco

### DIFF
--- a/feature/lldp/ate_tests/core_lldp_tlv_population_test/metadata.textproto
+++ b/feature/lldp/ate_tests/core_lldp_tlv_population_test/metadata.textproto
@@ -7,14 +7,6 @@ description: "Core LLDP TLV Population"
 testbed: TESTBED_DUT_DUT_4LINKS
 platform_exceptions: {
   platform: {
-    vendor: CISCO
-  }
-  deviations: {
-    lldp_interface_config_override_global: true
-  }
-}
-platform_exceptions: {
-  platform: {
     vendor: ARISTA
   }
   deviations: {

--- a/feature/lldp/otg_tests/core_lldp_tlv_population_test/metadata.textproto
+++ b/feature/lldp/otg_tests/core_lldp_tlv_population_test/metadata.textproto
@@ -7,14 +7,6 @@ description: "Core LLDP TLV Population"
 testbed: TESTBED_DUT_ATE_2LINKS
 platform_exceptions: {
   platform: {
-    vendor: CISCO
-  }
-  deviations: {
-    lldp_interface_config_override_global: true
-  }
-}
-platform_exceptions: {
-  platform: {
     vendor: ARISTA
   }
   deviations: {

--- a/internal/deviations/byexceptions.go
+++ b/internal/deviations/byexceptions.go
@@ -34,6 +34,7 @@ var (
 	backupNHGRequiresVrfWithDecap            = flag.Bool("deviation_backup_nhg_requires_vrf_with_decap", false, "Set to true for devices that require IPOverIP Decapsulation for Backup NHG without interfaces.")
 	atePortLinkStateOperationsUnsupported    = flag.Bool("deviation_ate_port_link_state_operations_unsupported", false, "Set to true for ATEs that do not support setting link state on their own ports.")
 	ateIPv6FlowLabelUnsupported              = flag.Bool("deviation_ate_ipv6_flow_label_unsupported", false, "Set to true for ATEs that do not support IPv6 flow labels")
+	lldpInterfaceConfigOverrideGlobal        = flag.Bool("deviation_lldp_interface_config_override_global", false, "Set to true for devices whose LLDP interface config overrides LLDP global config.")
 )
 
 func isFlagSet(name string) bool {
@@ -123,4 +124,13 @@ func ATEIPv6FlowLabelUnsupported(ate *ondatra.ATEDevice) bool {
 		return *ateIPv6FlowLabelUnsupported
 	}
 	return lookupATEDeviations(ate).GetAteIpv6FlowLabelUnsupported()
+}
+
+// LLDPInterfaceConfigOverrideGlobal returns if LLDP interface config should override the global config,
+// expect neighbours are seen when lldp is disabled globally but enabled on interface
+func LLDPInterfaceConfigOverrideGlobal(dut *ondatra.DUTDevice) bool {
+	if isFlagSet("deviation_lldp_interface_config_override_global") {
+		return *lldpInterfaceConfigOverrideGlobal
+	}
+	return lookupDUTDeviations(dut).GetLldpInterfaceConfigOverrideGlobal()
 }

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -304,12 +304,6 @@ func TraceRouteL4ProtocolUDP(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetTracerouteL4ProtocolUdp()
 }
 
-// LLDPInterfaceConfigOverrideGlobal returns if LLDP interface config should override the global config,
-// expect neighbours are seen when lldp is disabled globally but enabled on interface
-func LLDPInterfaceConfigOverrideGlobal(dut *ondatra.DUTDevice) bool {
-	return lookupDUTDeviations(dut).GetLldpInterfaceConfigOverrideGlobal()
-}
-
 // SubinterfacePacketCountersMissing returns if device is missing subinterface packet counters for IPv4/IPv6,
 // so the test will skip checking them.
 // Full OpenConfig compliant devices should pass both with and without this deviation.


### PR DESCRIPTION
PR to incorporate LLDP behavior change from ios-xr version 25.1.1: interface needs to be added to OC datastore explicitly before enabling LLDP on it

Proposed changes:
leafref fix + interface operation
remove the deviation "lldp_interface_config_override_global" which is not applicable anymore

Note: go test flag "lldpInterfaceConfigOverrideGlobal" has been added for backward compatibility - if consuming IOS-XR 2441 images for test, set this flag to true

