### PR TITLE
Update bgp_override_as_path_split_horizon_test.go

### DIFF
--- a/feature/bgp/otg_tests/bgp_override_as_path_split_horizon_test/bgp_override_as_path_split_horizon_test.go
+++ b/feature/bgp/otg_tests/bgp_override_as_path_split_horizon_test/bgp_override_as_path_split_horizon_test.go
@@ -207,7 +207,7 @@ func advBGPRouteFromOTG(t *testing.T, args *otgTestArgs, asSeg []uint32) {
 		SetPrefix(uint32(advertisedRoutesv4Prefix)).
 		SetCount(1)
 
-	bgpNeti1AsPath := bgpNeti1Bgp4PeerRoutes.AsPath().SetAsSetMode(gosnappi.BgpAsPathAsSetMode.INCLUDE_AS_SET)
+	bgpNeti1AsPath := bgpNeti1Bgp4PeerRoutes.AsPath().SetAsSetMode(gosnappi.BgpAsPathAsSetMode.INCLUDE_AS_SEQ)
 	bgpNeti1AsPath.Segments().Add().SetAsNumbers(asSeg).SetType(gosnappi.BgpAsPathSegmentType.AS_SEQ)
 
 	t.Logf("Pushing config to OTG and starting protocols...")


### PR DESCRIPTION
The prefix updates are being rejected as there is no order guarantee in the sequence AS paths coming the ixia when the mode is set to AS_SET instead of AS_SEQ.
Also AS_SET segment type itself is getting depricated in BGP RFC. 