### PR TITLE
TRANSCEIVER-9: transceiver component key fix

### DIFF
--- a/feature/platform/transceiver/laser_bias_current/tests/zr_laser_bias_current_test/zr_laser_bias_current_test.go
+++ b/feature/platform/transceiver/laser_bias_current/tests/zr_laser_bias_current_test/zr_laser_bias_current_test.go
@@ -154,7 +154,7 @@ func TestZRLaserBiasCurrentStateTransceiverOnOff(t *testing.T) {
 	defer p1Stream.Close()
 	verifyLaserBiasCurrentAll(t, p1Stream, dut1)
 	// power off interface transceiver
-	gnmi.Update(t, dut1, gnmi.OC().Component(dp1.Name()).Name().Config(), dp1.Name())
+	gnmi.Update(t, dut1, gnmi.OC().Component(transceiverState).Name().Config(), transceiverState)
 	// for transceiver disable, the input needs to be the transceiver name instead of the interface name
 	gnmi.Update(t, dut1, gnmi.OC().Component(transceiverState).Transceiver().Enabled().Config(), false)
 	verifyLaserBiasCurrentAll(t, p1Stream, dut1)

--- a/feature/platform/transceiver/laser_bias_current/tests/zrp_laser_bias_current_test/zrp_laser_bias_current_test.go
+++ b/feature/platform/transceiver/laser_bias_current/tests/zrp_laser_bias_current_test/zrp_laser_bias_current_test.go
@@ -185,7 +185,7 @@ func TestZRLaserBiasCurrentStateTransceiverOnOff(t *testing.T) {
 	defer p1Stream.Close()
 	verifyLaserBiasCurrentAll(t, p1Stream, dut1)
 	// power off interface transceiver
-	gnmi.Update(t, dut1, gnmi.OC().Component(dp1.Name()).Name().Config(), dp1.Name())
+	gnmi.Update(t, dut1, gnmi.OC().Component(transceiverState).Name().Config(), transceiverState)
 	// for transceiver disable, the input needs to be the transceiver name instead of the interface name
 	gnmi.Update(t, dut1, gnmi.OC().Component(transceiverState).Transceiver().Enabled().Config(), false)
 	// Cannot use Interface_OperStatus_DOWN here as the interface is "Not Present"


### PR DESCRIPTION
change gnmi update request to use the name of transceiver leaf resolved from interface container by port name, instead of the port name itself. 