### PR TITLE
Fixing chained_policies_test for the export policy changes PR 3366

### DIFF
--- a/feature/bgp/policybase/otg_tests/chained_policies_test/chained_policies_test.go
+++ b/feature/bgp/policybase/otg_tests/chained_policies_test/chained_policies_test.go
@@ -400,7 +400,6 @@ func configureExportRoutingPolicy(t *testing.T, dut *ondatra.DUTDevice, operatio
 	}
 	if deviations.SkipSettingStatementForPolicy(dut) {
 		gnmi.Update(t, dut, path.Config(), policy)
-		gnmi.Update(t, dut, importPolPath.Config(), eBGPPeerPolicy)
 	} else {
 		if operation == "set" {
 			gnmi.BatchReplace(batch, path.Config(), policy)
@@ -620,7 +619,6 @@ func configureExportRoutingPolicyV6(t *testing.T, dut *ondatra.DUTDevice, operat
 	}
 	if deviations.SkipSettingStatementForPolicy(dut) {
 		gnmi.Update(t, dut, path.Config(), policy)
-		gnmi.Update(t, dut, importPolPath.Config(), eBGPPeerPolicy)
 	} else {
 		if operation == "set" {
 			gnmi.BatchReplace(batch, path.Config(), policy)


### PR DESCRIPTION
PR 3366 added export policy to satisfy the default behavior of BGP.
For Cisco this is not required as the default behavior of BGP is to reject all routes when there is no policy for the BGP peer. 

Hence removing the changes that is not required.
