### PR TITLE
gNMI-1.16:Fix configure power admin state (oc.Platform_ComponentPowerType_POWER_ENABLED) via GNMI Replace

### DIFF
--- a/feature/platform/fabric/otg_tests/fabric_redundancy_test/fabric_redundancy_test.go
+++ b/feature/platform/fabric/otg_tests/fabric_redundancy_test/fabric_redundancy_test.go
@@ -250,6 +250,8 @@ func testFabricInventory(t *testing.T, dut *ondatra.DUTDevice, fabrics []string,
 		powerAdminStateStateKey := strings.Join([]string{fabric, "state/power-admin-state"}, ":")
 
 		/* fabricLeafOrValuePresent: Key: fabric:leaf, Value: []any{isLeafPresent, leafValue} */
+		gnmi.Replace(t, dut, powerAdminState.Config(), oc.Platform_ComponentPowerType_POWER_ENABLED)
+		time.Sleep(10 * time.Second)
 		fabricLeafOrValuePresent[descriptionKey] = []any{gnmi.Lookup(t, dut, description.State()).IsPresent()}
 		fabricLeafOrValuePresent[hardwareVersionKey] = []any{gnmi.Lookup(t, dut, hardwareVersion.State()).IsPresent()}
 		fabricLeafOrValuePresent[idKey] = []any{gnmi.Lookup(t, dut, id.State()).IsPresent()}


### PR DESCRIPTION
powerAdminState.Config() wasn't configured, querying this leaf was  not returning anything.Added this configuration to avoid this issue.


