### PR TITLE
Removed 'explicit_port_speed' deviations from remaining files.

### DIFF
--- a/feature/aft/afts_summary/otg_tests/scale_aft_summary/metadata.textproto
+++ b/feature/aft/afts_summary/otg_tests/scale_aft_summary/metadata.textproto
@@ -14,7 +14,6 @@ platform_exceptions: {
     isis_interface_level1_disable_required: true
     missing_isis_interface_afi_safi_enable: true
     isis_restart_suppress_unsupported: true
-    explicit_port_speed: true
     explicit_interface_in_default_vrf: true
     missing_value_for_defaults: true
     interface_enabled: true

--- a/feature/bgp/bgp_session_mode/otg_tests/bgp_session_mode_configuration_test/metadata.textproto
+++ b/feature/bgp/bgp_session_mode/otg_tests/bgp_session_mode_configuration_test/metadata.textproto
@@ -20,7 +20,6 @@ platform_exceptions:  {
     vendor:  NOKIA
   }
   deviations:  {
-    explicit_port_speed:  true
     explicit_interface_in_default_vrf:  true
     missing_value_for_defaults:  true
     interface_enabled:  true

--- a/feature/gribi/otg_tests/gribi_route_test/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_route_test/metadata.textproto
@@ -23,7 +23,6 @@ platform_exceptions:  {
     vendor:  NOKIA
   }
   deviations:  {
-    explicit_port_speed: true
     explicit_interface_in_default_vrf: true
     aggregate_atomic_update: true
     interface_enabled: true

--- a/feature/interface/lacp/tests/lacp_interval_test/metadata.textproto
+++ b/feature/interface/lacp/tests/lacp_interval_test/metadata.textproto
@@ -18,7 +18,6 @@ platform_exceptions: {
     vendor: NOKIA
   }
   deviations: {
-    explicit_port_speed: true
     explicit_interface_in_default_vrf: true
     aggregate_atomic_update: true
     interface_enabled: true

--- a/feature/mtu/otg_tests/pmtu_handing/metadata.textproto
+++ b/feature/mtu/otg_tests/pmtu_handing/metadata.textproto
@@ -10,7 +10,6 @@ platform_exceptions: {
     vendor: NOKIA
   }
   deviations: {
-    explicit_port_speed: true
     explicit_interface_in_default_vrf: true
     omit_l2_mtu: true
     fragment_total_drops_unsupported: true


### PR DESCRIPTION
-Removed port speed deviation from below IDs.

`RT-1.55, MTU-1.5, RT-14.2, RT-4.11, RT-5.11 `

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."