### PR TITLE
RT-1.11 OTG fix for the AS Path segments processing

### DIFF
--- a/feature/bgp/otg_tests/bgp_remove_private_as/bgp_remove_private_as_test.go
+++ b/feature/bgp/otg_tests/bgp_remove_private_as/bgp_remove_private_as_test.go
@@ -357,10 +357,12 @@ func verifyBGPAsPath(t *testing.T, otg *otg.OTG, config gosnappi.Config, asSeg [
 			t.Errorf("Received prefixes on otg are not as expected got prefixes %v, want prefixes %v", gotPrefixCount, routeCount)
 		}
 		for _, prefix := range bgpPrefixes {
+			prefixAsSegments := []uint32{}
 			for _, gotASSeg := range prefix.AsPath {
-				if ok := cmp.Diff(gotASSeg.AsNumbers, wantASSeg); ok != "" {
-					t.Errorf("Remove private AS is not working: gotAsSeg %v wantAsSeg %v for Prefix %v", gotASSeg, wantASSeg, prefix.GetAddress())
-				}
+				prefixAsSegments = append(prefixAsSegments, gotASSeg.AsNumbers...)
+			}
+			if ok := cmp.Diff(prefixAsSegments, wantASSeg); ok != "" {
+				t.Errorf("Remove private AS is not working: prefixAsSegments %v wantAsSeg %v for Prefix %v", prefixAsSegments, wantASSeg, prefix.GetAddress())
 			}
 		}
 	}


### PR DESCRIPTION
Fixing the way the otg AS Path segments in BGP received routes is being processed.