### PR TITLE
Add "TRANSIT" tag to TE-14.1 test since it has transit VRF selection Transit tag

### DIFF
--- a/feature/gribi/otg_tests/gribi_scaling/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_scaling/metadata.textproto
@@ -42,4 +42,3 @@ platform_exceptions: {
     omit_l2_mtu: true
   }
 }
-tags:  TAGS_TRANSIT

--- a/feature/gribi/otg_tests/gribi_scaling/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_scaling/metadata.textproto
@@ -42,3 +42,4 @@ platform_exceptions: {
     omit_l2_mtu: true
   }
 }
+tags:  TAGS_TRANSIT

--- a/feature/gribi/otg_tests/gribi_scaling/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_scaling/metadata.textproto
@@ -42,3 +42,4 @@ platform_exceptions: {
     omit_l2_mtu: true
   }
 }
+tags: TAGS_TRANSIT


### PR DESCRIPTION
In Arista, we rely on the tags specified in the metadata.textproto to determine if the test needs to be run with transit prerequisite vendor specific configs.  This test was failing because it was missing the right tag in the proto file.