### PR TITLE
Fix Vendor OCAGENT procname in gnoi.go

### DIFF
--- a/internal/gnoi/gnoi.go
+++ b/internal/gnoi/gnoi.go
@@ -52,7 +52,7 @@ var (
 		},
 		ondatra.NOKIA: {
 			GRIBI:   "sr_grpc_server",
-			OCAGENT: "sr_oc_mgmt_serv",
+			OCAGENT: "sr_oc_mgmt_server",
 			P4RT:    "sr_grpc_server",
 			ROUTING: "sr_bgp_mgr",
 		},


### PR DESCRIPTION
Fixes procname for OCAGENT for latest release onward

---

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."