### PR TITLE
Credentialz: Add ssh retry mechanism when rotating host parameters

### DIFF
--- a/feature/security/gnsi/credentialz/tests/hiba_authentication/hiba_authentication_test.go
+++ b/feature/security/gnsi/credentialz/tests/hiba_authentication/hiba_authentication_test.go
@@ -86,7 +86,7 @@ func TestCredentialz(t *testing.T) {
 				break
 			}
 			if uint64(time.Since(startTime).Seconds()) > maxSSHRetryTime {
-				t.Fatalf("Dialing ssh succeeded, but we expected to fail.")
+				t.Fatalf("Exceeded maxSSHRetryTime, dialing ssh succeeded, but we expected to fail.")
 			}
 			t.Logf("Dialing ssh succeeded but expected to fail, retrying ...")
 			time.Sleep(5 * time.Second)
@@ -126,7 +126,7 @@ func TestCredentialz(t *testing.T) {
 				break
 			}
 			if uint64(time.Since(startTime).Seconds()) > maxSSHRetryTime {
-				t.Fatalf("Dialing ssh failed, but we expected to succeed, error: %s", err)
+				t.Fatalf("Exceeded maxSSHRetryTime, dialing ssh failed, but we expected to succeed, error: %s", err)
 			}
 			t.Logf("Dialing ssh failed, retrying ...")
 			time.Sleep(5 * time.Second)

--- a/feature/security/gnsi/credentialz/tests/ssh_password_login_disallowed/ssh_password_login_disallowed_test.go
+++ b/feature/security/gnsi/credentialz/tests/ssh_password_login_disallowed/ssh_password_login_disallowed_test.go
@@ -95,7 +95,7 @@ func TestCredentialz(t *testing.T) {
 				break
 			}
 			if uint64(time.Since(startTime).Seconds()) > maxSSHRetryTime {
-				t.Fatalf("Dialing ssh succeeded, but we expected to fail.")
+				t.Fatalf("Exceeded maxSSHRetryTime, dialing ssh succeeded, but we expected to fail.")
 			}
 			t.Logf("Dialing ssh succeeded but expected to fail, retrying ...")
 			time.Sleep(5 * time.Second)
@@ -130,7 +130,7 @@ func TestCredentialz(t *testing.T) {
 				break
 			}
 			if uint64(time.Since(startTime).Seconds()) > maxSSHRetryTime {
-				t.Fatalf("Dialing ssh failed, but we expected to succeed, error: %s", err)
+				t.Fatalf("Exceeded maxSSHRetryTime, dialing ssh failed, but we expected to succeed, error: %s", err)
 			}
 			t.Logf("Dialing ssh failed, retrying ...")
 			time.Sleep(5 * time.Second)

--- a/feature/security/gnsi/credentialz/tests/ssh_password_login_disallowed/ssh_password_login_disallowed_test.go
+++ b/feature/security/gnsi/credentialz/tests/ssh_password_login_disallowed/ssh_password_login_disallowed_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"os"
 
+	"golang.org/x/crypto/ssh"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -35,9 +37,10 @@ import (
 )
 
 const (
-	username      = "testuser"
-	userPrincipal = "my_principal"
-	command       = "show version"
+	username        = "testuser"
+	userPrincipal   = "my_principal"
+	command         = "show version"
+	maxSSHRetryTime = 30 // Unit is seconds.
 )
 
 func TestMain(m *testing.M) {
@@ -84,9 +87,18 @@ func TestCredentialz(t *testing.T) {
 		}
 
 		// Verify ssh with password fails as expected.
-		_, err := credz.SSHWithPassword(target, username, password)
-		if err == nil {
-			t.Fatalf("Dialing ssh succeeded, but we expected to fail.")
+		startTime := time.Now()
+		for {
+			_, err := credz.SSHWithPassword(target, username, password)
+			if err != nil {
+				t.Logf("Dialing ssh failed as expected.")
+				break
+			}
+			if uint64(time.Since(startTime).Seconds()) > maxSSHRetryTime {
+				t.Fatalf("Dialing ssh succeeded, but we expected to fail.")
+			}
+			t.Logf("Dialing ssh succeeded but expected to fail, retrying ...")
+			time.Sleep(5 * time.Second)
 		}
 
 		// Verify ssh counters.
@@ -108,11 +120,21 @@ func TestCredentialz(t *testing.T) {
 		}
 
 		// Verify ssh with certificate succeeds.
-		conn, err := credz.SSHWithCertificate(t, target, username, dir)
-		if err != nil {
-			t.Fatalf("Dialing ssh failed, but we expected to succeed, error: %s", err)
+		startTime := time.Now()
+		var conn *ssh.Client
+		for {
+			conn, err = credz.SSHWithCertificate(t, target, username, dir)
+			if err == nil {
+				t.Logf("Dialing ssh succeeded as expected.")
+				defer conn.Close()
+				break
+			}
+			if uint64(time.Since(startTime).Seconds()) > maxSSHRetryTime {
+				t.Fatalf("Dialing ssh failed, but we expected to succeed, error: %s", err)
+			}
+			t.Logf("Dialing ssh failed, retrying ...")
+			time.Sleep(5 * time.Second)
 		}
-		defer conn.Close()
 
 		// Send command for accounting.
 		sess, err := conn.NewSession()


### PR DESCRIPTION
Add ssh retry mechanism when rotating host parameters to allow time in case ssh server needs to restart on the dut.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."