### PR TITLE
Bandwidth computation for forwarding-unviable links

### DIFF
--- a/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/README.md
+++ b/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/README.md
@@ -157,7 +157,7 @@ The below yaml defines the OC paths and RPC intended to be covered by this test.
 ```yaml
 paths:
   /interfaces/interface/ethernet/config/aggregate-id:
-  /interfaces/interface/aggregation/state/lag-speed/state:
+  /interfaces/interface/aggregation/state/lag-speed:
   ## Config forwarding Viable to True/false
   /interfaces/interface/config/forwarding-viable:
   ## Define Lag type

--- a/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/README.md
+++ b/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/README.md
@@ -62,6 +62,7 @@ Ensure that when --all LAG member-- become set with forwarding-viable == FALSE
 -   Ensure there are no packet losses in steady state (no congestion).
 -   Ensure there is no traffic received on DUT LAG_3
 -   Ensure there is no traffic transmitted on DUT LAG_3
+-   Ensure that the total bandwidth computation for the bundle interface does not include links where "forwarding viable" is set to false.
 
 #### RT-5.7.1.2: Verify forwarding-viable behavior on an aggregate interface with all members down or set with forwarding-viable=FALSE.
 -   Ensure ISIS adjacency is UP on DUT LAG_2 and ATE LAG_2
@@ -156,6 +157,7 @@ The below yaml defines the OC paths and RPC intended to be covered by this test.
 ```yaml
 paths:
   /interfaces/interface/ethernet/config/aggregate-id:
+  /interfaces/interface/aggregation/state/lag-speed/state:
   ## Config forwarding Viable to True/false
   /interfaces/interface/config/forwarding-viable:
   ## Define Lag type

--- a/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/aggregate_all_not_forwarding_viable_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/aggregate_all_not_forwarding_viable_test.go
@@ -961,7 +961,6 @@ func checkBundleViableLinksBW(t *testing.T, dut *ondatra.DUTDevice, dutPorts []*
 		if got := gnmi.Get(t, dut, gnmi.OC().Interface(port.Name()).ForwardingViable().State()); got != false {
 			portSpeed := ethernetPortSpeedToMbps(gnmi.Get(t, dut, gnmi.OC().Interface(port.Name()).Ethernet().PortSpeed().State()))
 			lagSpeed += portSpeed
-			t.Logf("Lag speed is %v", lagSpeed)
 		}
 	}
 	return lagSpeed, nil

--- a/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/aggregate_all_not_forwarding_viable_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/aggregate_all_not_forwarding_viable_test.go
@@ -202,6 +202,9 @@ func TestAggregateAllNotForwardingViable(t *testing.T) {
 
 	t.Logf("ISIS cost of LAG_2 lower then ISIS cost of LAG_3 Test-01")
 	t.Run("RT-5.7.1.1: Setting Forwarding-Viable to False on Lag2 all ports except port 2", func(t *testing.T) {
+		if got, _ := gnmi.Lookup(t, dut, ocpath.Root().Interface(aggIDs[1]).Aggregation().LagSpeed().State()).Val(); got != 500000 {
+			t.Errorf("Forwarding unviable links counted as part of LAG bandwidth, got %v, want %v", got, 500000)
+		}
 		configForwardingViable(t, dut, dutPortList[2:agg2.ateLagCount+1], false)
 		startTraffic(t, dut, ate, top)
 		if err := checkBidirectionalTraffic(t, dut, dutPortList[1:2]); err != nil {
@@ -209,6 +212,9 @@ func TestAggregateAllNotForwardingViable(t *testing.T) {
 		}
 		if err := confirmNonViableForwardingTraffic(t, dut, ate, atePortList[2:agg2.ateLagCount+1], dutPortList[2:agg2.ateLagCount+1]); err != nil {
 			t.Fatal(err)
+		}
+		if got, _ := gnmi.Lookup(t, dut, ocpath.Root().Interface(aggIDs[1]).Aggregation().LagSpeed().State()).Val(); got != 100000 {
+			t.Errorf("Forwarding unviable links counted as part of LAG bandwidth, got %v, want %v", got, 100000)
 		}
 		// Ensure there is no traffic received/transmiited on DUT LAG_3
 		if got := validateLag3Traffic(t, dut, ate, dutPortList[(agg2.ateLagCount+1):]); got == true {

--- a/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/aggregate_all_not_forwarding_viable_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/aggregate_all_not_forwarding_viable_test.go
@@ -214,7 +214,7 @@ func TestAggregateAllNotForwardingViable(t *testing.T) {
 		expectedbundleBW, _ = checkBundleViableLinksBW(t, dut, dutPortList[1:agg2.ateLagCount+1])
 		if got, _ := gnmi.Lookup(t, dut, ocpath.Root().Interface(aggIDs[1]).Aggregation().LagSpeed().State()).Val(); got != expectedbundleBW {
 			t.Errorf("Forwarding unviable links counted as part of LAG bandwidth, got %v, want %v", got, expectedbundleBW)
-		}	
+		}
 		if err := confirmNonViableForwardingTraffic(t, dut, ate, atePortList[2:agg2.ateLagCount+1], dutPortList[2:agg2.ateLagCount+1]); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/fptest/portspeed.go
+++ b/internal/fptest/portspeed.go
@@ -32,12 +32,36 @@ import (
 	"github.com/openconfig/ondatra/gnmi/oc"
 )
 
+type speedEnumInfo struct {
+	// Speed value in string format in bits/second.
+	speedStr string
+	// Speed value in integer format in bits/second.
+	speedInt uint64
+}
+
 var portSpeed = map[ondatra.Speed]oc.E_IfEthernet_ETHERNET_SPEED{
 	ondatra.Speed1Gb:   oc.IfEthernet_ETHERNET_SPEED_SPEED_1GB,
 	ondatra.Speed5Gb:   oc.IfEthernet_ETHERNET_SPEED_SPEED_5GB,
 	ondatra.Speed10Gb:  oc.IfEthernet_ETHERNET_SPEED_SPEED_10GB,
 	ondatra.Speed100Gb: oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB,
 	ondatra.Speed400Gb: oc.IfEthernet_ETHERNET_SPEED_SPEED_400GB,
+}
+
+var enumToSpeedInfoMap = map[oc.E_IfEthernet_ETHERNET_SPEED]speedEnumInfo{
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_10MB:   speedEnumInfo{"10M", 10_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_100MB:  speedEnumInfo{"100M", 100_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_1GB:    speedEnumInfo{"1G", 1_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_2500MB: speedEnumInfo{"2500M", 2500_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_5GB:    speedEnumInfo{"5G", 5_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_10GB:   speedEnumInfo{"10G", 10_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_25GB:   speedEnumInfo{"25G", 25_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_40GB:   speedEnumInfo{"40G", 40_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_50GB:   speedEnumInfo{"50G", 50_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB:  speedEnumInfo{"100G", 100_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_200GB:  speedEnumInfo{"200G", 200_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_400GB:  speedEnumInfo{"400G", 400_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_600GB:  speedEnumInfo{"600G", 600_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_800GB:  speedEnumInfo{"800G", 800_000_000_000},
 }
 
 // SetPortSpeed sets the DUT config for the interface port-speed according
@@ -62,4 +86,12 @@ func GetIfSpeed(t *testing.T, p *ondatra.Port) oc.E_IfEthernet_ETHERNET_SPEED {
 	}
 	t.Logf("Configuring interface %v speed %v", p.Name(), speed)
 	return speed
+}
+
+// EthernetSpeedToUint64 returns the speed in uint64 format.
+func EthernetSpeedToUint64(speed oc.E_IfEthernet_ETHERNET_SPEED) uint64 {
+	if _, ok := enumToSpeedInfoMap[speed]; !ok {
+		return 0
+	}
+	return enumToSpeedInfoMap[speed].speedInt
 }

--- a/internal/fptest/portspeed.go
+++ b/internal/fptest/portspeed.go
@@ -48,20 +48,20 @@ var portSpeed = map[ondatra.Speed]oc.E_IfEthernet_ETHERNET_SPEED{
 }
 
 var enumToSpeedInfoMap = map[oc.E_IfEthernet_ETHERNET_SPEED]speedEnumInfo{
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_10MB:   speedEnumInfo{"10M", 10_000_000},
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_100MB:  speedEnumInfo{"100M", 100_000_000},
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_1GB:    speedEnumInfo{"1G", 1_000_000_000},
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_2500MB: speedEnumInfo{"2500M", 2500_000_000},
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_5GB:    speedEnumInfo{"5G", 5_000_000_000},
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_10GB:   speedEnumInfo{"10G", 10_000_000_000},
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_25GB:   speedEnumInfo{"25G", 25_000_000_000},
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_40GB:   speedEnumInfo{"40G", 40_000_000_000},
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_50GB:   speedEnumInfo{"50G", 50_000_000_000},
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB:  speedEnumInfo{"100G", 100_000_000_000},
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_200GB:  speedEnumInfo{"200G", 200_000_000_000},
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_400GB:  speedEnumInfo{"400G", 400_000_000_000},
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_600GB:  speedEnumInfo{"600G", 600_000_000_000},
-	oc.IfEthernet_ETHERNET_SPEED_SPEED_800GB:  speedEnumInfo{"800G", 800_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_10MB:   {"10M", 10_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_100MB:  {"100M", 100_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_1GB:    {"1G", 1_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_2500MB: {"2500M", 2500_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_5GB:    {"5G", 5_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_10GB:   {"10G", 10_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_25GB:   {"25G", 25_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_40GB:   {"40G", 40_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_50GB:   {"50G", 50_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB:  {"100G", 100_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_200GB:  {"200G", 200_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_400GB:  {"400G", 400_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_600GB:  {"600G", 600_000_000_000},
+	oc.IfEthernet_ETHERNET_SPEED_SPEED_800GB:  {"800G", 800_000_000_000},
 }
 
 // SetPortSpeed sets the DUT config for the interface port-speed according


### PR DESCRIPTION
Ensure that the total bandwidth computation for the bundle interface does not include links where "forwarding viable" is set to false.