### PR TITLE
Rt 5.5 increase holdtime down tolerance

### DIFF
--- a/feature/interface/holdtime/otg_tests/holdtime_test/README.md
+++ b/feature/interface/holdtime/otg_tests/holdtime_test/README.md
@@ -13,13 +13,13 @@ Verify oper-state behaviour
 *   Get hold-time state from device and check if it matches what was send in configuration. (some implementation may round-up/round-down values)
 ### TC2 - long down:
 *   Read timestamp of last oper-status change  form DUT port-1 
-*   Start sending Ethernet Remote Fault (RF) from OTG port-1 (or other mean which disable laser on OTG); read and store timestamp form OTG of this operation (OTG_STATE_CHANGE_TS).
-*   wait 1000 ms
+*   Start sending Ethernet Remote Fault (RF) from OTG port-1 (or other mean which disable laser on OTG); read and store the current time from DUT.
+*   wait 500 ms
 *   Read timestamp of last oper-status change  form DUT port-1 (DUT_LAST_CHANGE_TS)
 *   Verify that DUT LAG:
   * oper-status is DOWN
   * oper-status last change time has changed 
-  * DUT_LAST_CHANGE_TS = OTG_STATE_CHANGE_TS + 300ms +/- tolerance; Use tolerance of 200ms.
+  * DUT_LAST_CHANGE_TS = OTG_STATE_CHANGE_TS + 300ms +/- tolerance; Use tolerance of 700ms. (Ideal tolerance value is 200ms. But since we are reading the current time from DUT in step 2 instead of OTG we are accounting for processing delays)
 *   Stop sending Ethernet Remote Fault (RF) from OTG port-1 
 ### TC3 - short up:
 *   Start sending Ethernet Remote Fault (RF) from OTG port-1 (or other mean which disable laser on OTG)

--- a/feature/interface/holdtime/otg_tests/holdtime_test/holddown_timers_test.go
+++ b/feature/interface/holdtime/otg_tests/holdtime_test/holddown_timers_test.go
@@ -27,7 +27,7 @@ const (
 	lagName       = "LAGRx" // OTG LAG NAME
 	upTimer       = 5000
 	downTimer     = 300
-	toleranceMS   = 200 // Define the tolerance in milliseconds
+	toleranceMS   = 700 // Define the tolerance in milliseconds
 
 )
 


### PR DESCRIPTION
Increasing the holdtime down tolerance to 700ms. This is to account for processing delays after issuing RF request to OTG. 