### PR TITLE
removing deviation skip_controller_card_power_admin

### DIFF
--- a/feature/platform/tests/power_admin_down_up_test/metadata.textproto
+++ b/feature/platform/tests/power_admin_down_up_test/metadata.textproto
@@ -7,14 +7,6 @@ description: "Power admin DOWN/UP Test"
 testbed: TESTBED_DUT_ATE_2LINKS
 platform_exceptions: {
   platform: {
-    vendor: JUNIPER
-  }
-  deviations: {
-    skip_controller_card_power_admin: true
-  }
-}
-platform_exceptions: {
-  platform: {
     vendor: ARISTA
   }
   deviations: {


### PR DESCRIPTION
Hi 

This pull is to remove the deviation  skip_controller_card_power_admin for FP1.1 for power_admin_down_up_test.

Thanks 