### PR TITLE
Counter subscription subtest

### DIFF
--- a/feature/interface/otg_tests/telemetry_interface_packet_counters_test/README.md
+++ b/feature/interface/otg_tests/telemetry_interface_packet_counters_test/README.md
@@ -32,10 +32,13 @@ following features:
 *   For the parent interface counters in-pkts and out-pkts:
 
     Check the presence of packet counter paths and monitor counters every
-    30 seconds:
+    30 seconds. Generate traffic to get atleast 10 or more samples. 
 
     *   /interfaces/interface[name='port']/state/counters/in-pkts
     *   /interfaces/interface[name='port']/state/counters/out-pkts
+    *   /interfaces/interface[name='port']/subinterfaces/subinterface[index='index-id']/ipv4/state/counters/in-pkts
+    *   /interfaces/interface[name='port']/subinterfaces/subinterface[index='index-id']/ipv6/state/counters/in-pkts
+   
 
 *   Subinterfaces counters:
 

--- a/feature/interface/otg_tests/telemetry_interface_packet_counters_test/README.md
+++ b/feature/interface/otg_tests/telemetry_interface_packet_counters_test/README.md
@@ -29,7 +29,7 @@ following features:
 
     *   /interfaces/interface/rates/state/load-interval
 
-*   For the parent interface counters in-pkts and out-pkts:
+*   Validate if counters are being updated consistently
 
     Check the presence of packet counter paths and monitor counters every
     30 seconds. Generate traffic to get atleast 10 or more samples. 

--- a/feature/interface/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/interface/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -318,7 +318,6 @@ func validateInAndOutPktsPerSecond(t *testing.T, dut *ondatra.DUTDevice, i1, i2 
 	return pktCounterOK
 }
 
-
 func fetchInAndOutPkts(t *testing.T, dut *ondatra.DUTDevice, i1, i2 *interfaces.InterfacePath) (map[string]uint64, map[string]uint64) {
 	// TODO: Replace InUnicastPkts with InPkts and OutUnicastPkts with OutPkts.
 	if deviations.InterfaceCountersFromContainer(dut) {

--- a/feature/interface/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/interface/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -444,7 +444,7 @@ func TestIntfCounterUpdate(t *testing.T) {
 	t.Run("Check intf counters subscription", func(t *testing.T) {
 		inAndOutPktsPerSecoundCounterOK := validateInAndOutPktsPerSecond(t, dut, i1, i2)
 		if !inAndOutPktsPerSecoundCounterOK {
-			t.Error("Interface Packet Counters are not updated per second")
+			t.Errorf("Interface Packet Counters are not updated per second")
 		}
 	})
 	otg.StopTraffic(t)
@@ -521,10 +521,6 @@ func TestIntfCounterUpdate(t *testing.T) {
 		if got, want := dutOutPktsAfterTraffic[k]-dutOutPktsBeforeTraffic[k], ateOutPkts[k]; got < want {
 			t.Errorf("Get less outPkts from telemetry: got %v, want >= %v", got, want)
 		}
-	}
-	// Validate per second interface counters are updated
-	if !inAndOutPktsPerSecoundCounterOK {
-		t.Error("Interface Packet Counters are not updated per second")
 	}
 }
 

--- a/feature/interface/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/interface/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -303,7 +303,7 @@ func validateInAndOutPktsPerSecond(t *testing.T, dut *ondatra.DUTDevice, i1, i2 
 		pktCounterOK = false
 		t.Fatalf("Interface Packet Counters are not updated every 30 second")
 	}
-	
+
 	// Subscribe to sub-interface ipv4 counters
 	inSubInterfaceSamples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i1.Subinterface(0).Ipv4().Counters().InPkts().State(), 300*time.Second)
 	outSubInterfaceSamples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i2.Subinterface(0).Ipv4().Counters().OutPkts().State(), 300*time.Second)
@@ -313,17 +313,17 @@ func validateInAndOutPktsPerSecond(t *testing.T, dut *ondatra.DUTDevice, i1, i2 
 		pktCounterOK = false
 		t.Fatalf("Sub-interface IPv4 Packet Counters are not updated every 30 second")
 	}
-	
+
 	// Subscribe to sub-interface ipv6 counters
 	inSubInterfaceIpv6Samples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i1.Subinterface(0).Ipv6().Counters().InPkts().State(), 300*time.Second)
 	outSubInterfaceIpv6Samples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i2.Subinterface(0).Ipv6().Counters().OutPkts().State(), 300*time.Second)
 	inSubInterfaceIpv6Pkts := inSubInterfaceIpv6Samples.Await(t)
 	outSubInterfaceIpv6Pkts := outSubInterfaceIpv6Samples.Await(t)
 	if got := verifyCounters(t, dut, inSubInterfaceIpv6Pkts, outSubInterfaceIpv6Pkts); got == false {
-	pktCounterOK = false
-	t.Fatalf("Sub-interface IPv6 Packet Counters are not updated every 30 second")
+		pktCounterOK = false
+		t.Fatalf("Sub-interface IPv6 Packet Counters are not updated every 30 second")
 	}
-	
+
 	return pktCounterOK
 }
 

--- a/feature/interface/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/interface/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -299,22 +299,31 @@ func validateInAndOutPktsPerSecond(t *testing.T, dut *ondatra.DUTDevice, i1, i2 
 	outInterfaceCountersSamples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i2.Counters().OutPkts().State(), 300*time.Second)
 	inInterfaceCountersPkts := inInterfaceCountersSamples.Await(t)
 	outInterfaceCountersPkts := outInterfaceCountersSamples.Await(t)
-	pktCounterOK = verifyCounters(t, dut, inInterfaceCountersPkts, outInterfaceCountersPkts)
-
+	if got := verifyCounters(t, dut, inInterfaceCountersPkts, outInterfaceCountersPkts); got == false {
+		pktCounterOK = false
+		t.Fatalf("Interface Packet Counters are not updated every 30 second")
+	}
+	
 	// Subscribe to sub-interface ipv4 counters
 	inSubInterfaceSamples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i1.Subinterface(0).Ipv4().Counters().InPkts().State(), 300*time.Second)
 	outSubInterfaceSamples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i2.Subinterface(0).Ipv4().Counters().OutPkts().State(), 300*time.Second)
 	inSubInterfacePkts := inSubInterfaceSamples.Await(t)
 	outSubInterfacePkts := outSubInterfaceSamples.Await(t)
-	pktCounterOK = verifyCounters(t, dut, inSubInterfacePkts, outSubInterfacePkts)
-
+	if got := verifyCounters(t, dut, inSubInterfacePkts, outSubInterfacePkts); got == false {
+		pktCounterOK = false
+		t.Fatalf("Sub-interface IPv4 Packet Counters are not updated every 30 second")
+	}
+	
 	// Subscribe to sub-interface ipv6 counters
 	inSubInterfaceIpv6Samples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i1.Subinterface(0).Ipv6().Counters().InPkts().State(), 300*time.Second)
 	outSubInterfaceIpv6Samples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i2.Subinterface(0).Ipv6().Counters().OutPkts().State(), 300*time.Second)
 	inSubInterfaceIpv6Pkts := inSubInterfaceIpv6Samples.Await(t)
 	outSubInterfaceIpv6Pkts := outSubInterfaceIpv6Samples.Await(t)
-	pktCounterOK = verifyCounters(t, dut, inSubInterfaceIpv6Pkts, outSubInterfaceIpv6Pkts)
-
+	if got := verifyCounters(t, dut, inSubInterfaceIpv6Pkts, outSubInterfaceIpv6Pkts); got == false {
+	pktCounterOK = false
+	t.Fatalf("Sub-interface IPv6 Packet Counters are not updated every 30 second")
+	}
+	
 	return pktCounterOK
 }
 

--- a/feature/interface/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
+++ b/feature/interface/otg_tests/telemetry_interface_packet_counters_test/telemetry_interface_packet_counters_test.go
@@ -254,37 +254,23 @@ func TestInterfaceCounters(t *testing.T) {
 	}
 }
 
-func validateInAndOutPktsPerSecond(t *testing.T, dut *ondatra.DUTDevice, i1, i2 *interfaces.InterfacePath) bool {
-	if deviations.InterfaceCountersFromContainer(dut) {
-		time.Sleep(10 * time.Second)
-		return true
-	}
-	inSamples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i1.Counters().InUnicastPkts().State(), 90*time.Second)
-	outSamples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i2.Counters().OutUnicastPkts().State(), 90*time.Second)
-
-	inPkts := inSamples.Await(t)
-	outPkts := outSamples.Await(t)
-
-	if len(inPkts) < 2 || len(outPkts) < 2 {
-		t.Fatalf("did not get enough samples: in counters: %s out counters %s",
-			inPkts, outPkts)
-	}
-	t.Logf("Sample Size Incoming Packets: %d, Sample Size Outgoing Packets: %d", len(inPkts), len(outPkts))
-	var pktCounterOK = true
-	// check counters for first and last sample interval, they shouldn't be equal
+// verifyCounters verifies the interface counters are updated on every subscription request spaced at 30s time interval.
+func verifyCounters(t *testing.T, dut *ondatra.DUTDevice, inPkts, outPkts []*ygnmi.Value[uint64]) bool {
+	counterOK := true
 	inValFirst, _ := inPkts[0].Val()
 	outValFirst, _ := outPkts[0].Val()
 	inValFinal, _ := inPkts[len(inPkts)-1].Val()
 	outValFinal, _ := outPkts[len(inPkts)-1].Val()
 
 	if inValFinal == inValFirst || outValFinal == outValFirst {
-		t.Logf("Counters not incremented: Initial Incoming Packets: %d, Final Incoming Packets: %d", inValFirst, inValFinal)
-		t.Logf("Counters not incremented: Initial Outgoing Packets: %d,  Final Outgoing Packets: %d", outValFirst, outValFinal)
-		pktCounterOK = false
-		return pktCounterOK
+		t.Errorf("Counters not incremented: Initial Incoming Packets: %d, Final Incoming Packets: %d, Initial Outgoing Packets: %d,  Final Outgoing Packets: %d", inValFirst, inValFinal, outValFirst, outValFinal)
+		counterOK = false
+		return counterOK
 	}
 
-	var tolerance = uint64(70)
+	t.Logf("Logging, length of inPkts: %d, length of outPkts: %d", len(inPkts), len(outPkts))
+	t.Logf("inpkts: %v, outPkts: %v", inPkts, outPkts)
+	tolerance := uint64(70)
 	for i := 1; i < len(inPkts); i++ {
 		inValOld, _ := inPkts[i-1].Val()
 		outValOld, _ := outPkts[i-1].Val()
@@ -294,13 +280,44 @@ func validateInAndOutPktsPerSecond(t *testing.T, dut *ondatra.DUTDevice, i1, i2 
 		outValDelta := outValLatest - outValOld
 		t.Logf("Incoming Packets: %d, Outgoing Packets: %d", inValLatest, outValLatest)
 		if inValLatest == inValOld || outValLatest == outValOld || outValDelta <= inValDelta-tolerance || outValDelta >= inValDelta+tolerance {
-			t.Logf("Comparison with previous iteration: Incoming Packets Delta : %d, Outgoing Packets Delta: %d, Tolerance: %d", inValDelta, outValDelta, tolerance)
-			pktCounterOK = false
+			t.Errorf("Comparison with previous iteration: Incoming Packets Delta : %d, Outgoing Packets Delta: %d, Tolerance: %d", inValDelta, outValDelta, tolerance)
+			counterOK = false
 			break
 		}
 	}
+	return counterOK
+}
+
+func validateInAndOutPktsPerSecond(t *testing.T, dut *ondatra.DUTDevice, i1, i2 *interfaces.InterfacePath) bool {
+	if deviations.InterfaceCountersFromContainer(dut) {
+		time.Sleep(10 * time.Second)
+		return true
+	}
+	// Subscribe to input/output interface counters
+	pktCounterOK := true
+	inInterfaceCountersSamples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i1.Counters().InPkts().State(), 300*time.Second)
+	outInterfaceCountersSamples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i2.Counters().OutPkts().State(), 300*time.Second)
+	inInterfaceCountersPkts := inInterfaceCountersSamples.Await(t)
+	outInterfaceCountersPkts := outInterfaceCountersSamples.Await(t)
+	pktCounterOK = verifyCounters(t, dut, inInterfaceCountersPkts, outInterfaceCountersPkts)
+
+	// Subscribe to sub-interface ipv4 counters
+	inSubInterfaceSamples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i1.Subinterface(0).Ipv4().Counters().InPkts().State(), 300*time.Second)
+	outSubInterfaceSamples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i2.Subinterface(0).Ipv4().Counters().OutPkts().State(), 300*time.Second)
+	inSubInterfacePkts := inSubInterfaceSamples.Await(t)
+	outSubInterfacePkts := outSubInterfaceSamples.Await(t)
+	pktCounterOK = verifyCounters(t, dut, inSubInterfacePkts, outSubInterfacePkts)
+
+	// Subscribe to sub-interface ipv6 counters
+	inSubInterfaceIpv6Samples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i1.Subinterface(0).Ipv6().Counters().InPkts().State(), 300*time.Second)
+	outSubInterfaceIpv6Samples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i2.Subinterface(0).Ipv6().Counters().OutPkts().State(), 300*time.Second)
+	inSubInterfaceIpv6Pkts := inSubInterfaceIpv6Samples.Await(t)
+	outSubInterfaceIpv6Pkts := outSubInterfaceIpv6Samples.Await(t)
+	pktCounterOK = verifyCounters(t, dut, inSubInterfaceIpv6Pkts, outSubInterfaceIpv6Pkts)
+
 	return pktCounterOK
 }
+
 
 func fetchInAndOutPkts(t *testing.T, dut *ondatra.DUTDevice, i1, i2 *interfaces.InterfacePath) (map[string]uint64, map[string]uint64) {
 	// TODO: Replace InUnicastPkts with InPkts and OutUnicastPkts with OutPkts.
@@ -423,8 +440,13 @@ func TestIntfCounterUpdate(t *testing.T) {
 
 	otg.StartTraffic(t)
 	time.Sleep(2 * time.Second)
-	// Check incoming and outgoing interface counters updated per second
-	inAndOutPktsPerSecoundCounterOK := validateInAndOutPktsPerSecond(t, dut, i1, i2)
+	// Validate per second interface counters are updated
+	t.Run("Check intf counters subscription", func(t *testing.T) {
+		inAndOutPktsPerSecoundCounterOK := validateInAndOutPktsPerSecond(t, dut, i1, i2)
+		if !inAndOutPktsPerSecoundCounterOK {
+			t.Error("Interface Packet Counters are not updated per second")
+		}
+	})
 	otg.StopTraffic(t)
 
 	// Check interface status is up.

--- a/feature/qos/otg_tests/qos_output_queue_counters_test/README.md
+++ b/feature/qos/otg_tests/qos_output_queue_counters_test/README.md
@@ -13,6 +13,8 @@ Validate QoS interface output queue counters.
     *   /qos/interfaces/interface/output/queues/queue/state/transmit-octets
     *   /qos/interfaces/interface/output/queues/queue/state/dropped-pkts
     *   /qos/interfaces/interface/output/queues/queue/state/dropped-octets
+*   Start traffic and subscribe to packet counters every 30s. Collect 10 or more samples and verify if counters are being incremented for the below path. 
+    *   qos/interfaces/interface/output/queues/queue/state/transmit-octets
 
 ## Config Parameter coverage
 

--- a/feature/qos/otg_tests/qos_output_queue_counters_test/qos_output_queue_counters_test.go
+++ b/feature/qos/otg_tests/qos_output_queue_counters_test/qos_output_queue_counters_test.go
@@ -172,7 +172,6 @@ func TestQoSCounters(t *testing.T) {
 
 		flow.Size().SetFixed(uint32(data.frameSize))
 		flow.Rate().SetPercentage(float32(data.trafficRate))
-		flow.Duration().FixedPackets().SetPackets(10000)
 	}
 
 	var counterNames []string
@@ -231,8 +230,12 @@ func TestQoSCounters(t *testing.T) {
 	t.Logf("Running traffic 1 on DUT interfaces: %s => %s ", dp1.Name(), dp2.Name())
 	t.Logf("Sending traffic flows: \n%v\n\n", trafficFlows)
 	ate.OTG().StartTraffic(t)
-	time.Sleep(120 * time.Second)
+	time.Sleep(2 * time.Second)
+	outputQosPerSecoundCounterOK := validateoutputQosPerSecoundCounter(t, dut, dp1, dp2, trafficFlows)
 	ate.OTG().StopTraffic(t)
+	if !outputQosPerSecoundCounterOK {
+		t.Errorf("Output QoS per second counter is not updated correctly")
+	}
 	time.Sleep(30 * time.Second)
 
 	otgutils.LogFlowMetrics(t, ate.OTG(), top)
@@ -340,6 +343,34 @@ func ConfigureDUTIntf(t *testing.T, dut *ondatra.DUTDevice) {
 		fptest.SetPortSpeed(t, dp1)
 		fptest.SetPortSpeed(t, dp2)
 	}
+}
+
+// verifyCounters verifies the qos counters are updated on every subscription request spaced at 30s time interval.
+func validateoutputQosPerSecoundCounter(t *testing.T, dut *ondatra.DUTDevice, dp1, dp2 *ondatra.Port, trafficFlows map[string]*trafficData) bool {
+	i2 := gnmi.OC().Qos().Interface(dp2.Name())
+	qosCounterOK := true
+	trafficData, ok := trafficFlows["flow-af2"]
+	if !ok {
+		t.Fatalf("Traffic flow 'flow-af3' not found in provided map")
+		return false
+	}
+	qosOutputCountersSamples := gnmi.Collect(t, dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE), ygnmi.WithSampleInterval(30*time.Second)), i2.Output().Queue(trafficData.queue).TransmitPkts().State(), 300*time.Second)
+	outQosCountersPkts := qosOutputCountersSamples.Await(t)
+
+	tolerance := uint64(70)
+	// Check if the output queue counters are updated correctly every 30 seconds.
+	for i := 1; i < len(outQosCountersPkts); i++ {
+		outValOld, _ := outQosCountersPkts[i-1].Val()
+		outValLatest, _ := outQosCountersPkts[i].Val()
+		outValDelta := outValLatest - outValOld
+		t.Logf("Outgoing Packets: %d", outValLatest)
+		if outValLatest == outValOld {
+			t.Errorf("Comparison with previous iteration: Outgoing Packets Delta: %d, Tolerance: %d", outValDelta, tolerance)
+			qosCounterOK = false
+			break
+		}
+	}
+	return qosCounterOK
 }
 
 func ConfigureQoS(t *testing.T, dut *ondatra.DUTDevice) {

--- a/feature/qos/otg_tests/qos_output_queue_counters_test/qos_output_queue_counters_test.go
+++ b/feature/qos/otg_tests/qos_output_queue_counters_test/qos_output_queue_counters_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openconfig/ondatra/netutil"
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
 )
 
 type trafficData struct {

--- a/feature/qos/otg_tests/qos_output_queue_counters_test/qos_output_queue_counters_test.go
+++ b/feature/qos/otg_tests/qos_output_queue_counters_test/qos_output_queue_counters_test.go
@@ -23,13 +23,13 @@ import (
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/featureprofiles/internal/otgutils"
 	"github.com/openconfig/featureprofiles/internal/qoscfg"
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
 	"github.com/openconfig/ondatra/netutil"
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 )
 
 type trafficData struct {


### PR DESCRIPTION
gNMI-1.11: Telemetry: Interface Packet Counters

Start traffic and subscribe to packet counters every 30s. Collect 10 or more samples and verify if counters are being incremented for below paths. 
* /interfaces/interface[name='port']/state/counters/in-pkts
* /interfaces/interface[name='port']/state/counters/out-pkts
* /interfaces/interface[name='port']/subinterfaces/subinterface[index='index-id']/ipv4/state/counters/in-pkts
* /interfaces/interface[name='port']/subinterfaces/subinterface[index='index-id']/ipv6/state/counters/in-pkts

gNMI-1.11: Telemetry: Interface Packet Counters
Start traffic and subscribe to packet counters every 30s. Collect 10 or more samples and verify if counters are being incremented for below paths. 
* /qos/interfaces/interface[interface-id='id']/output/queues/queue[name=*]/state/transmit-octets