### PR TITLE
Removing tolerance deviation for TE-3.3 and TE-3.31

### DIFF
--- a/feature/gribi/otg_tests/hierarchical_weight_resolution_pbf_test/metadata.textproto
+++ b/feature/gribi/otg_tests/hierarchical_weight_resolution_pbf_test/metadata.textproto
@@ -10,7 +10,6 @@ platform_exceptions: {
     vendor: CISCO
   }
   deviations: {
-    hierarchical_weight_resolution_tolerance: 1.5
     ipv4_missing_enabled: true
     interface_ref_interface_id_format: true
     pf_require_match_default_rule: true

--- a/feature/gribi/otg_tests/hierarchical_weight_resolution_test/metadata.textproto
+++ b/feature/gribi/otg_tests/hierarchical_weight_resolution_test/metadata.textproto
@@ -10,7 +10,6 @@ platform_exceptions: {
     vendor: CISCO
   }
   deviations: {
-    hierarchical_weight_resolution_tolerance: 1.5
     ipv4_missing_enabled: true
     interface_ref_interface_id_format: true
   }


### PR DESCRIPTION
Removed hierarchical_weight_resolution_tolerance deviation for TE3.3 and TE3.31 tests.