### PR TITLE
RT-2.13 Adding MaxECMP Paths and Deviations

### DIFF
--- a/feature/isis/otg_tests/weighted_ecmp_test/README.md
+++ b/feature/isis/otg_tests/weighted_ecmp_test/README.md
@@ -152,6 +152,8 @@ paths:
   /network-instances/network-instance/protocols/protocol/isis/levels/level/config/metric-style:
   /network-instances/network-instance/protocols/protocol/isis/global/config/weighted-ecmp:
   /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/weighted-ecmp/config/load-balancing-weight:
+  /network-instances/network-instance/protocols/protocol/isis/global/config/max-ecmp-paths:
+    value: 3
   /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/ip-prefix:
   /routing-policy/defined-sets/prefix-sets/prefix-set/prefixes/prefix/config/masklength-range:
     value: exact

--- a/feature/isis/otg_tests/weighted_ecmp_test/metadata.textproto
+++ b/feature/isis/otg_tests/weighted_ecmp_test/metadata.textproto
@@ -42,3 +42,13 @@ platform_exceptions: {
     isis_level_enabled: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+  }
+  deviations: {
+    missing_isis_interface_afi_safi_enable: true
+    explicit_interface_in_default_vrf: true
+    interface_enabled: true
+  }
+}

--- a/feature/isis/otg_tests/weighted_ecmp_test/weighted_ecmp_test.go
+++ b/feature/isis/otg_tests/weighted_ecmp_test/weighted_ecmp_test.go
@@ -435,9 +435,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) []string {
 		e.PortSpeed = oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB
 	}
 	gnmi.Replace(t, dut, dc.Interface(i1.GetName()).Config(), i1)
-  if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-      fptest.AssignToNetworkInstance(t, dut, i1.GetName(), deviations.DefaultNetworkInstance(dut), 0)
-  }
+	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
+		fptest.AssignToNetworkInstance(t, dut, i1.GetName(), deviations.DefaultNetworkInstance(dut), 0)
+	}
 
 	var aggIDs []string
 	for aggIdx, a := range []attrs.Attributes{dutagg1, dutagg2, dutagg3} {
@@ -478,9 +478,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) []string {
 			gnmi.BatchReplace(b, gnmi.OC().Interface(port.Name()).Config(), i)
 		}
 		b.Set(t, dut)
-    if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-      fptest.AssignToNetworkInstance(t, dut, aggID, deviations.DefaultNetworkInstance(dut), 0)
-    }
+		if deviations.ExplicitInterfaceInDefaultVRF(dut) {
+			fptest.AssignToNetworkInstance(t, dut, aggID, deviations.DefaultNetworkInstance(dut), 0)
+		}
 	}
 	// Wait for LAG interfaces to be UP
 	for _, aggID := range aggIDs {
@@ -524,8 +524,8 @@ func configureDUTISIS(t *testing.T, dut *ondatra.DUTDevice, aggIDs []string) {
 	globalISIS.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled = ygot.Bool(true)
 	globalISIS.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV6, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled = ygot.Bool(true)
 
-  var maxPaths uint8 = 3
-  globalISIS.MaxEcmpPaths = &maxPaths
+	var maxPaths uint8 = 3
+	globalISIS.MaxEcmpPaths = &maxPaths
 	lspBit := globalISIS.GetOrCreateLspBit().GetOrCreateOverloadBit()
 	lspBit.SetBit = ygot.Bool(false)
 

--- a/feature/isis/otg_tests/weighted_ecmp_test/weighted_ecmp_test.go
+++ b/feature/isis/otg_tests/weighted_ecmp_test/weighted_ecmp_test.go
@@ -435,6 +435,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) []string {
 		e.PortSpeed = oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB
 	}
 	gnmi.Replace(t, dut, dc.Interface(i1.GetName()).Config(), i1)
+  if deviations.ExplicitInterfaceInDefaultVRF(dut) {
+      fptest.AssignToNetworkInstance(t, dut, i1.GetName(), deviations.DefaultNetworkInstance(dut), 0)
+  }
 
 	var aggIDs []string
 	for aggIdx, a := range []attrs.Attributes{dutagg1, dutagg2, dutagg3} {
@@ -475,6 +478,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) []string {
 			gnmi.BatchReplace(b, gnmi.OC().Interface(port.Name()).Config(), i)
 		}
 		b.Set(t, dut)
+    if deviations.ExplicitInterfaceInDefaultVRF(dut) {
+      fptest.AssignToNetworkInstance(t, dut, aggID, deviations.DefaultNetworkInstance(dut), 0)
+    }
 	}
 	// Wait for LAG interfaces to be UP
 	for _, aggID := range aggIDs {
@@ -518,6 +524,8 @@ func configureDUTISIS(t *testing.T, dut *ondatra.DUTDevice, aggIDs []string) {
 	globalISIS.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled = ygot.Bool(true)
 	globalISIS.GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV6, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled = ygot.Bool(true)
 
+  var maxPaths uint8 = 3
+  globalISIS.MaxEcmpPaths = &maxPaths
 	lspBit := globalISIS.GetOrCreateLspBit().GetOrCreateOverloadBit()
 	lspBit.SetBit = ygot.Bool(false)
 
@@ -572,10 +580,6 @@ func VerifyISISTelemetry(t *testing.T, dut *ondatra.DUTDevice, dutIntfs []string
 	t.Helper()
 	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, isisInstance).Isis()
 	for _, dutIntf := range dutIntfs {
-
-		if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-			dutIntf = dutIntf + ".0"
-		}
 		nbrPath := statePath.Interface(dutIntf)
 		query := nbrPath.LevelAny().AdjacencyAny().AdjacencyState().State()
 		_, ok := gnmi.WatchAll(t, dut, query, 3*time.Minute, func(val *ygnmi.Value[oc.E_Isis_IsisInterfaceAdjState]) bool {


### PR DESCRIPTION
(M) feature/isis/otg_tests/weighted_ecmp_test/weighted_ecmp_test.go
 - Removed unrequired ExplicitInterfaceInDefaultVRF in ISIS code block and added that deviation to handle LAG/Interface
 - Added MaxECMP paths to be 3 (as many as the number of Lags)
 - Added necessary deviations for interface/LAGs association in DEFAULT VRF

(M) feature/isis/otg_tests/weighted_ecmp_test/README.md
 - Added MaxECMP in the ConfigPaths

(M) feature/isis/otg_tests/weighted_ecmp_test/metadata.textproto
- Additions of Vendor specific deviations

---

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."