### PR TITLE
Plt1.1 breakout test

### DIFF
--- a/feature/platform/tests/breakout_configuration/breakout_base_test.go
+++ b/feature/platform/tests/breakout_configuration/breakout_base_test.go
@@ -63,7 +63,7 @@ func isBreakoutSupported(t *testing.T, dut *ondatra.DUTDevice, port string, numB
 
 // verifyBreakout checks if the breakout configuration matches the expected values.
 // It reports errors to the testing object if there is a mismatch.
-func verifyBreakout(index uint8, numBreakoutsWant uint8, numBreakoutsGot uint8, breakoutSpeedWant string, breakoutSpeedGot string, t *testing.T) {
+func verifyBreakout(index uint8, numBreakoutsWant uint8, numBreakoutsGot uint8, breakoutSpeedWant string, breakoutSpeedGot string, numPhysicalChannelsWant uint8, numPhysicalChannelsGot uint8, t *testing.T) {
 	// Ensure that the index is set to the expected value (1 in this case).
 	if index != uint8(1) {
 		t.Errorf("Index: got %v, want 1", index)
@@ -75,6 +75,10 @@ func verifyBreakout(index uint8, numBreakoutsWant uint8, numBreakoutsGot uint8, 
 	// Verify that the configured breakout speed is as expected.
 	if breakoutSpeedGot != breakoutSpeedWant {
 		t.Errorf("Breakout speed configured: got %v, want %v", breakoutSpeedGot, breakoutSpeedWant)
+	}
+	// Verify that the number of physical channels configured matches the expected value.
+	if numPhysicalChannelsGot != numPhysicalChannelsWant {
+		t.Errorf("Number of physical channels configured: got %v, want %v", numPhysicalChannelsGot, numPhysicalChannelsWant)
 	}
 
 }

--- a/feature/platform/tests/breakout_configuration/breakout_base_test.go
+++ b/feature/platform/tests/breakout_configuration/breakout_base_test.go
@@ -65,7 +65,7 @@ func isBreakoutSupported(t *testing.T, dut *ondatra.DUTDevice, port string, numB
 // It reports errors to the testing object if there is a mismatch.
 func verifyBreakout(index uint8, numBreakoutsWant uint8, numBreakoutsGot uint8, breakoutSpeedWant string, breakoutSpeedGot string, t *testing.T) {
 	// Ensure that the index is set to the expected value (1 in this case).
-	if index != uint8(0) {
+	if index != uint8(1) {
 		t.Errorf("Index: got %v, want 1", index)
 	}
 	// Check if the number of breakouts configured matches what was expected.
@@ -82,7 +82,7 @@ func verifyBreakout(index uint8, numBreakoutsWant uint8, numBreakoutsGot uint8, 
 func verifyDelete(t *testing.T, dut *ondatra.DUTDevice, compname string, schemaValue uint8) {
 
 	if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
-		gnmi.Get(t, dut, gnmi.OC().Component(compname).Port().BreakoutMode().Group(schemaValue).Index().Config()) //catch the error  as it is expected and absorb the panic.
+		gnmi.Get(t, dut, gnmi.OC().Component(compname).Port().BreakoutMode().Group(schemaValue).Index().Config()) // catch the error  as it is expected and absorb the panic.
 	}); errMsg != nil {
 		t.Log("Expected failure as this verifies the breakout config is removed")
 	} else {
@@ -128,35 +128,52 @@ func IncrementIPNetwork(ipStr string, numBreakouts uint8, isIPv4 bool, lastOctet
 // the newly broken out ports of OneHundredGigE0/0/0/0/10/0-4
 func findNewPortNames(dut *ondatra.DUTDevice, t *testing.T, originalPortName string, numBreakouts uint8) ([]string, error) {
 	// Fetch the current state of all interfaces from the device using gNMI.
-	intfs := gnmi.Get(t, dut, gnmi.OC().InterfaceMap().State())
 
-	// Split the original port name by '/' to extract the correct index (third-last segment in this case).
-	portSegments := strings.Split(originalPortName, "/")
-	if len(portSegments) < 4 {
-		return nil, fmt.Errorf("invalid port name format: %v", originalPortName)
-	}
-	portIndex := portSegments[len(portSegments)-2] // Get the third-last segment, which is "30"
+	switch dut.Vendor() {
+	case ondatra.CISCO:
+		intfs := gnmi.Get(t, dut, gnmi.OC().InterfaceMap().State())
 
-	// Define a pattern to match breakout port names that include the original port index.
-	breakoutPattern := fmt.Sprintf(`\w+/\d+/\d+/%s/\d+`, portIndex)
-
-	// Compile the pattern into a regular expression.
-	re := regexp.MustCompile(breakoutPattern)
-
-	// Loop through all interfaces and collect those that match the breakout pattern
-	newPortNames := []string{}
-	for intfName := range intfs {
-		if re.MatchString(intfName) {
-			newPortNames = append(newPortNames, intfName)
+		// Split the original port name by '/' to extract the correct index (third-last segment in this case).
+		portSegments := strings.Split(originalPortName, "/")
+		if len(portSegments) < 4 {
+			return nil, fmt.Errorf("invalid port name format: %v", originalPortName)
 		}
+		portIndex := portSegments[len(portSegments)-2] // Get the third-last segment, which is "30"
+
+		// Define a pattern to match breakout port names that include the original port index.
+		breakoutPattern := fmt.Sprintf(`\w+/\d+/\d+/%s/\d+`, portIndex)
+
+		// Compile the pattern into a regular expression.
+		re := regexp.MustCompile(breakoutPattern)
+
+		// Loop through all interfaces and collect those that match the breakout pattern
+		var newPortNames []string
+		for intfName := range intfs {
+			if re.MatchString(intfName) {
+				newPortNames = append(newPortNames, intfName)
+			}
+		}
+
+		// Check if the number of new ports found is equal to the number of breakouts expected.
+		if len(newPortNames) != int(numBreakouts) {
+			return nil, fmt.Errorf("expected to find %d new ports, found %d", numBreakouts, len(newPortNames))
+		}
+
+		return newPortNames, nil
+
+	// Returns all reserved ports (We are only reserving the breakout ports for the test)
+	case ondatra.ARISTA:
+		portsAll := dut.Ports()
+		newPortNames := []string{}
+		for _, port := range portsAll {
+			newPortNames = append(newPortNames, port.Name())
+		}
+		return newPortNames, nil
+	default:
+		t.Fatalf("Unsupported vendor %s. Need to add breakout component names.", dut.Vendor())
 	}
 
-	// Check if the number of new ports found is equal to the number of breakouts expected.
-	if len(newPortNames) != int(numBreakouts) {
-		return nil, fmt.Errorf("expected to find %d new ports, found %d", numBreakouts, len(newPortNames))
-	}
-
-	return newPortNames, nil
+	return nil, nil
 }
 
 // fetchResponses will fetch the ping response
@@ -211,18 +228,28 @@ func getCompName(dut *ondatra.DUTDevice, string, portPrefix string, t *testing.T
 	}
 
 	// Extract line card slot and port number from the interface name
-	var portNumber = string
-	var lcSlot = string
-	parts := strings.Split(dutPortName, "/")
-	if len(parts) >= 4 {
-		lcSlot = parts[2]
-		portNumber = parts[3]
-		t.Logf("Extracted Linecard Slot: %s, Port Number: %s", lcSlot, portNumber)
-		compName := fmt.Sprintf("Port0/%s/0/%s", lcSlot, portNumber)
-		t.Logf("compName is: %s", compName)
-		return compName, dutPortName, true
-	} else {
-		t.Logf("Invalid location format: %s", dutPortName)
+	switch dut.Vendor() {
+	case ondatra.CISCO:
+		var portNumber = string
+		var lcSlot = string
+		parts := strings.Split(dutPortName, "/")
+		if len(parts) >= 4 {
+			lcSlot = parts[2]
+			portNumber = parts[3]
+			t.Logf("Extracted Linecard Slot: %s, Port Number: %s", lcSlot, portNumber)
+			compName := fmt.Sprintf("Port0/%s/0/%s", lcSlot, portNumber)
+			t.Logf("compName is: %s", compName)
+			return compName, dutPortName, true
+		} else {
+			t.Logf("Invalid location format: %s", dutPortName)
+			return "", "", false
+		}
+	case ondatra.ARISTA:
+		lastIndex := strings.LastIndex(dutPortName, "/")
+		breakOutCompName := dutPortName[:lastIndex] + "-Port"
+		return breakOutCompName, dutPortName, true
+	default:
+		t.Fatalf("Unsupported vendor: %v", dut.Vendor())
 		return "", "", false
 	}
 }

--- a/feature/platform/tests/breakout_configuration/breakout_test.go
+++ b/feature/platform/tests/breakout_configuration/breakout_test.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	maxPingRetries = 3 // Set the number of retry attempts
+	schemaValue = 1
 
 )
 
@@ -33,7 +34,6 @@ var (
 	breakOutCompName           string
 	fullInterfaceName          string
 	foundComp                  bool
-	schemaValue                uint8
 	dutPort1                   = attrs.Attributes{
 		Desc:    "dutPort1",
 		IPv4:    "203.0.113.1",
@@ -190,14 +190,6 @@ func TestPlatformBreakoutConfig(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	var Dutipv4Subnets []string
 	var Ateipv4Subnets []string
-	switch dut.Vendor() {
-	case ondatra.CISCO:
-		schemaValue = 0
-	case ondatra.ARISTA:
-		schemaValue = 1
-	default:
-		t.Fatalf("Unsupported vendor %s. Need to add breakout component names.", dut.Vendor())
-	}
 
 	cases := []struct {
 		numbreakouts  uint8

--- a/feature/platform/tests/breakout_configuration/breakout_test.go
+++ b/feature/platform/tests/breakout_configuration/breakout_test.go
@@ -197,6 +197,7 @@ func TestPlatformBreakoutConfig(t *testing.T) {
 		dutIntfIP     string
 		ateIntfIp     string
 		expectedPMD   string
+		numPhysicalChannels uint8
 	}{
 		{
 			numbreakouts:  4,
@@ -204,6 +205,7 @@ func TestPlatformBreakoutConfig(t *testing.T) {
 			dutIntfIP:     dutPort1.IPv4,
 			ateIntfIp:     atePort1.IPv4,
 			expectedPMD:   "PMD_100GBASE_FR",
+			numPhysicalChannels: 2,
 		},
 		{
 
@@ -212,6 +214,7 @@ func TestPlatformBreakoutConfig(t *testing.T) {
 			dutIntfIP:     dutPort1.IPv4,
 			ateIntfIp:     atePort1.IPv4,
 			expectedPMD:   "PMD_100GBASE_FR",
+			numPhysicalChannels: 2,
 		},
 		{
 			numbreakouts:  4,
@@ -219,6 +222,7 @@ func TestPlatformBreakoutConfig(t *testing.T) {
 			dutIntfIP:     dutPort2.IPv4,
 			ateIntfIp:     atePort2.IPv4,
 			expectedPMD:   "PMD_100GBASE_FR",
+			numPhysicalChannels: 2,
 		},
 	}
 
@@ -272,6 +276,7 @@ func TestPlatformBreakoutConfig(t *testing.T) {
 					Index:         ygot.Uint8(1),
 					NumBreakouts:  ygot.Uint8(tc.numbreakouts),
 					BreakoutSpeed: oc.E_IfEthernet_ETHERNET_SPEED(tc.breakoutspeed),
+					NumPhysicalChannels: ygot.Uint8(tc.numPhysicalChannels),
 				}
 				groupContainer := &oc.Component_Port_BreakoutMode{Group: map[uint8]*oc.Component_Port_BreakoutMode_Group{1: configContainer}}
 				breakoutContainer := &oc.Component_Port{BreakoutMode: groupContainer}
@@ -308,8 +313,9 @@ func TestPlatformBreakoutConfig(t *testing.T) {
 					index := *groupDetails.Index
 					numBreakouts := *groupDetails.NumBreakouts
 					breakoutSpeed := groupDetails.BreakoutSpeed
+					numPhysicalChannels := *groupDetails.NumPhysicalChannels
 					verifyBreakout(index, tc.numbreakouts, numBreakouts, tc.breakoutspeed.String(),
-						breakoutSpeed.String(), t)
+						breakoutSpeed.String(), tc.numPhysicalChannels, numPhysicalChannels, t)
 				})
 
 				t.Run(fmt.Sprintf("Configure DUT Interfaces with IPv4 For %v %v",

--- a/feature/platform/tests/breakout_configuration/breakout_test.go
+++ b/feature/platform/tests/breakout_configuration/breakout_test.go
@@ -24,8 +24,7 @@ import (
 
 const (
 	maxPingRetries = 3 // Set the number of retry attempts
-	schemaValue = 1
-
+	schemaValue    = 1
 )
 
 var (
@@ -192,36 +191,36 @@ func TestPlatformBreakoutConfig(t *testing.T) {
 	var Ateipv4Subnets []string
 
 	cases := []struct {
-		numbreakouts  uint8
-		breakoutspeed oc.E_IfEthernet_ETHERNET_SPEED
-		dutIntfIP     string
-		ateIntfIp     string
-		expectedPMD   string
+		numbreakouts        uint8
+		breakoutspeed       oc.E_IfEthernet_ETHERNET_SPEED
+		dutIntfIP           string
+		ateIntfIp           string
+		expectedPMD         string
 		numPhysicalChannels uint8
 	}{
 		{
-			numbreakouts:  4,
-			breakoutspeed: oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB,
-			dutIntfIP:     dutPort1.IPv4,
-			ateIntfIp:     atePort1.IPv4,
-			expectedPMD:   "PMD_100GBASE_FR",
+			numbreakouts:        4,
+			breakoutspeed:       oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB,
+			dutIntfIP:           dutPort1.IPv4,
+			ateIntfIp:           atePort1.IPv4,
+			expectedPMD:         "PMD_100GBASE_FR",
 			numPhysicalChannels: 2,
 		},
 		{
 
-			numbreakouts:  2,
-			breakoutspeed: oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB,
-			dutIntfIP:     dutPort1.IPv4,
-			ateIntfIp:     atePort1.IPv4,
-			expectedPMD:   "PMD_100GBASE_FR",
+			numbreakouts:        2,
+			breakoutspeed:       oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB,
+			dutIntfIP:           dutPort1.IPv4,
+			ateIntfIp:           atePort1.IPv4,
+			expectedPMD:         "PMD_100GBASE_FR",
 			numPhysicalChannels: 2,
 		},
 		{
-			numbreakouts:  4,
-			breakoutspeed: oc.IfEthernet_ETHERNET_SPEED_SPEED_10GB,
-			dutIntfIP:     dutPort2.IPv4,
-			ateIntfIp:     atePort2.IPv4,
-			expectedPMD:   "PMD_100GBASE_FR",
+			numbreakouts:        4,
+			breakoutspeed:       oc.IfEthernet_ETHERNET_SPEED_SPEED_10GB,
+			dutIntfIP:           dutPort2.IPv4,
+			ateIntfIp:           atePort2.IPv4,
+			expectedPMD:         "PMD_100GBASE_FR",
 			numPhysicalChannels: 2,
 		},
 	}
@@ -273,9 +272,9 @@ func TestPlatformBreakoutConfig(t *testing.T) {
 			for _, componentName := range componentNameList {
 				t.Logf("Starting Test for %s %v", componentName, tc)
 				configContainer := &oc.Component_Port_BreakoutMode_Group{
-					Index:         ygot.Uint8(1),
-					NumBreakouts:  ygot.Uint8(tc.numbreakouts),
-					BreakoutSpeed: oc.E_IfEthernet_ETHERNET_SPEED(tc.breakoutspeed),
+					Index:               ygot.Uint8(1),
+					NumBreakouts:        ygot.Uint8(tc.numbreakouts),
+					BreakoutSpeed:       oc.E_IfEthernet_ETHERNET_SPEED(tc.breakoutspeed),
 					NumPhysicalChannels: ygot.Uint8(tc.numPhysicalChannels),
 				}
 				groupContainer := &oc.Component_Port_BreakoutMode{Group: map[uint8]*oc.Component_Port_BreakoutMode_Group{1: configContainer}}

--- a/feature/platform/tests/breakout_configuration/metadata.textproto
+++ b/feature/platform/tests/breakout_configuration/metadata.textproto
@@ -3,7 +3,7 @@
 plan_id: "PLT-1.1"
 uuid: "6ac4eed0-9e04-46f5-85d8-ca88ee5fec7d"
 description: "Interface breakout Test"
-testbed: TESTBED_DUT_ATE_8LINKS
+testbed: TESTBED_DUT_ATE_4LINKS
 platform_exceptions: {
   platform: {
     vendor: CISCO


### PR DESCRIPTION
Modified the test to be more vendor agnostic. Also the test runs on the assumption that 4 x 100g ports already configured for breakouts are only selected. Thus the index and schema value are also changed. 