### PR TITLE
🧹: Fix typo & remove TODO for gRIBI tests.

### DIFF
--- a/feature/gribi/otg_tests/fib_failed_due_to_hw_res_exhaust_test/README.md
+++ b/feature/gribi/otg_tests/fib_failed_due_to_hw_res_exhaust_test/README.md
@@ -12,7 +12,7 @@ Validate gRIBI FIB_FAILED functionality.
 
 *   Establish BGP session between ATE Port1 --- DUT Port1. Inject unique BGP routes to exhaust FIB on DUT.
 
-*   Continuously injecting the following gRIB structure until FIB FAILED is received. 
+*   Continuously injecting the following gRIBI structure until FIB FAILED is received. 
     Each DstIP and VIP should be unique and of /32. All the NHG and NH should be unique (of unique ID).
     DstIP/32 -> NHG -> NH {next-hop:} -> VIP/32 -> NHG -> NH {next-hop: AtePort2Ip}
     

--- a/feature/gribi/otg_tests/gribi_scaling/README.md
+++ b/feature/gribi/otg_tests/gribi_scaling/README.md
@@ -14,7 +14,7 @@ Validate gRIBI scaling requirements.
 *   On DUT, create a policy-based forwarding rule to redirect all traffic received from DUT port-1 into VRF-2 (based on src. IP match 222.222.222.222)
 *   Establish gRIBI client connection with DUT negotiating FIBACK as the
     requested ack_type and make it become leader.
-*   [**TODO**](https://github.com/openconfig/featureprofiles/issues/3676): Using gRIBI Modify RPC install the following IPv4Entry sets, and validate
+*   Using gRIBI Modify RPC install the following IPv4Entry sets, and validate
     the specified behaviours:
     *   Default VRF
         * A) Install 400 NextHops, egressing out different interfaces.
@@ -33,7 +33,7 @@ Validate gRIBI scaling requirements.
     *   VRF3
         *   Install 9000 IPv4Entries (Same IPAddress as VRF1).  Each points to a NextHopGroup from H).
 *   Validate that each entry above are installed as FIB_PROGRAMMED.
-*   **TODO**: Add flows destinating to IPBlocks and ensure ATEPort2 receives it with
+*   Add flows destinating to IPBlocks and ensure ATEPort2 receives it with
     no loss and proper weights
 
 ## OpenConfig Path and RPC Coverage


### PR DESCRIPTION
```
 * (M) feature/gribi/fib_failed_due_to_hw_res_exhaust_test/README.md
  - Fix typo in README.
 * (M) feature/gribi/gribi_scaling/README.md
  - Resolve TODO covering adding traffic validation in this test as it is
    covered in the implementation.
  - Resolve TODO covering gRIBI route programming as it has been added.
```

It wasn't clear to me whether the TODO #3676 was requesting that the programmed entries are validated using `Get` or not. It seemed like this isn't necessarily required because traffic generation will also do this verification.
