### PR TITLE
RT-2.12: Replaced GetAll with WatchAll & fixed watchAll conditions

### DIFF
--- a/feature/isis/otg_tests/static_route_isis_redistribution/static_route_isis_redistribution_test.go
+++ b/feature/isis/otg_tests/static_route_isis_redistribution/static_route_isis_redistribution_test.go
@@ -423,9 +423,18 @@ func verifyV6Prefix(t *testing.T, ts *isissession.TestSession, shouldBePresent b
 func verifyPrefixMetric(t *testing.T, ts *isissession.TestSession, expectedMetric uint32) {
 
 	t.Run("Verify Route Metric on OTG", func(t *testing.T) {
-		metricInReceivedLsp := gnmi.GetAll(t, ts.ATE.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().ExtendedIpv4Reachability().Prefix(v4Route).Metric().State())[0]
-		if metricInReceivedLsp != expectedMetric {
-			t.Errorf("Metric not matched for v4 route. Expected %d got %d ", expectedMetric, metricInReceivedLsp)
+		_, ok := gnmi.WatchAll(t, ts.ATE.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().ExtendedIpv4Reachability().Prefix(v4Route).Metric().State(), 30*time.Second, func(v *ygnmi.Value[uint32]) bool {
+			if !v.IsPresent() {
+				return false
+			}
+			if metricInReceivedLsp, _ := v.Val(); metricInReceivedLsp == expectedMetric {
+				t.Logf("Metric matched for v4 route, got: %d & want: %d", metricInReceivedLsp, expectedMetric)
+				return true
+			}
+			return false
+		}).Await(t)
+		if !ok {
+			t.Error("ERROR: Metrics mismatched for v4 route")
 		}
 	})
 }
@@ -433,9 +442,18 @@ func verifyPrefixMetric(t *testing.T, ts *isissession.TestSession, expectedMetri
 func verifyV6PrefixMetric(t *testing.T, ts *isissession.TestSession, expectedMetric uint32) {
 
 	t.Run("Verify Route Metric on OTG", func(t *testing.T) {
-		metricInReceivedLsp := gnmi.GetAll(t, ts.ATE.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(v6Route).Metric().State())[0]
-		if metricInReceivedLsp != expectedMetric {
-			t.Errorf("Metric not matched for v6 route. Expected %d got %d ", expectedMetric, metricInReceivedLsp)
+		_, ok := gnmi.WatchAll(t, ts.ATE.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(v6Route).Metric().State(), 30*time.Second, func(v *ygnmi.Value[uint32]) bool {
+			if !v.IsPresent() {
+				return false
+			}
+			if metricInReceivedLsp, _ := v.Val(); metricInReceivedLsp == expectedMetric {
+				t.Logf("Metric matched for v6 route, got: %d & want: %d", metricInReceivedLsp, expectedMetric)
+				return true
+			}
+			return false
+		}).Await(t)
+		if !ok {
+			t.Error("ERROR: Metrics mismatched for v6 route")
 		}
 	})
 }
@@ -493,7 +511,7 @@ func verifyMatchingPrefixWithTag(t *testing.T, ts *isissession.TestSession) {
 		gnmi.Replace(t, ts.DUT, gnmi.OC().RoutingPolicy().DefinedSets().TagSet(v4tagSet).TagValue().Config(), []oc.RoutingPolicy_DefinedSets_TagSet_TagValue_Union{oc.UnionUint32(V4tagValue)})
 	})
 	if !deviations.RoutingPolicyTagSetEmbedded(ts.DUT) {
-		t.Run("Verify Configuration for RPL TagSet", func(t *testing.T) {
+		t.Run("Verify Configuration for RPL TagSet in V4", func(t *testing.T) {
 			verifyRplConfig(t, ts.DUT, v4tagSet, oc.UnionUint32(V4tagValue))
 		})
 	}
@@ -508,7 +526,7 @@ func verifyMatchingV6PrefixWithTag(t *testing.T, ts *isissession.TestSession) {
 		gnmi.Replace(t, ts.DUT, gnmi.OC().RoutingPolicy().DefinedSets().TagSet(v6tagSet).TagValue().Config(), []oc.RoutingPolicy_DefinedSets_TagSet_TagValue_Union{oc.UnionUint32(V6tagValue)})
 	})
 	if !deviations.RoutingPolicyTagSetEmbedded(ts.DUT) {
-		t.Run("Verify Configuration for RPL TagSet", func(t *testing.T) {
+		t.Run("Verify Configuration for RPL TagSet in V6", func(t *testing.T) {
 			verifyRplConfig(t, ts.DUT, v6tagSet, oc.UnionUint32(V6tagValue))
 		})
 	}
@@ -536,10 +554,6 @@ func TestStaticToISISRedistribution(t *testing.T) {
 			configureOTGFlows(t, ts.ATETop, ts)
 			advertiseRoutesWithISIS(t, ts)
 			ts.PushAndStart(t)
-			ts.MustAdjacency(t)
-
-			otgutils.WaitForARP(t, ts.ATE.OTG(), ts.ATETop, "IPv4")
-			otgutils.WaitForARP(t, ts.ATE.OTG(), ts.ATETop, "IPv6")
 		})
 	})
 
@@ -638,12 +652,8 @@ func TestStaticToISISRedistribution(t *testing.T) {
 	}}
 
 	for _, tc := range cases {
-		if deviations.MatchTagSetConditionUnsupported(ts.DUT) && tc.TagSetCondition {
-			t.Skipf("Skipping test case %s due to match tag set condition not supported", tc.desc)
-		}
 
 		dni := deviations.DefaultNetworkInstance(ts.DUT)
-
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Run(fmt.Sprintf("Configure Policy Type %s", tc.policyStmtType.String()), func(t *testing.T) {
 				rpl, err := configureRoutePolicy(ts.DUT, tc.RplName, tc.RplStatement, tc.PrefixSetCondition,
@@ -654,12 +664,18 @@ func TestStaticToISISRedistribution(t *testing.T) {
 				}
 				gnmi.Update(t, ts.DUT, gnmi.OC().RoutingPolicy().Config(), rpl)
 			})
+			if deviations.MatchTagSetConditionUnsupported(ts.DUT) && tc.TagSetCondition {
+				t.Skipf("Skipping test case %s due to match tag set condition not supported", tc.desc)
+			}
 
 			if tc.TagSetCondition {
 				if !deviations.RoutingPolicyTagSetEmbedded(ts.DUT) {
 					t.Run("Verify Configuration for RPL TagSet", func(t *testing.T) {
-						verifyRplConfig(t, ts.DUT, v4tagSet, oc.UnionUint32(V4tagValue))
-						verifyRplConfig(t, ts.DUT, v6tagSet, oc.UnionUint32(V6tagValue))
+						if tc.protoAf == oc.Types_ADDRESS_FAMILY_IPV4 {
+							verifyRplConfig(t, ts.DUT, v4tagSet, oc.UnionUint32(tagValue))
+						} else {
+							verifyRplConfig(t, ts.DUT, v6tagSet, oc.UnionUint32(tagValue))
+						}
 					})
 				}
 			}
@@ -672,6 +688,13 @@ func TestStaticToISISRedistribution(t *testing.T) {
 				getAndVerifyIsisImportPolicy(t, ts.DUT, tc.metricPropogation, tc.RplName, tc.protoAf.String())
 			})
 
+			t.Run("Verify ISIS adjacency", func(t *testing.T) {
+				adj := ts.MustAdjacency(t)
+				t.Logf("ISIS adjacency established with ID: %s", adj)
+
+				otgutils.WaitForARP(t, ts.ATE.OTG(), ts.ATETop, "IPv4")
+				otgutils.WaitForARP(t, ts.ATE.OTG(), ts.ATETop, "IPv6")
+			})
 			tc.verifyRouteFunc(t, ts)
 
 			if tc.verifyTrafficStats {


### PR DESCRIPTION
  - Replaced GetAll with WatchAll for Metric propagation sub-cases in both v4 & v6.
  - Fixed watchAll condition in `func verifyPrefix` for 2.12.5 & 2.12.7 sub-cases.
  - Minor Log message fixes.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."