### PR TITLE
Correct typo in TE-17.1

### DIFF
--- a/feature/gribi/otg_tests/vrf_policy_driven_te/vrf_policy_driven_te_test.go
+++ b/feature/gribi/otg_tests/vrf_policy_driven_te/vrf_policy_driven_te_test.go
@@ -1229,7 +1229,7 @@ func configGribiBaselineAFT(ctx context.Context, t *testing.T, dut *ondatra.DUTD
 		chk.IgnoreOperationID(),
 	)
 
-	// Install an 0/0 static route in ENCAP_VRF_A and ENCAP_VRF_B pointing to the DEFAULT VRF.
+	// Install an 0/0 route in ENCAP_VRF_A and ENCAP_VRF_B pointing to the DEFAULT VRF.
 	args.client.Modify().AddEntry(t,
 		fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 			WithIndex(60).WithNextHopNetworkInstance(deviations.DefaultNetworkInstance(dut)),


### PR DESCRIPTION
This PR replaces the stale PR: https://github.com/openconfig/featureprofiles/pull/2976
