### PR TITLE
Fix RT-2.12 to use replace instead of update

### DIFF
--- a/feature/isis/otg_tests/static_route_isis_redistribution/static_route_isis_redistribution_test.go
+++ b/feature/isis/otg_tests/static_route_isis_redistribution/static_route_isis_redistribution_test.go
@@ -674,7 +674,7 @@ func TestStaticToISISRedistribution(t *testing.T) {
 					fmt.Println("Error configuring route policy:", err)
 					return
 				}
-				gnmi.Update(t, ts.DUT, gnmi.OC().RoutingPolicy().Config(), rpl)
+				gnmi.Replace(t, ts.DUT, gnmi.OC().RoutingPolicy().Config(), rpl)
 			})
 
 			if tc.TagSetCondition {


### PR DESCRIPTION
The config was being updated which was causing more config to be added without cleaning up the previous config, so replacing it would resolve the issue.