### PR TITLE
Vendor specific ZR optical channel operational mode

### DIFF
--- a/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
+++ b/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
@@ -32,8 +32,7 @@ const (
 var (
 	frequencies                = []uint64{191400000, 196100000} // 400ZR OIF wavelength range
 	targetOutputPowers         = []float64{-13, -9}             // 400ZR OIF Tx power range
-	operationalMode     uint16
-	operationalModeFlag *uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
 )
 
 func TestMain(m *testing.M) {
@@ -99,12 +98,7 @@ func TestCDValue(t *testing.T) {
 
 	dp1 := dut.Port(t, "port1")
 	dp2 := dut.Port(t, "port2")
-	if operationalModeFlag != nil {
-		operationalMode = uint16(*operationalModeFlag)
-	} else {
-		operationalMode = cfgplugins.GetOperationalModeFlag(dut1)
-	}
-	cfgplugins.Initialize(operationalMode)
+	cfgplugins.Initialize(operationalModeFlag, dut)
 	cfgplugins.InterfaceConfig(t, dut, dp1)
 	cfgplugins.InterfaceConfig(t, dut, dp2)
 

--- a/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
+++ b/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
@@ -100,7 +100,7 @@ func TestCDValue(t *testing.T) {
 	dp1 := dut.Port(t, "port1")
 	dp2 := dut.Port(t, "port2")
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalMode)
+	cfgplugins.InterfaceInitialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dp1)
 	cfgplugins.InterfaceConfig(t, dut, dp2)
 

--- a/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
+++ b/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
@@ -33,7 +33,6 @@ var (
 	frequencies          = []uint64{191400000, 196100000} // 400ZR OIF wavelength range
 	targetOutputPowers   = []float64{-13, -9}             // 400ZR OIF Tx power range
 	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
-	operationalModeValue uint16
 	operationalMode      uint16
 )
 
@@ -100,9 +99,8 @@ func TestCDValue(t *testing.T) {
 
 	dp1 := dut.Port(t, "port1")
 	dp2 := dut.Port(t, "port2")
-	operationalModeValue = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalModeValue)
-	operationalMode = cfgplugins.GetOpMode()
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dp1)
 	cfgplugins.InterfaceConfig(t, dut, dp2)
 

--- a/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
+++ b/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
@@ -32,7 +32,7 @@ const (
 var (
 	frequencies          = []uint64{191400000, 196100000} // 400ZR OIF wavelength range
 	targetOutputPowers   = []float64{-13, -9}             // 400ZR OIF Tx power range
-	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
 	operationalMode      uint16
 )
 

--- a/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
+++ b/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
@@ -30,8 +30,8 @@ const (
 )
 
 var (
-	frequencies                = []uint64{191400000, 196100000} // 400ZR OIF wavelength range
-	targetOutputPowers         = []float64{-13, -9}             // 400ZR OIF Tx power range
+	frequencies          = []uint64{191400000, 196100000} // 400ZR OIF wavelength range
+	targetOutputPowers   = []float64{-13, -9}             // 400ZR OIF Tx power range
 	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
 	operationalModeValue uint16
 	operationalMode      uint16

--- a/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
+++ b/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
@@ -32,7 +32,9 @@ const (
 var (
 	frequencies                = []uint64{191400000, 196100000} // 400ZR OIF wavelength range
 	targetOutputPowers         = []float64{-13, -9}             // 400ZR OIF Tx power range
-	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
+	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeValue uint16
+	operationalMode      uint16
 )
 
 func TestMain(m *testing.M) {
@@ -98,7 +100,9 @@ func TestCDValue(t *testing.T) {
 
 	dp1 := dut.Port(t, "port1")
 	dp2 := dut.Port(t, "port2")
-	cfgplugins.Initialize(operationalModeFlag, dut)
+	operationalModeValue = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalModeValue)
+	operationalMode = cfgplugins.GetOpMode()
 	cfgplugins.InterfaceConfig(t, dut, dp1)
 	cfgplugins.InterfaceConfig(t, dut, dp2)
 

--- a/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
+++ b/feature/platform/transceiver/chromatic_dispersion/tests/zr_cd_test/zr_cd_test.go
@@ -30,10 +30,10 @@ const (
 )
 
 var (
-	frequencies          = []uint64{191400000, 196100000} // 400ZR OIF wavelength range
-	targetOutputPowers   = []float64{-13, -9}             // 400ZR OIF Tx power range
-	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
-	operationalMode      uint16
+	frequencies         = []uint64{191400000, 196100000} // 400ZR OIF wavelength range
+	targetOutputPowers  = []float64{-13, -9}             // 400ZR OIF Tx power range
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
+	operationalMode     uint16
 )
 
 func TestMain(m *testing.M) {

--- a/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
+++ b/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
@@ -38,8 +38,9 @@ const (
 )
 
 var (
-	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
-)
+	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeValue uint16
+	operationalMode      uint16)
 
 func TestMain(m *testing.M) {
 	fptest.RunTests(m)
@@ -73,8 +74,10 @@ func TestZrUncorrectableFrames(t *testing.T) {
 	)
 
 	ports := []string{"port1", "port2"}
-	cfgplugins.Initialize(operationalModeFlag, dut)
-
+	operationalModeValue = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalModeValue)
+	operationalMode = cfgplugins.GetOpMode()
+	
 	for i, port := range ports {
 		dp := dut.Port(t, port)
 		cfgplugins.InterfaceConfig(t, dut, dp)

--- a/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
+++ b/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
@@ -75,7 +75,7 @@ func TestZrUncorrectableFrames(t *testing.T) {
 
 	ports := []string{"port1", "port2"}
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalMode)
+	cfgplugins.InterfaceInitialize(t, dut, operationalMode)
 
 	for i, port := range ports {
 		dp := dut.Port(t, port)

--- a/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
+++ b/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
@@ -40,7 +40,8 @@ const (
 var (
 	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
 	operationalModeValue uint16
-	operationalMode      uint16)
+	operationalMode      uint16
+)
 
 func TestMain(m *testing.M) {
 	fptest.RunTests(m)
@@ -77,7 +78,7 @@ func TestZrUncorrectableFrames(t *testing.T) {
 	operationalModeValue = uint16(*operationalModeFlag)
 	cfgplugins.Initialize(t, dut, operationalModeValue)
 	operationalMode = cfgplugins.GetOpMode()
-	
+
 	for i, port := range ports {
 		dp := dut.Port(t, port)
 		cfgplugins.InterfaceConfig(t, dut, dp)

--- a/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
+++ b/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
@@ -38,8 +38,8 @@ const (
 )
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
-	operationalMode      uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
+	operationalMode     uint16
 )
 
 func TestMain(m *testing.M) {

--- a/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
+++ b/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
 	operationalMode      uint16
 )
 

--- a/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
+++ b/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
@@ -38,10 +38,7 @@ const (
 )
 
 var (
-	operationalModeFlagCisco   = flag.Int("operational_mode", 5003, "vendor-specific operational-mode for the channel")
-	operationalModeFlagArista  = flag.Int("operational_mode", 1, "vendor-specific operational-mode for the channel")
-	operationalModeFlagDefault = flag.Int("operational_mode", 1, "default operational-mode for the channel")
-	operationalMode            uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
 )
 
 func TestMain(m *testing.M) {

--- a/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
+++ b/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
@@ -39,7 +39,6 @@ const (
 
 var (
 	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
-	operationalModeValue uint16
 	operationalMode      uint16
 )
 
@@ -75,9 +74,8 @@ func TestZrUncorrectableFrames(t *testing.T) {
 	)
 
 	ports := []string{"port1", "port2"}
-	operationalModeValue = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalModeValue)
-	operationalMode = cfgplugins.GetOpMode()
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalMode)
 
 	for i, port := range ports {
 		dp := dut.Port(t, port)

--- a/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
+++ b/feature/platform/transceiver/fec_uncorrectable_frames/tests/zr_fec_uncorrectable_frames_test/zr_fec_uncorrectable_frames_test.go
@@ -76,15 +76,7 @@ func TestZrUncorrectableFrames(t *testing.T) {
 	)
 
 	ports := []string{"port1", "port2"}
-	switch dut.Vendor() {
-	case ondatra.CISCO:
-		operationalMode = uint16(*operationalModeFlagCisco)
-	case ondatra.ARISTA:
-		operationalMode = uint16(*operationalModeFlagArista)
-	default:
-		operationalMode = uint16(*operationalModeFlagDefault)
-	}
-	cfgplugins.Initialize(operationalMode)
+	cfgplugins.Initialize(operationalModeFlag, dut)
 
 	for i, port := range ports {
 		dp := dut.Port(t, port)

--- a/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
+++ b/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
@@ -40,8 +40,8 @@ func TestMain(m *testing.M) {
 }
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
-	operationalMode      uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
+	operationalMode     uint16
 )
 
 // Topology: dut:port1 <--> port2:dut

--- a/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
+++ b/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
@@ -40,10 +40,7 @@ func TestMain(m *testing.M) {
 }
 
 var (
-	operationalModeFlagCisco   = flag.Int("operational_mode", 5003, "vendor-specific operational-mode for the channel")
-	operationalModeFlagArista  = flag.Int("operational_mode", 1, "vendor-specific operational-mode for the channel")
-	operationalModeFlagDefault = flag.Int("operational_mode", 1, "default operational-mode for the channel")
-	operationalMode            uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
 )
 
 // Topology: dut:port1 <--> port2:dut
@@ -80,16 +77,7 @@ func TestZRFirmwareVersionState(t *testing.T) {
 	dp2 := dut1.Port(t, "port2")
 	t.Logf("dut1: %v", dut1)
 	t.Logf("dut1 dp1 name: %v", dp1.Name())
-
-	switch dut1.Vendor() {
-	case ondatra.CISCO:
-		operationalMode = uint16(*operationalModeFlagCisco)
-	case ondatra.ARISTA:
-		operationalMode = uint16(*operationalModeFlagArista)
-	default:
-		operationalMode = uint16(*operationalModeFlagDefault)
-	}
-	cfgplugins.Initialize(operationalMode)
+	cfgplugins.Initialize(operationalModeFlag, dut)
 	cfgplugins.InterfaceConfig(t, dut1, dp1)
 	cfgplugins.InterfaceConfig(t, dut1, dp2)
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), time.Minute*2, oc.Interface_OperStatus_UP)

--- a/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
+++ b/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
@@ -79,7 +79,7 @@ func TestZRFirmwareVersionState(t *testing.T) {
 	t.Logf("dut1: %v", dut1)
 	t.Logf("dut1 dp1 name: %v", dp1.Name())
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut1, operationalMode)
+	cfgplugins.InterfaceInitialize(t, dut1, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut1, dp1)
 	cfgplugins.InterfaceConfig(t, dut1, dp2)
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), time.Minute*2, oc.Interface_OperStatus_UP)

--- a/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
+++ b/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
@@ -42,7 +42,8 @@ func TestMain(m *testing.M) {
 var (
 	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
 	operationalModeValue uint16
-	operationalMode      uint16)
+	operationalMode      uint16
+)
 
 // Topology: dut:port1 <--> port2:dut
 

--- a/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
+++ b/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
@@ -79,7 +79,7 @@ func TestZRFirmwareVersionState(t *testing.T) {
 	t.Logf("dut1: %v", dut1)
 	t.Logf("dut1 dp1 name: %v", dp1.Name())
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalMode)
+	cfgplugins.Initialize(t, dut1, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut1, dp1)
 	cfgplugins.InterfaceConfig(t, dut1, dp2)
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), time.Minute*2, oc.Interface_OperStatus_UP)

--- a/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
+++ b/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
@@ -41,7 +41,6 @@ func TestMain(m *testing.M) {
 
 var (
 	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
-	operationalModeValue uint16
 	operationalMode      uint16
 )
 
@@ -79,9 +78,8 @@ func TestZRFirmwareVersionState(t *testing.T) {
 	dp2 := dut1.Port(t, "port2")
 	t.Logf("dut1: %v", dut1)
 	t.Logf("dut1 dp1 name: %v", dp1.Name())
-	operationalModeValue = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut1, operationalModeValue)
-	operationalMode = cfgplugins.GetOpMode()
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut1, dp1)
 	cfgplugins.InterfaceConfig(t, dut1, dp2)
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), time.Minute*2, oc.Interface_OperStatus_UP)

--- a/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
+++ b/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
@@ -40,8 +40,9 @@ func TestMain(m *testing.M) {
 }
 
 var (
-	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
-)
+	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeValue uint16
+	operationalMode      uint16)
 
 // Topology: dut:port1 <--> port2:dut
 
@@ -77,7 +78,9 @@ func TestZRFirmwareVersionState(t *testing.T) {
 	dp2 := dut1.Port(t, "port2")
 	t.Logf("dut1: %v", dut1)
 	t.Logf("dut1 dp1 name: %v", dp1.Name())
-	cfgplugins.Initialize(operationalModeFlag, dut)
+	operationalModeValue = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut1, operationalModeValue)
+	operationalMode = cfgplugins.GetOpMode()
 	cfgplugins.InterfaceConfig(t, dut1, dp1)
 	cfgplugins.InterfaceConfig(t, dut1, dp2)
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), time.Minute*2, oc.Interface_OperStatus_UP)

--- a/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
+++ b/feature/platform/transceiver/firmware_version/tests/zr_firmware_version_test/zr_firmware_version_test.go
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 }
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
 	operationalMode      uint16
 )
 

--- a/feature/platform/transceiver/input_output_power/tests/zr_input_output_power_test/zr_input_output_power_test.go
+++ b/feature/platform/transceiver/input_output_power/tests/zr_input_output_power_test/zr_input_output_power_test.go
@@ -27,8 +27,7 @@ const (
 var (
 	frequencies          = []uint64{191400000, 196100000}
 	targetOpticalPowers  = []float64{-9, -13}
-	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
-	operationalModeValue uint16
+	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
 	operationalMode      uint16
 )
 
@@ -39,9 +38,8 @@ func TestMain(m *testing.M) {
 func TestOpticalPower(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
-	operationalModeValue = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalModeValue)
-	operationalMode = cfgplugins.GetOpMode()
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 

--- a/feature/platform/transceiver/input_output_power/tests/zr_input_output_power_test/zr_input_output_power_test.go
+++ b/feature/platform/transceiver/input_output_power/tests/zr_input_output_power_test/zr_input_output_power_test.go
@@ -39,7 +39,7 @@ func TestOpticalPower(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalMode)
+	cfgplugins.InterfaceInitialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 

--- a/feature/platform/transceiver/input_output_power/tests/zr_input_output_power_test/zr_input_output_power_test.go
+++ b/feature/platform/transceiver/input_output_power/tests/zr_input_output_power_test/zr_input_output_power_test.go
@@ -27,10 +27,7 @@ const (
 var (
 	frequencies                = []uint64{191400000, 196100000}
 	targetOpticalPowers        = []float64{-9, -13}
-	operationalModeFlagCisco   = flag.Int("operational_mode", 5003, "vendor-specific operational-mode for the channel")
-	operationalModeFlagArista  = flag.Int("operational_mode", 1, "vendor-specific operational-mode for the channel")
-	operationalModeFlagDefault = flag.Int("operational_mode", 1, "default operational-mode for the channel")
-	operationalMode            uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
 )
 
 func TestMain(m *testing.M) {
@@ -40,16 +37,7 @@ func TestMain(m *testing.M) {
 func TestOpticalPower(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
-
-	switch dut.Vendor() {
-	case ondatra.CISCO:
-		operationalMode = uint16(*operationalModeFlagCisco)
-	case ondatra.ARISTA:
-		operationalMode = uint16(*operationalModeFlagArista)
-	default:
-		operationalMode = uint16(*operationalModeFlagDefault)
-	}
-	cfgplugins.Initialize(operationalMode)
+	cfgplugins.Initialize(operationalModeFlag, dut)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 

--- a/feature/platform/transceiver/input_output_power/tests/zr_input_output_power_test/zr_input_output_power_test.go
+++ b/feature/platform/transceiver/input_output_power/tests/zr_input_output_power_test/zr_input_output_power_test.go
@@ -25,10 +25,10 @@ const (
 )
 
 var (
-	frequencies          = []uint64{191400000, 196100000}
-	targetOpticalPowers  = []float64{-9, -13}
-	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
-	operationalMode      uint16
+	frequencies         = []uint64{191400000, 196100000}
+	targetOpticalPowers = []float64{-9, -13}
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
+	operationalMode     uint16
 )
 
 func TestMain(m *testing.M) {

--- a/feature/platform/transceiver/input_output_power/tests/zr_input_output_power_test/zr_input_output_power_test.go
+++ b/feature/platform/transceiver/input_output_power/tests/zr_input_output_power_test/zr_input_output_power_test.go
@@ -27,7 +27,9 @@ const (
 var (
 	frequencies                = []uint64{191400000, 196100000}
 	targetOpticalPowers        = []float64{-9, -13}
-	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
+	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeValue uint16
+	operationalMode      uint16
 )
 
 func TestMain(m *testing.M) {
@@ -37,7 +39,9 @@ func TestMain(m *testing.M) {
 func TestOpticalPower(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
-	cfgplugins.Initialize(operationalModeFlag, dut)
+	operationalModeValue = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalModeValue)
+	operationalMode = cfgplugins.GetOpMode()
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 

--- a/feature/platform/transceiver/input_output_power/tests/zr_input_output_power_test/zr_input_output_power_test.go
+++ b/feature/platform/transceiver/input_output_power/tests/zr_input_output_power_test/zr_input_output_power_test.go
@@ -25,8 +25,8 @@ const (
 )
 
 var (
-	frequencies                = []uint64{191400000, 196100000}
-	targetOpticalPowers        = []float64{-9, -13}
+	frequencies          = []uint64{191400000, 196100000}
+	targetOpticalPowers  = []float64{-9, -13}
 	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
 	operationalModeValue uint16
 	operationalMode      uint16

--- a/feature/platform/transceiver/inventory/tests/zr_inventory_test/zr_inventory_test.go
+++ b/feature/platform/transceiver/inventory/tests/zr_inventory_test/zr_inventory_test.go
@@ -64,7 +64,7 @@ func TestInventory(t *testing.T) {
 	dp2 := dut.Port(t, "port2")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalMode)
+	cfgplugins.InterfaceInitialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dp1)
 	cfgplugins.InterfaceConfig(t, dut, dp2)
 

--- a/feature/platform/transceiver/inventory/tests/zr_inventory_test/zr_inventory_test.go
+++ b/feature/platform/transceiver/inventory/tests/zr_inventory_test/zr_inventory_test.go
@@ -21,10 +21,7 @@ const (
 )
 
 var (
-	operationalModeFlagCisco   = flag.Int("operational_mode", 5003, "vendor-specific operational-mode for the channel")
-	operationalModeFlagArista  = flag.Int("operational_mode", 1, "vendor-specific operational-mode for the channel")
-	operationalModeFlagDefault = flag.Int("operational_mode", 1, "default operational-mode for the channel")
-	operationalMode            uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
 )
 
 func TestMain(m *testing.M) {
@@ -65,16 +62,7 @@ func TestInventory(t *testing.T) {
 	dp1 := dut.Port(t, "port1")
 	dp2 := dut.Port(t, "port2")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
-
-	switch dut.Vendor() {
-	case ondatra.CISCO:
-		operationalMode = uint16(*operationalModeFlagCisco)
-	case ondatra.ARISTA:
-		operationalMode = uint16(*operationalModeFlagArista)
-	default:
-		operationalMode = uint16(*operationalModeFlagDefault)
-	}
-	cfgplugins.Initialize(operationalMode)
+	cfgplugins.Initialize(operationalModeFlag, dut)
 	cfgplugins.InterfaceConfig(t, dut, dp1)
 	cfgplugins.InterfaceConfig(t, dut, dp2)
 

--- a/feature/platform/transceiver/inventory/tests/zr_inventory_test/zr_inventory_test.go
+++ b/feature/platform/transceiver/inventory/tests/zr_inventory_test/zr_inventory_test.go
@@ -21,7 +21,9 @@ const (
 )
 
 var (
-	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
+	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeValue uint16
+	operationalMode      uint16
 )
 
 func TestMain(m *testing.M) {
@@ -62,7 +64,9 @@ func TestInventory(t *testing.T) {
 	dp1 := dut.Port(t, "port1")
 	dp2 := dut.Port(t, "port2")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
-	cfgplugins.Initialize(operationalModeFlag, dut)
+	operationalModeValue = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalModeValue)
+	operationalMode = cfgplugins.GetOpMode()
 	cfgplugins.InterfaceConfig(t, dut, dp1)
 	cfgplugins.InterfaceConfig(t, dut, dp2)
 

--- a/feature/platform/transceiver/inventory/tests/zr_inventory_test/zr_inventory_test.go
+++ b/feature/platform/transceiver/inventory/tests/zr_inventory_test/zr_inventory_test.go
@@ -21,8 +21,8 @@ const (
 )
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
-	operationalMode      uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
+	operationalMode     uint16
 )
 
 func TestMain(m *testing.M) {

--- a/feature/platform/transceiver/inventory/tests/zr_inventory_test/zr_inventory_test.go
+++ b/feature/platform/transceiver/inventory/tests/zr_inventory_test/zr_inventory_test.go
@@ -21,8 +21,7 @@ const (
 )
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
-	operationalModeValue uint16
+	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
 	operationalMode      uint16
 )
 
@@ -64,9 +63,8 @@ func TestInventory(t *testing.T) {
 	dp1 := dut.Port(t, "port1")
 	dp2 := dut.Port(t, "port2")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
-	operationalModeValue = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalModeValue)
-	operationalMode = cfgplugins.GetOpMode()
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dp1)
 	cfgplugins.InterfaceConfig(t, dut, dp2)
 

--- a/feature/platform/transceiver/logical_channels/tests/zr_logical_channels_test/zr_logical_channels_test.go
+++ b/feature/platform/transceiver/logical_channels/tests/zr_logical_channels_test/zr_logical_channels_test.go
@@ -28,8 +28,7 @@ const (
 )
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
-	operationalModeValue uint16
+	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
 	operationalMode      uint16
 )
 
@@ -50,9 +49,8 @@ func Test400ZRLogicalChannels(t *testing.T) {
 	p2 := dut.Port(t, "port2")
 
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
-	operationalModeValue = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalModeValue)
-	operationalMode = cfgplugins.GetOpMode()
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalMode)
 
 	cfgplugins.InterfaceConfig(t, dut, p1)
 	cfgplugins.InterfaceConfig(t, dut, p2)

--- a/feature/platform/transceiver/logical_channels/tests/zr_logical_channels_test/zr_logical_channels_test.go
+++ b/feature/platform/transceiver/logical_channels/tests/zr_logical_channels_test/zr_logical_channels_test.go
@@ -28,7 +28,9 @@ const (
 )
 
 var (
-	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
+	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeValue uint16
+	operationalMode      uint16
 )
 
 type testcase struct {
@@ -48,7 +50,9 @@ func Test400ZRLogicalChannels(t *testing.T) {
 	p2 := dut.Port(t, "port2")
 
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
-	cfgplugins.Initialize(operationalModeFlag, dut)
+	operationalModeValue = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalModeValue)
+	operationalMode = cfgplugins.GetOpMode()
 
 	cfgplugins.InterfaceConfig(t, dut, p1)
 	cfgplugins.InterfaceConfig(t, dut, p2)

--- a/feature/platform/transceiver/logical_channels/tests/zr_logical_channels_test/zr_logical_channels_test.go
+++ b/feature/platform/transceiver/logical_channels/tests/zr_logical_channels_test/zr_logical_channels_test.go
@@ -50,7 +50,7 @@ func Test400ZRLogicalChannels(t *testing.T) {
 
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalMode)
+	cfgplugins.InterfaceInitialize(t, dut, operationalMode)
 
 	cfgplugins.InterfaceConfig(t, dut, p1)
 	cfgplugins.InterfaceConfig(t, dut, p2)

--- a/feature/platform/transceiver/logical_channels/tests/zr_logical_channels_test/zr_logical_channels_test.go
+++ b/feature/platform/transceiver/logical_channels/tests/zr_logical_channels_test/zr_logical_channels_test.go
@@ -28,10 +28,7 @@ const (
 )
 
 var (
-	operationalModeFlagCisco   = flag.Int("operational_mode", 5003, "vendor-specific operational-mode for the channel")
-	operationalModeFlagArista  = flag.Int("operational_mode", 1, "vendor-specific operational-mode for the channel")
-	operationalModeFlagDefault = flag.Int("operational_mode", 1, "default operational-mode for the channel")
-	operationalMode            uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
 )
 
 type testcase struct {
@@ -51,16 +48,8 @@ func Test400ZRLogicalChannels(t *testing.T) {
 	p2 := dut.Port(t, "port2")
 
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
+	cfgplugins.Initialize(operationalModeFlag, dut)
 
-	switch dut.Vendor() {
-	case ondatra.CISCO:
-		operationalMode = uint16(*operationalModeFlagCisco)
-	case ondatra.ARISTA:
-		operationalMode = uint16(*operationalModeFlagArista)
-	default:
-		operationalMode = uint16(*operationalModeFlagDefault)
-	}
-	cfgplugins.Initialize(operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, p1)
 	cfgplugins.InterfaceConfig(t, dut, p2)
 

--- a/feature/platform/transceiver/logical_channels/tests/zr_logical_channels_test/zr_logical_channels_test.go
+++ b/feature/platform/transceiver/logical_channels/tests/zr_logical_channels_test/zr_logical_channels_test.go
@@ -28,8 +28,8 @@ const (
 )
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
-	operationalMode      uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
+	operationalMode     uint16
 )
 
 type testcase struct {

--- a/feature/platform/transceiver/low_power_mode/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
+++ b/feature/platform/transceiver/low_power_mode/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
@@ -90,14 +90,6 @@ func validateOutputPower(t *testing.T, streams map[string]*samplestream.SampleSt
 
 func TestLowPowerMode(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
-	switch dut.Vendor() {
-	case ondatra.CISCO:
-		operationalMode = uint16(*operationalModeFlagCisco)
-	case ondatra.ARISTA:
-		operationalMode = uint16(*operationalModeFlagArista)
-	default:
-		operationalMode = uint16(*operationalModeFlagDefault)
-	}
 	cfgplugins.Initialize(operationalModeFlag, dut)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))

--- a/feature/platform/transceiver/low_power_mode/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
+++ b/feature/platform/transceiver/low_power_mode/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
@@ -41,8 +41,7 @@ const (
 )
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
-	operationalModeValue uint16
+	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
 	operationalMode      uint16
 )
 
@@ -92,9 +91,8 @@ func validateOutputPower(t *testing.T, streams map[string]*samplestream.SampleSt
 
 func TestLowPowerMode(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
-	operationalModeValue = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalModeValue)
-	operationalMode = cfgplugins.GetOpMode()
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	samplingInterval := 10 * time.Second

--- a/feature/platform/transceiver/low_power_mode/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
+++ b/feature/platform/transceiver/low_power_mode/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
@@ -92,7 +92,7 @@ func validateOutputPower(t *testing.T, streams map[string]*samplestream.SampleSt
 func TestLowPowerMode(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalMode)
+	cfgplugins.InterfaceInitialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	samplingInterval := 10 * time.Second

--- a/feature/platform/transceiver/low_power_mode/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
+++ b/feature/platform/transceiver/low_power_mode/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
@@ -41,8 +41,8 @@ const (
 )
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
-	operationalMode      uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
+	operationalMode     uint16
 )
 
 func TestMain(m *testing.M) {

--- a/feature/platform/transceiver/low_power_mode/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
+++ b/feature/platform/transceiver/low_power_mode/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
@@ -41,7 +41,9 @@ const (
 )
 
 var (
-	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
+	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeValue uint16
+	operationalMode      uint16
 )
 
 func TestMain(m *testing.M) {
@@ -90,7 +92,9 @@ func validateOutputPower(t *testing.T, streams map[string]*samplestream.SampleSt
 
 func TestLowPowerMode(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
-	cfgplugins.Initialize(operationalModeFlag, dut)
+	operationalModeValue = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalModeValue)
+	operationalMode = cfgplugins.GetOpMode()
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	samplingInterval := 10 * time.Second

--- a/feature/platform/transceiver/low_power_mode/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
+++ b/feature/platform/transceiver/low_power_mode/tests/zr_low_power_mode_test/zr_low_power_mode_test.go
@@ -41,10 +41,7 @@ const (
 )
 
 var (
-	operationalModeFlagCisco   = flag.Int("operational_mode", 5003, "vendor-specific operational-mode for the channel")
-	operationalModeFlagArista  = flag.Int("operational_mode", 1, "vendor-specific operational-mode for the channel")
-	operationalModeFlagDefault = flag.Int("operational_mode", 1, "default operational-mode for the channel")
-	operationalMode            uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
 )
 
 func TestMain(m *testing.M) {
@@ -101,7 +98,7 @@ func TestLowPowerMode(t *testing.T) {
 	default:
 		operationalMode = uint16(*operationalModeFlagDefault)
 	}
-	cfgplugins.Initialize(operationalMode)
+	cfgplugins.Initialize(operationalModeFlag, dut)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	samplingInterval := 10 * time.Second

--- a/feature/platform/transceiver/performance_metrics/tests/zr_pm_test/zr_pm_test.go
+++ b/feature/platform/transceiver/performance_metrics/tests/zr_pm_test/zr_pm_test.go
@@ -48,7 +48,7 @@ func TestPM(t *testing.T) {
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalMode)
+	cfgplugins.InterfaceInitialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 

--- a/feature/platform/transceiver/performance_metrics/tests/zr_pm_test/zr_pm_test.go
+++ b/feature/platform/transceiver/performance_metrics/tests/zr_pm_test/zr_pm_test.go
@@ -34,7 +34,9 @@ const (
 var (
 	frequencies                = []uint64{191400000, 196100000}
 	targetOpticalPowers        = []float64{-9, -13}
-	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
+	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeValue uint16
+	operationalMode      uint16
 )
 
 func TestMain(m *testing.M) {
@@ -46,7 +48,9 @@ func TestPM(t *testing.T) {
 
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
-	cfgplugins.Initialize(operationalModeFlag, dut)
+	operationalModeValue = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalModeValue)
+	operationalMode = cfgplugins.GetOpMode()
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 

--- a/feature/platform/transceiver/performance_metrics/tests/zr_pm_test/zr_pm_test.go
+++ b/feature/platform/transceiver/performance_metrics/tests/zr_pm_test/zr_pm_test.go
@@ -32,8 +32,8 @@ const (
 )
 
 var (
-	frequencies                = []uint64{191400000, 196100000}
-	targetOpticalPowers        = []float64{-9, -13}
+	frequencies          = []uint64{191400000, 196100000}
+	targetOpticalPowers  = []float64{-9, -13}
 	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
 	operationalModeValue uint16
 	operationalMode      uint16

--- a/feature/platform/transceiver/performance_metrics/tests/zr_pm_test/zr_pm_test.go
+++ b/feature/platform/transceiver/performance_metrics/tests/zr_pm_test/zr_pm_test.go
@@ -32,10 +32,10 @@ const (
 )
 
 var (
-	frequencies          = []uint64{191400000, 196100000}
-	targetOpticalPowers  = []float64{-9, -13}
-	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
-	operationalMode      uint16
+	frequencies         = []uint64{191400000, 196100000}
+	targetOpticalPowers = []float64{-9, -13}
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
+	operationalMode     uint16
 )
 
 func TestMain(m *testing.M) {

--- a/feature/platform/transceiver/performance_metrics/tests/zr_pm_test/zr_pm_test.go
+++ b/feature/platform/transceiver/performance_metrics/tests/zr_pm_test/zr_pm_test.go
@@ -34,8 +34,7 @@ const (
 var (
 	frequencies          = []uint64{191400000, 196100000}
 	targetOpticalPowers  = []float64{-9, -13}
-	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
-	operationalModeValue uint16
+	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
 	operationalMode      uint16
 )
 
@@ -48,9 +47,8 @@ func TestPM(t *testing.T) {
 
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
-	operationalModeValue = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalModeValue)
-	operationalMode = cfgplugins.GetOpMode()
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 

--- a/feature/platform/transceiver/performance_metrics/tests/zr_pm_test/zr_pm_test.go
+++ b/feature/platform/transceiver/performance_metrics/tests/zr_pm_test/zr_pm_test.go
@@ -34,10 +34,7 @@ const (
 var (
 	frequencies                = []uint64{191400000, 196100000}
 	targetOpticalPowers        = []float64{-9, -13}
-	operationalModeFlagCisco   = flag.Int("operational_mode", 5003, "vendor-specific operational-mode for the channel")
-	operationalModeFlagArista  = flag.Int("operational_mode", 1, "vendor-specific operational-mode for the channel")
-	operationalModeFlagDefault = flag.Int("operational_mode", 1, "default operational-mode for the channel")
-	operationalMode            uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
 )
 
 func TestMain(m *testing.M) {
@@ -49,15 +46,7 @@ func TestPM(t *testing.T) {
 
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
-	switch dut.Vendor() {
-	case ondatra.CISCO:
-		operationalMode = uint16(*operationalModeFlagCisco)
-	case ondatra.ARISTA:
-		operationalMode = uint16(*operationalModeFlagArista)
-	default:
-		operationalMode = uint16(*operationalModeFlagDefault)
-	}
-	cfgplugins.Initialize(operationalMode)
+	cfgplugins.Initialize(operationalModeFlag, dut)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 

--- a/feature/platform/transceiver/supply_voltage/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
+++ b/feature/platform/transceiver/supply_voltage/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
@@ -65,7 +65,7 @@ func TestZrSupplyVoltage(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalMode)
+	cfgplugins.InterfaceInitialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 

--- a/feature/platform/transceiver/supply_voltage/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
+++ b/feature/platform/transceiver/supply_voltage/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
@@ -36,8 +36,8 @@ const (
 )
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
-	operationalMode      uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
+	operationalMode     uint16
 )
 
 func TestMain(m *testing.M) {

--- a/feature/platform/transceiver/supply_voltage/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
+++ b/feature/platform/transceiver/supply_voltage/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
@@ -36,8 +36,7 @@ const (
 )
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
-	operationalModeValue uint16
+	operationalModeFlag  = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel.")
 	operationalMode      uint16
 )
 
@@ -65,9 +64,8 @@ func verifyVoltageValue(t *testing.T, pStream *samplestream.SampleStream[float64
 func TestZrSupplyVoltage(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
-	operationalModeValue = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalModeValue)
-	operationalMode = cfgplugins.GetOpMode()
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 

--- a/feature/platform/transceiver/supply_voltage/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
+++ b/feature/platform/transceiver/supply_voltage/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
@@ -36,10 +36,7 @@ const (
 )
 
 var (
-	operationalModeFlagCisco   = flag.Int("operational_mode", 5003, "vendor-specific operational-mode for the channel")
-	operationalModeFlagArista  = flag.Int("operational_mode", 1, "vendor-specific operational-mode for the channel")
-	operationalModeFlagDefault = flag.Int("operational_mode", 1, "default operational-mode for the channel")
-	operationalMode            uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
 )
 
 func TestMain(m *testing.M) {
@@ -66,15 +63,7 @@ func verifyVoltageValue(t *testing.T, pStream *samplestream.SampleStream[float64
 func TestZrSupplyVoltage(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
-	switch dut.Vendor() {
-	case ondatra.CISCO:
-		operationalMode = uint16(*operationalModeFlagCisco)
-	case ondatra.ARISTA:
-		operationalMode = uint16(*operationalModeFlagArista)
-	default:
-		operationalMode = uint16(*operationalModeFlagDefault)
-	}
-	cfgplugins.Initialize(operationalMode)
+	cfgplugins.Initialize(operationalModeFlag, dut)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 

--- a/feature/platform/transceiver/supply_voltage/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
+++ b/feature/platform/transceiver/supply_voltage/tests/zr_supply_voltage_test/zr_supply_voltage_test.go
@@ -36,7 +36,9 @@ const (
 )
 
 var (
-	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
+	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeValue uint16
+	operationalMode      uint16
 )
 
 func TestMain(m *testing.M) {
@@ -63,7 +65,9 @@ func verifyVoltageValue(t *testing.T, pStream *samplestream.SampleStream[float64
 func TestZrSupplyVoltage(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
-	cfgplugins.Initialize(operationalModeFlag, dut)
+	operationalModeValue = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalModeValue)
+	operationalMode = cfgplugins.GetOpMode()
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 

--- a/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
+++ b/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
@@ -66,7 +66,7 @@ func TestZRTemperatureState(t *testing.T) {
 	t.Logf("dut1 dp1 name: %v", dp1.Name())
 	intUpdateTime := 2 * time.Minute
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut1, operationalMode)
+	cfgplugins.InterfaceInitialize(t, dut1, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut1, dp1)
 	cfgplugins.InterfaceConfig(t, dut1, dp2)
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)

--- a/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
+++ b/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
@@ -35,10 +35,7 @@ const (
 )
 
 var (
-	operationalModeFlagCisco   = flag.Int("operational_mode", 5003, "vendor-specific operational-mode for the channel")
-	operationalModeFlagArista  = flag.Int("operational_mode", 1, "vendor-specific operational-mode for the channel")
-	operationalModeFlagDefault = flag.Int("operational_mode", 1, "default operational-mode for the channel")
-	operationalMode            uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
 )
 
 func TestMain(m *testing.M) {
@@ -67,15 +64,7 @@ func TestZRTemperatureState(t *testing.T) {
 	t.Logf("dut1: %v", dut1)
 	t.Logf("dut1 dp1 name: %v", dp1.Name())
 	intUpdateTime := 2 * time.Minute
-	switch dut1.Vendor() {
-	case ondatra.CISCO:
-		operationalMode = uint16(*operationalModeFlagCisco)
-	case ondatra.ARISTA:
-		operationalMode = uint16(*operationalModeFlagArista)
-	default:
-		operationalMode = uint16(*operationalModeFlagDefault)
-	}
-	cfgplugins.Initialize(operationalMode)
+	cfgplugins.Initialize(operationalModeFlag, dut)
 	cfgplugins.InterfaceConfig(t, dut1, dp1)
 	cfgplugins.InterfaceConfig(t, dut1, dp2)
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)

--- a/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
+++ b/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
@@ -35,7 +35,9 @@ const (
 )
 
 var (
-	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
+	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeValue uint16
+	operationalMode      uint16
 )
 
 func TestMain(m *testing.M) {
@@ -64,7 +66,9 @@ func TestZRTemperatureState(t *testing.T) {
 	t.Logf("dut1: %v", dut1)
 	t.Logf("dut1 dp1 name: %v", dp1.Name())
 	intUpdateTime := 2 * time.Minute
-	cfgplugins.Initialize(operationalModeFlag, dut)
+	operationalModeValue = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut1, operationalModeValue)
+	operationalMode = cfgplugins.GetOpMode()
 	cfgplugins.InterfaceConfig(t, dut1, dp1)
 	cfgplugins.InterfaceConfig(t, dut1, dp2)
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)

--- a/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
+++ b/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
@@ -35,8 +35,8 @@ const (
 )
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
-	operationalMode      uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalMode     uint16
 )
 
 func TestMain(m *testing.M) {

--- a/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
+++ b/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
@@ -36,7 +36,6 @@ const (
 
 var (
 	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
-	operationalModeValue uint16
 	operationalMode      uint16
 )
 
@@ -66,9 +65,8 @@ func TestZRTemperatureState(t *testing.T) {
 	t.Logf("dut1: %v", dut1)
 	t.Logf("dut1 dp1 name: %v", dp1.Name())
 	intUpdateTime := 2 * time.Minute
-	operationalModeValue = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut1, operationalModeValue)
-	operationalMode = cfgplugins.GetOpMode()
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut1, dp1)
 	cfgplugins.InterfaceConfig(t, dut1, dp2)
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)

--- a/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
+++ b/feature/platform/transceiver/temperature/tests/zr_temperature_test/zr_temperature_test.go
@@ -66,7 +66,7 @@ func TestZRTemperatureState(t *testing.T) {
 	t.Logf("dut1 dp1 name: %v", dp1.Name())
 	intUpdateTime := 2 * time.Minute
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalMode)
+	cfgplugins.Initialize(t, dut1, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut1, dp1)
 	cfgplugins.InterfaceConfig(t, dut1, dp2)
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)

--- a/feature/platform/transceiver/tunable_parameters/tests/zr_tunable_parameters_test/zr_tunable_parameters_test.go
+++ b/feature/platform/transceiver/tunable_parameters/tests/zr_tunable_parameters_test/zr_tunable_parameters_test.go
@@ -203,7 +203,9 @@ func Test400ZRInterfaceFlap(t *testing.T) {
 	p2 := dut.Port(t, "port2")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
-	cfgplugins.Initialize(operationalMode)
+	operationalModeValue = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalModeValue)
+	operationalMode = cfgplugins.GetOpMode()
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	oc1 := opticalChannelFromPort(t, dut, p1)

--- a/feature/platform/transceiver/tunable_parameters/tests/zr_tunable_parameters_test/zr_tunable_parameters_test.go
+++ b/feature/platform/transceiver/tunable_parameters/tests/zr_tunable_parameters_test/zr_tunable_parameters_test.go
@@ -37,7 +37,7 @@ func Test400ZRTunableFrequency(t *testing.T) {
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalMode)
+	cfgplugins.InterfaceInitialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	oc1 := opticalChannelFromPort(t, dut, p1)
@@ -123,7 +123,7 @@ func Test400ZRTunableOutputPower(t *testing.T) {
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalMode)
+	cfgplugins.InterfaceInitialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	oc1 := opticalChannelFromPort(t, dut, p1)
@@ -201,7 +201,7 @@ func Test400ZRInterfaceFlap(t *testing.T) {
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
 	operationalMode = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalMode)
+	cfgplugins.InterfaceInitialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	oc1 := opticalChannelFromPort(t, dut, p1)

--- a/feature/platform/transceiver/tunable_parameters/tests/zr_tunable_parameters_test/zr_tunable_parameters_test.go
+++ b/feature/platform/transceiver/tunable_parameters/tests/zr_tunable_parameters_test/zr_tunable_parameters_test.go
@@ -23,8 +23,8 @@ const (
 )
 
 var (
-	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
-	operationalMode      uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalMode     uint16
 )
 
 func TestMain(m *testing.M) {

--- a/feature/platform/transceiver/tunable_parameters/tests/zr_tunable_parameters_test/zr_tunable_parameters_test.go
+++ b/feature/platform/transceiver/tunable_parameters/tests/zr_tunable_parameters_test/zr_tunable_parameters_test.go
@@ -23,7 +23,9 @@ const (
 )
 
 var (
-	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
+	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
+	operationalModeValue uint16
+	operationalMode      uint16
 )
 
 func TestMain(m *testing.M) {
@@ -35,7 +37,9 @@ func Test400ZRTunableFrequency(t *testing.T) {
 	p2 := dut.Port(t, "port2")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
-	cfgplugins.Initialize(operationalModeFlag, dut)
+	operationalModeValue = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalModeValue)
+	operationalMode = cfgplugins.GetOpMode()
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	oc1 := opticalChannelFromPort(t, dut, p1)
@@ -120,7 +124,9 @@ func Test400ZRTunableOutputPower(t *testing.T) {
 	p2 := dut.Port(t, "port2")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
-	cfgplugins.Initialize(operationalMode)
+	operationalModeValue = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalModeValue)
+	operationalMode = cfgplugins.GetOpMode()
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	oc1 := opticalChannelFromPort(t, dut, p1)

--- a/feature/platform/transceiver/tunable_parameters/tests/zr_tunable_parameters_test/zr_tunable_parameters_test.go
+++ b/feature/platform/transceiver/tunable_parameters/tests/zr_tunable_parameters_test/zr_tunable_parameters_test.go
@@ -23,10 +23,7 @@ const (
 )
 
 var (
-	operationalModeFlagCisco   = flag.Int("operational_mode", 5003, "vendor-specific operational-mode for the channel")
-	operationalModeFlagArista  = flag.Int("operational_mode", 1, "vendor-specific operational-mode for the channel")
-	operationalModeFlagDefault = flag.Int("operational_mode", 1, "default operational-mode for the channel")
-	operationalMode            uint16
+	operationalModeFlag = flag.Int("operational_mode", 0, "vendor-specific operational-mode for the channel")
 )
 
 func TestMain(m *testing.M) {
@@ -38,15 +35,7 @@ func Test400ZRTunableFrequency(t *testing.T) {
 	p2 := dut.Port(t, "port2")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
-	switch dut.Vendor() {
-	case ondatra.CISCO:
-		operationalMode = uint16(*operationalModeFlagCisco)
-	case ondatra.ARISTA:
-		operationalMode = uint16(*operationalModeFlagArista)
-	default:
-		operationalMode = uint16(*operationalModeFlagDefault)
-	}
-	cfgplugins.Initialize(operationalMode)
+	cfgplugins.Initialize(operationalModeFlag, dut)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	oc1 := opticalChannelFromPort(t, dut, p1)

--- a/feature/platform/transceiver/tunable_parameters/tests/zr_tunable_parameters_test/zr_tunable_parameters_test.go
+++ b/feature/platform/transceiver/tunable_parameters/tests/zr_tunable_parameters_test/zr_tunable_parameters_test.go
@@ -24,7 +24,6 @@ const (
 
 var (
 	operationalModeFlag  = flag.Int("operational_mode", 0, "Vendor-specific operational-mode for the channel.")
-	operationalModeValue uint16
 	operationalMode      uint16
 )
 
@@ -37,9 +36,8 @@ func Test400ZRTunableFrequency(t *testing.T) {
 	p2 := dut.Port(t, "port2")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
-	operationalModeValue = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalModeValue)
-	operationalMode = cfgplugins.GetOpMode()
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	oc1 := opticalChannelFromPort(t, dut, p1)
@@ -124,9 +122,8 @@ func Test400ZRTunableOutputPower(t *testing.T) {
 	p2 := dut.Port(t, "port2")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
-	operationalModeValue = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalModeValue)
-	operationalMode = cfgplugins.GetOpMode()
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	oc1 := opticalChannelFromPort(t, dut, p1)
@@ -203,9 +200,8 @@ func Test400ZRInterfaceFlap(t *testing.T) {
 	p2 := dut.Port(t, "port2")
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 
-	operationalModeValue = uint16(*operationalModeFlag)
-	cfgplugins.Initialize(t, dut, operationalModeValue)
-	operationalMode = cfgplugins.GetOpMode()
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.Initialize(t, dut, operationalMode)
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port1"))
 	cfgplugins.InterfaceConfig(t, dut, dut.Port(t, "port2"))
 	oc1 := opticalChannelFromPort(t, dut, p1)

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -45,7 +45,7 @@ func init() {
 }
 
 // Initialize assigns OpMode with value received through operationalMode flag.
-func Initialize(t *testing.T, dut *ondatra.DUTDevice, initialOperationalMode uint16) uint16 {
+func InterfaceInitialize(t *testing.T, dut *ondatra.DUTDevice, initialOperationalMode uint16) uint16 {
 	once.Do(func() {
 		t.Helper()
 		if initialOperationalMode == 0 { // '0' signals to use vendor-specific default

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -76,7 +76,7 @@ func Initialize(t *testing.T, dut *ondatra.DUTDevice, initialOperationalMode uin
 }
 
 // GetOpMode returns the opmode value after the Initialize function has been called
-func GetOpMode() uint16 {
+func InterfaceGetOpMode() uint16 {
 	return opmode
 }
 

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -46,22 +46,6 @@ func init() {
 	opmode = 1
 }
 
-// GetOperationalModeFlag returns the vendor specific operational mode flag.
-func GetOperationalModeFlag(dut *ondatra.DUTDevice) uint16 {
-	var operationalModeFlag *int
-	switch dut.Vendor() {
-	case ondatra.CISCO:
-		operationalModeFlag = flag.Int("operational_mode", 5003, "vendor-specific operational-mode for the channel")
-	case ondatra.ARISTA:
-		operationalModeFlag = flag.Int("operational_mode", 1, "vendor-specific operational-mode for the channel")
-	case ondatra.JUNIPER:
-		operationalModeFlag = flag.Int("operational_mode", 1, "vendor-specific operational-mode for the channel")
-	case ondatra.NOKIA:
-		operationalModeFlag = flag.Int("operational_mode", 1083, "vendor-specific operational-mode for the channel")
-	}
-	return uint16(*operationalModeFlag)	
-}
-
 // Initialize assigns OpMode with value received through operationalMode flag.
 func Initialize(t *testing.T, operationalModeFlag *int, dut *ondatra.DUTDevice) uint16 {
 	once.Do(func() {

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -45,7 +45,7 @@ func init() {
 }
 
 // Initialize assigns OpMode with value received through operationalMode flag.
-func Initialize(t *testing.T, dut *ondatra.DUTDevice, initialOperationalMode uint16) {
+func Initialize(t *testing.T, dut *ondatra.DUTDevice, initialOperationalMode uint16) uint16 {
 	once.Do(func() {
 		t.Helper()
 		if initialOperationalMode == 0 { // '0' signals to use vendor-specific default
@@ -72,6 +72,7 @@ func Initialize(t *testing.T, dut *ondatra.DUTDevice, initialOperationalMode uin
 		}
 		t.Logf("cfgplugins.Initialize: Initialization complete. Final opmode set to: %d", opmode)
 	})
+	return GetOpMode()
 }
 
 // GetOpMode returns the opmode value after the Initialize function has been called

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -16,7 +16,6 @@ package cfgplugins
 
 import (
 	"fmt"
-	"flag"
 	"math"
 	"sync"
 	"testing"

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -60,11 +60,11 @@ func Initialize(t testing.TB, dut *ondatra.DUTDevice, initialOperationalMode uin
 			case ondatra.JUNIPER:
 				opmode = 1
 				t.Logf("cfgplugins.Initialize: Juniper DUT, setting opmode to default: %d", opmode)
-			case ondatra.NOKIA: // Ensure ondatra.NOKIA is a valid constant
+			case ondatra.NOKIA:
 				opmode = 1083
 				t.Logf("cfgplugins.Initialize: Nokia DUT, setting opmode to default: %d", opmode)
 			default:
-				opmode = 1 // Or 0, or another sensible global default
+				opmode = 1
 				t.Logf("cfgplugins.Initialize: Using global default opmode: %d", dut.Vendor(), opmode)
 			}
 		} else {

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -46,26 +46,37 @@ func init() {
 }
 
 // Initialize assigns OpMode with value received through operationalMode flag.
-func Initialize(t *testing.T, operationalModeFlag *int, dut *ondatra.DUTDevice) uint16 {
+func Initialize(t testing.TB, dut *ondatra.DUTDevice, initialOperationalMode uint16) {
 	once.Do(func() {
 		t.Helper()
-		opModeFlagValue := uint16(*operationalModeFlag)
-		if opModeFlagValue == 0 {
+		if initialOperationalMode == 0 { // '0' signals to use vendor-specific default
 			switch dut.Vendor() {
 			case ondatra.CISCO:
 				opmode = 5003
+				t.Logf("cfgplugins.Initialize: Cisco DUT, setting opmode to default: %d", opmode)
 			case ondatra.ARISTA:
 				opmode = 1
+				t.Logf("cfgplugins.Initialize: Arista DUT, setting opmode to default: %d", opmode)
 			case ondatra.JUNIPER:
 				opmode = 1
-			case ondatra.NOKIA:
+				t.Logf("cfgplugins.Initialize: Juniper DUT, setting opmode to default: %d", opmode)
+			case ondatra.NOKIA: // Ensure ondatra.NOKIA is a valid constant
 				opmode = 1083
+				t.Logf("cfgplugins.Initialize: Nokia DUT, setting opmode to default: %d", opmode)
+			default:
+				opmode = 1 // Or 0, or another sensible global default
+				t.Logf("cfgplugins.Initialize: Using global default opmode: %d", dut.Vendor(), opmode)
 			}
 		} else {
-			opmode = opModeFlagValue
+			opmode = initialOperationalMode
+			t.Logf("cfgplugins.Initialize: Using provided initialOperationalMode: %d", opmode)
 		}
+		t.Logf("cfgplugins.Initialize: Initialization complete. Final opmode set to: %d", opmode)
 	})
-	fmt.Printf("Vendor %s, OperationalMode set to %d", dut.Vendor(), opmode)
+}
+
+// GetOpMode returns the opmode value after the Initialize function has been called
+func GetOpMode() uint16 {
 	return opmode
 }
 

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -45,7 +45,7 @@ func init() {
 }
 
 // Initialize assigns OpMode with value received through operationalMode flag.
-func Initialize(t testing.TB, dut *ondatra.DUTDevice, initialOperationalMode uint16) {
+func Initialize(t *testing.T, dut *ondatra.DUTDevice, initialOperationalMode uint16) {
 	once.Do(func() {
 		t.Helper()
 		if initialOperationalMode == 0 { // '0' signals to use vendor-specific default
@@ -64,7 +64,7 @@ func Initialize(t testing.TB, dut *ondatra.DUTDevice, initialOperationalMode uin
 				t.Logf("cfgplugins.Initialize: Nokia DUT, setting opmode to default: %d", opmode)
 			default:
 				opmode = 1
-				t.Logf("cfgplugins.Initialize: Using global default opmode: %d", dut.Vendor(), opmode)
+				t.Logf("cfgplugins.Initialize: Using global default opmode: %d", opmode)
 			}
 		} else {
 			opmode = initialOperationalMode

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -72,7 +72,7 @@ func InterfaceInitialize(t *testing.T, dut *ondatra.DUTDevice, initialOperationa
 		}
 		t.Logf("cfgplugins.Initialize: Initialization complete. Final opmode set to: %d", opmode)
 	})
-	return GetOpMode()
+	return InterfaceGetOpMode()
 }
 
 // GetOpMode returns the opmode value after the Initialize function has been called

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -15,7 +15,6 @@
 package cfgplugins
 
 import (
-	"fmt"
 	"math"
 	"sync"
 	"testing"

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -63,15 +63,27 @@ func GetOperationalModeFlag(dut *ondatra.DUTDevice) uint16 {
 }
 
 // Initialize assigns OpMode with value received through operationalMode flag.
-func Initialize(operationalMode uint16) {
+func Initialize(t *testing.T, operationalModeFlag *int, dut *ondatra.DUTDevice) uint16 {
 	once.Do(func() {
-		if operationalMode != 0 {
-			opmode = operationalMode
+		t.Helper()
+		opModeFlagValue := uint16(*operationalModeFlag)
+		if opModeFlagValue == 0 {
+			switch dut.Vendor() {
+			case ondatra.CISCO:
+				opmode = 5003
+			case ondatra.ARISTA:
+				opmode = 1
+			case ondatra.JUNIPER:
+				opmode = 1
+			case ondatra.NOKIA:
+				opmode = 1083
+			}
 		} else {
-			fmt.Sprintln("Please specify the vendor-specific operational-mode flag")
-			return
+			opmode = opModeFlagValue
 		}
 	})
+	fmt.Printf("Vendor %s, OperationalMode set to %d", dut.Vendor(), opmode)
+	return opmode
 }
 
 // InterfaceConfig configures the interface with the given port.


### PR DESCRIPTION
Update vendor specific operational mode values for ZR optic channels. 
Update: Logic is updated to use vendor specific values when '0' is passed as the OperationalMode variable. 