### PR TITLE
Modification to RT2.12-static_route_isis_redistribution_test.go

### DIFF
--- a/feature/isis/otg_tests/static_route_isis_redistribution/metadata.textproto
+++ b/feature/isis/otg_tests/static_route_isis_redistribution/metadata.textproto
@@ -36,7 +36,6 @@ platform_exceptions: {
   }
   deviations: {
     isis_level_enabled: true
-    skip_setting_disable_metric_propagation: true
     routing_policy_tag_set_embedded: true
     }
  }   


### PR DESCRIPTION
1. Script is replacing the policy without deleting the policy reference  in table connections. Updated script to handle this.
2. Removed deviation skip_setting_disable_metric_propagation