### PR TITLE
pull#4007 changes impact the config dependency for Juniper. Corrected to have otn->eth config sequence for Juniper device

### DIFF
--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -119,6 +119,7 @@ func ConfigOpticalChannel(t *testing.T, dut *ondatra.DUTDevice, och string, freq
 // ConfigOTNChannel configures the OTN channel.
 func ConfigOTNChannel(t *testing.T, dut *ondatra.DUTDevice, och string, otnIndex, ethIndex uint32) {
 	t.Helper()
+	t.Logf(" otnIndex:%v, ethIndex: %v", otnIndex, ethIndex)
 	if deviations.OTNChannelTribUnsupported(dut) {
 		gnmi.Replace(t, dut, gnmi.OC().TerminalDevice().Channel(otnIndex).Config(), &oc.TerminalDevice_Channel{
 			Description:        ygot.String("OTN Logical Channel"),
@@ -134,8 +135,24 @@ func ConfigOTNChannel(t *testing.T, dut *ondatra.DUTDevice, och string, otnIndex
 				},
 			},
 		})
+	} else if dut.Vendor() == ondatra.JUNIPER {
+		gnmi.Replace(t, dut, gnmi.OC().TerminalDevice().Channel(otnIndex).Config(), &oc.TerminalDevice_Channel{
+			Description:        ygot.String("OTN Logical Channel"),
+			Index:              ygot.Uint32(otnIndex),
+			LogicalChannelType: oc.TransportTypes_LOGICAL_ELEMENT_PROTOCOL_TYPE_PROT_OTN,
+			TribProtocol:       oc.TransportTypes_TRIBUTARY_PROTOCOL_TYPE_PROT_400GE,
+			AdminState:         oc.TerminalDevice_AdminStateType_ENABLED,
+			Assignment: map[uint32]*oc.TerminalDevice_Channel_Assignment{
+				0: {
+					Index:          ygot.Uint32(0),
+					OpticalChannel: ygot.String(och),
+					Description:    ygot.String("OTN to Optical Channel"),
+					Allocation:     ygot.Float64(400),
+					AssignmentType: oc.Assignment_AssignmentType_OPTICAL_CHANNEL,
+				},
+			},
+		})
 	} else {
-		t.Logf(" otnIndex:%v, ethIndex: %v", otnIndex, ethIndex)
 		gnmi.Replace(t, dut, gnmi.OC().TerminalDevice().Channel(ethIndex).Config(), &oc.TerminalDevice_Channel{
 			Description:        ygot.String("ETH Logical Channel"),
 			Index:              ygot.Uint32(ethIndex),


### PR DESCRIPTION
Corrected the config required for Juniper. 

Ingress Interface --->  ETH  LC 4001 -----> OTN LC 4001 ------>  Optical Channel


4001(OTN) -----------> Assignment to Optical Channel OC:FPC0:PIC0:PORT0:XCVR:OCH
         |
         |
         |
         |  
         <------------------- 4001 (ETH)  <------  Ingress et-0/0/0
Assignment to OTN LC 4001 


