### PR TITLE
Explicitly set extended community set name

### DIFF
--- a/feature/bgp/policybase/otg_tests/link_bandwidth_test/link_bandwidth_test.go
+++ b/feature/bgp/policybase/otg_tests/link_bandwidth_test/link_bandwidth_test.go
@@ -688,10 +688,8 @@ func configureExtCommunityRoutingPolicy(t *testing.T, dut *ondatra.DUTDevice) {
 		for name, community := range extCommunitySet {
 			rp := root.GetOrCreateRoutingPolicy()
 			pdef := rp.GetOrCreateDefinedSets().GetOrCreateBgpDefinedSets()
-			stmt, err := pdef.NewExtCommunitySet(name)
-			if err != nil {
-				t.Fatalf("NewExtCommunitySet failed: %v", err)
-			}
+			stmt := pdef.GetOrCreateExtCommunitySet(name)
+			stmt.SetExtCommunitySetName(name)
 			stmt.SetExtCommunityMember([]string{community})
 			gnmi.Update(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
 		}


### PR DESCRIPTION
The change is to add coverage to the below path and so extended community set name is set explicitly. 
/routing-policy/defined-sets/bgp-defined-sets/ext-community-sets/ext-community-set/config/ext-community-set-name: