### PR TITLE
Authz: add sleep when polling dut post reboot

### DIFF
--- a/feature/security/gnsi/authz/tests/authz/authz1_4_test.go
+++ b/feature/security/gnsi/authz/tests/authz/authz1_4_test.go
@@ -684,6 +684,7 @@ func TestAuthz4(t *testing.T) {
 	t.Logf("Wait for DUT to boot up by polling the telemetry output.")
 	for {
 		t.Logf("Time elapsed %.2f seconds since reboot started.", time.Since(startReboot).Seconds())
+		time.Sleep(time.Minute)
 		if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
 			currentTime = gnmi.Get(t, dut, gnmi.OC().System().CurrentDatetime().State())
 		}); errMsg != nil {


### PR DESCRIPTION
Added sleep in the for loop which polls the dut post reboot otherwise logs can fill up instantaneously

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."