### PR TITLE
Fix controller_card_redundancy_test

### DIFF
--- a/feature/platform/controllercard/tests/controller_card_redundancy_test/controller_card_redundancy_test.go
+++ b/feature/platform/controllercard/tests/controller_card_redundancy_test/controller_card_redundancy_test.go
@@ -118,11 +118,33 @@ func testControllerCardSwitchover(t *testing.T, dut *ondatra.DUTDevice, controll
 		t.Errorf("Get rpStandbyAfterSwitch: got %v, want %v", got, want)
 	}
 
+	// Validate controller card last switchover time
+	lastSwitchoverTime := gnmi.OC().Component(rpActiveAfterSwitch).LastSwitchoverTime()
+	lastSwitchoverTimeCard := gnmi.Get(t, dut, lastSwitchoverTime.State())
+	if !(gnmi.Lookup(t, dut, lastSwitchoverTime.State()).IsPresent()) {
+		t.Errorf("Controller card last switchover time is not returning a valid value for %s", lastSwitchoverTime.State())
+	}
+	t.Logf("The value of last switchover time is %v", lastSwitchoverTimeCard)
+	// Validate controller card last switchover reason trigger
+	lastSwitchoverReasonTrigger := gnmi.OC().Component(rpActiveAfterSwitch).LastSwitchoverReason().Trigger()
+	lastSwitchoverReasonTriggerCard := gnmi.Get(t, dut, lastSwitchoverReasonTrigger.State())
+	if !(gnmi.Lookup(t, dut, lastSwitchoverReasonTrigger.State()).IsPresent()) {
+		t.Errorf("Controller card last switchover reason trigger is not returning a valid value for %s", lastSwitchoverReasonTrigger.State())
+	}
+	t.Logf("The value of last switchover reason trigger is %v", lastSwitchoverReasonTriggerCard)
+	// Validate controller card last switchover reason details
+	lastSwitchoverReasonDetails := gnmi.OC().Component(rpActiveAfterSwitch).LastSwitchoverReason().Details()
+	lastSwitchoverReasonDetailsCard := gnmi.Get(t, dut, lastSwitchoverReasonDetails.State())
+	if !(gnmi.Lookup(t, dut, lastSwitchoverReasonDetails.State()).IsPresent()) {
+		t.Errorf("Controller card last switchover reason details is not returning a valid value for %s", lastSwitchoverReasonDetails.State())
+	}
+	t.Logf("The value of last switchover reason details is %v", lastSwitchoverReasonDetailsCard)
+
 	// Verify that all controller_cards has switchover-ready=TRUE
 	switchoverReadyActiverp := gnmi.OC().Component(rpActiveAfterSwitch).SwitchoverReady()
-	switchoverReadyStandbyrp := gnmi.OC().Component(rpActiveAfterSwitch).SwitchoverReady()
-	gnmi.Await(t, dut, switchoverReadyActiverp.State(), 20*time.Minute, true)
-	gnmi.Await(t, dut, switchoverReadyStandbyrp.State(), 20*time.Minute, true)
+	switchoverReadyStandbyrp := gnmi.OC().Component(rpStandbyAfterSwitch).SwitchoverReady()
+	gnmi.Await(t, dut, switchoverReadyActiverp.State(), 25*time.Minute, true)
+	gnmi.Await(t, dut, switchoverReadyStandbyrp.State(), 25*time.Minute, true)
 	t.Logf("SwitchoverReady().Get(t): %v", gnmi.Get(t, dut, switchoverReady.State()))
 	if got, want := gnmi.Get(t, dut, switchoverReadyActiverp.State()), true; got != want {
 		t.Errorf("switchoverReady.Get(t): got %v, want %v", got, want)
@@ -170,27 +192,6 @@ func testControllerCardInventory(t *testing.T, dut *ondatra.DUTDevice, controlle
 			t.Errorf("Controller card redundant role is not returning a valid value for %s", redundantRole.State())
 		}
 		t.Logf("The value of redundant role is %v", redundantRoleCard)
-		// Validate controller card last switchover time
-		lastSwitchoverTime := gnmi.OC().Component(controllerCard).LastSwitchoverTime()
-		lastSwitchoverTimeCard := gnmi.Get(t, dut, lastSwitchoverTime.State())
-		if !(gnmi.Lookup(t, dut, lastSwitchoverTime.State()).IsPresent()) {
-			t.Errorf("Controller card last switchover time is not returning a valid value for %s", lastSwitchoverTime.State())
-		}
-		t.Logf("The value of last switchover time is %v", lastSwitchoverTimeCard)
-		// Validate controller card last switchover reason trigger
-		lastSwitchoverReasonTrigger := gnmi.OC().Component(controllerCard).LastSwitchoverReason().Trigger()
-		lastSwitchoverReasonTriggerCard := gnmi.Get(t, dut, lastSwitchoverReasonTrigger.State())
-		if !(gnmi.Lookup(t, dut, lastSwitchoverReasonTrigger.State()).IsPresent()) {
-			t.Errorf("Controller card last switchover reason trigger is not returning a valid value for %s", lastSwitchoverReasonTrigger.State())
-		}
-		t.Logf("The value of last switchover reason trigger is %v", lastSwitchoverReasonTriggerCard)
-		// Validate controller card last switchover reason details
-		lastSwitchoverReasonDetails := gnmi.OC().Component(controllerCard).LastSwitchoverReason().Details()
-		lastSwitchoverReasonDetailsCard := gnmi.Get(t, dut, lastSwitchoverReasonDetails.State())
-		if !(gnmi.Lookup(t, dut, lastSwitchoverReasonDetails.State()).IsPresent()) {
-			t.Errorf("Controller card last switchover reason details is not returning a valid value for %s", lastSwitchoverReasonDetails.State())
-		}
-		t.Logf("The value of last switchover reason details is %v", lastSwitchoverReasonDetailsCard)
 		// Validate controller card last reboot time
 		lastRebootTime := gnmi.OC().Component(controllerCard).LastRebootTime()
 		lastRebootTimeCard := gnmi.Get(t, dut, lastRebootTime.State())


### PR DESCRIPTION
In testlet 1: testControllerCardInventory, the following GNMI queries are problematic because they are related to last switchover, and the test has not yet performed a switchover:

- /components/component/state/last-switchover-time

- /components/component/state/last-switchover-reason/trigger

- /components/component/state/last-switchover-reason/details


This will cause the queries to return empty and the test to fail. To fix this issue I moved these queries to testlet 2: testControllerCardSwitchover, where the test performs switchover. By running these queries after a switchover the test is guaranteed to receive valid data in these queries. 




I also found a bug in testlet 2, where after switchover the test is supposed to be verifying that both the active and standby supervisors eventually become switchover ready. The problem is there is a bug in the code such that the test is verifying that the active supervisor is switchover ready 2 times and not checking on the standby at all. I fixed this so that the test verifies both the active and standby are switchover ready. I also bumped the await up to 25 minutes because 20 minutes may not always be enough for the supervisors to become switchover ready. 
