### PR TITLE
Update testregistry.textproto

### DIFF
--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -76,7 +76,7 @@ test: {
   id: "ACL-1.3"
   description: "Large Scale ACL with TCAM profile"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/acl/otg_tests/large_scale_acl/README.md"
-  exec: " " 
+  exec: " "
 }
 test: {
   id: "attestz-1"
@@ -471,7 +471,8 @@ test: {
   description: "Ingress handling of the TTL"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/ttl/otg_tests/ingress/README.md"
   exec: " "
-}test: {
+}
+test: {
   id: "PF-1.9"
   description: "Egress handling of the TTL, all egress packets should have their TTL decremented,egress packets with TTL=1 should generate ICMP time exceeded to source"
   readme: " "
@@ -879,7 +880,7 @@ test: {
 test: {
   id: "RT-2.17"
   description: "Graceful Restart Restarting"
-    readme: "https://github.com/openconfig/featureprofiles/feature/isis/otg_tests/graceful_restart_restarting/README.md"
+  readme: "https://github.com/openconfig/featureprofiles/feature/isis/otg_tests/graceful_restart_restarting/README.md"
   exec: " "
 }
 test: {
@@ -1145,8 +1146,20 @@ test: {
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/replay/tests/p4rt_replay/README.md"
 }
 test: {
-  id: "SFLOW-1"
-  description: "sFlow Configuration and Traffic Sampling"
+  id: "SFLOW-1.1"
+  description: "Configure sFlow on DUT on a non-default VRF"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/sflow/otg_tests/sflow_base_test/README.md"
+  exec: " "
+}
+test: {
+  id: "SFLOW-1.2"
+  description: "Send traffic via OTG and verify sFlow packet on OTG"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/sflow/otg_tests/sflow_base_test/README.md"
+  exec: " "
+}
+test: {
+  id: "SFLOW-1.3"
+  description: "Additional sflow packet verifications"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/sflow/otg_tests/sflow_base_test/README.md"
   exec: " "
 }
@@ -1901,8 +1914,26 @@ test: {
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnoi/factory_reset/tests/factory_reset_test/README.md"
 }
 test: {
-  id: "gNPSI-1"
-  description: "Sampling and Subscription Test"
+  id: "gNPSI-1.1"
+  description: "Validate DUT configuration of gNPSI server, connect OTG client and verify samples"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnpsi/otg_tests/sampling_test/README.md"
+  exec: " "
+}
+test: {
+  id: "gNPSI-1.2"
+  description: "Verify multiple clients can connect to the gNPSI Service and receive samples"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnpsi/otg_tests/sampling_test/README.md"
+  exec: " "
+}
+test: {
+  id: "gNPSI-1.3"
+  description: "Verify client reconnection to the gNPSI service"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnpsi/otg_tests/sampling_test/README.md"
+  exec: " "
+}
+test: {
+  id: "gNPSI-1.4"
+  description: "Verify client connection after gNPSI service restart"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gnpsi/otg_tests/sampling_test/README.md"
   exec: " "
 }


### PR DESCRIPTION
Split out the `SFLOW` and `gNPSI` tests into the numbered values in their READMEs.

Also fix the whitespace of the file.