### PR TITLE
Update MPLS-2.2

### DIFF
--- a/feature/mpls/otg_tests/static_bgp_nexthop/README.md
+++ b/feature/mpls/otg_tests/static_bgp_nexthop/README.md
@@ -20,10 +20,9 @@ Validate static LSP functionality with BGP resolved next-hop. This test verifies
                          |         | ---- | ATE Port 3 |
     ```
 
-2)  Configure eBGP peer on ATE Port 2 interface and advertise `BGP-NH-V4= 203.0.200.0/24` and `BGP-NH-V6= 2001:db8:128:200::/64`
-3) Configure static routes on the DUT to discard traffic destined for BGP-NH-V4 and BGP-NH-V6. These routes should point to a Null0  with an administrative distance of 254 to ensure they are less preferred than the BGP routes. This prevents the DUT from using its IGP to reach the BGP next-hops.
-4)  Enable MPLS forwarding.
-5)  Create egress static LSP for IPv4 and IPV6 traffic to pop the label and resolve the next-hop BGP-NH-V4 and BGP-NH-V6 respectivelly
+2)  Configure eBGP peer on ATE Port 2 interface and advertise `BGP-NH-V4=198.51.100.0/24` and `BGP-NH-V6=2001:DB8:100::0/64`
+3)  Enable MPLS forwarding.
+4)  Create egress static LSP for IPv4 and IPV6 traffic to pop the label and resolve the next-hop BGP-NH-V4 and BGP-NH-V6 respectivelly
 
 ```yaml
 network-instances:  
@@ -35,20 +34,20 @@ network-instances:
             config:  
               name: "lsp-egress-v4"  
             egress:  
-              next-hop: 203.0.200.1 
+              next-hop: <ATE IP port 3> 
               incoming-label: 1000004  
           - static-lsp:  
             config:  
               name: "lsp-egress-v6"  
             egress:  
-              next-hop: 2001:db8:128:200::1  
+              next-hop: <ATE IP port 3> 
               incoming-label: 1000006
 ```
     *  Set resolve NH action for both LSPs.
 
 **TODO:** OC model does not support resolve next-hop option for LSPs.
 
-7)  Configure static routes i.e. `IPV4-DST = 203.0.113.0/24` and `IPV6-DST = 2001:db8:128:128::/64` to ATE Port 3.
+7)  Configure static routes i.e. `IPV4-DST = 198.51.100.0/24` and `IPV6-DST = 2001:DB8:100::0/64` to ATE Port 3 with administrative distance (preference) 254.
 ```yaml
 network-instances:
   - network-instance:
@@ -57,20 +56,22 @@ network-instances:
         static-routes:
           - static:
             config:
-              prefix: "203.0.113.0/24"
+              prefix: "198.51.100.0/24"
             next-hops:
               - next-hop:
                 config:
                   index:  1
                   next-hop: "ATE PORT 3"
+                  preference: 254
           - static:
             config:
-              prefix: "2001:db8:128:128::/64"
+              prefix: "2001:DB8:100::0/64"
             next-hops:
               - next-hop:
                 config:
                   index:  1
                   next-hop: "ATE PORT 3"
+                  preference: 254
 ```
 
 ### MPLS-2.2.1: Verify IPv4 MPLS forwarding
@@ -90,14 +91,14 @@ network-instances:
 *   Withdraw BGP-NH-V4 advertisement.    
 *   Push the above DUT configuration.
 *   Start traffic flow with MPLS[lbl-1000004] and IPv4 destination set to IPV4-DST.
-*   Verify that traffic is discarded.
+*   Verify that traffic is forwarded to ATE Port 3.
 
 ### MPLS-2.2.4: Verify IPv6 traffic discard when BGP-NH is not available.
 
 *   Withdraw BGP-NH-V6 advertisement.    
 *   Push the above DUT configuration.
 *   Start traffic flow with MPLS[lbl-1000006] and IPv6 destination set to IPV6-DST.
-*   Verify that traffic is discarded.
+*   Verify that traffic is forwarded to ATE Port 3.
 
 ## OpenConfig Path and RPC Coverage
 


### PR DESCRIPTION
Clarify static route usage in MPLS static LSP to indirect next-hop test.