### PR TITLE
Rt 3.2-Test multiple vrf selection policies

### DIFF
--- a/feature/policy_forwarding/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/README.md
+++ b/feature/policy_forwarding/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/README.md
@@ -6,11 +6,21 @@ Ensure that multiple protocol and dscp based VRF selection rules are matched cor
 
 ## Procedure
 
-Configure DUT with 1 input interface connected to ATE port-1, and a second interface (output) connected to ATE port-2 with VLAN-based subinterfaces, with the following assignments: 
+Configure DUT with 1 input interface connected to ATE port-1, and a second 
+interface (output) connected to ATE port-2 with VLAN-based subinterfaces, 
+with the following assignments: 
 
 * network-instance “10” corresponding to VLAN 10, default route via VLAN 10 subinterface. 
 * network-instance “20” corresponding to VLAN 20, default route via VLAN 20 subinterface. 
 * network-instance “30” corresponding to VLAN 30, default route via VLAN 30 subinterface. 
+
+Connect DUT port-3 input interface connected to ATE port-3, and a second 
+interface (output) connected to ATE port-4 with VLAN-based subinterfaces, 
+with the following assignments:
+
+* network-instance “40” corresponding to VLAN 40, default route via VLAN 40 subinterface. 
+* network-instance “50” corresponding to VLAN 50, default route via VLAN 50 subinterface. 
+* network-instance “60” corresponding to VLAN 60, default route via VLAN 60 subinterface. 
 
 Configure DUT with the following rules and determine measurement: 
 
@@ -49,6 +59,14 @@ It's ok that some NOS does not support this config (duplicated matching conditio
     * Protocol IPinIP, DSCP 20 to network-instance 20 
 
 Ensure that unspecified fields are wildcard and IPinIP packets are only received at VLAN 10 subinterface. 
+
+### Case #5:
+
+* Rules: 
+    * Protocol IPinIP, DSCP 10 to network-instance 10 
+    * Protocol IPinIP, DSCP 40 to network-instance 40 
+    
+Ensure that the dut is able to evaluate more than one vrf selection policies. 
 
 ## OpenConfig Path and RPC Coverage
 ```yaml

--- a/feature/policy_forwarding/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/metadata.textproto
+++ b/feature/policy_forwarding/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/metadata.textproto
@@ -4,7 +4,7 @@
 uuid: "d54b1029-6f8e-4dc7-a50d-99d6e4f59474"
 plan_id: "RT-3.2"
 description: "Multiple <Protocol, DSCP> Rules for VRF Selection"
-testbed: TESTBED_DUT_ATE_2LINKS
+testbed: TESTBED_DUT_ATE_4LINKS
 platform_exceptions: {
   platform: {
     vendor: CISCO

--- a/feature/policy_forwarding/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/policy_forwarding/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openconfig/ygot/ygot"
 )
 
+
 const (
 	trafficDuration = 1 * time.Minute
 	ipv4PrefixLen   = 30
@@ -139,56 +140,191 @@ var (
 		IPv6:    "2001:0db8::192:0:2:12",
 		IPv6Len: ipv6PrefixLen,
 	}
+
+	dutPort3 = attrs.Attributes{
+		Desc:    "dutPort3",
+		MAC:     "03:00:01:01:01:01",
+		IPv4:    "192.0.2.21",
+		IPv4Len: ipv4PrefixLen,
+		IPv6:    "2001:0db8::192:0:2:21",
+		IPv6Len: ipv6PrefixLen,
+	}
+
+	atePort3 = attrs.Attributes{
+		Name:    "atePort3",
+		MAC:     "00:12:01:00:00:03",
+		IPv4:    "192.0.2.22",
+		IPv4Len: ipv4PrefixLen,
+		IPv6:    "2001:0db8::192:0:2:22",
+		IPv6Len: ipv6PrefixLen,
+	}
+
+	dutPort4 = attrs.Attributes{
+		Desc:    "dutPort4",
+		MAC:     "04:00:01:01:01:01",
+		IPv4:    "192.0.2.33",
+		IPv4Len: ipv4PrefixLen,
+		IPv6:    "2001:0db8::192:0:2:33",
+		IPv6Len: ipv6PrefixLen,
+	}
+
+	atePort4 = attrs.Attributes{
+		Name:    "atePort4",
+		MAC:     "00:12:01:00:00:04",
+		IPv4:    "192.0.2.34",
+		IPv4Len: ipv4PrefixLen,
+		IPv6:    "2001:0db8::192:0:2:34",
+		IPv6Len: ipv6PrefixLen,
+	}
+
+	dutPort4Vlan40 = attrs.Attributes{
+		Desc:    "dutPort4Vlan40",
+		MAC:     "04:00:01:01:01:01",
+		IPv4:    "192.0.2.37",
+		IPv4Len: ipv4PrefixLen,
+		IPv6:    "2001:0db8::192:0:2:37",
+		IPv6Len: ipv6PrefixLen,
+	}
+
+	atePort4Vlan40 = attrs.Attributes{
+		Name:    "atePort4Vlan40",
+		MAC:     "00:12:01:00:00:04",
+		IPv4:    "192.0.2.38",
+		IPv4Len: ipv4PrefixLen,
+		IPv6:    "2001:0db8::192:0:2:38",
+		IPv6Len: ipv6PrefixLen,
+	}
+
+	dutPort4Vlan50 = attrs.Attributes{
+		Desc:    "dutPort4Vlan50",
+		MAC:     "04:00:01:01:01:01",
+		IPv4:    "192.0.2.41",
+		IPv4Len: ipv4PrefixLen,
+		IPv6:    "2001:0db8::192:0:2:41",
+		IPv6Len: ipv6PrefixLen,
+	}
+
+	atePort4Vlan50 = attrs.Attributes{
+		Name:    "atePort4Vlan50",
+		MAC:     "00:12:01:00:00:04",
+		IPv4:    "192.0.2.42",
+		IPv4Len: ipv4PrefixLen,
+		IPv6:    "2001:0db8::192:0:2:42",
+		IPv6Len: ipv6PrefixLen,
+	}
+
+	dutPort4Vlan60 = attrs.Attributes{
+		Desc:    "dutPort4Vlan60",
+		MAC:     "04:00:01:01:01:01",
+		IPv4:    "192.0.2.45",
+		IPv4Len: ipv4PrefixLen,
+		IPv6:    "2001:0db8::192:0:2:45",
+		IPv6Len: ipv6PrefixLen,
+	}
+
+	atePort4Vlan60 = attrs.Attributes{
+		Name:    "atePort4Vlan60",
+		MAC:     "00:12:01:00:00:04",
+		IPv4:    "192.0.2.46",
+		IPv4Len: ipv4PrefixLen,
+		IPv6:    "2001:0db8::192:0:2:46",
+		IPv6Len: ipv6PrefixLen,
+	}
 )
 
 func TestMain(m *testing.M) {
 	fptest.RunTests(m)
 }
 
-// configureATE configures port1, port2 and vlans on port2 on the ATE.
+// configureATE configures port1, port2, port3, port4 and vlans on port2 and port4 on the ATE.
 func configureATE(t *testing.T, ate *ondatra.ATEDevice, dut *ondatra.DUTDevice) gosnappi.Config {
 	top := gosnappi.NewConfig()
 
+	// ATE Port 1 (Ingress)
 	p1 := ate.Port(t, "port1")
 	top.Ports().Add().SetName(p1.ID())
-	srcDev := top.Devices().Add().SetName(atePort1.Name)
-	ethSrc := srcDev.Ethernets().Add().SetName(atePort1.Name + ".eth").SetMac(atePort1.MAC)
-	ethSrc.Connection().SetPortName(p1.ID())
-	ethSrc.Ipv4Addresses().Add().SetName(srcDev.Name() + ".ipv4").SetAddress(atePort1.IPv4).SetGateway(dutPort1.IPv4).SetPrefix(uint32(atePort1.IPv4Len))
-	ethSrc.Ipv6Addresses().Add().SetName(srcDev.Name() + ".ipv6").SetAddress(atePort1.IPv6).SetGateway(dutPort1.IPv6).SetPrefix(uint32(atePort1.IPv6Len))
+	srcDev1 := top.Devices().Add().SetName(atePort1.Name)
+	ethSrc1 := srcDev1.Ethernets().Add().SetName(atePort1.Name + ".eth").SetMac(atePort1.MAC)
+	ethSrc1.Connection().SetPortName(p1.ID())
+	ethSrc1.Ipv4Addresses().Add().SetName(srcDev1.Name() + ".ipv4").SetAddress(atePort1.IPv4).SetGateway(dutPort1.IPv4).SetPrefix(uint32(atePort1.IPv4Len))
+	ethSrc1.Ipv6Addresses().Add().SetName(srcDev1.Name() + ".ipv6").SetAddress(atePort1.IPv6).SetGateway(dutPort1.IPv6).SetPrefix(uint32(atePort1.IPv6Len))
 
+	// ATE Port 2 (Egress for Port 1)
 	p2 := ate.Port(t, "port2")
 	top.Ports().Add().SetName(p2.ID())
-	dstDev := top.Devices().Add().SetName(atePort2.Name)
-	ethDst := dstDev.Ethernets().Add().SetName(atePort2.Name + ".eth").SetMac(atePort2.MAC)
+	dstDev2 := top.Devices().Add().SetName(atePort2.Name)
+	ethDst2 := dstDev2.Ethernets().Add().SetName(atePort2.Name + ".eth").SetMac(atePort2.MAC)
 	if deviations.NoMixOfTaggedAndUntaggedSubinterfaces(dut) {
-		ethDst.Vlans().Add().SetName(atePort2.Name + "vlan").SetId(1)
+		ethDst2.Vlans().Add().SetName(atePort2.Name + "vlan").SetId(1)
 	}
-	ethDst.Connection().SetPortName(p2.ID())
-	ethDst.Ipv4Addresses().Add().SetName(dstDev.Name() + ".ipv4").SetAddress(atePort2.IPv4).SetGateway(dutPort2.IPv4).SetPrefix(uint32(atePort2.IPv4Len))
-	ethDst.Ipv6Addresses().Add().SetName(dstDev.Name() + ".ipv6").SetAddress(atePort2.IPv6).SetGateway(dutPort2.IPv6).SetPrefix(uint32(atePort2.IPv6Len))
+	ethDst2.Connection().SetPortName(p2.ID())
+	ethDst2.Ipv4Addresses().Add().SetName(dstDev2.Name() + ".ipv4").SetAddress(atePort2.IPv4).SetGateway(dutPort2.IPv4).SetPrefix(uint32(atePort2.IPv4Len))
+	ethDst2.Ipv6Addresses().Add().SetName(dstDev2.Name() + ".ipv6").SetAddress(atePort2.IPv6).SetGateway(dutPort2.IPv6).SetPrefix(uint32(atePort2.IPv6Len))
 
-	// configure vlans on ATE port2
-	dstDevVlan10 := top.Devices().Add().SetName(atePort2Vlan10.Name)
-	ethDstVlan10 := dstDevVlan10.Ethernets().Add().SetName(atePort2Vlan10.Name + ".eth").SetMac(atePort2Vlan10.MAC)
-	ethDstVlan10.Connection().SetPortName(p2.ID())
-	ethDstVlan10.Vlans().Add().SetName(atePort2Vlan10.Name + "vlan").SetId(10)
-	ethDstVlan10.Ipv4Addresses().Add().SetName(atePort2Vlan10.Name + ".ipv4").SetAddress(atePort2Vlan10.IPv4).SetGateway(dutPort2Vlan10.IPv4).SetPrefix(uint32(atePort2Vlan10.IPv4Len))
-	ethDstVlan10.Ipv6Addresses().Add().SetName(atePort2Vlan10.Name + ".ipv6").SetAddress(atePort2Vlan10.IPv6).SetGateway(dutPort2Vlan10.IPv6).SetPrefix(uint32(atePort2Vlan10.IPv6Len))
+	// Configure VLANs on ATE port2
+	dstDev2Vlan10 := top.Devices().Add().SetName(atePort2Vlan10.Name)
+	ethDst2Vlan10 := dstDev2Vlan10.Ethernets().Add().SetName(atePort2Vlan10.Name + ".eth").SetMac(atePort2Vlan10.MAC)
+	ethDst2Vlan10.Connection().SetPortName(p2.ID())
+	ethDst2Vlan10.Vlans().Add().SetName(atePort2Vlan10.Name + "vlan").SetId(10)
+	ethDst2Vlan10.Ipv4Addresses().Add().SetName(atePort2Vlan10.Name + ".ipv4").SetAddress(atePort2Vlan10.IPv4).SetGateway(dutPort2Vlan10.IPv4).SetPrefix(uint32(atePort2Vlan10.IPv4Len))
+	ethDst2Vlan10.Ipv6Addresses().Add().SetName(atePort2Vlan10.Name + ".ipv6").SetAddress(atePort2Vlan10.IPv6).SetGateway(dutPort2Vlan10.IPv6).SetPrefix(uint32(atePort2Vlan10.IPv6Len))
 
-	dstDevVlan20 := top.Devices().Add().SetName(atePort2Vlan20.Name)
-	ethDstVlan20 := dstDevVlan20.Ethernets().Add().SetName(atePort2Vlan20.Name + ".eth").SetMac(atePort2Vlan20.MAC)
-	ethDstVlan20.Connection().SetPortName(p2.ID())
-	ethDstVlan20.Vlans().Add().SetName(atePort2Vlan20.Name + "vlan").SetId(20)
-	ethDstVlan20.Ipv4Addresses().Add().SetName(atePort2Vlan20.Name + ".ipv4").SetAddress(atePort2Vlan20.IPv4).SetGateway(dutPort2Vlan20.IPv4).SetPrefix(uint32(atePort2Vlan20.IPv4Len))
-	ethDstVlan20.Ipv6Addresses().Add().SetName(atePort2Vlan20.Name + ".ipv6").SetAddress(atePort2Vlan20.IPv6).SetGateway(dutPort2Vlan20.IPv6).SetPrefix(uint32(atePort2Vlan20.IPv6Len))
+	dstDev2Vlan20 := top.Devices().Add().SetName(atePort2Vlan20.Name)
+	ethDst2Vlan20 := dstDev2Vlan20.Ethernets().Add().SetName(atePort2Vlan20.Name + ".eth").SetMac(atePort2Vlan20.MAC)
+	ethDst2Vlan20.Connection().SetPortName(p2.ID())
+	ethDst2Vlan20.Vlans().Add().SetName(atePort2Vlan20.Name + "vlan").SetId(20)
+	ethDst2Vlan20.Ipv4Addresses().Add().SetName(atePort2Vlan20.Name + ".ipv4").SetAddress(atePort2Vlan20.IPv4).SetGateway(dutPort2Vlan20.IPv4).SetPrefix(uint32(atePort2Vlan20.IPv4Len))
+	ethDst2Vlan20.Ipv6Addresses().Add().SetName(atePort2Vlan20.Name + ".ipv6").SetAddress(atePort2Vlan20.IPv6).SetGateway(dutPort2Vlan20.IPv6).SetPrefix(uint32(atePort2Vlan20.IPv6Len))
 
-	dstDevVlan30 := top.Devices().Add().SetName(atePort2Vlan30.Name)
-	ethDstVlan30 := dstDevVlan30.Ethernets().Add().SetName(atePort2Vlan30.Name + ".eth").SetMac(atePort2Vlan30.MAC)
-	ethDstVlan30.Connection().SetPortName(p2.ID())
-	ethDstVlan30.Vlans().Add().SetName(atePort2Vlan30.Name + "vlan").SetId(30)
-	ethDstVlan30.Ipv4Addresses().Add().SetName(atePort2Vlan30.Name + ".ipv4").SetAddress(atePort2Vlan30.IPv4).SetGateway(dutPort2Vlan30.IPv4).SetPrefix(uint32(atePort2Vlan30.IPv4Len))
-	ethDstVlan30.Ipv6Addresses().Add().SetName(atePort2Vlan30.Name + ".ipv6").SetAddress(atePort2Vlan30.IPv6).SetGateway(dutPort2Vlan30.IPv6).SetPrefix(uint32(atePort2Vlan30.IPv6Len))
+	dstDev2Vlan30 := top.Devices().Add().SetName(atePort2Vlan30.Name)
+	ethDst2Vlan30 := dstDev2Vlan30.Ethernets().Add().SetName(atePort2Vlan30.Name + ".eth").SetMac(atePort2Vlan30.MAC)
+	ethDst2Vlan30.Connection().SetPortName(p2.ID())
+	ethDst2Vlan30.Vlans().Add().SetName(atePort2Vlan30.Name + "vlan").SetId(30)
+	ethDst2Vlan30.Ipv4Addresses().Add().SetName(atePort2Vlan30.Name + ".ipv4").SetAddress(atePort2Vlan30.IPv4).SetGateway(dutPort2Vlan30.IPv4).SetPrefix(uint32(atePort2Vlan30.IPv4Len))
+	ethDst2Vlan30.Ipv6Addresses().Add().SetName(atePort2Vlan30.Name + ".ipv6").SetAddress(atePort2Vlan30.IPv6).SetGateway(dutPort2Vlan30.IPv6).SetPrefix(uint32(atePort2Vlan30.IPv6Len))
+
+	// ATE Port 3 (Ingress)
+	p3 := ate.Port(t, "port3")
+	top.Ports().Add().SetName(p3.ID())
+	srcDev3 := top.Devices().Add().SetName(atePort3.Name)
+	ethSrc3 := srcDev3.Ethernets().Add().SetName(atePort3.Name + ".eth").SetMac(atePort3.MAC)
+	ethSrc3.Connection().SetPortName(p3.ID())
+	ethSrc3.Ipv4Addresses().Add().SetName(srcDev3.Name() + ".ipv4").SetAddress(atePort3.IPv4).SetGateway(dutPort3.IPv4).SetPrefix(uint32(atePort3.IPv4Len))
+	ethSrc3.Ipv6Addresses().Add().SetName(srcDev3.Name() + ".ipv6").SetAddress(atePort3.IPv6).SetGateway(dutPort3.IPv6).SetPrefix(uint32(atePort3.IPv6Len))
+
+	// ATE Port 4 (Egress for Port 3)
+	p4 := ate.Port(t, "port4")
+	top.Ports().Add().SetName(p4.ID())
+	dstDev4 := top.Devices().Add().SetName(atePort4.Name)
+	ethDst4 := dstDev4.Ethernets().Add().SetName(atePort4.Name + ".eth").SetMac(atePort4.MAC)
+	if deviations.NoMixOfTaggedAndUntaggedSubinterfaces(dut) {
+		ethDst4.Vlans().Add().SetName(atePort4.Name + "vlan").SetId(1)
+	}
+	ethDst4.Connection().SetPortName(p4.ID())
+	ethDst4.Ipv4Addresses().Add().SetName(dstDev4.Name() + ".ipv4").SetAddress(atePort4.IPv4).SetGateway(dutPort4.IPv4).SetPrefix(uint32(atePort4.IPv4Len))
+	ethDst4.Ipv6Addresses().Add().SetName(dstDev4.Name() + ".ipv6").SetAddress(atePort4.IPv6).SetGateway(dutPort4.IPv6).SetPrefix(uint32(atePort4.IPv6Len))
+
+	// Configure VLANs on ATE port4
+	dstDev4Vlan40 := top.Devices().Add().SetName(atePort4Vlan40.Name)
+	ethDst4Vlan40 := dstDev4Vlan40.Ethernets().Add().SetName(atePort4Vlan40.Name + ".eth").SetMac(atePort4Vlan40.MAC)
+	ethDst4Vlan40.Connection().SetPortName(p4.ID())
+	ethDst4Vlan40.Vlans().Add().SetName(atePort4Vlan40.Name + "vlan").SetId(40)
+	ethDst4Vlan40.Ipv4Addresses().Add().SetName(atePort4Vlan40.Name + ".ipv4").SetAddress(atePort4Vlan40.IPv4).SetGateway(dutPort4Vlan40.IPv4).SetPrefix(uint32(atePort4Vlan40.IPv4Len))
+	ethDst4Vlan40.Ipv6Addresses().Add().SetName(atePort4Vlan40.Name + ".ipv6").SetAddress(atePort4Vlan40.IPv6).SetGateway(dutPort4Vlan40.IPv6).SetPrefix(uint32(atePort4Vlan40.IPv6Len))
+
+	dstDev4Vlan50 := top.Devices().Add().SetName(atePort4Vlan50.Name)
+	ethDst4Vlan50 := dstDev4Vlan50.Ethernets().Add().SetName(atePort4Vlan50.Name + ".eth").SetMac(atePort4Vlan50.MAC)
+	ethDst4Vlan50.Connection().SetPortName(p4.ID())
+	ethDst4Vlan50.Vlans().Add().SetName(atePort4Vlan50.Name + "vlan").SetId(50)
+	ethDst4Vlan50.Ipv4Addresses().Add().SetName(atePort4Vlan50.Name + ".ipv4").SetAddress(atePort4Vlan50.IPv4).SetGateway(dutPort4Vlan50.IPv4).SetPrefix(uint32(atePort4Vlan50.IPv4Len))
+	ethDst4Vlan50.Ipv6Addresses().Add().SetName(atePort4Vlan50.Name + ".ipv6").SetAddress(atePort4Vlan50.IPv6).SetGateway(dutPort4Vlan50.IPv6).SetPrefix(uint32(atePort4Vlan50.IPv6Len))
+
+	dstDev4Vlan60 := top.Devices().Add().SetName(atePort4Vlan60.Name)
+	ethDst4Vlan60 := dstDev4Vlan60.Ethernets().Add().SetName(atePort4Vlan60.Name + ".eth").SetMac(atePort4Vlan60.MAC)
+	ethDst4Vlan60.Connection().SetPortName(p4.ID())
+	ethDst4Vlan60.Vlans().Add().SetName(atePort4Vlan60.Name + "vlan").SetId(60)
+	ethDst4Vlan60.Ipv4Addresses().Add().SetName(atePort4Vlan60.Name + ".ipv4").SetAddress(atePort4Vlan60.IPv4).SetGateway(dutPort4Vlan60.IPv4).SetPrefix(uint32(atePort4Vlan60.IPv4Len))
+	ethDst4Vlan60.Ipv6Addresses().Add().SetName(atePort4Vlan60.Name + ".ipv6").SetAddress(atePort4Vlan60.IPv6).SetGateway(dutPort4Vlan60.IPv6).SetPrefix(uint32(atePort4Vlan60.IPv6Len))
 
 	return top
 }
@@ -265,10 +401,12 @@ func configInterfaceDUT(i *oc.Interface, dutPort *attrs.Attributes, dut *ondatra
 func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	d := gnmi.OC()
 
+	// DUT Port 1 (Ingress)
 	p1 := dut.Port(t, "port1")
 	i1 := &oc.Interface{Name: ygot.String(p1.Name())}
 	gnmi.Replace(t, dut, d.Interface(p1.Name()).Config(), configInterfaceDUT(i1, &dutPort1, dut))
 
+	// DUT Port 2 (Egress for Port 1)
 	p2 := dut.Port(t, "port2")
 	i2 := &oc.Interface{Name: ygot.String(p2.Name())}
 	gnmi.Replace(t, dut, d.Interface(p2.Name()).Config(), configInterfaceDUT(i2, &dutPort2, dut))
@@ -279,27 +417,56 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		gnmi.Update(t, dut, d.Interface(p2.Name()).Config(), i3)
 	}
 
+	outpath2 := d.Interface(p2.Name())
+	// create VRFs and VRF enabled subinterfaces for port2
+	configNetworkInstance(t, dut, "VRF10", p2.Name(), uint32(1), 10)
+	gnmi.Update(t, dut, outpath2.Subinterface(1).Config(), getSubInterface(&dutPort2Vlan10, 1, 10, dut))
+
+	configNetworkInstance(t, dut, "VRF20", p2.Name(), uint32(2), 20)
+	gnmi.Update(t, dut, outpath2.Subinterface(2).Config(), getSubInterface(&dutPort2Vlan20, 2, 20, dut))
+
+	configNetworkInstance(t, dut, "VRF30", p2.Name(), uint32(3), 30)
+	gnmi.Update(t, dut, outpath2.Subinterface(3).Config(), getSubInterface(&dutPort2Vlan30, 3, 30, dut))
+
+	// DUT Port 3 (Ingress)
+	p3 := dut.Port(t, "port3")
+	i4 := &oc.Interface{Name: ygot.String(p3.Name())}
+	gnmi.Replace(t, dut, d.Interface(p3.Name()).Config(), configInterfaceDUT(i4, &dutPort3, dut))
+
+	// DUT Port 4 (Egress for Port 3)
+	p4 := dut.Port(t, "port4")
+	i5 := &oc.Interface{Name: ygot.String(p4.Name())}
+	gnmi.Replace(t, dut, d.Interface(p4.Name()).Config(), configInterfaceDUT(i5, &dutPort4, dut))
+	if deviations.NoMixOfTaggedAndUntaggedSubinterfaces(dut) {
+		i6 := &oc.Interface{Name: ygot.String(p4.Name())}
+		s := i6.GetOrCreateSubinterface(0)
+		s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(1)
+		gnmi.Update(t, dut, d.Interface(p4.Name()).Config(), i6)
+	}
+
+	outpath4 := d.Interface(p4.Name())
+	// create VRFs and VRF enabled subinterfaces for port4
+	configNetworkInstance(t, dut, "VRF40", p4.Name(), uint32(4), 40)
+	gnmi.Update(t, dut, outpath4.Subinterface(4).Config(), getSubInterface(&dutPort4Vlan40, 4, 40, dut))
+
+	configNetworkInstance(t, dut, "VRF50", p4.Name(), uint32(5), 50)
+	gnmi.Update(t, dut, outpath4.Subinterface(5).Config(), getSubInterface(&dutPort4Vlan50, 5, 50, dut))
+
+	configNetworkInstance(t, dut, "VRF60", p4.Name(), uint32(6), 60)
+	gnmi.Update(t, dut, outpath4.Subinterface(6).Config(), getSubInterface(&dutPort4Vlan60, 6, 60, dut))
+
 	if deviations.ExplicitPortSpeed(dut) {
 		fptest.SetPortSpeed(t, p1)
 		fptest.SetPortSpeed(t, p2)
+		fptest.SetPortSpeed(t, p3)
+		fptest.SetPortSpeed(t, p4)
 	}
 	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
 		fptest.AssignToNetworkInstance(t, dut, p1.Name(), deviations.DefaultNetworkInstance(dut), 0)
 		fptest.AssignToNetworkInstance(t, dut, p2.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p3.Name(), deviations.DefaultNetworkInstance(dut), 0)
+		fptest.AssignToNetworkInstance(t, dut, p4.Name(), deviations.DefaultNetworkInstance(dut), 0) // Assign port4 to default VRF
 	}
-
-	outpath := d.Interface(p2.Name())
-	// create VRFs and VRF enabled subinterfaces
-	configNetworkInstance(t, dut, "VRF10", p2.Name(), uint32(1), 10)
-
-	// configure IP addresses on subinterfaces
-	gnmi.Update(t, dut, outpath.Subinterface(1).Config(), getSubInterface(&dutPort2Vlan10, 1, 10, dut))
-
-	configNetworkInstance(t, dut, "VRF20", p2.Name(), uint32(2), 20)
-	gnmi.Update(t, dut, outpath.Subinterface(2).Config(), getSubInterface(&dutPort2Vlan20, 2, 20, dut))
-
-	configNetworkInstance(t, dut, "VRF30", p2.Name(), uint32(3), 30)
-	gnmi.Update(t, dut, outpath.Subinterface(3).Config(), getSubInterface(&dutPort2Vlan30, 3, 30, dut))
 }
 
 // getIPinIPFlow returns an IPv4inIPv4 *ondatra.Flow with provided DSCP value for a given set of endpoints.
@@ -326,21 +493,21 @@ func getIPinIPFlow(args *testArgs, src attrs.Attributes, dst attrs.Attributes, f
 }
 
 // testTrafficFlows verifies traffic for one or more flows.
-func testTrafficFlows(t *testing.T, args *testArgs, expectPass bool, flows ...gosnappi.Flow) {
+func testTrafficFlows(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config, expectPass bool, flows ...gosnappi.Flow) {
 
-	args.top.Flows().Clear()
+	top.Flows().Clear()
 	for _, flow := range flows {
-		args.top.Flows().Append(flow)
+		top.Flows().Append(flow)
 	}
-	args.ate.OTG().PushConfig(t, args.top)
-	args.ate.OTG().StartProtocols(t)
-	otgutils.WaitForARP(t, args.ate.OTG(), args.top, "IPv4")
+	ate.OTG().PushConfig(t, top)
+	ate.OTG().StartProtocols(t)
+	otgutils.WaitForARP(t, ate.OTG(), top, "IPv4")
 
 	t.Logf("*** Starting traffic ...")
-	args.ate.OTG().StartTraffic(t)
+	ate.OTG().StartTraffic(t)
 	time.Sleep(trafficDuration)
 	t.Logf("*** Stop traffic ...")
-	args.ate.OTG().StopTraffic(t)
+	ate.OTG().StopTraffic(t)
 
 	if expectPass {
 		t.Log("Expecting traffic to pass for the flows")
@@ -348,13 +515,13 @@ func testTrafficFlows(t *testing.T, args *testArgs, expectPass bool, flows ...go
 		t.Log("Expecting traffic to fail for the flows")
 	}
 
-	top := args.ate.OTG().GetConfig(t)
-	otgutils.LogFlowMetrics(t, args.ate.OTG(), top)
+	otgTop := ate.OTG().GetConfig(t)
+	otgutils.LogFlowMetrics(t, ate.OTG(), otgTop)
 	for _, flow := range flows {
 		t.Run(flow.Name(), func(t *testing.T) {
 			t.Logf("*** Verifying %v traffic on OTG ... ", flow.Name())
-			outPkts := float32(gnmi.Get(t, args.ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State()))
-			inPkts := float32(gnmi.Get(t, args.ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().InPkts().State()))
+			outPkts := float32(gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State()))
+			inPkts := float32(gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().InPkts().State()))
 
 			if outPkts == 0 {
 				t.Fatalf("OutPkts == 0, want >0.")
@@ -372,7 +539,7 @@ func testTrafficFlows(t *testing.T, args *testArgs, expectPass bool, flows ...go
 			} else if (expectPass == false) && (lossPct == 100) {
 				t.Logf("Traffic for %v flow is failing as expected", flow.Name())
 			} else {
-				t.Fatalf("Traffic is not working as expected for flow: %v.", flow.Name())
+				t.Fatalf("Traffic is not working as expected for flow: %v. LossPct: %f", flow.Name(), lossPct)
 			}
 		})
 	}
@@ -405,9 +572,9 @@ func getL3PBRRule(args *testArgs, networkInstance string, index uint32, dscpset 
 }
 
 // getPBRPolicyForwarding returns pointer to policy-forwarding populated with pbr policy and rules
-func getPBRPolicyForwarding(args *testArgs, rules ...*oc.NetworkInstance_PolicyForwarding_Policy_Rule) *oc.NetworkInstance_PolicyForwarding {
+func getPBRPolicyForwarding(policyName string, rules ...*oc.NetworkInstance_PolicyForwarding_Policy_Rule) *oc.NetworkInstance_PolicyForwarding {
 	pf := oc.NetworkInstance_PolicyForwarding{}
-	p := pf.GetOrCreatePolicy(args.policyName)
+	p := pf.GetOrCreatePolicy(policyName)
 	p.Type = oc.Policy_Type_VRF_SELECTION_POLICY
 	for _, rule := range rules {
 		p.AppendRule(rule)
@@ -416,7 +583,7 @@ func getPBRPolicyForwarding(args *testArgs, rules ...*oc.NetworkInstance_PolicyF
 }
 
 func TestPBR(t *testing.T) {
-	t.Logf("Description: Test RT3.2 with multiple DSCP, IPinIP protocol rule based VRF selection")
+	t.Logf("Description: Test RT3.2 with multiple DSCP, IPinIP protocol rule based VRF selection with two ingress/egress pairs.")
 	dut := ondatra.DUT(t, "dut")
 
 	// configure DUT
@@ -428,105 +595,151 @@ func TestPBR(t *testing.T) {
 	ate.OTG().PushConfig(t, top)
 	ate.OTG().StartProtocols(t)
 
-	args := &testArgs{
-		dut:        dut,
-		ate:        ate,
-		top:        top,
-		policyName: "L3",
-		iptype:     "ipv4",
-		protocol:   oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP,
-	}
-
-	// dut ingress interface
+	// Ingress interface for policies
 	port1 := dut.Port(t, "port1")
+	port3 := dut.Port(t, "port3")
 
 	cases := []struct {
 		name         string
 		desc         string
 		policy       *oc.NetworkInstance_PolicyForwarding
+		policyName   string
+		ingressPort  *ondatra.Port
+		testArgs     *testArgs
 		passingFlows []gosnappi.Flow
 		failingFlows []gosnappi.Flow
 		rejectable   bool
 	}{
 		{
-			name: "RT3.2 Case1",
-			desc: "Ensure matching IPinIP with DSCP (10 - VRF10, 20- VRF20, 30-VRF30) traffic reaches appropriate VLAN.",
-			policy: getPBRPolicyForwarding(args,
-				getL3PBRRule(args, "VRF10", 1, []uint8{10}),
-				getL3PBRRule(args, "VRF20", 2, []uint8{20}),
-				getL3PBRRule(args, "VRF30", 3, []uint8{30})),
-			// use IPinIP DSCP10, DSCP20, DSCP30 flows for VLAN10, VLAN20 and VLAN30 respectively.
+			name:        "RT3.2 Case1 - Port 1 Ingress to Port 2 Egress",
+			desc:        "Ensure matching IPinIP with DSCP (10 - VRF10, 20- VRF20, 30-VRF30) traffic reaches appropriate VLAN on Port 2 (Egress for Port 1).",
+			policyName:  "L3_Port1",
+			ingressPort: port1,
+			testArgs: &testArgs{
+				dut:      dut,
+				ate:      ate,
+				top:      top,
+				iptype:   "ipv4",
+				protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP,
+			},
+			policy: getPBRPolicyForwarding("L3_Port1",
+				getL3PBRRule(&testArgs{iptype: "ipv4", protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP}, "VRF10", 1, []uint8{10}),
+				getL3PBRRule(&testArgs{iptype: "ipv4", protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP}, "VRF20", 2, []uint8{20}),
+				getL3PBRRule(&testArgs{iptype: "ipv4", protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP}, "VRF30", 3, []uint8{30})),
 			passingFlows: []gosnappi.Flow{
-				getIPinIPFlow(args, atePort1, atePort2Vlan10, "ipinipd10", 10),
-				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd20", 20),
-				getIPinIPFlow(args, atePort1, atePort2Vlan30, "ipinipd30", 30)},
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan10, "ipinipd10_p1_p2", 10),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan20, "ipinipd20_p1_p2", 20),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan30, "ipinipd30_p1_p2", 30)},
 		},
 		{
-			name: "RT3.2 Case2",
-			desc: "Ensure matching IPinIP with DSCP (10-12 - VRF10, 20-22- VRF20, 30-32-VRF30) traffic reaches appropriate VLAN.",
-			policy: getPBRPolicyForwarding(args,
-				getL3PBRRule(args, "VRF10", 1, []uint8{10, 11, 12}),
-				getL3PBRRule(args, "VRF20", 2, []uint8{20, 21, 22}),
-				getL3PBRRule(args, "VRF30", 3, []uint8{30, 31, 32})),
-			// use IPinIP flows with DSCP10-12 for VLAN10, DSCP20-22 for VLAN20, DSCP30-32 for VLAN30.
+			name:        "RT3.2 Case2 - Port 1 Ingress to Port 2 Egress (Range DSCP)",
+			desc:        "Ensure matching IPinIP with DSCP (10-12 - VRF10, 20-22- VRF20, 30-32-VRF30) traffic reaches appropriate VLAN on Port 2 (Egress for Port 1).",
+			policyName:  "L3_Port1",
+			ingressPort: port1,
+			testArgs: &testArgs{
+				dut:      dut,
+				ate:      ate,
+				top:      top,
+				iptype:   "ipv4",
+				protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP,
+			},
+			policy: getPBRPolicyForwarding("L3_Port1",
+				getL3PBRRule(&testArgs{iptype: "ipv4", protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP}, "VRF10", 1, []uint8{10, 11, 12}),
+				getL3PBRRule(&testArgs{iptype: "ipv4", protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP}, "VRF20", 2, []uint8{20, 21, 22}),
+				getL3PBRRule(&testArgs{iptype: "ipv4", protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP}, "VRF30", 3, []uint8{30, 31, 32})),
 			passingFlows: []gosnappi.Flow{
-				getIPinIPFlow(args, atePort1, atePort2Vlan10, "ipinipd10", 10),
-				getIPinIPFlow(args, atePort1, atePort2Vlan10, "ipinipd11", 11),
-				getIPinIPFlow(args, atePort1, atePort2Vlan10, "ipinipd12", 12),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan10, "ipinipd10_p1_p2", 10),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan10, "ipinipd11_p1_p2", 11),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan10, "ipinipd12_p1_p2", 12),
 
-				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd20", 20),
-				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd21", 21),
-				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd22", 22),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan20, "ipinipd20_p1_p2", 20),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan20, "ipinipd21_p1_p2", 21),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan20, "ipinipd22_p1_p2", 22),
 
-				getIPinIPFlow(args, atePort1, atePort2Vlan30, "ipinipd30", 30),
-				getIPinIPFlow(args, atePort1, atePort2Vlan30, "ipinipd31", 31),
-				getIPinIPFlow(args, atePort1, atePort2Vlan30, "ipinipd32", 32)},
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan30, "ipinipd30_p1_p2", 30),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan30, "ipinipd31_p1_p2", 31),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan30, "ipinipd32_p1_p2", 32)},
 		},
 		{
-			name: "RT3.2 Case3",
-			desc: "Ensure first matching of IPinIP with DSCP (10-12 - VRF10, 10-12 - VRF20) rule takes precedence.",
-			policy: getPBRPolicyForwarding(args,
-				getL3PBRRule(args, "VRF10", 1, []uint8{10, 11, 12}),
-				getL3PBRRule(args, "VRF20", 2, []uint8{10, 11, 12})),
-			// use IPinIP DSCP10-12 flows for VLAN10 as well as VLAN20.
+			name:        "RT3.2 Case3 - Port 1 Ingress (Precedence)",
+			desc:        "Ensure first matching of IPinIP with DSCP (10-12 - VRF10, 10-12 - VRF20) rule takes precedence on Port 1.",
+			policyName:  "L3_Port1",
+			ingressPort: port1,
+			testArgs: &testArgs{
+				dut:      dut,
+				ate:      ate,
+				top:      top,
+				iptype:   "ipv4",
+				protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP,
+			},
+			policy: getPBRPolicyForwarding("L3_Port1",
+				getL3PBRRule(&testArgs{iptype: "ipv4", protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP}, "VRF10", 1, []uint8{10, 11, 12}),
+				getL3PBRRule(&testArgs{iptype: "ipv4", protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP}, "VRF20", 2, []uint8{10, 11, 12})),
 			passingFlows: []gosnappi.Flow{
-				getIPinIPFlow(args, atePort1, atePort2Vlan10, "ipinipd10", 10),
-				getIPinIPFlow(args, atePort1, atePort2Vlan10, "ipinipd11", 11),
-				getIPinIPFlow(args, atePort1, atePort2Vlan10, "ipinipd12", 12)},
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan10, "ipinipd10_p1_p2", 10),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan10, "ipinipd11_p1_p2", 11),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan10, "ipinipd12_p1_p2", 12)},
 			failingFlows: []gosnappi.Flow{
-				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd10v20", 10),
-				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd11v20", 11),
-				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd12v20", 12)},
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan20, "ipinipd10v20_p1_p2", 10),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan20, "ipinipd11v20_p1_p2", 11),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan20, "ipinipd12v20_p1_p2", 12)},
 			rejectable: true,
 		},
 		{
-			name: "RT3.2 Case4",
-			desc: "Ensure matching IPinIP to VRF10, IPinIP with DSCP20 to VRF20 causes unspecified DSCP IPinIP traffic to match VRF10.",
-			policy: getPBRPolicyForwarding(args,
-				getL3PBRRule(args, "VRF10", 1, []uint8{}),
-				getL3PBRRule(args, "VRF20", 2, []uint8{20})),
-			// use IPinIP DSCP10-12 flows to match IPinIP to VRF10
-			// use IPinIP DSCP20 flow to match to VRF20
-			// use IPinIP DSCP10-12 flows to match to VRF20 to show they fail for VRF20
+			name:        "RT3.2 Case4 - Port 1 Ingress (Default Match)",
+			desc:        "Ensure matching IPinIP to VRF10, IPinIP with DSCP20 to VRF20 causes unspecified DSCP IPinIP traffic to match VRF10 on Port 1.",
+			policyName:  "L3_Port1",
+			ingressPort: port1,
+			testArgs: &testArgs{
+				dut:      dut,
+				ate:      ate,
+				top:      top,
+				iptype:   "ipv4",
+				protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP,
+			},
+			policy: getPBRPolicyForwarding("L3_Port1",
+				getL3PBRRule(&testArgs{iptype: "ipv4", protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP}, "VRF10", 1, []uint8{}),
+				getL3PBRRule(&testArgs{iptype: "ipv4", protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP}, "VRF20", 2, []uint8{20})),
 			passingFlows: []gosnappi.Flow{
-				getIPinIPFlow(args, atePort1, atePort2Vlan10, "ipinipd10", 10),
-				getIPinIPFlow(args, atePort1, atePort2Vlan10, "ipinipd11", 11),
-				getIPinIPFlow(args, atePort1, atePort2Vlan10, "ipinipd12", 12)},
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan10, "ipinipd10_p1_p2", 10),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan10, "ipinipd11_p1_p2", 11),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan10, "ipinipd12_p1_p2", 12)},
 			failingFlows: []gosnappi.Flow{
-				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd10v20", 10),
-				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd11v20", 11),
-				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd12v20", 12),
-				getIPinIPFlow(args, atePort1, atePort2Vlan20, "ipinipd20", 20)},
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan20, "ipinipd10v20_p1_p2", 10),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan20, "ipinipd11v20_p1_p2", 11),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan20, "ipinipd12v20_p1_p2", 12),
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan20, "ipinipd20_p1_p2", 20)},
+		},
+		{
+			name:        "RT3.2 Case5 - Multiple Policies (Port 1 and Port 3)",
+			desc:        "Verify traffic for both policies simultaneously: Port 1 to Port 2 (VLAN 10) and Port 3 to Port 4 (VLAN 40).",
+			policyName:  "L3_Port1", // Second policy (Port 3) will be applied within the test run
+			ingressPort: port1,
+			testArgs: &testArgs{ // Args for Port 1's flow
+				dut:      dut,
+				ate:      ate,
+				top:      top,
+				iptype:   "ipv4",
+				protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP,
+			},
+			policy: getPBRPolicyForwarding("L3_Port1",
+				getL3PBRRule(&testArgs{iptype: "ipv4", protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP}, "VRF10", 1, []uint8{10})),
+			passingFlows: []gosnappi.Flow{
+				// Initial flow for Port 1's policy
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan10, "ipinipd10-multi_p1_p2", 10),
+			},
+			failingFlows: []gosnappi.Flow{
+				// Initial flow for Port 1's policy
+				getIPinIPFlow(&testArgs{iptype: "ipv4"}, atePort1, atePort2Vlan20, "ipinipd21_p1_p2", 21),
+			},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Log(tc.desc)
 			pfpath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding()
-
-			//configure pbr policy-forwarding
+			// Configure pbr policy-forwarding
 			fptest.ConfigureDefaultNetworkInstance(t, dut)
-
 			errMsg := testt.CaptureFatal(t, func(t testing.TB) {
 				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Config(), tc.policy)
 			})
@@ -536,34 +749,69 @@ func TestPBR(t *testing.T) {
 				}
 				t.Fatalf("PolicyForwarding config update failed: %v", *errMsg)
 			}
-			// defer cleaning policy-forwarding
-			defer gnmi.Delete(t, args.dut, pfpath.Config())
+			// Defer cleaning policy-forwarding
+			defer gnmi.Delete(t, dut, pfpath.Config())
 
-			// apply pbr policy on ingress interface
-			p1 := port1.Name()
+			// Apply PBR policy on the ingress interface
+			ingressPortName := tc.ingressPort.Name()
 			d := &oc.Root{}
-			interfaceID := p1
+			interfaceID := ingressPortName
 			if deviations.InterfaceRefInterfaceIDFormat(dut) {
-				interfaceID = p1 + ".0"
+				interfaceID = ingressPortName + ".0"
 			}
 			pfIntf := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreatePolicyForwarding().GetOrCreateInterface(interfaceID)
 			pfIntfConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Interface(interfaceID)
-			pfIntf.GetOrCreateInterfaceRef().Interface = ygot.String(p1)
+			pfIntf.GetOrCreateInterfaceRef().Interface = ygot.String(ingressPortName)
 			pfIntf.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
 			if deviations.InterfaceRefConfigUnsupported(dut) {
 				pfIntf.InterfaceRef = nil
 			}
-			pfIntf.SetApplyVrfSelectionPolicy(args.policyName)
+			pfIntf.SetApplyVrfSelectionPolicy(tc.policyName)
 			gnmi.Update(t, dut, pfIntfConfPath.Config(), pfIntf)
 
-			// defer deletion of policy from interface
-			defer gnmi.Delete(t, args.dut, pfIntfConfPath.Config())
+			// Defer deletion of policy from interface
+			defer gnmi.Delete(t, dut, pfIntfConfPath.Config())
+
+			// "Multiple Policies" test case where a second policy is applied to Port 3
+			if tc.name == "RT3.2 Case5 - Multiple Policies (Port 1 and Port 3)" {
+				t.Log("Applying second policy (L3_Port3) to Port 3 for multiple policy scenario.")
+				// Define testArgs for the second policy's flows and rules
+				argsForPort3Policy := &testArgs{
+					dut:      dut,
+					ate:      ate,
+					top:      top,
+					iptype:   "ipv4",
+					protocol: oc.PacketMatchTypes_IP_PROTOCOL_IP_IN_IP,
+				}
+				multiPolicy := getPBRPolicyForwarding("L3_Port3", getL3PBRRule(argsForPort3Policy, "VRF40", 1, []uint8{40}))
+				gnmi.Update(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Config(), multiPolicy)
+				defer gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Policy("L3_Port3").Config())
+				interface3ID := port3.Name()
+				if deviations.InterfaceRefInterfaceIDFormat(dut) {
+					interface3ID = port3.Name() + ".0"
+				}
+				pfIntfPort3 := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreatePolicyForwarding().GetOrCreateInterface(interface3ID)
+				pfIntfConfPathPort3 := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Interface(interface3ID)
+				pfIntfPort3.GetOrCreateInterfaceRef().Interface = ygot.String(port3.Name())
+				pfIntfPort3.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
+				if deviations.InterfaceRefConfigUnsupported(dut) {
+					pfIntfPort3.InterfaceRef = nil
+				}
+				pfIntfPort3.SetApplyVrfSelectionPolicy("L3_Port3")
+				gnmi.Update(t, dut, pfIntfConfPathPort3.Config(), pfIntfPort3)
+				defer gnmi.Delete(t, dut, pfIntfConfPathPort3.Config())
+
+				// Add flows for Port 3 to the passing flows
+				tc.passingFlows = append(tc.passingFlows, getIPinIPFlow(argsForPort3Policy, atePort3, atePort4Vlan40, "ipinipd40-multi_p3_p4", 40))
+				tc.failingFlows = append(tc.failingFlows, getIPinIPFlow(argsForPort3Policy, atePort3, atePort4Vlan50, "ipinipd50-multi_p3_p4", 51))
+			}
+
 			// traffic should pass
-			testTrafficFlows(t, args, true, tc.passingFlows...)
+			testTrafficFlows(t, ate, top, true, tc.passingFlows...)
 
 			if len(tc.failingFlows) > 0 {
 				// traffic should fail
-				testTrafficFlows(t, args, false, tc.failingFlows...)
+				testTrafficFlows(t, ate, top, false, tc.failingFlows...)
 			}
 		})
 	}

--- a/feature/policy_forwarding/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/policy_forwarding/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -41,11 +41,11 @@ const (
 
 // testArgs holds the objects needed by a test case.
 type testArgs struct {
-	dut        *ondatra.DUTDevice
-	ate        *ondatra.ATEDevice
-	top        gosnappi.Config
-	iptype     string
-	protocol   oc.E_PacketMatchTypes_IP_PROTOCOL
+	dut      *ondatra.DUTDevice
+	ate      *ondatra.ATEDevice
+	top      gosnappi.Config
+	iptype   string
+	protocol oc.E_PacketMatchTypes_IP_PROTOCOL
 }
 
 var (

--- a/feature/policy_forwarding/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/policy_forwarding/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -44,7 +44,6 @@ type testArgs struct {
 	dut        *ondatra.DUTDevice
 	ate        *ondatra.ATEDevice
 	top        gosnappi.Config
-	policyName string
 	iptype     string
 	protocol   oc.E_PacketMatchTypes_IP_PROTOCOL
 }

--- a/feature/policy_forwarding/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/policy_forwarding/policy_vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/openconfig/ygot/ygot"
 )
 
-
 const (
 	trafficDuration = 1 * time.Minute
 	ipv4PrefixLen   = 30


### PR DESCRIPTION
Adding a subtest to cover DUT forwarding behaviour when more than one vrf selection policies are configured. 