### PR TITLE
gNOI-3.2 - Skip empty fabrics

### DIFF
--- a/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
+++ b/feature/gnoi/system/tests/per_component_reboot_test/per_component_reboot_test.go
@@ -516,6 +516,10 @@ func TestFabricReboot(t *testing.T) {
 
 	var removableFabric string
 	for _, fabric := range fabrics {
+		if empty, ok := gnmi.Lookup(t, dut, gnmi.OC().Component(fabric).Empty().State()).Val(); ok && empty {
+			t.Logf("Skipping fabric: %v is empty", fabric)
+			continue
+		}
 		t.Logf("Check if %s is removable", fabric)
 		if removable, ok := gnmi.Lookup(t, dut, gnmi.OC().Component(fabric).Removable().State()).Val(); ok && removable {
 			t.Logf("Found removable fabric component: %v", fabric)


### PR DESCRIPTION
(m) per_component_reboot_test.go
  - allow skipping fabric(s) if state empty == true

---

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."