### PR TITLE
add bgp/bfd traffic flow validation for ipv4 encap test case.

### DIFF
--- a/feature/policy_forwarding/otg_tests/mpls_gre_ipv4_encap_test/mpls_gre_ipv4_encap_test.go
+++ b/feature/policy_forwarding/otg_tests/mpls_gre_ipv4_encap_test/mpls_gre_ipv4_encap_test.go
@@ -527,7 +527,7 @@ func TestMPLSOGREEncapBFDv4(t *testing.T) {
 	ate := ondatra.ATE(t, "ate")
 	createflow(t, top, flowBFDv4, true)
 	sendTraffic(t, ate)
-	if err := FlowBFDv4Validation.ValidateLossOnFlows(t, ate); err != nil {
+	if err := flowBFDv4Validation.ValidateLossOnFlows(t, ate); err != nil {
 		t.Errorf("ValidateLossOnFlows(): got err: %q", err)
 	}
 }


### PR DESCRIPTION
Add bgp/bfd traffic flow validation for ipv4 encap test case.
Pass link : https://fusion2.corp.google.com/invocations/bf9f10de-a8ee-415e-8d0c-d98557fe8adc/targets/%2F%2Fthird_party%2Fopenconfig%2Ffeatureprofiles%2Ffeature%2Fpolicy_forwarding%2Fotg_tests%2Fmpls_gre_ipv4_encap_test:mpls_gre_ipv4_encap_test_arista_7280/tests