### PR TITLE
RT-1.29: Remove bgp_set_med_action_unsupported deviation for Arista

### DIFF
--- a/feature/bgp/policybase/otg_tests/chained_policies_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/chained_policies_test/metadata.textproto
@@ -16,7 +16,6 @@ platform_exceptions: {
     missing_value_for_defaults: true
     skip_setting_statement_for_policy: true
     default_import_export_policy_unsupported: true
-    bgp_set_med_action_unsupported: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
Remove bgp_set_med_action_unsupported from deviation for Arista, Arista supports set-med-action