### PR TITLE
RT-2.11: add isis_interface_level_passive_unsupported deviation

### DIFF
--- a/feature/isis/otg_tests/isis_interface_level_passive_test/isis_interface_level_passive_test.go
+++ b/feature/isis/otg_tests/isis_interface_level_passive_test/isis_interface_level_passive_test.go
@@ -196,10 +196,12 @@ func TestISISLevelPassive(t *testing.T) {
 				switch dut.Vendor() {
 				case ondatra.CISCO:
 					isispassiveconfig = fmt.Sprintf("router isis DEFAULT\n interface %s\n passive\n", intfName)
+					helpers.GnmiCLIConfig(t, dut, isispassiveconfig)
+				case ondatra.ARISTA:
+					gnmi.Update(t, ts.DUT, statePath.Interface(intfName).Passive().Config(), true)
 				default:
 					t.Fatalf("Unsupported vendor %s for deviation 'IsisInterfaceLevelPassiveUnsupported'", dut.Vendor())
 				}
-				helpers.GnmiCLIConfig(t, dut, isispassiveconfig)
 			} else {
 				gnmi.Update(t, ts.DUT, statePath.Interface(intfName).Level(2).Passive().Config(), true)
 			}
@@ -221,10 +223,12 @@ func TestISISLevelPassive(t *testing.T) {
 				switch dut.Vendor() {
 				case ondatra.CISCO:
 					isispassiveconfig = fmt.Sprintf("router isis DEFAULT\n interface %s\n no passive\n", intfName)
+					helpers.GnmiCLIConfig(t, dut, isispassiveconfig)
+				case ondatra.ARISTA:
+					gnmi.Update(t, ts.DUT, statePath.Interface(intfName).Passive().Config(), false)
 				default:
 					t.Fatalf("Unsupported vendor %s for deviation 'IsisInterfaceLevelPassiveUnsupported'", dut.Vendor())
 				}
-				helpers.GnmiCLIConfig(t, dut, isispassiveconfig)
 			} else {
 				gnmi.Update(t, ts.DUT, statePath.Interface(intfName).Level(2).Passive().Config(), false)
 			}

--- a/feature/isis/otg_tests/isis_interface_level_passive_test/metadata.textproto
+++ b/feature/isis/otg_tests/isis_interface_level_passive_test/metadata.textproto
@@ -43,6 +43,7 @@ platform_exceptions: {
     isis_timers_csnp_interval_unsupported: true
     isis_counter_manual_address_drop_from_areas_unsupported: true
     isis_counter_part_changes_unsupported: true
+    isis_interface_level_passive_unsupported: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
Add isis_interface_level_passive_unsupported into RT-2.11 deviations because Arista does not support interface level passive. Using per interface passive configuration instead.