### PR TITLE
add software-version test to ensure the string is non empty.

### DIFF
--- a/feature/system/system_base_test/tests/system_software_version/README.md
+++ b/feature/system/system_base_test/tests/system_software_version/README.md
@@ -1,0 +1,27 @@
+# System-1.3: System software-version test
+
+## Summary
+
+Ensures the device support basic system requirements for a device supporting g* APIs.
+
+### Procedure
+
+Each test will require the DUT configured with a basic service configuration that
+should be provided as part of the basic configuration. This setup should also include
+any security setup for connecting to the services.
+
+### Tests
+
+1. Configure DUT with service configurations for all required services
+2. The test will verify if the software-version state path can be read and is non-empty.
+
+## OpenConfig Path and RPC Coverage
+
+```yaml
+paths:
+   /system/state/software-version:
+
+rpcs:
+   gnmi:
+      gNMI.Subscribe:
+```

--- a/feature/system/system_base_test/tests/system_software_version/metadata.textproto
+++ b/feature/system/system_base_test/tests/system_software_version/metadata.textproto
@@ -1,0 +1,7 @@
+# proto-file: third_party/openconfig/featureprofiles/proto/metadata.proto
+# proto-message: Metadata
+
+uuid:  "8bfbf7b1-ab92-47bd-a64b-fe84f5067927"
+plan_id:  "GEN-OCST-0.1"
+description:  "System software version test"
+testbed:  TESTBED_DUT

--- a/feature/system/system_base_test/tests/system_software_version/system_software_version_test.go
+++ b/feature/system/system_base_test/tests/system_software_version/system_software_version_test.go
@@ -1,0 +1,43 @@
+/*
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package system_software_version_test
+
+import (
+        "testing"
+
+        "github.com/openconfig/featureprofiles/internal/fptest"
+        "github.com/openconfig/ondatra/gnmi"
+        "github.com/openconfig/ondatra"
+)
+
+// TestSoftwareVersion verifies that the software version state path can be read and is not empty.
+// telemetry_path:/system/state/software-version
+
+func TestMain(m *testing.M) {
+        fptest.RunTests(m)
+}
+
+func TestSoftwareVersion(t *testing.T) {
+        dut := ondatra.DUT(t, "dut")
+        state := gnmi.OC().System().SoftwareVersion()
+        t.Run("Test Software Version", func(t *testing.T) {
+                stateGot := gnmi.Get(t, dut, state.State())
+                if stateGot == "" {
+                        t.Error("Telemetry software version is empty, want non-empty")
+                }
+        })
+}


### PR DESCRIPTION
the software-version value is useful to perform the inventory of network devices.
network vendors may set it in native models or in components and may miss setting it for the main system on this xpath.