### PR TITLE
Fix failing static checks

### DIFF
--- a/feature/policy_forwarding/otg_tests/mpls_gre_ipv4_decap_test/mpls_gre_ipv4_decap_test.go
+++ b/feature/policy_forwarding/otg_tests/mpls_gre_ipv4_decap_test/mpls_gre_ipv4_decap_test.go
@@ -334,7 +334,7 @@ func TestMPLSOGREDecapInnerPayloadPreserve(t *testing.T) {
 	if err := FlowOuterIPv4Validation.ValidateLossOnFlows(t, ate); err != nil {
 		t.Errorf("ValidateLossOnFlows(): got err: %q, want nil", err)
 	}
-	if err := packetvalidationhelpers.CaptureAndValidatePackets(t, top, ate, decapValidationIPv4); err != nil {
+	if err := packetvalidationhelpers.CaptureAndValidatePackets(t, ate, decapValidationIPv4); err != nil {
 		t.Errorf("CaptureAndValidatePackets(): got err: %q", err)
 	}
 }

--- a/feature/policy_forwarding/otg_tests/mpls_gre_ipv4_encap_test/mpls_gre_ipv4_encap_test.go
+++ b/feature/policy_forwarding/otg_tests/mpls_gre_ipv4_encap_test/mpls_gre_ipv4_encap_test.go
@@ -433,7 +433,7 @@ func TestMPLSOGREEncapIPv4(t *testing.T) {
 		t.Errorf("Validation on flows failed (): %q", err)
 	}
 
-	if err := packetvalidationhelpers.CaptureAndValidatePackets(t, top, ate, EncapPacketValidation); err != nil {
+	if err := packetvalidationhelpers.CaptureAndValidatePackets(t, ate, EncapPacketValidation); err != nil {
 		packetvalidationhelpers.ClearCapture(t, top, ate)
 		t.Errorf("Capture And ValidatePackets Failed (): %q", err)
 	}
@@ -481,7 +481,7 @@ func TestMPLSOGREEncapIPv6(t *testing.T) {
 		packetvalidationhelpers.ValidateInnerIPv6Header,
 	}
 
-	if err := packetvalidationhelpers.CaptureAndValidatePackets(t, top, ate, EncapPacketValidation); err != nil {
+	if err := packetvalidationhelpers.CaptureAndValidatePackets(t, ate, EncapPacketValidation); err != nil {
 		packetvalidationhelpers.ClearCapture(t, top, ate)
 		t.Errorf("CaptureAndValidatePackets(): %q", err)
 	}

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1498,7 +1498,7 @@ func InterfaceOutputQueueNonStandardName(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetInterfaceOutputQueueNonStandardName()
 }
 
-// MplsExpIngressClassifierOcUnsupported true if devices do not support classifying ingress packets based on the MPLS exp field
+// MplsExpIngressClassifierOcUnsupported returns true if devices do not support classifying ingress packets based on the MPLS exp field
 func MplsExpIngressClassifierOcUnsupported(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetMplsExpIngressClassifierOcUnsupported()
 }

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1498,7 +1498,7 @@ func InterfaceOutputQueueNonStandardName(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetInterfaceOutputQueueNonStandardName()
 }
 
-// MplsExpIngressClassifierUnsupported returns true if devices do not support classifying ingress packets based on the MPLS exp field
+// MplsExpIngressClassifierOcUnsupported true if devices do not support classifying ingress packets based on the MPLS exp field
 func MplsExpIngressClassifierOcUnsupported(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetMplsExpIngressClassifierOcUnsupported()
 }

--- a/internal/otg_helpers/packetvalidationhelpers/packetvalidationhelpers.go
+++ b/internal/otg_helpers/packetvalidationhelpers/packetvalidationhelpers.go
@@ -44,7 +44,7 @@ Validations = []packetvalidationhelpers.ValidationType{
 		t.Errorf("ValidateLossOnFlows(): got err: %q", err)
 	}
 
-	if err := packetvalidationhelpers.CaptureAndValidatePackets(t, top, ate, EncapPacketValidation); err != nil {
+	if err := packetvalidationhelpers.CaptureAndValidatePackets(t, ate, EncapPacketValidation); err != nil {
 		t.Errorf("CaptureAndValidatePackets(): got err: %q", err)
 	}
 
@@ -156,7 +156,7 @@ func StopCapture(t *testing.T, ate *ondatra.ATEDevice, cs gosnappi.ControlState)
 }
 
 // CaptureAndValidatePackets captures the packets and validates the traffic.
-func CaptureAndValidatePackets(t *testing.T, top gosnappi.Config, ate *ondatra.ATEDevice, packetVal *PacketValidation) error {
+func CaptureAndValidatePackets(t *testing.T, ate *ondatra.ATEDevice, packetVal *PacketValidation) error {
 	t.Helper()
 	bytes := ate.OTG().GetCapture(t, gosnappi.NewCaptureRequest().SetPortName(packetVal.PortName))
 	f, err := os.CreateTemp("", "pcap")


### PR DESCRIPTION
Some checks are failing. We fix them. :)

### `CaptureAndValidatePackets` had an unused `top` parameter:

* Removed the unused `top` parameter from the `CaptureAndValidatePackets` function in `packetvalidationhelpers.go` to simplify its signature. All calls to this function across various test cases were updated accordingly. ([[1]](diffhunk://#diff-e59a1678d2eded1caaed6126b3061b81e11a259df05d4115e8314287808cce97L159-R159), [[2]](diffhunk://#diff-2e1f4bf0ec85a1bcf0e4be5fc860d688f8abf18f09bb90de2798697f99e3b646L337-R337), [[3]](diffhunk://#diff-c84fa280fa822959d00c1588087dc984d972637a0f3a6661ae83f32c3eec1935L436-R436), [[4]](diffhunk://#diff-c84fa280fa822959d00c1588087dc984d972637a0f3a6661ae83f32c3eec1935L484-R484))

### Documentation typo to match function name:

* Fixed a typo in the comment for the `MplsExpIngressClassifierOcUnsupported` function in `deviations.go` to improve clarity. The updated comment now correctly states: "MplsExpIngressClassifierOcUnsupported true if devices do not support classifying ingress packets based on the MPLS exp field." ([internal/deviations/deviations.goL1501-R1501](diffhunk://#diff-b5c7bd119da0491c8203a39ae9c42b48450a258a081d59deada69e0672677469L1501-R1501))