### PR TITLE
RT-6.1: Add deviation to handle unsupported LLDP fields in test.

### DIFF
--- a/feature/lldp/otg_tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
+++ b/feature/lldp/otg_tests/core_lldp_tlv_population_test/core_lldp_tlv_population_test.go
@@ -142,10 +142,13 @@ func configureDUT(t *testing.T, name string, lldpEnabled bool) (*ondatra.DUTDevi
 	p := node.Port(t, portName)
 	d := &oc.Root{}
 	lldp := d.GetOrCreateLldp()
-	lldp.SystemDescription = ygot.String("DUT")
 
 	llint := lldp.GetOrCreateInterface(p.Name())
-	llint.SetName(portName)
+
+	if !deviations.SkipLldpOptionalConfig(node) {
+		lldp.SystemDescription = ygot.String("DUT")
+		llint.SetName(portName)
+	}
 
 	gnmi.Replace(t, node, gnmi.OC().Lldp().Enabled().Config(), lldpEnabled)
 
@@ -216,8 +219,10 @@ func verifyNodeConfig(t *testing.T, node gnmi.DeviceOrOpts, port *ondatra.Port, 
 	} else {
 		t.Errorf("LLDP SystemName is not proper, got %s", state.GetSystemName())
 	}
-	if state.GetSystemDescription() != "DUT" {
-		t.Errorf("LLDP systemDescription is not proper, got %s", state.GetSystemDescription())
+	if !deviations.SkipLldpOptionalConfig(node.(*ondatra.DUTDevice)) {
+		if state.GetSystemDescription() != "DUT" {
+			t.Errorf("LLDP systemDescription is not proper, got %s", state.GetSystemDescription())
+		}
 	}
 
 	got := state.GetInterface(port.Name()).GetName()

--- a/feature/lldp/otg_tests/core_lldp_tlv_population_test/metadata.textproto
+++ b/feature/lldp/otg_tests/core_lldp_tlv_population_test/metadata.textproto
@@ -20,6 +20,7 @@ platform_exceptions: {
   deviations: {
     missing_value_for_defaults: true
     interface_enabled: true
+    skip_lldp_optional_config: true
   }
 }
 platform_exceptions: {

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1512,3 +1512,8 @@ func DefaultNoIgpMetricPropagation(dut *ondatra.DUTDevice) bool {
 func SkipBgpPeerGroupSendCommunityType(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetSkipBgpPeerGroupSendCommunityType()
 }
+
+// SkipLldpOptionalConfig returns true if device requires skipping optional lldp config
+func SkipLldpOptionalConfig(dut *ondatra.DUTDevice) bool {
+	return lookupDUTDeviations(dut).GetSkipLldpOptionalConfig()
+}

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -844,6 +844,9 @@ message Metadata {
     // Skip setting send-community-type in bgp peer-group config
     bool skip_bgp_peer_group_send_community_type = 299;
 
+    // Devices that do not support setting LLDP interface config name field when it duplicates the list key.
+    bool skip_lldp_optional_config = 300;
+
     // Reserved field numbers and identifiers.
     reserved 84, 9, 28, 20, 38, 43, 90, 97, 55, 89, 19, 36, 35, 40, 113, 131, 141, 173, 234, 254, 231;
   }

--- a/proto/metadata_go_proto/metadata.pb.go
+++ b/proto/metadata_go_proto/metadata.pb.go
@@ -1074,8 +1074,10 @@ type Metadata_Deviations struct {
 	DefaultNoIgpMetricPropagation bool `protobuf:"varint,298,opt,name=default_no_igp_metric_propagation,json=defaultNoIgpMetricPropagation,proto3" json:"default_no_igp_metric_propagation,omitempty"`
 	// Skip setting send-community-type in bgp peer-group config
 	SkipBgpPeerGroupSendCommunityType bool `protobuf:"varint,299,opt,name=skip_bgp_peer_group_send_community_type,json=skipBgpPeerGroupSendCommunityType,proto3" json:"skip_bgp_peer_group_send_community_type,omitempty"`
-	unknownFields                     protoimpl.UnknownFields
-	sizeCache                         protoimpl.SizeCache
+	// Devices that do not support setting LLDP interface config name field when it duplicates the list key.
+	SkipLldpOptionalConfig bool `protobuf:"varint,300,opt,name=skip_lldp_optional_config,json=skipLldpOptionalConfig,proto3" json:"skip_lldp_optional_config,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *Metadata_Deviations) Reset() {
@@ -2984,6 +2986,13 @@ func (x *Metadata_Deviations) GetSkipBgpPeerGroupSendCommunityType() bool {
 	return false
 }
 
+func (x *Metadata_Deviations) GetSkipLldpOptionalConfig() bool {
+	if x != nil {
+		return x.SkipLldpOptionalConfig
+	}
+	return false
+}
+
 type Metadata_PlatformExceptions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Platform      *Metadata_Platform     `protobuf:"bytes,1,opt,name=platform,proto3" json:"platform,omitempty"`
@@ -3040,7 +3049,7 @@ var File_metadata_proto protoreflect.FileDescriptor
 
 const file_metadata_proto_rawDesc = "" +
 	"\n" +
-	"\x0emetadata.proto\x12\x12openconfig.testing\x1a1github.com/openconfig/ondatra/proto/testbed.proto\"\x95\xa3\x01\n" +
+	"\x0emetadata.proto\x12\x12openconfig.testing\x1a1github.com/openconfig/ondatra/proto/testbed.proto\"ѣ\x01\n" +
 	"\bMetadata\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\x12\x17\n" +
 	"\aplan_id\x18\x02 \x01(\tR\x06planId\x12 \n" +
@@ -3052,7 +3061,7 @@ const file_metadata_proto_rawDesc = "" +
 	"\bPlatform\x12.\n" +
 	"\x06vendor\x18\x01 \x01(\x0e2\x16.ondatra.Device.VendorR\x06vendor\x120\n" +
 	"\x14hardware_model_regex\x18\x03 \x01(\tR\x12hardwareModelRegex\x124\n" +
-	"\x16software_version_regex\x18\x04 \x01(\tR\x14softwareVersionRegexJ\x04\b\x02\x10\x03R\x0ehardware_model\x1a\xe9\x99\x01\n" +
+	"\x16software_version_regex\x18\x04 \x01(\tR\x14softwareVersionRegexJ\x04\b\x02\x10\x03R\x0ehardware_model\x1a\xa5\x9a\x01\n" +
 	"\n" +
 	"Deviations\x120\n" +
 	"\x14ipv4_missing_enabled\x18\x01 \x01(\bR\x12ipv4MissingEnabled\x129\n" +
@@ -3324,7 +3333,8 @@ const file_metadata_proto_rawDesc = "" +
 	"(interface_output_queue_non_standard_name\x18\xa8\x02 \x01(\bR#interfaceOutputQueueNonStandardName\x12Z\n" +
 	"*mpls_exp_ingress_classifier_oc_unsupported\x18\xa9\x02 \x01(\bR%mplsExpIngressClassifierOcUnsupported\x12I\n" +
 	"!default_no_igp_metric_propagation\x18\xaa\x02 \x01(\bR\x1ddefaultNoIgpMetricPropagation\x12S\n" +
-	"'skip_bgp_peer_group_send_community_type\x18\xab\x02 \x01(\bR!skipBgpPeerGroupSendCommunityTypeJ\x04\bT\x10UJ\x04\b\t\x10\n" +
+	"'skip_bgp_peer_group_send_community_type\x18\xab\x02 \x01(\bR!skipBgpPeerGroupSendCommunityType\x12:\n" +
+	"\x19skip_lldp_optional_config\x18\xac\x02 \x01(\bR\x16skipLldpOptionalConfigJ\x04\bT\x10UJ\x04\b\t\x10\n" +
 	"J\x04\b\x1c\x10\x1dJ\x04\b\x14\x10\x15J\x04\b&\x10'J\x04\b+\x10,J\x04\bZ\x10[J\x04\ba\x10bJ\x04\b7\x108J\x04\bY\x10ZJ\x04\b\x13\x10\x14J\x04\b$\x10%J\x04\b#\x10$J\x04\b(\x10)J\x04\bq\x10rJ\x06\b\x83\x01\x10\x84\x01J\x06\b\x8d\x01\x10\x8e\x01J\x06\b\xad\x01\x10\xae\x01J\x06\b\xea\x01\x10\xeb\x01J\x06\b\xfe\x01\x10\xff\x01J\x06\b\xe7\x01\x10\xe8\x01\x1a\xa0\x01\n" +
 	"\x12PlatformExceptions\x12A\n" +
 	"\bplatform\x18\x01 \x01(\v2%.openconfig.testing.Metadata.PlatformR\bplatform\x12G\n" +


### PR DESCRIPTION
Add deviation to skip configuring and verifying optional LLDP fields system-description and interface name on unsupported devices.