### PR TITLE
Use SHA256 instead of MD5. MD5 is collision prone.

### DIFF
--- a/feature/gnoi/factory_reset/tests/factory_reset_test/factory_reset_test.go
+++ b/feature/gnoi/factory_reset/tests/factory_reset_test/factory_reset_test.go
@@ -16,8 +16,8 @@ package factory_reset_test
 
 import (
 	"context"
-	"crypto/sha256"
 	"crypto/rand"
+	"crypto/sha256"
 	"io"
 	"path/filepath"
 	"regexp"


### PR DESCRIPTION
* Use SHA256 instead of MD5. MD5 is collision prone.