### PR TITLE
Update package name for isis_extensions_segment_routing_test.go

### DIFF
--- a/feature/isis/otg_tests/isis_extensions_segment_routing_test/isis_extensions_segment_routing_test.go
+++ b/feature/isis/otg_tests/isis_extensions_segment_routing_test/isis_extensions_segment_routing_test.go
@@ -26,7 +26,7 @@
 //			[ ATE Port 1 ] ----  |   DUT   | ---- [ ATE Port 2]
 //      		                 |         |
 
-package isisextensionssegmentroutingtest
+package isis_extensions_segment_routing_test
 
 import (
 	"context"


### PR DESCRIPTION
Update package name for `isis_extensions_segment_routing_test.go` as package name should match the name of the test file.