### PR TITLE
Revert "RT-2.14: Added MaxEcmpPaths & increased time duration"

### DIFF
--- a/feature/isis/otg_tests/isis_drain_test/README.md
+++ b/feature/isis/otg_tests/isis_drain_test/README.md
@@ -4,11 +4,6 @@
 
 Ensure that IS-IS metric change can drain traffic from a DUT trunk interface
 
-## Canonical OC
-```json
-{}
-```  
-
 ## Procedure
 * Connect three ATE ports to the DUT
 * Port-2 and port-3 each makes a one-member trunk port with the same ISIS metric 10 configured for the trunk interfaces (trunk-2 and trunk-3).  


### PR DESCRIPTION
Reverts openconfig/featureprofiles#4297

max-ecmp-paths is not the intent in the readme. This should be covered by a deviation if a vendor needs it to pass. 
Observed Arista failing after this change