### PR TITLE
AFT-1.1: Update Arista deviations

### DIFF
--- a/feature/afts/otg_tests/afts_base/afts_base_test.go
+++ b/feature/afts/otg_tests/afts_base/afts_base_test.go
@@ -187,7 +187,14 @@ func (tc *testCase) configureDUT(t *testing.T) error {
 		}
 	})
 	ts.ATEIntf1.Isis().Advanced().SetEnableHelloPadding(false)
-	ts.PushAndStart(t)
+
+	if err := ts.PushAndStart(t); err != nil {
+		return err
+	}
+
+	if _, err = ts.AwaitAdjacency(); err != nil {
+		return fmt.Errorf("no IS-IS adjacency formed: %v", err)
+	}
 	return nil
 }
 

--- a/feature/afts/otg_tests/afts_base/metadata.textproto
+++ b/feature/afts/otg_tests/afts_base/metadata.textproto
@@ -20,7 +20,9 @@ platform_exceptions: {
   }
   deviations: {
     default_network_instance: "default"
-    isis_single_topology_required: true
+    isis_instance_enabled_required: true
+    isis_interface_afi_unsupported: true
     low_scale_aft: true
+    interface_enabled: true
   }
 }


### PR DESCRIPTION
Update Arista deviations for AFT-1.1 to enable interfaces and correctly configure ISIS. Also add a check for ISIS when configuring and establishing an adjacency.