### PR TITLE
Refactor aft script to use config push in a common library

### DIFF
--- a/feature/afts/otg_tests/afts_base/afts_base_test.go
+++ b/feature/afts/otg_tests/afts_base/afts_base_test.go
@@ -19,19 +19,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-traffic-generator/snappi/gosnappi"
-	"github.com/openconfig/featureprofiles/internal/attrs"
-	"github.com/openconfig/featureprofiles/internal/deviations"
-	"github.com/openconfig/featureprofiles/internal/fptest"
-	"github.com/openconfig/featureprofiles/internal/isissession"
-	"github.com/openconfig/featureprofiles/internal/telemetry/aftcache"
-	"github.com/openconfig/ondatra"
-	"github.com/openconfig/ondatra/gnmi"
-	"github.com/openconfig/ondatra/gnmi/oc"
-	"github.com/openconfig/ondatra/netutil"
-	"github.com/openconfig/ygnmi/ygnmi"
+	"google3/third_party/open_traffic_generator/gosnappi/gosnappi"
+	"google3/third_party/openconfig/featureprofiles/internal/afts/afts"
+	"google3/third_party/openconfig/featureprofiles/internal/attrs/attrs"
+	"google3/third_party/openconfig/featureprofiles/internal/deviations/deviations"
+	"google3/third_party/openconfig/featureprofiles/internal/fptest/fptest"
+	"google3/third_party/openconfig/featureprofiles/internal/isissession/isissession"
+	"google3/third_party/openconfig/featureprofiles/internal/telemetry/aftcache/aftcache"
+	"google3/third_party/openconfig/ondatra/gnmi/gnmi"
+	"google3/third_party/openconfig/ondatra/gnmi/oc/oc"
+	"google3/third_party/openconfig/ondatra/netutil/netutil"
+	"google3/third_party/openconfig/ondatra/ondatra"
+	"google3/third_party/openconfig/ygnmi/ygnmi/ygnmi"
 
-	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+	gnmipb "google3/third_party/openconfig/gnmi/proto/gnmi/gnmi_go_proto"
 )
 
 func TestMain(m *testing.M) {
@@ -39,85 +40,80 @@ func TestMain(m *testing.M) {
 }
 
 const (
-	advertisedRoutesV4Prefix  = 32
-	advertisedRoutesV6Prefix  = 128
-	dutAS                     = 65501
-	ateAS                     = 200
-	v4PrefixLen               = 30
-	v6PrefixLen               = 126
-	mtu                       = 1500
-	isisSystemID              = "650000000001"
-	applyPolicyType           = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
-	applyPolicyName           = "ALLOW"
-	peerGrpNameV4P1           = "BGP-PEER-GROUP-V4-P1"
-	peerGrpNameV6P1           = "BGP-PEER-GROUP-V6-P1"
-	peerGrpNameV4P2           = "BGP-PEER-GROUP-V4-P2"
-	peerGrpNameV6P2           = "BGP-PEER-GROUP-V6-P2"
-	port1MAC                  = "00:00:02:02:02:02"
-	port2MAC                  = "00:00:03:03:03:03"
-	bgpRoute                  = "200.0.0.0"
-	bgpRoutev6                = "3001:1::0"
-	startingBGPRouteIPv4      = "200.0.0.0/32"
-	startingBGPRouteIPv6      = "3001:1::0/128"
-	isisRouteCount            = 100
-	isisRoute                 = "199.0.0.1"
-	isisRoutev6               = "2001:db8::203:0:113:1"
-	startingISISRouteIPv4     = "199.0.0.1/32"
-	startingISISRouteIPv6     = "2001:db8::203:0:113:1/128"
-	aftConvergenceTime        = 20 * time.Minute
-	bgpTimeout                = 2 * time.Minute
-	linkLocalAddress          = "fe80::200:2ff:fe02:202"
-	bgpRouteCountIPv4LowScale = 100000
-	bgpRouteCountIPv6LowScale = 100000
-	bgpRouteCountIPv4Default  = 2000000
-	bgpRouteCountIPv6Default  = 1000000
+	advertisedRoutesV4Prefix = 32
+	advertisedRoutesV6Prefix = 128
+	aftConvergenceTime       = 20 * time.Minute
+	applyPolicyName          = "ALLOW"
+	applyPolicyType          = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+	ateASN                   = 200
+	bgpRoute                 = "200.0.0.0"
+	bgpRoutev6               = "3001:1::0"
+	bgpTimeout               = 2 * time.Minute
+	dutASN                   = 65501
+	isisRoute                = "199.0.0.1"
+	isisRouteCount           = 100
+	isisRoutev6              = "2001:db8::203:0:113:1"
+	isisSystemID             = "650000000001"
+	linkLocalAddress         = "fe80::200:2ff:fe02:202"
+	mtu                      = 1500
+	peerGrpNameV4P1          = "BGP-PEER-GROUP-V4-P1"
+	peerGrpNameV4P2          = "BGP-PEER-GROUP-V4-P2"
+	peerGrpNameV6P1          = "BGP-PEER-GROUP-V6-P1"
+	peerGrpNameV6P2          = "BGP-PEER-GROUP-V6-P2"
+	port1MAC                 = "00:00:02:02:02:02"
+	port2MAC                 = "00:00:03:03:03:03"
+	startingBGPRouteIPv4     = "200.0.0.0/32"
+	startingBGPRouteIPv6     = "3001:1::0/128"
+	startingISISRouteIPv4    = "199.0.0.1/32"
+	startingISISRouteIPv6    = "2001:db8::203:0:113:1/128"
+	v4PrefixLen              = 30
+	v6PrefixLen              = 126
 )
 
 var (
-	dutP1 = attrs.Attributes{
-		IPv4:    "192.0.2.1",
-		IPv6:    "2001:db8::1",
-		IPv4Len: v4PrefixLen,
-		IPv6Len: v6PrefixLen,
-	}
 	ateP1 = attrs.Attributes{
 		IPv4:    "192.0.2.2",
-		IPv6:    "2001:db8::2",
 		IPv4Len: v4PrefixLen,
+		IPv6:    "2001:db8::2",
+		IPv6Len: v6PrefixLen,
+		MAC:     "00:00:02:02:02:02",
+	}
+	ateP2 = attrs.Attributes{
+		IPv4:    "192.0.2.6",
+		IPv4Len: v4PrefixLen,
+		IPv6:    "2001:db8::6",
+		IPv6Len: v6PrefixLen,
+		MAC:     "00:00:03:03:03:03",
+	}
+	dutP1 = attrs.Attributes{
+		IPv4:    "192.0.2.1",
+		IPv4Len: v4PrefixLen,
+		IPv6:    "2001:db8::1",
 		IPv6Len: v6PrefixLen,
 	}
 	dutP2 = attrs.Attributes{
 		IPv4:    "192.0.2.5",
+		IPv4Len: v4PrefixLen,
 		IPv6:    "2001:db8::5",
-		IPv4Len: v4PrefixLen,
 		IPv6Len: v6PrefixLen,
 	}
-	ateP2 = attrs.Attributes{
-		IPv4:    "192.0.2.6",
-		IPv6:    "2001:db8::6",
-		IPv4Len: v4PrefixLen,
-		IPv6Len: v6PrefixLen,
+	port1Name = "port1"
+	port2Name = "port2"
+
+	dutAttrs = []*attrs.Attributes{
+		&dutP1,
+		&dutP2,
 	}
+	ateAttrs = []*attrs.Attributes{
+		&ateP1,
+		&ateP2,
+	}
+	portNames = []string{port1Name, port2Name}
+
 	wantIPv4NHs          = map[string]bool{ateP1.IPv4: true, ateP2.IPv4: true}
 	wantIPv6NHs          = map[string]bool{ateP1.IPv6: true, ateP2.IPv6: true}
 	wantIPv4NHsPostChurn = map[string]bool{ateP1.IPv4: true}
-	port1Name            = "port1"
-	port2Name            = "port2"
 )
-
-// getRouteCount returns the expected route count for the given dut and IP family.
-func getRouteCount(dut *ondatra.DUTDevice, afi IPFamily) uint32 {
-	if deviations.LowScaleAft(dut) {
-		if afi == IPv4 {
-			return bgpRouteCountIPv4LowScale
-		}
-		return bgpRouteCountIPv6LowScale
-	}
-	if afi == IPv4 {
-		return bgpRouteCountIPv4Default
-	}
-	return bgpRouteCountIPv6Default
-}
 
 // getPostChurnIPv6NH returns the expected IPv6 next hops after a churn event.
 // It returns a map of IP addresses to a boolean indicating if the address is expected.
@@ -128,53 +124,44 @@ func getPostChurnIPv6NH(dut *ondatra.DUTDevice) map[string]bool {
 	return map[string]bool{ateP1.IPv6: true}
 }
 
-// configureDUT configures all the interfaces and BGP on the DUT.
-func (tc *testCase) configureDUT(t *testing.T) error {
-	dut := tc.dut
-	p1 := dut.Port(t, port1Name).Name()
-	i1 := dutP1.NewOCInterface(p1, dut)
-	gnmi.Update(t, dut, gnmi.OC().Interface(p1).Config(), i1)
-
-	p2 := dut.Port(t, port2Name).Name()
-	i2 := dutP2.NewOCInterface(p2, dut)
-	gnmi.Update(t, dut, gnmi.OC().Interface(p2).Config(), i2)
-
-	// Configure Network instance type on DUT.
-	t.Log("Configure/update Network Instance")
-	fptest.ConfigureDefaultNetworkInstance(t, dut)
-
-	if deviations.ExplicitPortSpeed(dut) {
-		fptest.SetPortSpeed(t, dut.Port(t, port1Name))
-		fptest.SetPortSpeed(t, dut.Port(t, port2Name))
-	}
-	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.AssignToNetworkInstance(t, dut, p1, deviations.DefaultNetworkInstance(dut), 0)
-		fptest.AssignToNetworkInstance(t, dut, p2, deviations.DefaultNetworkInstance(dut), 0)
-	}
-
+func (tc *testCase) configureDUTRoutingPolicy(t *testing.T, applyPolicyName string) {
+	t.Helper()
 	d := &oc.Root{}
 	routePolicy := d.GetOrCreateRoutingPolicy()
 	policyDefinition := routePolicy.GetOrCreatePolicyDefinition(applyPolicyName)
 	statement, err := policyDefinition.AppendNewStatement("id-1")
 	if err != nil {
-		return err
+		t.Fatalf("failed to append new statement: %v", err)
 	}
 	statement.GetOrCreateActions().PolicyResult = applyPolicyType
-	gnmi.Update(t, dut, gnmi.OC().RoutingPolicy().Config(), routePolicy)
+	gnmi.Update(t, tc.dut, gnmi.OC().RoutingPolicy().Config(), routePolicy)
+}
 
-	dutConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
-	nbrs := []*BGPNeighbor{
-		{as: ateAS, neighborip: ateP1.IPv4, version: IPv4},
-		{as: ateAS, neighborip: ateP1.IPv6, version: IPv6},
+func (tc *testCase) configureDUTBGP(t *testing.T, applyPolicyName string) {
+	t.Helper()
+	routerID := dutP1.IPv4
+	bgpProtocol := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(tc.dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
+	for _, ateAttr := range ateAttrs {
+		nbrs := []*afts.BGPNeighbor{
+			{IP: ateAttr.IPv4, Version: oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST},
+			{IP: ateAttr.IPv6, Version: oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST},
+		}
+		eParams := &afts.EBGPParams{
+			DUT:             tc.dut,
+			DUTASN:          dutASN,
+			RouterID:        routerID,
+			PeerGrpNameV4:   peerGrpNameV4P1,
+			PeerGrpNameV6:   peerGrpNameV6P1,
+			Neighbors:       nbrs,
+			ApplyPolicyName: applyPolicyName,
+		}
+		dutConf := afts.CreateEBGPNeighbor(t, eParams)
+		gnmi.Update(t, tc.dut, bgpProtocol.Config(), dutConf)
 	}
-	dutConf := createBGPNeighbor(peerGrpNameV4P1, peerGrpNameV6P1, nbrs, dut)
-	gnmi.Update(t, dut, dutConfPath.Config(), dutConf)
-	nbrs = []*BGPNeighbor{
-		{as: ateAS, neighborip: ateP2.IPv4, version: IPv4},
-		{as: ateAS, neighborip: ateP2.IPv6, version: IPv6},
-	}
-	dutConf = createBGPNeighbor(peerGrpNameV4P2, peerGrpNameV6P2, nbrs, dut)
-	gnmi.Update(t, dut, dutConfPath.Config(), dutConf)
+}
+
+func (tc *testCase) configureDUTISIS(t *testing.T) {
+	t.Helper()
 	ts := isissession.MustNew(t).WithISIS()
 	ts.ConfigISIS(func(isis *oc.NetworkInstance_Protocol_Isis) {
 		global := isis.GetOrCreateGlobal()
@@ -188,7 +175,31 @@ func (tc *testCase) configureDUT(t *testing.T) error {
 	})
 	ts.ATEIntf1.Isis().Advanced().SetEnableHelloPadding(false)
 	ts.PushAndStart(t)
-	return nil
+}
+
+// configureDUT configures all the interfaces and BGP on the DUT.
+func (tc *testCase) configureDUT(t *testing.T) {
+	t.Helper()
+	dut := tc.dut
+	fptest.ConfigureDefaultNetworkInstance(t, dut)
+	for ix, dutAttr := range dutAttrs {
+		portName := portNames[ix]
+		p := dut.Port(t, portName).Name()
+		i := dutAttr.NewOCInterface(p, dut)
+		gnmi.Update(t, dut, gnmi.OC().Interface(p).Config(), i)
+
+		if deviations.ExplicitPortSpeed(dut) {
+			fptest.SetPortSpeed(t, dut.Port(t, portName))
+		}
+		if deviations.ExplicitInterfaceInDefaultVRF(dut) {
+			fptest.AssignToNetworkInstance(t, dut, p, deviations.DefaultNetworkInstance(dut), 0)
+		}
+	}
+
+	applyPolicyName := "ALLOW"
+	tc.configureDUTRoutingPolicy(t, applyPolicyName)
+	tc.configureDUTBGP(t, applyPolicyName)
+	tc.configureDUTISIS(t)
 }
 
 type BGPNeighbor struct {
@@ -204,63 +215,6 @@ const (
 	IPv4
 	IPv6
 )
-
-func createBGPNeighbor(peerGrpNameV4, peerGrpNameV6 string, nbrs []*BGPNeighbor, dut *ondatra.DUTDevice) *oc.NetworkInstance_Protocol {
-	d := &oc.Root{}
-	ni := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
-	niProtocol := ni.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
-	bgp := niProtocol.GetOrCreateBgp()
-
-	global := bgp.GetOrCreateGlobal()
-	global.SetAs(dutAS)
-	global.SetRouterId(dutP1.IPv4)
-
-	// Note: we have to define the peer group even if we aren't setting any policy because it's
-	// invalid OC for the neighbor to be part of a peer group that doesn't exist.
-	peerGroupV4 := bgp.GetOrCreatePeerGroup(peerGrpNameV4)
-	peerGroupV4.SetPeerAs(ateAS)
-	peerGroupV6 := bgp.GetOrCreatePeerGroup(peerGrpNameV6)
-	peerGroupV6.SetPeerAs(ateAS)
-
-	afiSAFI := global.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
-	afiSAFI.SetEnabled(true)
-	afiSAFI.GetOrCreateUseMultiplePaths().GetOrCreateEbgp().SetMaximumPaths(2)
-	asisafi6 := global.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST)
-	asisafi6.SetEnabled(true)
-	asisafi6.GetOrCreateUseMultiplePaths().GetOrCreateEbgp().SetMaximumPaths(2)
-
-	peerGroupV4AfiSafi := peerGroupV4.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
-	peerGroupV4AfiSafi.SetEnabled(true)
-	peerGroupV4AfiSafi.GetOrCreateUseMultiplePaths().SetEnabled(true)
-	peerGroupV6AfiSafi := peerGroupV6.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST)
-	peerGroupV6AfiSafi.SetEnabled(true)
-	peerGroupV6AfiSafi.GetOrCreateUseMultiplePaths().SetEnabled(true)
-
-	for _, nbr := range nbrs {
-		neighbor := bgp.GetOrCreateNeighbor(nbr.neighborip)
-		neighbor.SetPeerAs(nbr.as)
-		neighbor.SetEnabled(true)
-		switch nbr.version {
-		case IPv4:
-			neighbor.SetPeerGroup(peerGrpNameV4)
-			neighbor.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).SetEnabled(true)
-			neighbourAFV4 := peerGroupV4.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
-			neighbourAFV4.SetEnabled(true)
-			applyPolicy := neighbourAFV4.GetOrCreateApplyPolicy()
-			applyPolicy.ImportPolicy = []string{applyPolicyName}
-			applyPolicy.ExportPolicy = []string{applyPolicyName}
-		case IPv6:
-			neighbor.SetPeerGroup(peerGrpNameV6)
-			neighbor.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).SetEnabled(true)
-			neighbourAFV6 := peerGroupV6.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST)
-			neighbourAFV6.SetEnabled(true)
-			applyPolicy := neighbourAFV6.GetOrCreateApplyPolicy()
-			applyPolicy.ImportPolicy = []string{applyPolicyName}
-			applyPolicy.ExportPolicy = []string{applyPolicyName}
-		}
-	}
-	return niProtocol
-}
 
 func (tc *testCase) waitForBGPSession(t *testing.T) error {
 	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(tc.dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
@@ -290,166 +244,71 @@ func (tc *testCase) waitForBGPSession(t *testing.T) error {
 
 func (tc *testCase) configureATE(t *testing.T) {
 	ate := tc.ate
-	ap1 := ate.Port(t, port1Name)
-	ap2 := ate.Port(t, port2Name)
 	config := gosnappi.NewConfig()
-	// add ports
-	p1 := config.Ports().Add().SetName(ap1.ID())
-	p2 := config.Ports().Add().SetName(ap2.ID())
-	// add devices
-	d1 := config.Devices().Add().SetName(p1.Name() + ".d1")
-	d2 := config.Devices().Add().SetName(p2.Name() + ".d2")
 
-	// Configuration on port1.
-	d1Eth := d1.Ethernets().
-		Add().
-		SetName(d1.Name() + ".eth").
-		SetMac(port1MAC).
-		SetMtu(mtu)
-	d1Eth.
-		Connection().
-		SetPortName(p1.Name())
+	for ix, ateAttr := range ateAttrs {
+		dutAttr := dutAttrs[ix]
+		portName := portNames[ix]
+		ap := ate.Port(t, portName)
+		p := config.Ports().Add().SetName(ap.ID())
+		d := config.Devices().Add().SetName(fmt.Sprintf("%s.d%d", p.Name(), ix))
+		eth := d.Ethernets().Add().SetName(d.Name() + ".eth").
+			SetMac(ateAttr.MAC).
+			SetMtu(mtu)
+		eth.Connection().
+			SetPortName(p.Name())
+		ipv4 := eth.Ipv4Addresses().Add().SetName(eth.Name() + ".IPv4").
+			SetAddress(ateAttr.IPv4).
+			SetGateway(dutAttr.IPv4).
+			SetPrefix(uint32(ateAttr.IPv4Len))
+		ipv6 := eth.Ipv6Addresses().Add().SetName(eth.Name() + ".IPv6").
+			SetAddress(ateAttr.IPv6).
+			SetGateway(dutAttr.IPv6).
+			SetPrefix(uint32(ateAttr.IPv6Len))
 
-	d1IPv4 := d1Eth.
-		Ipv4Addresses().
-		Add().
-		SetName(d1Eth.Name() + ".IPv4").
-		SetAddress(ateP1.IPv4).
-		SetGateway(dutP1.IPv4).
-		SetPrefix(v4PrefixLen)
+		isisParams := &afts.ISISParams{
+			Dev:      d,
+			V4Addr:   ateAttr.IPv4,
+			EthName:  eth.Name(),
+			PortName: ap.ID(),
 
-	d1IPv6 := d1Eth.
-		Ipv6Addresses().
-		Add().
-		SetName(d1Eth.Name() + ".IPv6").
-		SetAddress(ateP1.IPv6).
-		SetGateway(dutP1.IPv6).
-		SetPrefix(v6PrefixLen)
+			V4AdvertisedAddr:   isisRoute,
+			V4AdvertisedPrefix: advertisedRoutesV4Prefix,
+			V4AdvertisedCount:  isisRouteCount,
 
-	d1ISIS := d1.Isis().
-		SetName(d1.Name() + ".isis").
-		SetSystemId(isisSystemID)
-	d1ISIS.Basic().
-		SetIpv4TeRouterId(d1IPv4.Address()).
-		SetHostname("ixia-c-port1")
-	d1ISIS.Advanced().SetAreaAddresses([]string{"49"})
-	d1ISISInt := d1ISIS.Interfaces().
-		Add().
-		SetName(d1ISIS.Name() + ".intf").
-		SetEthName(d1Eth.Name()).
-		SetNetworkType(gosnappi.IsisInterfaceNetworkType.POINT_TO_POINT).
-		SetLevelType(gosnappi.IsisInterfaceLevelType.LEVEL_2).
-		SetMetric(10)
-	d1ISISInt.TrafficEngineering().Add().PriorityBandwidths()
-	d1ISISInt.Advanced().SetAutoAdjustMtu(true).SetAutoAdjustArea(true).SetAutoAdjustSupportedProtocols(true)
+			V6AdvertisedAddr:   isisRoutev6,
+			V6AdvertisedPrefix: advertisedRoutesV6Prefix,
+			V6AdvertisedCount:  isisRouteCount,
+		}
+		afts.ConfigureAdvertisedISISRoutes(t, isisParams)
 
-	d1ISISRoute := d1ISIS.V4Routes().Add().SetName(d1ISIS.Name() + ".rr")
-	d1ISISRoute.Addresses().
-		Add().
-		SetAddress(isisRoute).
-		SetPrefix(advertisedRoutesV4Prefix).SetCount(isisRouteCount)
+		bgpRoute := &afts.BGPRoute{
+			Dev: d,
 
-	d1ISISRouteV6 := d1ISIS.V6Routes().Add().SetName(d1ISISRoute.Name() + ".v6")
-	d1ISISRouteV6.Addresses().
-		Add().
-		SetAddress(isisRoutev6).
-		SetPrefix(advertisedRoutesV6Prefix).SetCount(isisRouteCount)
+			RouterID: ateP1.IPv4,
+			ASN:      ateASN,
 
-	tc.configureBGPDev(d1, d1IPv4, d1IPv6)
+			IPV4DevAddr:  ipv4,
+			V4Prefix:     advertisedRoutesV4Prefix,
+			V4RouteCount: afts.RouteCount(tc.dut, true),
 
-	// Configuration on port2
-	d2Eth := d2.Ethernets().
-		Add().
-		SetName(d2.Name() + ".eth").
-		SetMac(port2MAC).
-		SetMtu(mtu)
-	d2Eth.
-		Connection().
-		SetPortName(p2.Name())
-	d2IPv4 := d2Eth.Ipv4Addresses().
-		Add().
-		SetName(d2Eth.Name() + ".IPv4").
-		SetAddress(ateP2.IPv4).
-		SetGateway(dutP2.IPv4).
-		SetPrefix(v4PrefixLen)
-
-	d2IPv6 := d2Eth.
-		Ipv6Addresses().
-		Add().
-		SetName(d2Eth.Name() + ".IPv6").
-		SetAddress(ateP2.IPv6).
-		SetGateway(dutP2.IPv6).
-		SetPrefix(v6PrefixLen)
-
-	d2ISIS := d2.Isis().
-		SetName(d2.Name() + ".isis").
-		SetSystemId(isisSystemID)
-	d2ISIS.Basic().
-		SetIpv4TeRouterId(d2IPv4.Address()).
-		SetHostname("ixia-c-port2")
-	d2ISIS.Advanced().SetAreaAddresses([]string{"49"})
-	d2ISISInt := d2ISIS.Interfaces().
-		Add().
-		SetName(d2ISIS.Name() + ".intf").
-		SetEthName(d2Eth.Name()).
-		SetNetworkType(gosnappi.IsisInterfaceNetworkType.POINT_TO_POINT).
-		SetLevelType(gosnappi.IsisInterfaceLevelType.LEVEL_2).
-		SetMetric(10)
-	d2ISISInt.TrafficEngineering().Add().PriorityBandwidths()
-	d2ISISInt.Advanced().SetAutoAdjustMtu(true).SetAutoAdjustArea(true).SetAutoAdjustSupportedProtocols(true)
-
-	d2ISISRoute := d2ISIS.V4Routes().Add().SetName(d2ISIS.Name() + ".rr")
-	d2ISISRoute.Addresses().
-		Add().
-		SetAddress(isisRoute).
-		SetPrefix(advertisedRoutesV4Prefix).
-		SetCount(isisRouteCount)
-
-	d2ISISRouteV6 := d2ISIS.V6Routes().Add().SetName(d2ISISRoute.Name() + ".v6")
-	d2ISISRouteV6.Addresses().
-		Add().
-		SetAddress(isisRoutev6).
-		SetPrefix(advertisedRoutesV6Prefix).
-		SetCount(isisRouteCount)
-
-	tc.configureBGPDev(d2, d2IPv4, d2IPv6)
+			IPV6DevAddr:  ipv6,
+			V6Prefix:     advertisedRoutesV6Prefix,
+			V6RouteCount: afts.RouteCount(tc.dut, false),
+		}
+		afts.ConfigureAdvertisedEBGPRoutes(t, bgpRoute)
+	}
 
 	ate.OTG().PushConfig(t, config)
 	ate.OTG().StartProtocols(t)
 }
 
-func (tc *testCase) configureBGPDev(dev gosnappi.Device, ipv4 gosnappi.DeviceIpv4, ipv6 gosnappi.DeviceIpv6) {
-	bgp := dev.Bgp().SetRouterId(ipv4.Address())
-	bgp4Peer := bgp.Ipv4Interfaces().Add().SetIpv4Name(ipv4.Name()).Peers().Add().SetName(dev.Name() + ".BGP4.peer")
-	bgp4Peer.SetPeerAddress(ipv4.Gateway()).SetAsNumber(uint32(ateAS)).SetAsType(gosnappi.BgpV4PeerAsType.EBGP)
-	bgp6Peer := bgp.Ipv6Interfaces().Add().SetIpv6Name(ipv6.Name()).Peers().Add().SetName(dev.Name() + ".BGP6.peer")
-	bgp6Peer.SetPeerAddress(ipv6.Gateway()).SetAsNumber(uint32(ateAS)).SetAsType(gosnappi.BgpV6PeerAsType.EBGP)
-
-	routes := bgp4Peer.V4Routes().Add().SetName(bgp4Peer.Name() + ".v4route")
-	routes.SetNextHopIpv4Address(ipv4.Address()).
-		SetNextHopAddressType(gosnappi.BgpV4RouteRangeNextHopAddressType.IPV4).
-		SetNextHopMode(gosnappi.BgpV4RouteRangeNextHopMode.MANUAL)
-	routes.Addresses().Add().
-		SetAddress(bgpRoute).
-		SetPrefix(advertisedRoutesV4Prefix).
-		SetCount(getRouteCount(tc.dut, IPv4))
-
-	routesV6 := bgp6Peer.V6Routes().Add().SetName(bgp6Peer.Name() + ".v6route")
-	routesV6.SetNextHopIpv6Address(ipv6.Address()).
-		SetNextHopAddressType(gosnappi.BgpV6RouteRangeNextHopAddressType.IPV6).
-		SetNextHopMode(gosnappi.BgpV6RouteRangeNextHopMode.MANUAL)
-	routesV6.Addresses().Add().
-		SetAddress(bgpRoutev6).
-		SetPrefix(advertisedRoutesV6Prefix).
-		SetCount(getRouteCount(tc.dut, IPv6))
-}
-
 func (tc *testCase) generateWantPrefixes(t *testing.T) map[string]bool {
 	wantPrefixes := make(map[string]bool)
-	for pfix := range netutil.GenCIDRs(t, startingBGPRouteIPv4, int(getRouteCount(tc.dut, IPv4))) {
+	for pfix := range netutil.GenCIDRs(t, startingBGPRouteIPv4, int(afts.RouteCount(tc.dut, true))) {
 		wantPrefixes[pfix] = true
 	}
-	for pfix6 := range netutil.GenCIDRs(t, startingBGPRouteIPv6, int(getRouteCount(tc.dut, IPv6))) {
+	for pfix6 := range netutil.GenCIDRs(t, startingBGPRouteIPv6, int(afts.RouteCount(tc.dut, false))) {
 		wantPrefixes[pfix6] = true
 	}
 	return wantPrefixes
@@ -558,19 +417,17 @@ func TestBGP(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get AFT Cache: %v", err)
 		}
-		if err := tc.verifyPrefixes(t, aft, startingBGPRouteIPv4, int(getRouteCount(dut, IPv4)), wantNHCount); err != nil {
+		if err := tc.verifyPrefixes(t, aft, startingBGPRouteIPv4, int(afts.RouteCount(dut, true)), wantNHCount); err != nil {
 			t.Errorf("failed to verify IPv4 BGP prefixes: %v", err)
 		}
-		if err := tc.verifyPrefixes(t, aft, startingBGPRouteIPv6, int(getRouteCount(dut, IPv6)), wantNHCount); err != nil {
+		if err := tc.verifyPrefixes(t, aft, startingBGPRouteIPv6, int(afts.RouteCount(dut, false)), wantNHCount); err != nil {
 			t.Errorf("failed to verify IPv6 BGP prefixes: %v", err)
 		}
 		return aft
 	}
 
 	// --- Test Setup ---
-	if err := tc.configureDUT(t); err != nil {
-		t.Fatalf("failed to configure DUT: %v", err)
-	}
+	tc.configureDUT(t)
 	tc.configureATE(t)
 
 	t.Log("Waiting for BGPv4 neighbor to establish...")

--- a/feature/afts/otg_tests/afts_base/afts_base_test.go
+++ b/feature/afts/otg_tests/afts_base/afts_base_test.go
@@ -19,20 +19,20 @@ import (
 	"testing"
 	"time"
 
-	"google3/third_party/open_traffic_generator/gosnappi/gosnappi"
-	"google3/third_party/openconfig/featureprofiles/internal/afts/afts"
-	"google3/third_party/openconfig/featureprofiles/internal/attrs/attrs"
-	"google3/third_party/openconfig/featureprofiles/internal/deviations/deviations"
-	"google3/third_party/openconfig/featureprofiles/internal/fptest/fptest"
-	"google3/third_party/openconfig/featureprofiles/internal/isissession/isissession"
-	"google3/third_party/openconfig/featureprofiles/internal/telemetry/aftcache/aftcache"
-	"google3/third_party/openconfig/ondatra/gnmi/gnmi"
-	"google3/third_party/openconfig/ondatra/gnmi/oc/oc"
-	"google3/third_party/openconfig/ondatra/netutil/netutil"
-	"google3/third_party/openconfig/ondatra/ondatra"
-	"google3/third_party/openconfig/ygnmi/ygnmi/ygnmi"
+	"github.com/open_traffic_generator/gosnappi"
+	"github.com/openconfig/featureprofiles/internal/afts"
+	"github.com/openconfig/featureprofiles/internal/attrs"
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/featureprofiles/internal/isissession"
+	"github.com/openconfig/featureprofiles/internal/telemetry/aftcache"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/ondatra/netutil"
+	"github.com/openconfig/ygnmi/ygnmi"
 
-	gnmipb "google3/third_party/openconfig/gnmi/proto/gnmi/gnmi_go_proto"
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 )
 
 func TestMain(m *testing.M) {

--- a/feature/afts/otg_tests/afts_base/afts_base_test.go
+++ b/feature/afts/otg_tests/afts_base/afts_base_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open_traffic_generator/gosnappi"
+	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/openconfig/featureprofiles/internal/afts"
 	"github.com/openconfig/featureprofiles/internal/attrs"
 	"github.com/openconfig/featureprofiles/internal/deviations"

--- a/internal/afts/afts.go
+++ b/internal/afts/afts.go
@@ -1,0 +1,301 @@
+// Package afts provides helper functions to advertise routes to be verified in AFT.
+package afts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/open-traffic-generator/snappi/gosnappi"
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi/oc"
+)
+
+const (
+	bgpRouteCountIPv4Default  = 2000000
+	bgpRouteCountIPv4LowScale = 100000
+	bgpRouteCountIPv6Default  = 1000000
+	bgpRouteCountIPv6LowScale = 100000
+)
+
+// BGPRoute represents a collection of BGP routes to be advertised from the ATE.
+type BGPRoute struct {
+	RouterID    string
+	IPV4DevAddr gosnappi.DeviceIpv4
+	IPV6DevAddr gosnappi.DeviceIpv6
+
+	ASN uint32
+
+	// Dev is the device on which the BGP routes are advertised.
+	Dev gosnappi.Device
+
+	AdvertiseV4  string
+	V4Prefix     uint32
+	V4RouteCount uint32
+
+	AdvertiseV6  string
+	V6Prefix     uint32
+	V6RouteCount uint32
+}
+
+func validRoute(route *BGPRoute) error {
+	if route == nil {
+		return fmt.Errorf("route is nil")
+	}
+	if route.RouterID == "" {
+		return fmt.Errorf("bgpV4Addr is nil")
+	}
+	if route.Dev == nil {
+		return fmt.Errorf("device is nil")
+	}
+	return nil
+}
+
+// ConfigureAdvertisedEBGPRoutes advertises the given routes over eBGP from the ATE on the given interfaces.
+func ConfigureAdvertisedEBGPRoutes(t *testing.T, route *BGPRoute) error {
+	if err := validRoute(route); err != nil {
+		return err
+	}
+	bgp := route.Dev.Bgp().SetRouterId(route.RouterID)
+
+	bgp4Peer := bgp.Ipv4Interfaces().Add().SetIpv4Name(route.IPV4DevAddr.Name()).Peers().Add().SetName(route.Dev.Name() + ".BGP4.peer")
+	bgp4Peer.SetPeerAddress(route.IPV4DevAddr.Gateway()).SetAsNumber(route.ASN).SetAsType(gosnappi.BgpV4PeerAsType.EBGP)
+	routes := bgp4Peer.V4Routes().Add().SetName(bgp4Peer.Name() + ".v4route")
+	routes.SetNextHopIpv4Address(route.IPV4DevAddr.Address()).
+		SetNextHopAddressType(gosnappi.BgpV4RouteRangeNextHopAddressType.IPV4).
+		SetNextHopMode(gosnappi.BgpV4RouteRangeNextHopMode.MANUAL)
+	routes.Addresses().Add().
+		SetAddress(route.AdvertiseV4).
+		SetPrefix(route.V4Prefix).
+		SetCount(route.V4RouteCount)
+
+	bgp6Peer := bgp.Ipv6Interfaces().Add().SetIpv6Name(route.IPV6DevAddr.Name()).Peers().Add().SetName(route.Dev.Name() + ".BGP6.peer")
+	bgp6Peer.SetPeerAddress(route.IPV6DevAddr.Gateway()).SetAsNumber(route.ASN).SetAsType(gosnappi.BgpV6PeerAsType.EBGP)
+	routesV6 := bgp6Peer.V6Routes().Add().SetName(bgp6Peer.Name() + ".v6route")
+	routesV6.SetNextHopIpv6Address(route.IPV6DevAddr.Address()).
+		SetNextHopAddressType(gosnappi.BgpV6RouteRangeNextHopAddressType.IPV6).
+		SetNextHopMode(gosnappi.BgpV6RouteRangeNextHopMode.MANUAL)
+	routesV6.Addresses().Add().
+		SetAddress(route.AdvertiseV6).
+		SetPrefix(route.V6Prefix).
+		SetCount(route.V6RouteCount)
+	return nil
+}
+
+// BGPNeighbor represents a BGP neighbor.
+type BGPNeighbor struct {
+	IP      string
+	Version oc.E_BgpTypes_AFI_SAFI_TYPE
+}
+
+// EBGPParams represents the parameters for creating an eBGP neighbor.
+type EBGPParams struct {
+	// DUT is the DUT to configure the eBGP neighbors with.
+	DUT *ondatra.DUTDevice
+	// DUTASN is the ASN of the DUT.
+	DUTASN uint32
+	// NeighborASN is the ASN of ALL the provided neighbors.
+	NeighborASN uint32
+
+	// RouterID is the BGP router ID of the DUT.
+	RouterID string
+	// PeerGrpNameV4 is the peer group name for IPv4.
+	PeerGrpNameV4 string
+	// PeerGrpNameV6 is the peer group name for IPv6.
+	PeerGrpNameV6 string
+	// Neighbors is the list of BGP neighbors to configure.
+	Neighbors []*BGPNeighbor
+
+	// ApplyPolicyName is the name of the policy to apply to the created neighbor(s).
+	ApplyPolicyName string
+}
+
+func verifyEBGPParams(t *testing.T, params *EBGPParams) error {
+	t.Helper()
+	if params == nil {
+		return fmt.Errorf("params is nil")
+	}
+	if params.DUT == nil {
+		return fmt.Errorf("DUT is nil")
+	}
+	if params.DUTASN == 0 {
+		return fmt.Errorf("DUT ASN is 0")
+	}
+	if params.RouterID == "" {
+		return fmt.Errorf("Router ID is empty")
+	}
+	if params.PeerGrpNameV4 == "" {
+		return fmt.Errorf("Peer Group Name V4 is empty")
+	}
+	if params.PeerGrpNameV6 == "" {
+		return fmt.Errorf("Peer Group Name V6 is empty")
+	}
+	if len(params.Neighbors) == 0 {
+		return fmt.Errorf("no neighbors specified")
+	}
+	for _, nbr := range params.Neighbors {
+		if nbr.IP == "" {
+			return fmt.Errorf("neighbor IP is empty")
+		}
+		isV4 := nbr.Version == oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST
+		isV6 := nbr.Version == oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST
+		if !isV4 && !isV6 {
+			return fmt.Errorf("neighbor version is not supported")
+		}
+	}
+	return nil
+}
+
+// CreateEBGPNeighbor creates an eBGP neighbor from the provided parameters. The number of max paths
+// is determined by the number of neighbors.
+func CreateEBGPNeighbor(t *testing.T, params *EBGPParams) *oc.NetworkInstance_Protocol {
+	t.Helper()
+	if err := verifyEBGPParams(t, params); err != nil {
+		t.Fatalf("Failed to verify params: %v", err)
+	}
+	d := &oc.Root{}
+	ni := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(params.DUT))
+	protocol := ni.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP")
+	bgp := protocol.GetOrCreateBgp()
+
+	global := bgp.GetOrCreateGlobal()
+	global.SetAs(params.DUTASN)
+	global.SetRouterId(params.RouterID)
+
+	// Note: we have to define the peer group even if we aren't setting any policy because it's
+	// invalid OC for the neighbor to be part of a peer group that doesn't exist.
+	peerGroupV4 := bgp.GetOrCreatePeerGroup(params.PeerGrpNameV4)
+	peerGroupV4.SetPeerAs(params.NeighborASN)
+	afiSAFI := global.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
+	afiSAFI.SetEnabled(true)
+	afiSAFI.GetOrCreateUseMultiplePaths().GetOrCreateEbgp().SetMaximumPaths(uint32(len(params.Neighbors)))
+	peerGroupV4AfiSafi := peerGroupV4.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
+	peerGroupV4AfiSafi.SetEnabled(true)
+	peerGroupV4AfiSafi.GetOrCreateUseMultiplePaths().SetEnabled(true)
+
+	peerGroupV6 := bgp.GetOrCreatePeerGroup(params.PeerGrpNameV6)
+	peerGroupV6.SetPeerAs(params.NeighborASN)
+	asisafi6 := global.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST)
+	asisafi6.SetEnabled(true)
+	asisafi6.GetOrCreateUseMultiplePaths().GetOrCreateEbgp().SetMaximumPaths(uint32(len(params.Neighbors)))
+	peerGroupV6AfiSafi := peerGroupV6.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST)
+	peerGroupV6AfiSafi.SetEnabled(true)
+	peerGroupV6AfiSafi.GetOrCreateUseMultiplePaths().SetEnabled(true)
+
+	for _, nbr := range params.Neighbors {
+		neighbor := bgp.GetOrCreateNeighbor(nbr.IP)
+		neighbor.SetPeerAs(params.NeighborASN)
+		neighbor.SetEnabled(true)
+		switch ver := nbr.Version; ver {
+		case oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST:
+			neighbor.SetPeerGroup(params.PeerGrpNameV4)
+			neighbor.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).SetEnabled(true)
+			neighbourAFV4 := peerGroupV4.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
+			neighbourAFV4.SetEnabled(true)
+			applyPolicy := neighbourAFV4.GetOrCreateApplyPolicy()
+			applyPolicy.ImportPolicy = []string{params.ApplyPolicyName}
+			applyPolicy.ExportPolicy = []string{params.ApplyPolicyName}
+		case oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST:
+			neighbor.SetPeerGroup(params.PeerGrpNameV6)
+			neighbor.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).SetEnabled(true)
+			neighbourAFV6 := peerGroupV6.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST)
+			neighbourAFV6.SetEnabled(true)
+			applyPolicy := neighbourAFV6.GetOrCreateApplyPolicy()
+			applyPolicy.ImportPolicy = []string{params.ApplyPolicyName}
+			applyPolicy.ExportPolicy = []string{params.ApplyPolicyName}
+		}
+	}
+	return protocol
+}
+
+// RouteCount returns the expected route count for the given dut and IP family.
+func RouteCount(dut *ondatra.DUTDevice, isV4 bool) uint32 {
+	if deviations.LowScaleAft(dut) {
+		if isV4 {
+			return bgpRouteCountIPv4LowScale
+		}
+		return bgpRouteCountIPv6LowScale
+	}
+	if isV4 {
+		return bgpRouteCountIPv4Default
+	}
+	return bgpRouteCountIPv6Default
+}
+
+// ISISParams represents the parameters for creating and advertising ISIS neighbors for a provided
+// device.
+type ISISParams struct {
+	Dev gosnappi.Device
+
+	V4Addr, EthName, PortName, SystemID string
+
+	V4AdvertisedAddr   string
+	V4AdvertisedPrefix uint32
+	V4AdvertisedCount  uint32
+
+	V6AdvertisedAddr   string
+	V6AdvertisedPrefix uint32
+	V6AdvertisedCount  uint32
+}
+
+func validISISParams(params *ISISParams) error {
+	if params == nil {
+		return fmt.Errorf("params is nil")
+	}
+	if params.Dev == nil {
+		return fmt.Errorf("device is nil")
+	}
+	if params.V4Addr == "" {
+		return fmt.Errorf("V4Addr is empty")
+	}
+	if params.EthName == "" {
+		return fmt.Errorf("EthName is empty")
+	}
+	if params.PortName == "" {
+		return fmt.Errorf("PortName is empty")
+	}
+	if params.SystemID == "" {
+		return fmt.Errorf("SystemID is empty")
+	}
+	if params.V4AdvertisedAddr == "" {
+		return fmt.Errorf("V4AdvertisedAddr is empty")
+	}
+	if params.V6AdvertisedAddr == "" {
+		return fmt.Errorf("V6AdvertisedAddr is empty")
+	}
+	return nil
+}
+
+// ConfigureAdvertisedISISRoutes configures the ATE to advertise ISIS routes.
+func ConfigureAdvertisedISISRoutes(t *testing.T, params *ISISParams) {
+	t.Helper()
+
+	isis := params.Dev.Isis().SetName(params.Dev.Name() + ".isis").
+		SetSystemId(params.SystemID)
+	isis.Basic().
+		SetIpv4TeRouterId(params.V4Addr).
+		SetHostname(fmt.Sprintf("ixia-c-%s", params.PortName))
+	isis.Advanced().
+		SetAreaAddresses([]string{"49"})
+	isisInt := isis.Interfaces().Add().SetName(isis.Name() + ".intf").
+		SetEthName(params.EthName).
+		SetNetworkType(gosnappi.IsisInterfaceNetworkType.POINT_TO_POINT).
+		SetLevelType(gosnappi.IsisInterfaceLevelType.LEVEL_2).
+		SetMetric(10)
+	isisInt.TrafficEngineering().Add().PriorityBandwidths()
+	isisInt.Advanced().
+		SetAutoAdjustMtu(true).
+		SetAutoAdjustArea(true).
+		SetAutoAdjustSupportedProtocols(true)
+
+	isisV4Routes := isis.V4Routes().Add().SetName(isis.Name() + ".v4")
+	isisV4Routes.Addresses().Add().
+		SetAddress(params.V4AdvertisedAddr).
+		SetPrefix(params.V4AdvertisedPrefix).
+		SetCount(params.V4AdvertisedCount)
+	isisV6Routes := isis.V6Routes().Add().SetName(isis.Name() + ".v6")
+	isisV6Routes.Addresses().Add().
+		SetAddress(params.V6AdvertisedAddr).
+		SetPrefix(params.V6AdvertisedPrefix).
+		SetCount(params.V6AdvertisedCount)
+}

--- a/internal/afts/afts.go
+++ b/internal/afts/afts.go
@@ -20,21 +20,31 @@ const (
 
 // BGPRoute represents a collection of BGP routes to be advertised from the ATE.
 type BGPRoute struct {
-	RouterID    string
+	// RouterID is the DUT Router ID.
+	RouterID string
+	// IPV4DevAddr represnts a BGP IPv4 peer.
 	IPV4DevAddr gosnappi.DeviceIpv4
+	// IPV6DevAddr represents a BGP IPv6 peer.
 	IPV6DevAddr gosnappi.DeviceIpv6
 
+	// ASN is a fixed ASN used for all BGP peers.
 	ASN uint32
 
 	// Dev is the device on which the BGP routes are advertised.
 	Dev gosnappi.Device
 
-	AdvertiseV4  string
-	V4Prefix     uint32
+	// AdvertiseV4 is the starting address for the IPv4 routes to be advertised.
+	AdvertiseV4 string
+	// V4Prefix is the prefix on each of the advertised IPv4 routes.
+	V4Prefix uint32
+	// V4RouteCount is the total number of IPv4 routes to be advertised.
 	V4RouteCount uint32
 
-	AdvertiseV6  string
-	V6Prefix     uint32
+	// AdvertiseV6 is the starting address for the IPv6 routes to be advertised.
+	AdvertiseV6 string
+	// V6Prefix is the prefix on each of the advertised IPv6 addresses.
+	V6Prefix uint32
+	// V6RouteCount is the total number of IPv6 routes to be advertised.
 	V6RouteCount uint32
 }
 


### PR DESCRIPTION
In preparation for writing the AFT Reboot script, which will use a lot of the same infrastructure, we factor out some logic to do the configuration into a common library to be called by the old and new scripts.