### PR TITLE
Update RT-7.1 and RT-1.27 

### DIFF
--- a/feature/bgp/policybase/otg_tests/default_policies_test/bgp_default_policies_test.go
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/bgp_default_policies_test.go
@@ -837,7 +837,7 @@ func verifyPostPolicyPrefixTelemetry(t *testing.T, dut *ondatra.DUTDevice, nbr *
 		}
 	}
 
-	if gotInstalled, ok := gnmi.Watch(t, dut, afiSafiPath.Prefixes().Installed().State(), 30*time.Second, func(val *ygnmi.Value[uint32]) bool {
+	if gotInstalled, ok := gnmi.Watch(t, dut, afiSafiPath.Prefixes().Installed().State(), 60*time.Second, func(val *ygnmi.Value[uint32]) bool {
 		gotInstalled, ok := val.Val()
 		return ok && gotInstalled == nbr.wantInstalled
 	}).Await(t); !ok {

--- a/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/metadata.textproto
+++ b/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/metadata.textproto
@@ -48,6 +48,7 @@ platform_exceptions:  {
     tc_subscription_unsupported: true
     default_bgp_instance_name: "default"
     bgp_set_med_action_unsupported: true
+    skip_bgp_peer_group_send_community_type: true
   }
 }
 platform_exceptions:  {


### PR DESCRIPTION
RT-7.1 - Update timeout to avoid test falkiness
RT-1.27 - Add "skip_bgp_peer_group_send_community_type" deviation for Cisco