### PR TITLE
AFT-1.1: Fix stale gnmi sessions

### DIFF
--- a/feature/afts/otg_tests/afts_base/afts_base_test.go
+++ b/feature/afts/otg_tests/afts_base/afts_base_test.go
@@ -515,8 +515,11 @@ func (tc *testCase) verifyPrefixes(t *testing.T, aft *aftcache.AFTData, ip strin
 
 func (tc *testCase) cache(t *testing.T, stoppingCondition aftcache.PeriodicHook) (*aftcache.AFTData, error) {
 	t.Helper()
-	aftSession := aftcache.NewAFTStreamSession(t.Context(), t, tc.gnmiClient, tc.dut)
-	aftSession.ListenUntil(t.Context(), t, aftConvergenceTime, stoppingCondition)
+	streamContext, streamCancel := context.WithCancel(t.Context())
+	aftSession := aftcache.NewAFTStreamSession(streamContext, t, tc.gnmiClient, tc.dut)
+	aftSession.ListenUntil(streamContext, t, aftConvergenceTime, stoppingCondition)
+	// This should the cancel the subscribe AFT stream created above
+	streamCancel()
 
 	// Get the AFT from the cache.
 	aft, err := aftSession.Cache.ToAFT(tc.dut)


### PR DESCRIPTION
At a high level, 'verifyAFTState' function is called from 'TestBGP' after every trigger to verify AFT state received on a gNMI session. After the verification of AFT state gNMI session is not closed, before proceeding to the next trigger, this results in gNMI session being open & not draining the messages. On the gNMI server side, it keeps track of these messages as they need to be sent to the client which causes OOM due to the scale of updates to various stale gNMI sessions in the test.

'verifyAFTState' function relies on 'cache' function to receive all expected AFT state (IPv4, IPv6 routes, NHGs & NHs). 'aftSubscribe' function, called from 'NewAFTStreamSession', is responsible for creating a new subscription or gNMI session based on test's context. It creates a go routine to receive the messages from gNMI session & puts them into a buffered channel. This go routine has code that can detect context cancellation but the test's context won't be cancelled till the end of the test.

The fix is to create a child context based on test context in 'cache' function, pass it to 'NewAFTStreamSession' & cancel this child context after returning from 'ListenUntil' function. This function won't return until the expected AFT state has been received (which is checked every 4 minutes) or 20 minutes timeout. After this point there is no need to keep the gNMI session intact.

AFT-1.1 test passed with this diff & following PR: https://github.com/openconfig/featureprofiles/pull/4455