### PR TITLE
Perfomance improvements in AFT FNT

### DIFF
--- a/feature/afts/otg_tests/afts_base/afts_base_test.go
+++ b/feature/afts/otg_tests/afts_base/afts_base_test.go
@@ -583,7 +583,7 @@ func TestBGP(t *testing.T) {
 	}
 	tc.configureATE(t)
 
-	t.Log("Waiting for BGPv4 neighbor to establish...")
+	t.Log("Waiting for BGP neighbor to establish...")
 	if err := tc.waitForBGPSession(t); err != nil {
 		t.Fatalf("Unable to establish BGP session: %v", err)
 	}
@@ -598,7 +598,7 @@ func TestBGP(t *testing.T) {
 	if err := tc.verifyPrefixes(t, aft, startingISISRouteIPv6, isisRouteCount, 1); err != nil {
 		t.Errorf("failed to verify IPv6 ISIS prefixes: %v", err)
 	}
-	t.Log("ISIS verification successful")
+	t.Log("ISIS verification completed")
 
 	// Step 2: Stop Port2 interface to create Churn (BGP: 1 NH)
 	t.Log("Stopping Port2 interface to create Churn")
@@ -622,4 +622,3 @@ func TestBGP(t *testing.T) {
 	tc.otgInterfaceState(t, port2Name, gosnappi.StatePortLinkState.UP)
 	verifyAFTState("AFT verification after port 2 up", 2, wantIPv4NHs, wantIPv6NHs)
 }
-

--- a/feature/afts/otg_tests/afts_base/afts_base_test.go
+++ b/feature/afts/otg_tests/afts_base/afts_base_test.go
@@ -15,6 +15,7 @@
 package afts_base_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -514,9 +515,12 @@ func (tc *testCase) verifyPrefixes(t *testing.T, aft *aftcache.AFTData, ip strin
 	return nil
 }
 
-func (tc *testCase) cache(t *testing.T, aftSession *aftcache.AFTStreamSession, stoppingCondition aftcache.PeriodicHook) (*aftcache.AFTData, error) {
+func (tc *testCase) cache(t *testing.T, stoppingCondition aftcache.PeriodicHook) (*aftcache.AFTData, error) {
 	t.Helper()
-	aftSession.ListenUntil(t.Context(), t, aftConvergenceTime, stoppingCondition)
+	streamContext, streamCancel := context.WithCancel(t.Context())
+	aftSession := aftcache.NewAFTStreamSession(streamContext, t, tc.gnmiClient, tc.dut)
+	aftSession.ListenUntil(streamContext, t, aftConvergenceTime, stoppingCondition)
+	streamCancel()
 	// Get the AFT from the cache.
 	aft, err := aftSession.Cache.ToAFT(tc.dut)
 	if err != nil {
@@ -555,15 +559,12 @@ func TestBGP(t *testing.T) {
 	// Pre-generate all expected prefixes once for efficiency
 	wantPrefixes := tc.generateWantPrefixes(t)
 
-	// Create a single AFTStreamSession to be reused.
-	aftSession := aftcache.NewAFTStreamSession(t.Context(), t, tc.gnmiClient, tc.dut)
-
 	// Helper function for verifying AFT state when given prefixes and expected next hops.
 	verifyAFTState := func(desc string, wantNHCount int, wantV4NHs, wantV6NHs map[string]bool) *aftcache.AFTData {
 		t.Helper()
 		t.Log(desc)
 		stoppingCondition := aftcache.InitialSyncStoppingCondition(t, dut, wantPrefixes, wantV4NHs, wantV6NHs)
-		aft, err := tc.cache(t, aftSession, stoppingCondition)
+		aft, err := tc.cache(t, stoppingCondition)
 		if err != nil {
 			t.Fatalf("failed to get AFT Cache: %v", err)
 		}
@@ -582,7 +583,7 @@ func TestBGP(t *testing.T) {
 	}
 	tc.configureATE(t)
 
-	t.Log("Waiting for BGP neighbor to establish...")
+	t.Log("Waiting for BGPv4 neighbor to establish...")
 	if err := tc.waitForBGPSession(t); err != nil {
 		t.Fatalf("Unable to establish BGP session: %v", err)
 	}
@@ -597,7 +598,7 @@ func TestBGP(t *testing.T) {
 	if err := tc.verifyPrefixes(t, aft, startingISISRouteIPv6, isisRouteCount, 1); err != nil {
 		t.Errorf("failed to verify IPv6 ISIS prefixes: %v", err)
 	}
-	t.Log("ISIS verification completed")
+	t.Log("ISIS verification successful")
 
 	// Step 2: Stop Port2 interface to create Churn (BGP: 1 NH)
 	t.Log("Stopping Port2 interface to create Churn")
@@ -607,7 +608,7 @@ func TestBGP(t *testing.T) {
 	// Step 3: Stop Port1 interface to create full Churn (BGP: deletion expected)
 	t.Log("Stopping Port1 interface to create Churn")
 	tc.otgInterfaceState(t, port1Name, gosnappi.StatePortLinkState.DOWN)
-	if _, err := tc.cache(t, aftSession, aftcache.DeletionStoppingCondition(t, dut, wantPrefixes)); err != nil {
+	if _, err := tc.cache(t, aftcache.DeletionStoppingCondition(t, dut, wantPrefixes)); err != nil {
 		t.Fatalf("failed to get AFT Cache after deletion: %v", err)
 	}
 
@@ -621,3 +622,4 @@ func TestBGP(t *testing.T) {
 	tc.otgInterfaceState(t, port2Name, gosnappi.StatePortLinkState.UP)
 	verifyAFTState("AFT verification after port 2 up", 2, wantIPv4NHs, wantIPv6NHs)
 }
+

--- a/feature/afts/otg_tests/afts_base/metadata.textproto
+++ b/feature/afts/otg_tests/afts_base/metadata.textproto
@@ -26,13 +26,3 @@ platform_exceptions: {
     interface_enabled: true
   }
 }
-
-platform_exceptions: {
-  platform: {
-    vendor: JUNIPER
-  }
-  deviations: {
-    isis_level_enabled: true
-    multipath_unsupported_neighbor_or_afisafi: true
-  }
-}

--- a/feature/afts/otg_tests/afts_base/metadata.textproto
+++ b/feature/afts/otg_tests/afts_base/metadata.textproto
@@ -26,3 +26,13 @@ platform_exceptions: {
     interface_enabled: true
   }
 }
+
+platform_exceptions: {
+  platform: {
+    vendor: JUNIPER
+  }
+  deviations: {
+    isis_level_enabled: true
+    multipath_unsupported_neighbor_or_afisafi: true
+  }
+}

--- a/internal/telemetry/aftcache/aft_cache.go
+++ b/internal/telemetry/aftcache/aft_cache.go
@@ -50,9 +50,9 @@ const (
 	nextHopWeightPath         = "/network-instances/network-instance/afts/next-hop-groups/next-hop-group/next-hops/next-hop/state/weight"
 	nextHopGroupConditionPath = "/network-instances/network-instance/afts/next-hop-groups/next-hop-group/condition"
 	// periodicInterval is the time between execution of periodic hooks.
-	periodicInterval = 4 * time.Minute
+	periodicInterval = 2 * time.Minute
 	// periodicDeadline is the deadline for all periodic hooks in a run. Should be < periodicInterval.
-	periodicDeadline = 3 * time.Minute
+	periodicDeadline = 1*time.Minute + 45*time.Second
 	// aftBufferSize is the capacity of the internal channel queueing notifications from DUT
 	// before applying them to our internal cache. It should be large enough to prevent DUT from
 	// timing out from a pending send longer than the timeout while our internal cache is
@@ -61,7 +61,7 @@ const (
 	// heap from a higher buffer value just because the buffer may contain multiple updates for the
 	// same leaf, while our internal cache would not.
 	// We expect the buffer to be large enough to hold 2M IPv4 prefixes and 1M IPv6 prefixes.
-	aftBufferSize = 3000000
+	aftBufferSize = 4000000
 	// missingPrefixesFile is the name of the file where missing prefixes are written.
 	missingPrefixesFile = "missing_prefixes.txt"
 )
@@ -78,9 +78,11 @@ var unusedPaths = []string{
 	"/network-instances/network-instance/afts/ipv4-unicast/ipv4-entry/prefix",
 	"/network-instances/network-instance/afts/ipv4-unicast/ipv4-entry/state/origin-protocol",
 	"/network-instances/network-instance/afts/ipv4-unicast/ipv4-entry/state/next-hop-group-network-instance",
+	"/network-instances/network-instance/afts/ipv4-unicast/ipv4-entry/state/origin-network-instance",
 	"/network-instances/network-instance/afts/ipv6-unicast/ipv6-entry/prefix",
 	"/network-instances/network-instance/afts/ipv6-unicast/ipv6-entry/state/origin-protocol",
 	"/network-instances/network-instance/afts/ipv6-unicast/ipv6-entry/state/next-hop-group-network-instance",
+	"/network-instances/network-instance/afts/ipv6-unicast/ipv6-entry/state/origin-network-instance",
 }
 
 func subscriptionPaths(dut *ondatra.DUTDevice) map[string][]string {
@@ -610,7 +612,6 @@ func InitialSyncStoppingCondition(t *testing.T, dut *ondatra.DUTDevice, wantPref
 				got := map[string]bool{}
 				switch {
 				case errors.Is(err, ErrNotExist):
-					log.Warningf("error resolving next hops for prefix %v: %v", p, err)
 				case err != nil:
 					return false, fmt.Errorf("error resolving next hops for prefix %v: %w", p, err)
 				default:

--- a/internal/telemetry/aftcache/aft_cache.go
+++ b/internal/telemetry/aftcache/aft_cache.go
@@ -76,13 +76,31 @@ var (
 
 var unusedPaths = []string{
 	"/network-instances/network-instance/afts/ipv4-unicast/ipv4-entry/prefix",
-	"/network-instances/network-instance/afts/ipv4-unicast/ipv4-entry/state/origin-protocol",
+	"/network-instances/network-instance/afts/ipv4-unicast/ipv4-entry/state/counters/octets-forwarded",
+	"/network-instances/network-instance/afts/ipv4-unicast/ipv4-entry/state/counters/packets-forwarded",
+	"/network-instances/network-instance/afts/ipv4-unicast/ipv4-entry/state/decapsulate-header",
+	"/network-instances/network-instance/afts/ipv4-unicast/ipv4-entry/state/entry-metadata",
 	"/network-instances/network-instance/afts/ipv4-unicast/ipv4-entry/state/next-hop-group-network-instance",
 	"/network-instances/network-instance/afts/ipv4-unicast/ipv4-entry/state/origin-network-instance",
+	"/network-instances/network-instance/afts/ipv4-unicast/ipv4-entry/state/origin-protocol",
 	"/network-instances/network-instance/afts/ipv6-unicast/ipv6-entry/prefix",
-	"/network-instances/network-instance/afts/ipv6-unicast/ipv6-entry/state/origin-protocol",
+	"/network-instances/network-instance/afts/ipv6-unicast/ipv6-entry/state/counters/octets-forwarded",
+	"/network-instances/network-instance/afts/ipv6-unicast/ipv6-entry/state/counters/packets-forwarded",
+	"/network-instances/network-instance/afts/ipv6-unicast/ipv6-entry/state/decapsulate-header",
+	"/network-instances/network-instance/afts/ipv6-unicast/ipv6-entry/state/entry-metadata",
 	"/network-instances/network-instance/afts/ipv6-unicast/ipv6-entry/state/next-hop-group-network-instance",
 	"/network-instances/network-instance/afts/ipv6-unicast/ipv6-entry/state/origin-network-instance",
+	"/network-instances/network-instance/afts/ipv6-unicast/ipv6-entry/state/origin-protocol",
+	"/network-instances/network-instance/afts/next-hop-groups/next-hop-group/id",
+	"/network-instances/network-instance/afts/next-hop-groups/next-hop-group/next-hops/next-hop/index",
+	"/network-instances/network-instance/afts/next-hop-groups/next-hop-group/state/backup-next-hop-group",
+	"/network-instances/network-instance/afts/next-hops/next-hop/index",
+	"/network-instances/network-instance/afts/next-hops/next-hop/interface-ref/state/subinterface",
+	"/network-instances/network-instance/afts/next-hops/next-hop/state/counters/octets-forwarded",
+	"/network-instances/network-instance/afts/next-hops/next-hop/state/counters/packets-forwarded",
+	"/network-instances/network-instance/afts/next-hops/next-hop/state/encapsulate-header",
+	"/network-instances/network-instance/afts/next-hops/next-hop/state/mac-address",
+	"/network-instances/network-instance/afts/next-hops/next-hop/state/origin-protocol",
 }
 
 func subscriptionPaths(dut *ondatra.DUTDevice) map[string][]string {
@@ -611,6 +629,7 @@ func InitialSyncStoppingCondition(t *testing.T, dut *ondatra.DUTDevice, wantPref
 				resolved, err := a.resolveRoute(p)
 				got := map[string]bool{}
 				switch {
+				// Skip the check if NH is not found, retry on next periodic hook. Report missing NHs after timeout.
 				case errors.Is(err, ErrNotExist):
 				case err != nil:
 					return false, fmt.Errorf("error resolving next hops for prefix %v: %w", p, err)


### PR DESCRIPTION
Changes include:

1. Instead of having 1 stream for entire test, creating new stream and cancelling the context results in faster aft convergence. Made the change
2. Changing periodic hook interval and deadline
3. Adding few unused paths
4. Removing unnecessary warning