### PR TITLE
Switch CISCO authentication from Type 7 to Type 10

### DIFF
--- a/topologies/kne/cisco/8000e/config.cfg
+++ b/topologies/kne/cisco/8000e/config.cfg
@@ -4,7 +4,7 @@
 username cisco
  group root-lr
  group cisco-support
- password 7 01100F175804575D72
+ secret 10 $6$nd8Pp1emKxgJDp1.$PeQSLpqjl3esYN6QmpmWPFuS.34wiD7Fb7cxVvx8sQXpvvPwhXVUx5pFm4vRxxrV.qK7uhFKCzdhyDDgXXirE.
 !
 interface Loopback0
  ipv4 address 44.44.44.44 255.255.255.255

--- a/topologies/kne/cisco/xrd/config.cfg
+++ b/topologies/kne/cisco/xrd/config.cfg
@@ -4,7 +4,7 @@
 username cisco
  group root-lr
  group cisco-support
- password 7 01100F175804575D72
+ secret 10 $6$nd8Pp1emKxgJDp1.$PeQSLpqjl3esYN6QmpmWPFuS.34wiD7Fb7cxVvx8sQXpvvPwhXVUx5pFm4vRxxrV.qK7uhFKCzdhyDDgXXirE.
 !
 interface Loopback0
  ipv4 address 44.44.44.44 255.255.255.255


### PR DESCRIPTION
Per CISCO recommendation: https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/security/25xx/configuration/guide/b-system-security-cg-cisco8000-25xx/configuring-aaa-services.html#concept_lbt_ywl_g2c

Fix verified manually by running KNE version of [aspath_and_community_test.go](https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/policybase/otg_tests/aspath_and_community_test/aspath_and_community_test.go)