### PR TITLE
Don't fail on coveralls service issues.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,6 +49,7 @@ jobs:
         run: sudo apt-get -y install libpcap-dev
       - run: go test -v -coverprofile=profile.cov $(go list ./... | grep -v /.*test.*)
       - name: Send coverage
+        continue-on-error: true
         uses: shogo82148/actions-goveralls@7b1bd2871942af030d707d6574e5f684f9891fb2
         with:
           path-to-profile: profile.cov


### PR DESCRIPTION
Coveralls was returning 500 errors for some CI runs:

https://github.com/openconfig/featureprofiles/actions/runs/16963202852/job/48080687192?pr=4458

We can ignore failures on the upload step because we mostly care about the 'go test ...' step.

```
/home/runner/work/_actions/shogo82148/actions-goveralls/7b1bd2871942af030d707d6574e5f684f9891fb2/bin/goveralls_linux_amd64 -service=github -coverprofile=profile.cov
bad response status from coveralls: 500
<!doctype html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <title>We're sorry, but something went wrong: Web application could not be started</title>
...
```