### PR TITLE
Fix build error in otgvalidationhelpers.go

### DIFF
--- a/internal/otg_helpers/otg_validation_helpers/otgvalidationhelpers.go
+++ b/internal/otg_helpers/otg_validation_helpers/otgvalidationhelpers.go
@@ -115,7 +115,7 @@ func (v *OTGValidation) ReturnLossPercentage(t *testing.T, ate *ondatra.ATEDevic
 
 // ValidateOTGISISTelemetry validates the isis adjancency states
 func ValidateOTGISISTelemetry(t *testing.T, ate *ondatra.ATEDevice, expectedAdj map[string]interface{}) {
-	isisAdj := gnmi.GetAll(t, ate.OTG(), gnmi.OTG().IsisRouter(expectedAdj["IsisRouterName"].(string)).Adjacencies().AdjacencyAny().State())
+	isisAdj := gnmi.GetAll(t, ate.OTG(), gnmi.OTG().IsisRouter(expectedAdj["IsisRouterName"].(string)).Adjacencies().AdjacenciesAny().State())
 
 	for _, adj := range isisAdj {
 		if adj.LocalState.GetLevelType().String() != expectedAdj["LocalStateTypeExp"].(string) {


### PR DESCRIPTION
Fix build error in `otgvalidationhelpers.go`: Replace `AdjacencyAny` with `AdjacenciesAny` as `AdjacencyAny` does not exist.