### PR TITLE
Otg mpls 1.2

### DIFF
--- a/feature/mpls/otg_tests/mpls_tc/metadata.textproto
+++ b/feature/mpls/otg_tests/mpls_tc/metadata.textproto
@@ -4,8 +4,7 @@
 uuid:  "32ac61df-e182-4e2e-ab68-b517453dabbf"
 plan_id:  "MPLS-1.2"
 description:  "MPLS Traffic Class Marking"
-#testbed:  TESTBED_DUT_DUT_2LINKS
-testbed:  TESTBED_DUT_ATE_4LINKS
+testbed:  TESTBED_DUT_DUT_2LINKS
 
 platform_exceptions: {
   platform: {

--- a/feature/mpls/otg_tests/mpls_tc/metadata.textproto
+++ b/feature/mpls/otg_tests/mpls_tc/metadata.textproto
@@ -4,7 +4,8 @@
 uuid:  "32ac61df-e182-4e2e-ab68-b517453dabbf"
 plan_id:  "MPLS-1.2"
 description:  "MPLS Traffic Class Marking"
-testbed:  TESTBED_DUT_DUT_2LINKS
+#testbed:  TESTBED_DUT_DUT_2LINKS
+testbed:  TESTBED_DUT_ATE_4LINKS
 
 platform_exceptions: {
   platform: {

--- a/feature/mpls/otg_tests/mpls_tc/metadata.textproto
+++ b/feature/mpls/otg_tests/mpls_tc/metadata.textproto
@@ -4,4 +4,31 @@
 uuid:  "32ac61df-e182-4e2e-ab68-b517453dabbf"
 plan_id:  "MPLS-1.2"
 description:  "MPLS Traffic Class Marking"
-testbed:  TESTBED_DUT_ATE_2LINKS
+testbed:  TESTBED_DUT_DUT_2LINKS
+
+platform_exceptions: {
+  platform: {
+    vendor: ARISTA
+  }
+  deviations: {
+    interface_enabled: true
+    default_network_instance: "default"
+    isis_counter_manual_address_drop_from_areas_unsupported: true
+    isis_counter_part_changes_unsupported: true
+    isis_instance_enabled_required: true
+    isis_interface_afi_unsupported: true
+    isis_metric_style_telemetry_unsupported: true
+    isis_timers_csnp_interval_unsupported: true
+    missing_isis_interface_afi_safi_enable: true
+    static_mpls_unsupported: true
+    static_mpls_lsp_oc_unsupported: true
+  }
+}
+platform_exceptions: {
+  platform: {
+    vendor: CISCO
+  }
+  deviations: {
+    sr_igp_config_unsupported: true
+  }
+}

--- a/feature/mpls/otg_tests/mpls_tc/metadata.textproto
+++ b/feature/mpls/otg_tests/mpls_tc/metadata.textproto
@@ -4,7 +4,7 @@
 uuid:  "32ac61df-e182-4e2e-ab68-b517453dabbf"
 plan_id:  "MPLS-1.2"
 description:  "MPLS Traffic Class Marking"
-testbed:  TESTBED_DUT_DUT_2LINKS
+testbed:  TESTBED_DUT_DUT_4LINKS
 
 platform_exceptions: {
   platform: {

--- a/feature/mpls/otg_tests/mpls_tc/mpls_traffic_class_marking_test.go
+++ b/feature/mpls/otg_tests/mpls_tc/mpls_traffic_class_marking_test.go
@@ -216,6 +216,7 @@ func configureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 
 	// Define the MPLS classifier.
 	classifier := qos.GetOrCreateClassifier(mplsClassifierName)
+	classifier.SetName(mplsClassifierName)
 	classifier.SetType(oc.Qos_Classifier_Type_MPLS)
 
 	// Define the term to match MPLS label range.
@@ -240,6 +241,7 @@ func configureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 
 	// Push QoS configuration to the DUT.
 	gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), qos)
+
 }
 
 // verifyQoS verifies the QoS classifier configuration and state on the DUT.

--- a/feature/mpls/otg_tests/mpls_tc/mpls_traffic_class_marking_test.go
+++ b/feature/mpls/otg_tests/mpls_tc/mpls_traffic_class_marking_test.go
@@ -1,0 +1,254 @@
+package mpls_traffic_class_marking_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openconfig/featureprofiles/internal/attrs"
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/ygnmi/ygnmi"
+	"github.com/openconfig/ygot/ygot"
+)
+
+const (
+	plenIPv4           = 30
+	plenIPv4Loopback   = 32
+	isisInstance       = "DEFAULT"
+	mplsClassifierName = "mpls-class"
+	mplsTermName       = "mpls-class-term"
+	mplsStartLabel     = 16
+	mplsEndLabel       = 1048575
+	mplsTCValue        = 5
+	mplsWaitTime       = 2 * time.Minute
+	loopbackIntf       = "Loopback50"
+	ldpLabelSpace      = 0 // Use the platform-wide label space.
+)
+
+var (
+	dutA_p1 = attrs.Attributes{
+		Desc:    "DUT-A to DUT-B",
+		IPv4:    "192.168.1.1",
+		IPv4Len: plenIPv4,
+	}
+
+	dutB_p2 = attrs.Attributes{
+		Desc:    "DUT-B to DUT-A",
+		IPv4:    "192.168.1.2",
+		IPv4Len: plenIPv4,
+	}
+
+	dutA_lo50 = attrs.Attributes{
+		Desc:    loopbackIntf,
+		IPv4:    "100.100.100.1",
+		IPv4Len: plenIPv4Loopback,
+	}
+
+	dutB_lo50 = attrs.Attributes{
+		Desc:    loopbackIntf,
+		IPv4:    "200.200.200.2",
+		IPv4Len: plenIPv4Loopback,
+	}
+)
+
+func TestMain(m *testing.M) {
+	fptest.RunTests(m)
+}
+
+// TestMplsTcMarking configures and verifies MPLS Traffic Class marking
+// based on a QoS classifier.
+func TestMplsTcMarking(t *testing.T) {
+	dutA := ondatra.DUT(t, "dut1")
+	dutB := ondatra.DUT(t, "dut2")
+
+	// Configure initial network setup (interfaces, ISIS, MPLS, LDP).
+	configureInitialDUTs(t, dutA, dutB)
+
+	// Verify LDP session is established.
+	verifyLDP(t, dutA, dutB_lo50.IPv4)
+
+	t.Run("ConfigureAndVerifyClassifier", func(t *testing.T) {
+		// Configure QoS on DUT-A.
+		configureQoS(t, dutA)
+
+		// Verify QoS configuration state on DUT-A.
+		verifyQoS(t, dutA)
+	})
+}
+
+// configureDUT is a helper to configure interfaces, ISIS, MPLS, and LDP on a single DUT.
+func configureDUT(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.Port, dutAttr, loopbackAttr *attrs.Attributes) {
+	t.Helper()
+	d := gnmi.OC()
+	niName := deviations.DefaultNetworkInstance(dut)
+	niOC := &oc.Root{}
+	ni := niOC.GetOrCreateNetworkInstance(niName)
+
+	// Configure default network instance.
+	fptest.ConfigureDefaultNetworkInstance(t, dut)
+
+	// Configure physical and loopback interfaces.
+	dutPortCfg := dutAttr.NewOCInterface(dutPort.Name(), dut)
+	gnmi.Replace(t, dut, d.Interface(dutPort.Name()).Config(), dutPortCfg)
+
+	lo50Name := loopbackIntf
+	lo50Cfg := loopbackAttr.NewOCInterface(lo50Name, dut)
+	gnmi.Replace(t, dut, d.Interface(lo50Name).Config(), lo50Cfg)
+
+	if deviations.ExplicitPortSpeed(dut) {
+		fptest.SetPortSpeed(t, dutPort)
+	}
+	if deviations.ExplicitInterfaceInDefaultVRF(dut) {
+		fptest.AssignToNetworkInstance(t, dut, dutPort.Name(), niName, 0)
+		fptest.AssignToNetworkInstance(t, dut, lo50Name, niName, 0)
+	}
+
+	// Configure ISIS protocol.
+	isis := ni.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, isisInstance).GetOrCreateIsis()
+	isis.GetOrCreateGlobal().GetOrCreateAf(oc.IsisTypes_AFI_TYPE_IPV4, oc.IsisTypes_SAFI_TYPE_UNICAST).Enabled = ygot.Bool(true)
+	isisIntf := isis.GetOrCreateInterface(dutPort.Name())
+	isisIntf.Enabled = ygot.Bool(true)
+	isisIntf.GetOrCreateLevel(2).Enabled = ygot.Bool(true)
+
+	isisLo50 := isis.GetOrCreateInterface(lo50Name)
+	isisLo50.Enabled = ygot.Bool(true)
+	isisLo50.GetOrCreateLevel(2).Enabled = ygot.Bool(true)
+	isisLo50.Passive = ygot.Bool(true)
+
+	// Configure MPLS and LDP.
+	mpls := ni.GetOrCreateMpls()
+	mpls.GetOrCreateGlobal().GetOrCreateInterface(dutPort.Name()).MplsEnabled = ygot.Bool(true)
+	ldp := mpls.GetOrCreateSignalingProtocols().GetOrCreateLdp()
+	ldp.GetOrCreateGlobal().LsrId = ygot.String(loopbackAttr.IPv4)
+	ldpIntf := ldp.GetOrCreateInterfaceAttributes().GetOrCreateInterface(dutPort.Name())
+	ldpIntf.GetOrCreateAddressFamily(oc.MplsLdp_MplsLdpAfi_IPV4).SetEnabled(true)
+
+	gnmi.Update(t, dut, d.NetworkInstance(niName).Config(), ni)
+}
+
+// configureInitialDUTs configures both DUTs.
+func configureInitialDUTs(t *testing.T, dutA, dutB *ondatra.DUTDevice) {
+	t.Helper()
+	p1A := dutA.Port(t, "port1")
+	p2B := dutB.Port(t, "port2")
+
+	configureDUT(t, dutA, p1A, &dutA_p1, &dutA_lo50)
+	configureDUT(t, dutB, p2B, &dutB_p2, &dutB_lo50)
+}
+
+// verifyLDP waits for the LDP session between dutA and its peer to be established.
+func verifyLDP(t *testing.T, dut *ondatra.DUTDevice, peerIP string) {
+	t.Helper()
+	niName := deviations.DefaultNetworkInstance(dut)
+	// FIX 1: The LDP neighbor path requires two keys: lsr-id and label-space-id.
+	// The label-space-id is 0 for the default platform-wide label space.
+	ldpPath := gnmi.OC().NetworkInstance(niName).Mpls().SignalingProtocols().Ldp()
+
+	// Wait for neighbor session to become OPERATIONAL.
+	_, ok := gnmi.Watch(t, dut, ldpPath.Neighbor(peerIP, ldpLabelSpace).SessionState().State(), mplsWaitTime, func(val *ygnmi.Value[oc.E_MplsLdp_Neighbor_SessionState]) bool {
+		state, present := val.Val()
+		return present && state == oc.MplsLdp_Neighbor_SessionState_OPERATIONAL
+	}).Await(t)
+
+	if !ok {
+		t.Fatalf("LDP session to peer %s on DUT %s did not become OPERATIONAL", peerIP, dut.Name())
+	}
+	t.Logf("LDP session to peer %s on DUT %s is OPERATIONAL", peerIP, dut.Name())
+}
+
+// configureQoS configures a QoS classifier on DUT-A to match MPLS packets and mark their TC.
+func configureQoS(t *testing.T, dut *ondatra.DUTDevice) {
+	t.Helper()
+	dutPort1 := dut.Port(t, "port1").Name()
+	d := &oc.Root{}
+	qos := d.GetOrCreateQos()
+
+	// Define the MPLS classifier.
+	classifier := qos.GetOrCreateClassifier(mplsClassifierName)
+	classifier.SetType(oc.Qos_Classifier_Type_MPLS)
+
+	// Define the term to match MPLS label range.
+	term := classifier.GetOrCreateTerm(mplsTermName)
+	term.SetId(mplsTermName)
+
+	// Define MPLS matching conditions.
+	mplsCond := term.GetOrCreateConditions().GetOrCreateMpls()
+	mplsCond.SetStartLabelValue(oc.UnionUint32(mplsStartLabel))
+	mplsCond.SetEndLabelValue(oc.UnionUint32(mplsEndLabel))
+
+	// Define remark action to set MPLS TC.
+	actions := term.GetOrCreateActions()
+	remark := actions.GetOrCreateRemark()
+	remark.SetSetMplsTc(mplsTCValue)
+
+	// Apply the classifier to the input of the interface.
+	iface := qos.GetOrCreateInterface(dutPort1)
+	ifaceIn := iface.GetOrCreateInput()
+	// FIX: Use the correct enum type for the input classifier.
+	ifaceIn.GetOrCreateClassifier(oc.Input_Classifier_Type_MPLS).SetName(mplsClassifierName)
+
+	// Push QoS configuration to the DUT.
+	gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), qos)
+}
+
+// verifyQoS verifies the QoS classifier configuration and state on the DUT.
+func verifyQoS(t *testing.T, dut *ondatra.DUTDevice) {
+	t.Helper()
+	dutPort1Name := dut.Port(t, "port1").Name()
+
+	// State paths for QoS verification.
+	qosPath := gnmi.OC().Qos()
+	classifierPath := qosPath.Classifier(mplsClassifierName)
+	termPath := classifierPath.Term(mplsTermName)
+	mplsCondPath := termPath.Conditions().Mpls()
+	mplsActionPath := termPath.Actions().Remark()
+
+	// Verify classifier state.
+	t.Logf("Verifying QoS classifier state for %s", mplsClassifierName)
+	if got := gnmi.Get(t, dut, classifierPath.Name().State()); got != mplsClassifierName {
+		t.Errorf("Classifier name mismatch: got %q, want %q", got, mplsClassifierName)
+	}
+	if got := gnmi.Get(t, dut, classifierPath.Type().State()); got != oc.Qos_Classifier_Type_MPLS {
+		t.Errorf("Classifier type mismatch: got %v, want %v", got, oc.Qos_Classifier_Type_MPLS)
+	}
+
+	// Verify term state.
+	if got := gnmi.Get(t, dut, termPath.Id().State()); got != mplsTermName {
+		t.Errorf("Term ID mismatch: got %q, want %q", got, mplsTermName)
+	}
+
+	// Verify MPLS condition state.
+	startLabelUnion := gnmi.Get(t, dut, mplsCondPath.StartLabelValue().State())
+	startLabelWrapper, ok := startLabelUnion.(oc.UnionUint32)
+	if !ok {
+		t.Fatalf("StartLabelValue is not of type oc.UnionUint32, it is %T", startLabelUnion)
+	}
+	if uint32(startLabelWrapper) != mplsStartLabel {
+		t.Errorf("MPLS Start Label Value mismatch: got %d, want %d", startLabelWrapper, mplsStartLabel)
+	}
+
+	endLabelUnion := gnmi.Get(t, dut, mplsCondPath.EndLabelValue().State())
+	endLabelWrapper, ok := endLabelUnion.(oc.UnionUint32)
+	if !ok {
+		t.Fatalf("EndLabelValue is not of type oc.UnionUint32, it is %T", endLabelUnion)
+	}
+	if uint32(endLabelWrapper) != mplsEndLabel {
+		t.Errorf("MPLS End Label Value mismatch: got %d, want %d", endLabelWrapper, mplsEndLabel)
+	}
+
+	// Verify MPLS TC marking action state.
+	if got := gnmi.Get(t, dut, mplsActionPath.SetMplsTc().State()); got != mplsTCValue {
+		t.Errorf("Set MPLS TC value mismatch: got %d, want %d", got, mplsTCValue)
+	}
+
+	// Verify that the classifier is correctly applied to the interface.
+	ifaceClassifierPath := qosPath.Interface(dutPort1Name).Input().Classifier(oc.Input_Classifier_Type_MPLS)
+	if got := gnmi.Get(t, dut, ifaceClassifierPath.Name().State()); got != mplsClassifierName {
+		t.Errorf("Classifier on interface %s has name %q, want %q", dutPort1Name, got, mplsClassifierName)
+	}
+
+	t.Logf("Successfully verified all QoS classifier states.")
+}

--- a/feature/mpls/otg_tests/mpls_tc/mpls_traffic_class_marking_test.go
+++ b/feature/mpls/otg_tests/mpls_tc/mpls_traffic_class_marking_test.go
@@ -38,25 +38,25 @@ const (
 )
 
 var (
-	dutAP1 = attrs.Attributes{
+	dut1P1 = attrs.Attributes{
 		Desc:    "DUT-1 to DUT-2",
 		IPv4:    "192.168.1.1",
 		IPv4Len: plenIPv4,
 	}
 
-	dutBP2 = attrs.Attributes{
+	dut2P2 = attrs.Attributes{
 		Desc:    "DUT-2 to DUT-1",
 		IPv4:    "192.168.1.2",
 		IPv4Len: plenIPv4,
 	}
 
-	dutALo50 = attrs.Attributes{
+	dut1Lo50 = attrs.Attributes{
 		Desc:    loopbackIntf,
 		IPv4:    "100.100.100.1",
 		IPv4Len: plenIPv4Loopback,
 	}
 
-	dutBLo50 = attrs.Attributes{
+	dut2Lo50 = attrs.Attributes{
 		Desc:    loopbackIntf,
 		IPv4:    "200.200.200.2",
 		IPv4Len: plenIPv4Loopback,
@@ -81,21 +81,21 @@ func TestMain(m *testing.M) {
 //  3. Configure QoS classifier on DUT-1 for MPLS TC marking
 //  4. Verify QoS configuration state
 func TestMplsTcMarking(t *testing.T) {
-	dutA := ondatra.DUT(t, "dut1")
-	dutB := ondatra.DUT(t, "dut2")
+	dut1 := ondatra.DUT(t, "dut1")
+	dut2 := ondatra.DUT(t, "dut2")
 
 	// Configure initial network setup (interfaces, ISIS, MPLS, LDP).
-	configureInitialDUTs(t, dutA, dutB)
+	configureInitialDUTs(t, dut1, dut2)
 
 	// Verify LDP session is established.
-	verifyLDP(t, dutA, dutBLo50.IPv4)
+	verifyLDP(t, dut1, dut2Lo50.IPv4)
 
 	t.Run("Configure and verify MPLS TC marking classifier", func(t *testing.T) {
 		// Configure QoS on DUT-1.
-		configureQoS(t, dutA)
+		configureQoS(t, dut1)
 
 		// Verify QoS configuration state on DUT-1.
-		verifyQoS(t, dutA)
+		verifyQoS(t, dut1)
 	})
 }
 
@@ -173,7 +173,7 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.Port, d
 	mpls := networkInstance.GetOrCreateMpls()
 	ldp := mpls.GetOrCreateSignalingProtocols().GetOrCreateLdp()
 	ldpg := ldp.GetOrCreateGlobal()
-	ldpg.LsrId = ygot.String(dutALo50.IPv4)
+	ldpg.LsrId = ygot.String(dut1Lo50.IPv4)
 
 	ldpif := ldp.GetOrCreateInterfaceAttributes().GetOrCreateInterface(dutPort.Name())
 	ldpif.GetOrCreateAddressFamily(oc.MplsLdp_MplsLdpAfi_IPV4).SetEnabled(true)
@@ -182,16 +182,16 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice, dutPort *ondatra.Port, d
 }
 
 // configureInitialDUTs configures both DUTs.
-func configureInitialDUTs(t *testing.T, dutA, dutB *ondatra.DUTDevice) {
+func configureInitialDUTs(t *testing.T, dut1, dut2 *ondatra.DUTDevice) {
 	t.Helper()
-	p1A := dutA.Port(t, "port1")
-	p2B := dutB.Port(t, "port2")
+	p1 := dut1.Port(t, "port1")
+	p2 := dut2.Port(t, "port2")
 
-	configureDUT(t, dutA, p1A, &dutAP1, &dutALo50, dut1AreaAddress, dut1SysID)
-	configureDUT(t, dutB, p2B, &dutBP2, &dutBLo50, dut2AreaAddress, dut2SysID)
+	configureDUT(t, dut1, p1, &dut1P1, &dut1Lo50, dut1AreaAddress, dut1SysID)
+	configureDUT(t, dut2, p2, &dut2P2, &dut2Lo50, dut2AreaAddress, dut2SysID)
 }
 
-// verifyLDP waits for the LDP session between dutA and its peer to be established.
+// verifyLDP waits for the LDP session between dut1 and its peer to be established.
 func verifyLDP(t *testing.T, dut *ondatra.DUTDevice, peerIP string) {
 	t.Helper()
 	niName := deviations.DefaultNetworkInstance(dut)

--- a/feature/mpls/otg_tests/mpls_tc/mpls_traffic_class_marking_test.go
+++ b/feature/mpls/otg_tests/mpls_tc/mpls_traffic_class_marking_test.go
@@ -90,7 +90,7 @@ func TestMplsTcMarking(t *testing.T) {
 	// Verify LDP session is established.
 	verifyLDP(t, dut1, dut2Lo50.IPv4)
 
-	t.Run("Configure and verify MPLS TC marking classifier", func(t *testing.T) {
+	t.Run("Configure_verify_MPLS_TC_classifier", func(t *testing.T) {
 		// Configure QoS on DUT-1.
 		configureQoS(t, dut1)
 


### PR DESCRIPTION
# MPLS-1.2: MPLS Traffic Class Marking - uses 2x DUTs to verify MPLS Traffic Class Marking configuration.

Readme location here: https://github.com/openconfig/featureprofiles/tree/main/feature/mpls/otg_tests/mpls_tc