### PR TITLE
RT-1.26 Static IP Update Fix

### DIFF
--- a/feature/staticroute/otg_tests/basic_static_route_support_test/basic_static_route_support_test.go
+++ b/feature/staticroute/otg_tests/basic_static_route_support_test/basic_static_route_support_test.go
@@ -249,8 +249,8 @@ func TestStaticRouteAddRemove(t *testing.T) {
 		NetworkInstance: deviations.DefaultNetworkInstance(dut),
 		Prefix:          prefix.cidr(t),
 		NextHops: map[string]oc.NetworkInstance_Protocol_Static_NextHop_NextHop_Union{
-			"0": oc.UnionString(atePort2.IPv4),
-			"1": oc.UnionString(atePort3.IPv4),
+			"0": oc.UnionString(atePort1.IPv4),
+			"1": oc.UnionString(atePort2.IPv4),
 		},
 	}
 	if _, err := cfgplugins.NewStaticRouteCfg(b, sV4, dut); err != nil {
@@ -283,8 +283,8 @@ func TestStaticRouteAddRemove(t *testing.T) {
 		NetworkInstance: deviations.DefaultNetworkInstance(dut),
 		Prefix:          prefix.cidr(t),
 		NextHops: map[string]oc.NetworkInstance_Protocol_Static_NextHop_NextHop_Union{
-			"0": oc.UnionString(atePort2.IPv4),
-			"1": oc.UnionString(atePort3.IPv4),
+			"0": oc.UnionString(atePort1.IPv4),
+			"1": oc.UnionString(atePort2.IPv4),
 		},
 	}
 	if _, err := cfgplugins.NewStaticRouteCfg(b, sV4, dut); err != nil {


### PR DESCRIPTION
To fix the below failures:
```
    basic_static_route_support_test.go:310: Static route 203.0.113.0/24: got: 2, want: 2
    basic_static_route_support_test.go:310: Static route 203.0.113.0/24: got: 4, want: 4
    basic_static_route_support_test.go:310: Static route 203.0.113.0/24: got: 2, want: 2
    basic_static_route_support_test.go:295: 
    
    ```
    The update order is not reflected properly; that's why I have changed the order of the update in the static route.
    