### PR TITLE
Add JUNIPER case to container lifecycle test

### DIFF
--- a/feature/container/containerz/tests/container_lifecycle/.gitignore
+++ b/feature/container/containerz/tests/container_lifecycle/.gitignore
@@ -1,0 +1,4 @@
+internal/cntrsrv/cntrsrv
+vendor/
+internal/cntrsrv/cntrsrv
+vendor/

--- a/feature/container/containerz/tests/container_lifecycle/containerz_test.go
+++ b/feature/container/containerz/tests/container_lifecycle/containerz_test.go
@@ -53,6 +53,8 @@ func containerzClient(ctx context.Context, t *testing.T) *client.Client {
 				!
 			`).Append(t)
 		}
+	case ondatra.JUNIPER:
+	       //
 	case ondatra.NOKIA:
 		break
 	default:


### PR DESCRIPTION
This PR adds support for the JUNIPER platform in containerz_test.go and ignores build artifacts (cntrsrv binary and vendor/ directory) using a .gitignore file.