### PR TITLE
Updated Watch time to 2 minute to have pkt counters incremented correctly

### DIFF
--- a/feature/interface/ip/otg_tests/ipv6_link_local_test/ipv6_link_local_test.go
+++ b/feature/interface/ip/otg_tests/ipv6_link_local_test/ipv6_link_local_test.go
@@ -255,7 +255,7 @@ func verifyLinkLocalTraffic(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.A
 	p1 := dut.Port(t, "port1")
 	beforeInPkts := gnmi.Get(t, dut, gnmi.OC().Interface(p1.Name()).Counters().InPkts().State())
 	ate.OTG().StartTraffic(t)
-	_, ok := gnmi.Watch(t, dut, gnmi.OC().Interface(p1.Name()).Counters().InPkts().State(), 2 * time.Minute, func(v *ygnmi.Value[uint64]) bool {
+	_, ok := gnmi.Watch(t, dut, gnmi.OC().Interface(p1.Name()).Counters().InPkts().State(), 2*time.Minute, func(v *ygnmi.Value[uint64]) bool {
 		gotPkts, present := v.Val()
 		return present && (gotPkts-beforeInPkts) >= 100
 	}).Await(t)


### PR DESCRIPTION
 This change provides 2 min  adequate time for the packet counts when the expected number of packets is not received after immediately starting traffic. 

