### PR TITLE
Adding 2 gnmi sessions in AFT FNT

### DIFF
--- a/feature/afts/otg_tests/afts_base/afts_base_test.go
+++ b/feature/afts/otg_tests/afts_base/afts_base_test.go
@@ -562,11 +562,11 @@ func (tc *testCase) fetchAFT(t *testing.T, stoppingCondition aftcache.PeriodicHo
 	wg.Wait()
 
 	// Get the AFT from the cache.
-	aft1, err := aftSession1.Cache.ToAFT(tc.dut)
+	aft1, err := aftSession1.Cache.ToAFT(t, tc.dut)
 	if err != nil {
 		return nil, fmt.Errorf("error getting AFT from session 1: %v", err)
 	}
-	aft2, err := aftSession2.Cache.ToAFT(tc.dut)
+	aft2, err := aftSession2.Cache.ToAFT(t, tc.dut)
 	if err != nil {
 		return nil, fmt.Errorf("error getting AFT from session 2: %v", err)
 	}


### PR DESCRIPTION
1. Update the testCase struct to hold two gNMI clients.
2. In the TestBGP function, created two gNMI client connections.
3. The cache function is updated to run two AFT streaming sessions concurrently, one for each client. It then compares the AFT data from both sessions to ensure consistency.
4. The calls to cache within TestBGP are adjusted to provide separate stopping conditions for each of the two concurrent sessions.