### PR TITLE
remove excessive logging from FindComponent utils

### DIFF
--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -56,21 +56,15 @@ func fetchCachedComponents(t *testing.T, dut *ondatra.DUTDevice) []*oc.Component
 
 // FindComponentsByType finds the list of components based on hardware type.
 func FindComponentsByType(t *testing.T, dut *ondatra.DUTDevice, cType oc.E_PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT) []string {
+	t.Helper()
 	components := fetchCachedComponents(t, dut)
 	var s []string
 	for _, c := range components {
-		if c.GetType() == nil {
-			t.Logf("Component %s type is missing from telemetry", c.GetName())
-			continue
-		}
-		t.Logf("Component %s has type: %v", c.GetName(), c.GetType())
 		switch v := c.GetType().(type) {
 		case oc.E_PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT:
 			if v == cType {
 				s = append(s, c.GetName())
 			}
-		default:
-			t.Logf("Detected non-hardware component: (%T, %v)", c.GetType(), c.GetType())
 		}
 	}
 	return s
@@ -78,21 +72,15 @@ func FindComponentsByType(t *testing.T, dut *ondatra.DUTDevice, cType oc.E_Platf
 
 // FindActiveComponentsByType finds the list of active components based on hardware type.
 func FindActiveComponentsByType(t *testing.T, dut *ondatra.DUTDevice, cType oc.E_PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT) []string {
+	t.Helper()
 	components := gnmi.GetAll[*oc.Component](t, dut, gnmi.OC().ComponentAny().State())
 	var s []string
 	for _, c := range components {
-		if c.GetType() == nil {
-			t.Logf("Component %s type is missing from telemetry", c.GetName())
-			continue
-		}
-		t.Logf("Component %s has type: %v", c.GetName(), c.GetType())
 		switch v := c.GetType().(type) {
 		case oc.E_PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT:
 			if v == cType && c.OperStatus == oc.PlatformTypes_COMPONENT_OPER_STATUS_ACTIVE {
 				s = append(s, c.GetName())
 			}
-		default:
-			t.Logf("Detected non-hardware component: (%T, %v)", c.GetType(), c.GetType())
 		}
 	}
 	return s
@@ -100,20 +88,15 @@ func FindActiveComponentsByType(t *testing.T, dut *ondatra.DUTDevice, cType oc.E
 
 // FindSWComponentsByType finds the list of SW components based on a type.
 func FindSWComponentsByType(t *testing.T, dut *ondatra.DUTDevice, cType oc.E_PlatformTypes_OPENCONFIG_SOFTWARE_COMPONENT) []string {
+	t.Helper()
 	components := fetchCachedComponents(t, dut)
 	var s []string
 	for _, c := range components {
-		if c.GetType() == nil {
-			continue
-		}
-		t.Logf("Component %s has type: %v", c.GetName(), c.GetType())
 		switch v := c.GetType().(type) {
 		case oc.E_PlatformTypes_OPENCONFIG_SOFTWARE_COMPONENT:
 			if v == cType {
 				s = append(s, c.GetName())
 			}
-		default:
-			// no-op for non-software components.
 		}
 	}
 	return s


### PR DESCRIPTION
This logging doesn't really belong in a util and often ends up obfuscating more important logs