### PR TITLE
Removing `bgp_as_path_prepend_order_mismtach` deviation that causes false-positive test result.

### DIFF
--- a/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/metadata.textproto
+++ b/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/metadata.textproto
@@ -60,6 +60,5 @@ platform_exceptions:  {
     routing_policy_tag_set_embedded: true
     bgp_community_set_refs_unsupported: true
     bgp_set_med_action_unsupported: true
-    bgp_as_path_prepend_order_mismtach: true
   }
 }

--- a/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/static_route_bgp_redistribution_test.go
+++ b/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/static_route_bgp_redistribution_test.go
@@ -1226,9 +1226,6 @@ func validatePrefixASN(t *testing.T, ate *ondatra.ATEDevice, isV4 bool, bgpPeerN
 
 	foundPrefix := false
 	dut := ondatra.DUT(t, "dut")
-	if deviations.BgpAsPathPrependOrderMismtach(dut) && isV4 {
-		wantASPath = []uint32{65499, 65499, 65499, 64512}
-	}
 
 	if isV4 {
 		prefixPath := gnmi.OTG().BgpPeer(bgpPeerName).UnicastIpv4PrefixAny()

--- a/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/static_route_bgp_redistribution_test.go
+++ b/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/static_route_bgp_redistribution_test.go
@@ -1225,8 +1225,7 @@ func validateRedistributeIPv6RoutePolicy(t *testing.T, dut *ondatra.DUTDevice, a
 func validatePrefixASN(t *testing.T, ate *ondatra.ATEDevice, isV4 bool, bgpPeerName, subnet string, wantASPath []uint32) {
 
 	foundPrefix := false
-	dut := ondatra.DUT(t, "dut")
-
+	
 	if isV4 {
 		prefixPath := gnmi.OTG().BgpPeer(bgpPeerName).UnicastIpv4PrefixAny()
 		prefix, ok := gnmi.WatchAll(t, ate.OTG(), prefixPath.State(), 20*time.Second, func(val *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv4Prefix]) bool {


### PR DESCRIPTION
This devivation accepted UPDATE with AS_PATH leftmost as was the one set by redistribution poliy, not the one added as mandatory prepend on eBGP session.

Since redistribution policy can prepend arbitrary ASN, as result AS_PATH leftmost AS is different then Local_AS of eBGP advertising speaker. Consequently eBGP reciver sees mismatch between peer ASN and leftmost ASN on AS_PATH. Many implementation consider such UPDATE as insane/illegal/posoned, and silently reject it.

By removing deviation we ensure that above make tast result FAIL.