### PR TITLE
Revise README RT-10.1 for table connections import-match

### DIFF
--- a/feature/networkinstance/local_aggregates/tests/policy_advertise_aggregate/README.md
+++ b/feature/networkinstance/local_aggregates/tests/policy_advertise_aggregate/README.md
@@ -31,9 +31,10 @@
 
 ### Canonical OC 
 
-TODO ([openconfig/public#1368](https://github.com/openconfig/public/issues/1368)): Add advertise-aggregate path to the OpenConfig public data models. 
-`/routing-policy/policy-definitions/policy-definition/statements/statement/actions/config/advertise-aggregate = `"LOCAL-AGG"`
+TODO ([openconfig/public#1368](https://github.com/openconfig/public/issues/1368)): Add `import-match-table` path to the OpenConfig public data models. 
 
+The following path should then be added to the canonical OC below
+`/network-instances/network-instance/table-connections/table-connection/config/import-match-table = `"BGP"`
 
 ```json
 {
@@ -112,6 +113,7 @@ TODO ([openconfig/public#1368](https://github.com/openconfig/public/issues/1368)
                 "aggregate": [
                   {
                     "config": {
+                      "discard": true,
                       "prefix": "0.0.0.0/0"
                     },
                     "prefix": "0.0.0.0/0"
@@ -119,6 +121,24 @@ TODO ([openconfig/public#1368](https://github.com/openconfig/public/issues/1368)
                 ]
               },
               "name": "DEFAULT-AGG"
+            }
+          ]
+        },
+        "table-connections": {
+          "table-connection": [
+            {
+              "address-family": "IPV4",
+              "config": {
+                "address-family": "IPV4",
+                "default-import-policy": "REJECT_ROUTE",
+                "dst-protocol": "BGP",
+                "import-policy": [
+                  "SEND-DEF-IF-NOT-FOUND-IPV4"
+                ],
+                "src-protocol": "LOCAL_AGGREGATE"
+              },
+              "dst-protocol": "BGP",
+              "src-protocol": "LOCAL_AGGREGATE"
             }
           ]
         }
@@ -132,9 +152,9 @@ TODO ([openconfig/public#1368](https://github.com/openconfig/public/issues/1368)
           {
             "config": {
               "mode": "IPV4",
-              "name": "EBGP-IMPORT-IPV4"
+              "name": "SEND-DEF-IF-NOT-FOUND-IPV4"
             },
-            "name": "EBGP-IMPORT-IPV4",
+            "name": "SEND-DEF-IF-NOT-FOUND-IPV4",
             "prefixes": {
               "prefix": [
                 {
@@ -155,9 +175,9 @@ TODO ([openconfig/public#1368](https://github.com/openconfig/public/issues/1368)
       "policy-definition": [
         {
           "config": {
-            "name": "EBGP-IMPORT-IPV4"
+            "name": "SEND-DEF-IF-NOT-FOUND-IPV4"
           },
-          "name": "EBGP-IMPORT-IPV4",
+          "name": "SEND-DEF-IF-NOT-FOUND-IPV4",
           "statements": {
             "statement": [
               {
@@ -169,8 +189,7 @@ TODO ([openconfig/public#1368](https://github.com/openconfig/public/issues/1368)
                 "conditions": {
                   "match-prefix-set": {
                     "config": {
-                      "match-set-options": "INVERT",
-                      "prefix-set": "EBGP-IMPORT-IPV4"
+                      "prefix-set": "SEND-DEF-IF-NOT-FOUND-IPV4"
                     }
                   }
                 },
@@ -186,7 +205,6 @@ TODO ([openconfig/public#1368](https://github.com/openconfig/public/issues/1368)
     }
   }
 }
-
 ```
 
 ### OpenConfig Path and RPC Coverage

--- a/feature/networkinstance/local_aggregates/tests/policy_advertise_aggregate/README.md
+++ b/feature/networkinstance/local_aggregates/tests/policy_advertise_aggregate/README.md
@@ -141,6 +141,26 @@ The following path should then be added to the canonical OC below
               "src-protocol": "LOCAL_AGGREGATE"
             }
           ]
+        },
+        "tables": {
+          "table": [
+            {
+              "address-family": "IPV4",
+              "config": {
+                "address-family": "IPV4",
+                "protocol": "BGP"
+              },
+              "protocol": "BGP"
+            },
+            {
+              "address-family": "IPV4",
+              "config": {
+                "address-family": "IPV4",
+                "protocol": "LOCAL_AGGREGATE"
+              },
+              "protocol": "LOCAL_AGGREGATE"
+            }
+          ]
         }
       }
     ]


### PR DESCRIPTION
 Today, table-connections only defines an import-policy leaf and implies that the matching conditions are evaluated against the src-protocol and the resulting matching routes are copied into the dst-protocol.  But RT-10.1 defines a need to match a route in a different table/protocol.  (in this case, the route we want to match is in the `dst-protocol` table)

`/routing-policy/policy-definitions/policy-definition/statements/statement/actions/config/import-match-protocol = "BGP"`

For context, here is the tree for table-connections with the proposed `import-match-protocol` leaf:
```diff
        +--rw table-connections
        |  +--rw table-connection* [src-protocol dst-protocol address-family]
        |     +--rw src-protocol      -> ../config/src-protocol
        |     +--rw dst-protocol      -> ../config/dst-protocol
        |     +--rw address-family    -> ../config/address-family
        |     +--rw config
        |     |  +--rw src-protocol?                 -> ../../../../tables/table/config/protocol
        |     |  +--rw address-family?               -> ../../../../tables/table[protocol=current()/../src-protocol]/config/address-family
        |     |  +--rw dst-protocol?                 -> ../../../../tables/table/config/protocol
        |     |  +--rw disable-metric-propagation?   boolean
        |     |  +--rw import-policy*                -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
+       |     |  +--rw import-match-protocol          -> ../../../../tables/table/config/protocol
        |     |  +--rw default-import-policy?        default-policy-type
        |     +--ro state
        |        +--ro src-protocol?                 -> ../../../../tables/table/config/protocol
        |        +--ro address-family?               -> ../../../../tables/table[protocol=current()/../src-protocol]/config/address-family
        |        +--ro dst-protocol?                 -> ../../../../tables/table/config/protocol
        |        +--ro disable-metric-propagation?   boolean
        |        +--ro import-policy*                -> /oc-rpol:routing-policy/policy-definitions/policy-definition/name
+       |        +--rw import-match-protocol          -> ../../../../tables/table/config/protocol
        |        +--ro default-import-policy?        default-policy-type
```