### PR TITLE
Vendor fix RT-5.11

### DIFF
--- a/feature/interface/lacp/tests/lacp_interval_test/lacp_interval_test.go
+++ b/feature/interface/lacp/tests/lacp_interval_test/lacp_interval_test.go
@@ -165,7 +165,7 @@ func (tc *testCase) configDstAggregateDUT(i *oc.Interface, a *attrs.Attributes) 
 }
 
 func (tc *testCase) configSrcDUT(i *oc.Interface, a *attrs.Attributes) {
-	i.Description = ygot.String(a.Desc)
+	i.Description = ygot.String(dut1Src.Desc)
 	if deviations.InterfaceEnabled(tc.dut1) {
 		i.Enabled = ygot.Bool(true)
 	}
@@ -224,8 +224,11 @@ func (tc *testCase) configureDUT(t *testing.T) {
 	gnmi.Replace(t, tc.dut2, aggPath.Config(), agg2)
 
 	if deviations.ExplicitInterfaceInDefaultVRF(tc.dut1) {
-		fptest.AssignToNetworkInstance(t, tc.dut1, tc.aggID, deviations.DefaultNetworkInstance(tc.dut1), 0)
-		fptest.AssignToNetworkInstance(t, tc.dut1, dut1Src.Name, deviations.DefaultNetworkInstance(tc.dut1), 0)
+		duts := []*ondatra.DUTDevice{tc.dut1, tc.dut2}
+		for _, dut := range duts {
+			fptest.AssignToNetworkInstance(t, dut, tc.aggID,
+				deviations.DefaultNetworkInstance(dut), 0)
+		}
 	}
 	for _, port := range tc.dut1Ports {
 		i := &oc.Interface{Name: ygot.String(port.Name())}


### PR DESCRIPTION
(m) lacp_interval_test.go
- Fixed vendor deviation to handle multi-dut / removed the push for lag members.
- Fixed LAG description to not push `""` - but push `"dutdut"`

---

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."