### PR TITLE
Fix RT-14.2.2 test case to reflect B4 production use case

### DIFF
--- a/feature/gribi/otg_tests/gribi_route_test/README.md
+++ b/feature/gribi/otg_tests/gribi_route_test/README.md
@@ -76,7 +76,10 @@ network-instances {
     {NH#3, DEFAULT VRF, weight:1}, interface-ref:dut-port-2-interface,
   }
 - IPv4Entry {0.0.0.0/0 (ENCAP_TE_VRF_A)} -> NHG#5 (DEFAULT VRF) -> {
-    {NH#5, DEFAULT VRF, weight:1, interface-ref:dut-port-3-interface},
+    {NH#5, DEFAULT VRF, weight:1},
+  }
+  NH#5 -> {
+    network_instance: "DEFAULT"
   }
 - IPv4Entry {138.0.11.8/32 (ENCAP_TE_VRF_A)} -> NHG#4 (DEFAULT VRF) -> {
     {NH#4, DEFAULT VRF, weight:1},
@@ -109,7 +112,8 @@ Test-2, Match on source prefix, flow hits ENCAP_TE_VRF_A followed by Default VRF
 
 ```
   1. Send flow with source IP ipv4_outer_src_111 with destination IP ipv4PrefixNotEncapped.
-  2. Verify v4 packet not matched with tunnel prefix and egress via port-3.
+  2. Verify v4 packet not matched with tunnel prefix, falls back to DEFAULT VRF
+     via 0/0 route and is routed based on BGP route, egress via port-3.
   3. No traffic loss in steady state
 
 ```

--- a/feature/gribi/otg_tests/gribi_route_test/gribi_route_test.go
+++ b/feature/gribi/otg_tests/gribi_route_test/gribi_route_test.go
@@ -331,6 +331,7 @@ func configureOTGBGP(t *testing.T, dev gosnappi.Device, top gosnappi.Config, nbr
 		SetNextHopAddressType(gosnappi.BgpV4RouteRangeNextHopAddressType.IPV4).
 		SetNextHopMode(gosnappi.BgpV4RouteRangeNextHopMode.MANUAL)
 	bgpNeti1Bgp4PeerRoutes.Addresses().Add().SetAddress(ipv4InnerDst).SetPrefix(32).SetCount(1)
+	bgpNeti1Bgp4PeerRoutes.Addresses().Add().SetAddress(ipv4OuterDst222).SetPrefix(32).SetCount(1)
 }
 
 func configureOTG(t *testing.T, ate *ondatra.ATEDevice) gosnappi.Config {
@@ -513,10 +514,9 @@ func configureGribiRoute(t *testing.T, dut *ondatra.DUTDevice, tcArgs *testArgs)
 
 	tcArgs.client.Modify().AddEntry(t,
 		fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(tcArgs.dut)).
-			WithIndex(uint64(5)).WithIPAddress(atePort3.IPv4),
+			WithIndex(uint64(5)).WithNextHopNetworkInstance(deviations.DefaultNetworkInstance(dut)),
 		fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(tcArgs.dut)).
 			WithID(uint64(5)).AddNextHop(uint64(5), uint64(1)),
-
 		fluent.IPv4Entry().WithNetworkInstance(niEncapTeVrfA).
 			WithNextHopGroupNetworkInstance(deviations.DefaultNetworkInstance(dut)).
 			WithPrefix("0.0.0.0/0").WithNextHopGroup(uint64(5)))


### PR DESCRIPTION
In Google transit, the ENCAP_TE_VRF will have a 0/0 route pointing to DEFAULT VRF to redirect any traffic that does not match on a specific prefix into default VRF. The current test validation where 0/0 points to a egress interface is not supported in EOS for some platforms and this does not reflect the actual production use case. I have changed the test to have the default route point to default VRF and validate that the packet is routed based on the BGP route in the default VRF.

This default route in encap VRF use case has already been discussed with nachiketas from Google.