### PR TITLE
Address failure caused due to discrepancy between config and verification data

### DIFF
--- a/feature/sflow/otg_tests/sflow_base_test/sflow_base_test.go
+++ b/feature/sflow/otg_tests/sflow_base_test/sflow_base_test.go
@@ -65,14 +65,14 @@ var (
 	sflowCfgv4 = &cfgplugins.SFlowGlobalParams{
 		Ni:              mgmtVRF,
 		IntfName:        "port1",
-		SrcAddrV4:       "192.0.2.1",
+		SrcAddrV4:       "203.0.113.1",
 		IP:              "IPv4",
 		MinSamplingRate: 100000,
 	}
 	sflowCfgv6 = &cfgplugins.SFlowGlobalParams{
 		Ni:              mgmtVRF,
 		IntfName:        "port1",
-		SrcAddrV6:       "2001:db8::1",
+		SrcAddrV6:       "2001:db8::203:0:113:1",
 		IP:              "IPv6",
 		MinSamplingRate: 100000,
 	}


### PR DESCRIPTION
As part of code refactoring, Pull/4590 changed the source address configured for the sFlow collector from the device's lo0 address to the ip address of the interface where sampling is enabled. This was leading to discrepancy between what was configured on the device and what the verification parts (OTG captures) were based on. This PR addresses the discrepancy.