### PR TITLE
Acctz-4.2 : Allow larger gRPC responses by increasing MaxCallRecvMsgSize

### DIFF
--- a/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
+++ b/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
-	"github.com/openconfig/featureprofiles/internal/helpers"
 	acctzpb "github.com/openconfig/gnsi/acctz"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"


### PR DESCRIPTION
#### Summary

This change increases the gRPC MaxCallRecvMsgSize limit to 11 MB. By default, gRPC clients reject responses larger than the configured maximum size, which was causing failures when handling larger payloads.

#### Motivation

Some service calls were returning responses that exceeded the default message size limit.
Raising the limit ensures the client can safely handle larger responses from the server.

####  Changes

Added grpc.MaxCallRecvMsgSize(11000000) option when initializing the gRPC client.
This sets the maximum receive message size to ~11 MB.

####  Impact

Positive: Prevents client errors for large responses.
Neutral: No changes for normal-sized responses.
