### PR TITLE
DP-1.4: Updating sleep value for result consistency

### DIFF
--- a/feature/qos/otg_tests/qos_output_queue_counters_test/qos_output_queue_counters_test.go
+++ b/feature/qos/otg_tests/qos_output_queue_counters_test/qos_output_queue_counters_test.go
@@ -231,7 +231,7 @@ func TestQoSCounters(t *testing.T) {
 	t.Logf("Running traffic 1 on DUT interfaces: %s => %s ", dp1.Name(), dp2.Name())
 	t.Logf("Sending traffic flows: \n%v\n\n", trafficFlows)
 	ate.OTG().StartTraffic(t)
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 	outputQosPerSecoundCounterOK := validateoutputQosPerSecoundCounter(t, dut, dp1, dp2, trafficFlows)
 	ate.OTG().StopTraffic(t)
 	if !outputQosPerSecoundCounterOK {


### PR DESCRIPTION
To avoid intermittent failure, need to update sleep value from 2 seconds to 5 seconds.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."