### PR TITLE
gNMI-1.10: Adding support for different QoS queue count on different platform for same vendor

### DIFF
--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -48,11 +48,11 @@ const (
 )
 
 var (
-	vendorQueueNo = map[ondatra.Vendor]int{
-		ondatra.ARISTA:  16,
-		ondatra.CISCO:   6,
-		ondatra.JUNIPER: 8,
-		ondatra.NOKIA:   16,
+	vendorQueueNo = map[ondatra.Vendor][]int{
+		ondatra.ARISTA:  {16},
+		ondatra.CISCO:   {6},
+		ondatra.JUNIPER: {8},
+		ondatra.NOKIA:   {16, 8},
 	}
 )
 
@@ -357,9 +357,16 @@ func TestQoSCounters(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
+			gotQueueCount := len(tc.counters)
+			matchedQueueCount := false
+			for _, expectedQueueCount := range vendorQueueNo[dut.Vendor()] {
+				if gotQueueCount == expectedQueueCount {
+					matchedQueueCount = true
+				}
+			}
 
-			if len(tc.counters) != vendorQueueNo[dut.Vendor()] {
-				t.Errorf("Get QoS queue# for %q: got %d, want %d", dut.Vendor(), len(tc.counters), vendorQueueNo[dut.Vendor()])
+			if !matchedQueueCount {
+				t.Errorf("Get QoS queue# for %q: got %d, want %v", dut.Vendor(), len(tc.counters), vendorQueueNo[dut.Vendor()])
 			}
 			for i, counter := range tc.counters {
 				val, present := counter.Val()


### PR DESCRIPTION

Supporting vendor having multiple platforms that support different QoS queue counts.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."