### PR TITLE
Register FNT for Auto Link-Bandwidth Community

### DIFF
--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -1173,6 +1173,7 @@ test: {
   id: "RT-7.51"
   description: "BGP - Auto-generate Link Bandwidth community based on interface available capacity"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/otg_tests/auto_link_bandwidth_test/README.md"
+  exec: " "
 }
 test: {
   id: "RT-7.6"

--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -1170,6 +1170,11 @@ test: {
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/otg_tests/link_bandwidth_test/README.md"
 }
 test: {
+  id: "RT-7.51"
+  description: "BGP - Auto-generate Link Bandwidth community based on interface available capacity"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/bgp/otg_tests/auto_link_bandwidth_test/README.md"
+}
+test: {
   id: "RT-7.6"
   description: "RT-7.6: BGP Link Bandwidth Community - Aggregation"
   readme: ""


### PR DESCRIPTION
Pre-allocating a new test ID and path in the test registry
for the forthcoming Functional Network Test (FNT) covering the
BGP auto-generated link-bandwidth feature.

The new test, registered as RT-7.51, will validate the device's
ability to automatically generate and attach a link-bandwidth
community to routes learned on import, based on the real-time
capacity of the ingress interface.

This is a preparatory change. The full test specification (`README.md`)
will be added in a subsequent commit.
