### PR TITLE
RT-7.1: Removing bgp_default_policy_unsupported deviation

### DIFF
--- a/feature/bgp/policybase/otg_tests/default_policies_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/default_policies_test/metadata.textproto
@@ -38,7 +38,6 @@ platform_exceptions:  {
     static_protocol_name: "static"
     skip_non_bgp_route_export_check:  true
     missing_isis_interface_afi_safi_enable: true
-    bgp_default_policy_unsupported: true
     skip_prefix_set_mode: true
   }
 }


### PR DESCRIPTION
- Removed vendor specific `bgp_default_policy_unsupported` deviation from RT-7.1

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."