### PR TITLE
Gnmi 1.3 add new deviation

### DIFF
--- a/feature/gnmi/otg_tests/drained_configuration_convergence_time/drained_configuration_convergence_time_bgp_test.go
+++ b/feature/gnmi/otg_tests/drained_configuration_convergence_time/drained_configuration_convergence_time_bgp_test.go
@@ -31,308 +31,345 @@ import (
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )
-
 func TestMain(m *testing.M) {
-	fptest.RunTests(m)
+        fptest.RunTests(m)
 }
 
 const (
-	asPathRepeatValue      = 3
-	aclStatement2          = "20"
-	aclStatement3          = "30"
-	setASpathPrependPolicy = "SET-ASPATH-PREPEND"
-	setMEDPolicy           = "SET-MED"
-	setALLOWPolicy         = "ALLOW"
-	bgpMED                 = 25
+        asPathRepeatValue       = 3
+        aclStatement2           = "20"
+        aclStatement3           = "30"
+        setASpathPrependPolicy  = "SET-ASPATH-PREPEND"
+        setMEDPolicy            = "SET-MED"
+        setALLOWPolicy          = "ALLOW"
+        setALLOWPeerGroupPolicy = "ALLOW-PEER-GROUP"
+        setALLOWAFISAFIPolicy   = "ALLOW-AFI-SAFI"
+        bgpMED                  = 25
 )
 
 // setAllow is used to configure ALLOW routing policy on DUT.
 func setAllow(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root) {
 
-	// Configure Allow Policy on DUT.
-	rp := d.GetOrCreateRoutingPolicy()
-	pd := rp.GetOrCreatePolicyDefinition(setALLOWPolicy)
-	st, err := pd.AppendNewStatement("id-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	st.GetOrCreateActions().PolicyResult = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+        // Configure Allow Policy on DUT.
+        rp := d.GetOrCreateRoutingPolicy()
+        pd := rp.GetOrCreatePolicyDefinition(setALLOWPolicy)
+        st, err := pd.AppendNewStatement("id-1")
+        if err != nil {
+                t.Fatal(err)
+        }
+        st.GetOrCreateActions().PolicyResult = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+        gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
+}
 
-	gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
+// setAllowPeerGroup is used to configure the ALLOW-PEER-GROUP routing policy on DUT.
+func setAllowPeerGroup(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root) {
+        rp := d.GetOrCreateRoutingPolicy()
+        pd := rp.GetOrCreatePolicyDefinition(setALLOWPeerGroupPolicy)
+        st, err := pd.AppendNewStatement("id-1")
+        if err != nil {
+                t.Fatal(err)
+        }
+        st.GetOrCreateActions().PolicyResult = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+        gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
+}
+
+// setAllowAfiSafi is used to configure the ALLOW-AFI-SAFI routing policy on DUT.
+func setAllowAfiSafi(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root) {
+        rp := d.GetOrCreateRoutingPolicy()
+        pd := rp.GetOrCreatePolicyDefinition(setALLOWAFISAFIPolicy)
+        st, err := pd.AppendNewStatement("id-1")
+        if err != nil {
+                t.Fatal(err)
+        }
+        st.GetOrCreateActions().PolicyResult = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+        gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
 }
 
 // setMED is used to configure routing policy to set BGP MED on DUT.
 func setMED(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root) {
-
-	// Configure SetMED on DUT.
-	rp := d.GetOrCreateRoutingPolicy()
-	pdef5 := rp.GetOrCreatePolicyDefinition(setMEDPolicy)
-	stmt, err := pdef5.AppendNewStatement(aclStatement3)
-	if err != nil {
-		t.Fatal(err)
-	}
-	actions5 := stmt.GetOrCreateActions()
-	setMedBGP := actions5.GetOrCreateBgpActions()
-	setMedBGP.SetMed = oc.UnionUint32(bgpMED)
-	if !deviations.BGPSetMedActionUnsupported(dut) {
-		setMedBGP.SetMedAction = oc.BgpPolicy_BgpSetMedAction_SET
-	}
-	actions5.PolicyResult = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
-	if deviations.BGPSetMedRequiresEqualOspfSetMetric(dut) {
-		actions5.GetOrCreateOspfActions().GetOrCreateSetMetric().SetMetric(bgpMED)
-	}
-
-	gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
+        // Configure SetMED on DUT.
+        rp := d.GetOrCreateRoutingPolicy()
+        pdef5 := rp.GetOrCreatePolicyDefinition(setMEDPolicy)
+        stmt, err := pdef5.AppendNewStatement(aclStatement3)
+        if err != nil {
+                t.Fatal(err)
+        }
+        actions5 := stmt.GetOrCreateActions()
+        setMedBGP := actions5.GetOrCreateBgpActions()
+        setMedBGP.SetMed = oc.UnionUint32(bgpMED)
+        if !deviations.BGPSetMedActionUnsupported(dut) {
+                setMedBGP.SetMedAction = oc.BgpPolicy_BgpSetMedAction_SET
+        }
+        actions5.PolicyResult = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+        gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
 }
 
 // setASPath is used to configure route policy set-as-path prepend on DUT.
 func setASPath(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root) {
+        // Configure SetASPATH routing policy on DUT.
+        rp := d.GetOrCreateRoutingPolicy()
+        pdef5 := rp.GetOrCreatePolicyDefinition(setASpathPrependPolicy)
+        stmt, err := pdef5.AppendNewStatement(aclStatement2)
+        if err != nil {
+                t.Fatal(err)
+        }
+        actions5 := stmt.GetOrCreateActions()
+        actions5.PolicyResult = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
+        aspend := actions5.GetOrCreateBgpActions().GetOrCreateSetAsPathPrepend()
+        aspend.Asn = ygot.Uint32(setup.DUTAs)
+        aspend.RepeatN = ygot.Uint8(asPathRepeatValue)
+        gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
 
-	// Configure SetASPATH routing policy on DUT.
-	rp := d.GetOrCreateRoutingPolicy()
-	pdef5 := rp.GetOrCreatePolicyDefinition(setASpathPrependPolicy)
-	stmt, err := pdef5.AppendNewStatement(aclStatement2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	actions5 := stmt.GetOrCreateActions()
-	actions5.PolicyResult = oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE
-	aspend := actions5.GetOrCreateBgpActions().GetOrCreateSetAsPathPrepend()
-	aspend.Asn = ygot.Uint32(setup.DUTAs)
-	aspend.RepeatN = ygot.Uint8(asPathRepeatValue)
+        netInstance := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
+        bgp := netInstance.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
+        pg := bgp.GetOrCreatePeerGroup(setup.PeerGrpName)
+        rpl := pg.GetOrCreateApplyPolicy()
 
-	gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
+        if deviations.SameAfiSafiAndPeergroupPoliciesUnsupported(dut) {
+                // Apply the peer-group specific policy.
+                rpl.SetImportPolicy([]string{setALLOWPeerGroupPolicy})
+        } else {
+                // Original behavior.
+                rpl.SetImportPolicy([]string{setALLOWPolicy})
+        }
 
-	netInstance := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
-	bgp := netInstance.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
-	pg := bgp.GetOrCreatePeerGroup(setup.PeerGrpName)
-	rpl := pg.GetOrCreateApplyPolicy()
-	rpl.SetImportPolicy([]string{setALLOWPolicy})
-
-	gnmi.Update(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).Config(), pg)
-
+        gnmi.Update(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).Config(), pg)
 }
 
+// setPolicyPeerGroup to set BGP Import policy.
 func setPolicyPeerGroup(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root, policy []string) {
+        netInstance := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
+        bgp := netInstance.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
+        pg := bgp.GetOrCreatePeerGroup(setup.PeerGrpName)
+        pg.PeerAs = ygot.Uint32(setup.ATEAs)
+        pg.PeerGroupName = ygot.String(setup.PeerGrpName)
+        afipg := pg.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
+        afipg.Enabled = ygot.Bool(true)
+        if deviations.RoutePolicyUnderAFIUnsupported(dut) {
+                pgpolicy := pg.GetOrCreateApplyPolicy()
+                pgpolicy.ImportPolicy = policy
+                gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).Config(), pg)
+        } else {
+                pgpolicy := afipg.GetOrCreateApplyPolicy()
+                pgpolicy.ImportPolicy = policy
+                gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).Config(), pg)
+        }
+}
 
-	// Set BGP Import policy
-	netInstance := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
-	bgp := netInstance.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
-	pg := bgp.GetOrCreatePeerGroup(setup.PeerGrpName)
-	pg.PeerAs = ygot.Uint32(setup.ATEAs)
-	pg.PeerGroupName = ygot.String(setup.PeerGrpName)
-	afipg := pg.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
-	afipg.Enabled = ygot.Bool(true)
-	if deviations.RoutePolicyUnderAFIUnsupported(dut) {
-		pgpolicy := pg.GetOrCreateApplyPolicy()
-		pgpolicy.ImportPolicy = policy
-		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).Config(), pg)
+// setPolicyAfiSafi applies an import policy at the AFI-SAFI level, if supported.
+func setPolicyAfiSafi(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root, policy []string) {
+        netInstance := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
+        bgp := netInstance.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
+        pg := bgp.GetOrCreatePeerGroup(setup.PeerGrpName)
+        pg.PeerAs = ygot.Uint32(setup.ATEAs)
+        pg.PeerGroupName = ygot.String(setup.PeerGrpName)
 
-	} else {
-		pgpolicy := afipg.GetOrCreateApplyPolicy()
-		pgpolicy.ImportPolicy = policy
-		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).Config(), pg)
-
-	}
+        // This function only applies policy at the AFI-SAFI level if the device supports it.
+        if !deviations.RoutePolicyUnderAFIUnsupported(dut) {
+                afipg := pg.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
+                afipg.Enabled = ygot.Bool(true)
+                pgpolicy := afipg.GetOrCreateApplyPolicy()
+                pgpolicy.ImportPolicy = policy
+                gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Config(), afipg)
+        }
 }
 
 // isConverged function is used to check if ATE has received all the prefixes.
 func isConverged(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice, ap *ondatra.Port) {
-
-	// Add 10 second timer for BGP update to propagate
-	time.Sleep(10 * time.Second)
-	// Check if all prefixes are learned at ATE.
-	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
-		Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+        // Add 10 second timer for BGP update to propagate
+        time.Sleep(10 * time.Second)
+        // Check if all prefixes are learned at ATE.
+        statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
+                Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 prefixLoop:
-	for repeat := 4; repeat > 0; repeat-- {
-		prefixesv4 := statePath.Neighbor(setup.ATEIPList[ap.ID()].String()).
-			AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Prefixes()
-		gotSent := gnmi.Get(t, dut, prefixesv4.Sent().State())
-		switch {
-		case gotSent == setup.RouteCount:
-			t.Logf("Prefixes sent from ingress port are learnt at ATE dst port : %v are %v", setup.ATEIPList[ap.ID()].String(), setup.RouteCount)
-			break prefixLoop
-		case repeat > 0 && gotSent < setup.RouteCount:
-			t.Logf("All the prefixes are not learnt , wait for 5 secs before retry.. got %v, want %v", gotSent, setup.RouteCount)
-			time.Sleep(time.Second * 5)
-		case repeat == 0 && gotSent < setup.RouteCount:
-			t.Errorf("sent prefixes from DUT to neighbor %v is mismatch: got %v, want %v", setup.ATEIPList[ap.ID()].String(), gotSent, setup.RouteCount)
-		}
-	}
-
+        for repeat := 4; repeat > 0; repeat-- {
+                prefixesv4 := statePath.Neighbor(setup.ATEIPList[ap.ID()].String()).
+                        AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Prefixes()
+                gotSent := gnmi.Get(t, dut, prefixesv4.Sent().State())
+                switch {
+                case gotSent == setup.RouteCount:
+                        t.Logf("Prefixes sent from ingress port are learnt at ATE dst port : %v are %v", setup.ATEIPList[ap.ID()].String(), setup.RouteCount)
+                        break prefixLoop
+                case repeat > 0 && gotSent < setup.RouteCount:
+                        t.Logf("All the prefixes are not learnt , wait for 5 secs before retry.. got %v, want %v", gotSent, setup.RouteCount)
+                        time.Sleep(time.Second * 5)
+                case repeat == 0 && gotSent < setup.RouteCount:
+                        t.Errorf("sent prefixes from DUT to neighbor %v is mismatch: got %v, want %v", setup.ATEIPList[ap.ID()].String(), gotSent, setup.RouteCount)
+                }
+        }
 }
 
 // verifyBGPAsPath is to Validate AS Path attribute using bgp rib telemetry on ATE.
 func verifyBGPAsPath(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
+        // Start the timer.
+        start := time.Now()
+        if deviations.RoutePolicyUnderAFIUnsupported(dut) {
+                dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
+                        Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
+                        PeerGroup(setup.PeerGrpName).ApplyPolicy().ExportPolicy()
 
-	// Start the timer.
-	start := time.Now()
-	if deviations.RoutePolicyUnderAFIUnsupported(dut) {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
-			Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
-			PeerGroup(setup.PeerGrpName).ApplyPolicy().ExportPolicy()
-
-		gnmi.Replace(t, dut, dutPolicyConfPath.Config(), []string{setASpathPrependPolicy})
-	} else {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
-			Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
-			PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ExportPolicy()
-		gnmi.Replace(t, dut, dutPolicyConfPath.Config(), []string{setASpathPrependPolicy})
-	}
-	t.Run("BGP-AS-PATH Verification", func(t *testing.T) {
-		for _, ap := range ate.Ports() {
-			if ap.ID() == "port1" {
-				// port1 is ingress, skip verification on ingress port.
-				continue
-			}
-
-			// Validate if all prefixes are received by ATE.
-			isConverged(t, dut, ate, ap)
-
-			prefixPath := gnmi.OTG().BgpPeer(ap.ID() + ".BGP4.peer").UnicastIpv4PrefixAny()
-
-			gnmi.WatchAll(t, ate.OTG(), prefixPath.Address().State(), time.Minute, func(v *ygnmi.Value[string]) bool {
-				_, present := v.Val()
-				return present
-			}).Await(t)
-
-			singlepath := []uint32{setup.DUTAs, setup.DUTAs, setup.DUTAs, setup.DUTAs, setup.ATEAs2}
-			_, ok := gnmi.WatchAll(t, ate.OTG(), prefixPath.AsPathAny().State(), 5*time.Minute, func(v *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv4Prefix_AsPath]) bool {
-				val, present := v.Val()
-				return present && cmp.Diff(val.AsNumbers, singlepath) == ""
-			}).Await(t)
-			if !ok {
-				t.Errorf("Obtained AS path on ATE is not as expected")
-			}
-		}
-	})
-
-	// End the timer and calculate time.
-	elapsed := time.Since(start)
-	t.Logf("Duration taken to apply as path prepend policy is  %v", elapsed)
+                gnmi.Replace(t, dut, dutPolicyConfPath.Config(), []string{setASpathPrependPolicy})
+        } else {
+                dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
+                        Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
+                        PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ExportPolicy()
+                gnmi.Replace(t, dut, dutPolicyConfPath.Config(), []string{setASpathPrependPolicy})
+        }
+        t.Run("BGP-AS-PATH Verification", func(t *testing.T) {
+                for _, ap := range ate.Ports() {
+                        if ap.ID() == "port1" {
+                                // port1 is ingress, skip verification on ingress port.
+                                continue
+                        }
+                        // Validate if all prefixes are received by ATE.
+                        isConverged(t, dut, ate, ap)
+                        prefixPath := gnmi.OTG().BgpPeer(ap.ID() + ".BGP4.peer").UnicastIpv4PrefixAny()
+                        gnmi.WatchAll(t, ate.OTG(), prefixPath.Address().State(), time.Minute, func(v *ygnmi.Value[string]) bool {
+                                _, present := v.Val()
+                                return present
+                        }).Await(t)
+                        singlepath := []uint32{setup.DUTAs, setup.DUTAs, setup.DUTAs, setup.DUTAs, setup.ATEAs2}
+                        _, ok := gnmi.WatchAll(t, ate.OTG(), prefixPath.AsPathAny().State(), 5*time.Minute, func(v *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv4Prefix_AsPath]) bool {
+                                val, present := v.Val()
+                                return present && cmp.Diff(val.AsNumbers, singlepath) == ""
+                        }).Await(t)
+                        if !ok {
+                                t.Errorf("Obtained AS path on ATE is not as expected")
+                        }
+                }
+        })
+        // End the timer and calculate time.
+        elapsed := time.Since(start)
+        t.Logf("Duration taken to apply as path prepend policy is  %v", elapsed)
 }
 
 // verifyBGPSetMED is to Validate MED attribute using bgp rib telemetry on ATE.
 func verifyBGPSetMED(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
-
-	// Start the timer.
-	start := time.Now()
-	if deviations.RoutePolicyUnderAFIUnsupported(dut) {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
-			Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
-			PeerGroup(setup.PeerGrpName).ApplyPolicy().ExportPolicy()
-		gnmi.Replace(t, dut, dutPolicyConfPath.Config(), []string{setMEDPolicy})
-	} else {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
-			Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
-			PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ExportPolicy()
-		gnmi.Replace(t, dut, dutPolicyConfPath.Config(), []string{setMEDPolicy})
-	}
-
-	t.Run("BGP-MED-Verification", func(t *testing.T) {
-
-		for _, ap := range ate.Ports() {
-			if ap.ID() == "port1" {
-				continue
-			}
-
-			// Validate if all prefixes are received by ATE.
-			isConverged(t, dut, ate, ap)
-
-			bgpPrefixes := gnmi.GetAll(t, ate.OTG(), gnmi.OTG().BgpPeer(ap.ID()+".BGP4.peer").UnicastIpv4PrefixAny().State())
-			for _, prefix := range bgpPrefixes {
-				if prefix.GetMultiExitDiscriminator() != bgpMED {
-					t.Errorf("Received Prefix Med %d Expected Med %d for Prefix %v", prefix.GetMultiExitDiscriminator(), bgpMED, prefix.GetAddress())
-				}
-			}
-
-		}
-	})
-	// End the timer and calculate time taken to apply setMED.
-	elapsed := time.Since(start)
-	t.Logf("Duration taken to apply setMed routing policy is  %v", elapsed)
+        // Start the timer.
+        start := time.Now()
+        if deviations.RoutePolicyUnderAFIUnsupported(dut) {
+                dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
+                        Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
+                        PeerGroup(setup.PeerGrpName).ApplyPolicy().ExportPolicy()
+                gnmi.Replace(t, dut, dutPolicyConfPath.Config(), []string{setMEDPolicy})
+        } else {
+                dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
+                        Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
+                        PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ExportPolicy()
+                gnmi.Replace(t, dut, dutPolicyConfPath.Config(), []string{setMEDPolicy})
+        }
+        t.Run("BGP-MED-Verification", func(t *testing.T) {
+                for _, ap := range ate.Ports() {
+                        if ap.ID() == "port1" {
+                                continue
+                        }
+                        // Validate if all prefixes are received by ATE.
+                        isConverged(t, dut, ate, ap)
+                        bgpPrefixes := gnmi.GetAll(t, ate.OTG(), gnmi.OTG().BgpPeer(ap.ID()+".BGP4.peer").UnicastIpv4PrefixAny().State())
+                        for _, prefix := range bgpPrefixes {
+                                if prefix.GetMultiExitDiscriminator() != bgpMED {
+                                        t.Errorf("Received Prefix Med %d Expected Med %d for Prefix %v", prefix.GetMultiExitDiscriminator(), bgpMED, prefix.GetAddress())
+                                }
+                        }
+                }
+        })
+        // End the timer and calculate time taken to apply setMED.
+        elapsed := time.Since(start)
+        t.Logf("Duration taken to apply setMed routing policy is  %v", elapsed)
 }
 
 // TestEstablish is to configure Interface, BGP and ISIS configurations on DUT
 // using gnmi set request. It also verifies for bgp and isis adjacencies.
 func TestEstablish(t *testing.T) {
-
-	dut := ondatra.DUT(t, "dut")
-	dutConfigPath := gnmi.OC()
-
-	t.Log("Configure Network Instance type to DEFAULT on DUT.")
-	fptest.ConfigureDefaultNetworkInstance(t, dut)
-
-	t.Log("Build Benchmarking BGP and ISIS test configs.")
-	dutBenchmarkConfig := setup.BuildBenchmarkingConfig(t)
-	if !deviations.ExplicitInterfaceInDefaultVRF(dut) {
-		fptest.LogQuery(t, "Benchmarking configs to configure on DUT", dutConfigPath.Config(), dutBenchmarkConfig)
-	}
-	// Apply benchmarking configs on dut
-	gnmi.Update(t, dut, dutConfigPath.Config(), dutBenchmarkConfig)
-
-	t.Log("Configure ATE with Interfaces, BGP, ISIS configs.")
-	ate := ondatra.ATE(t, "ate")
-	setup.ConfigureOTG(t, ate)
-
-	t.Log("Verify BGP Session state , should be in ESTABLISHED State.")
-	setup.VerifyBgpTelemetry(t, dut)
-
-	t.Log("Verify ISIS adjacency state, should be UP.")
-	setup.VerifyISISTelemetry(t, dut)
+        dut := ondatra.DUT(t, "dut")
+        dutConfigPath := gnmi.OC()
+        t.Log("Configure Network Instance type to DEFAULT on DUT.")
+        fptest.ConfigureDefaultNetworkInstance(t, dut)
+        t.Log("Build Benchmarking BGP and ISIS test configs.")
+        dutBenchmarkConfig := setup.BuildBenchmarkingConfig(t)
+        if !deviations.ExplicitInterfaceInDefaultVRF(dut) {
+                fptest.LogQuery(t, "Benchmarking configs to configure on DUT", dutConfigPath.Config(), dutBenchmarkConfig)
+        }
+        // Apply benchmarking configs on dut
+        gnmi.Update(t, dut, dutConfigPath.Config(), dutBenchmarkConfig)
+        t.Log("Configure ATE with Interfaces, BGP, ISIS configs.")
+        ate := ondatra.ATE(t, "ate")
+        setup.ConfigureOTG(t, ate)
+        t.Log("Verify BGP Session state , should be in ESTABLISHED State.")
+        setup.VerifyBgpTelemetry(t, dut)
+        t.Log("Verify ISIS adjacency state, should be UP.")
+        setup.VerifyISISTelemetry(t, dut)
 }
 
 // TestBGPBenchmarking is test time taken to apply set as path prepend and set med routing
 // policies on routes in bgp rib. Verification of routing policy is done on ATE using bgp
 // rib table.
 func TestBGPBenchmarking(t *testing.T) {
+        d := &oc.Root{}
+        dut := ondatra.DUT(t, "dut")
+        ate := ondatra.ATE(t, "ate")
+        // Cleanup existing policy details.
+        if deviations.RoutePolicyUnderAFIUnsupported(dut) {
+                dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).ApplyPolicy()
+                gnmi.Delete(t, dut, dutPolicyConfPath.ExportPolicy().Config())
+                gnmi.Delete(t, dut, dutPolicyConfPath.ImportPolicy().Config())
+        } else {
+                dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
+                gnmi.Delete(t, dut, dutPolicyConfPath.ExportPolicy().Config())
+                gnmi.Delete(t, dut, dutPolicyConfPath.ImportPolicy().Config())
+        }
+        gnmi.Delete(t, dut, gnmi.OC().RoutingPolicy().Config())
 
-	d := &oc.Root{}
-	dut := ondatra.DUT(t, "dut")
-	ate := ondatra.ATE(t, "ate")
-	// Cleanup existing policy details.
-	if deviations.RoutePolicyUnderAFIUnsupported(dut) {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).ApplyPolicy()
-		gnmi.Delete(t, dut, dutPolicyConfPath.ExportPolicy().Config())
-		gnmi.Delete(t, dut, dutPolicyConfPath.ImportPolicy().Config())
-	} else {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
-		gnmi.Delete(t, dut, dutPolicyConfPath.ExportPolicy().Config())
-		gnmi.Delete(t, dut, dutPolicyConfPath.ImportPolicy().Config())
-	}
-	gnmi.Delete(t, dut, gnmi.OC().RoutingPolicy().Config())
+        if deviations.SameAfiSafiAndPeergroupPoliciesUnsupported(dut) {
+                t.Logf("Configure Allow policies.")
+                setAllowPeerGroup(t, dut, d)
+                setAllowAfiSafi(t, dut, d)
+        } else {
+                t.Logf("Configure Allow policy.")
+                setAllow(t, dut, d)
+        }
 
-	t.Logf("Configure Allow policy.")
-	setAllow(t, dut, d)
+        t.Logf("Configure MED routing policy.")
+        setMED(t, dut, d)
 
-	t.Logf("Configure MED routing policy.")
-	setMED(t, dut, d)
+        if deviations.SameAfiSafiAndPeergroupPoliciesUnsupported(dut) {
+                t.Logf("Configure Allow Import routing policy in BGP AFI-SAFI.")
+                setPolicyAfiSafi(t, dut, d, []string{setALLOWAFISAFIPolicy})
+        } else {
+                t.Logf("Configure Allow Import routing policy in BGP.")
+                setPolicyPeerGroup(t, dut, d, []string{setALLOWPolicy})
+        }
 
-	t.Logf("Configure Allow Import routing policy in BGP.")
-	setPolicyPeerGroup(t, dut, d, []string{setALLOWPolicy})
+        t.Logf("Verify time taken to apply MED to all routes in bgp rib.")
+        verifyBGPSetMED(t, dut, ate)
 
-	t.Logf("Verify time taken to apply MED to all routes in bgp rib.")
-	verifyBGPSetMED(t, dut, ate)
+        // Cleanup existing policy details.
+        if deviations.RoutePolicyUnderAFIUnsupported(dut) {
+                dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).ApplyPolicy()
+                gnmi.Delete(t, dut, dutPolicyConfPath.ExportPolicy().Config())
+                gnmi.Delete(t, dut, dutPolicyConfPath.ImportPolicy().Config())
+        } else {
+                dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
+                gnmi.Delete(t, dut, dutPolicyConfPath.ExportPolicy().Config())
+                gnmi.Delete(t, dut, dutPolicyConfPath.ImportPolicy().Config())
+        }
+        gnmi.Delete(t, dut, gnmi.OC().RoutingPolicy().Config())
 
-	// Cleanup existing policy details.
-	if deviations.RoutePolicyUnderAFIUnsupported(dut) {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).ApplyPolicy()
-		gnmi.Delete(t, dut, dutPolicyConfPath.ExportPolicy().Config())
-		gnmi.Delete(t, dut, dutPolicyConfPath.ImportPolicy().Config())
-	} else {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
-		gnmi.Delete(t, dut, dutPolicyConfPath.ExportPolicy().Config())
-		gnmi.Delete(t, dut, dutPolicyConfPath.ImportPolicy().Config())
-	}
-	gnmi.Delete(t, dut, gnmi.OC().RoutingPolicy().Config())
+        if deviations.SameAfiSafiAndPeergroupPoliciesUnsupported(dut) {
+                t.Logf("Configure SET-AS-PATH routing policy and peer-group policy.")
+        } else {
+                t.Logf("Configure SET-AS-PATH routing policy.")
+        }
+        setASPath(t, dut, d)
 
-	t.Logf("Configure SET-AS-PATH routing policy.")
-	setASPath(t, dut, d)
+        if deviations.SameAfiSafiAndPeergroupPoliciesUnsupported(dut) {
+                t.Logf("Configure Allow Import routing policy in BGP AFI-SAFI.")
+                setPolicyAfiSafi(t, dut, d, []string{setALLOWAFISAFIPolicy})
+        } else {
+                t.Logf("Configure Allow Import routing policy in BGP.")
+                setPolicyPeerGroup(t, dut, d, []string{setALLOWPolicy})
+        }
 
-	t.Logf("Configure Allow Import routing policy in BGP.")
-	setPolicyPeerGroup(t, dut, d, []string{setALLOWPolicy})
-
-	t.Logf("Verify time taken to apply SET-AS-PATH to all routes in bgp rib.")
-	verifyBGPAsPath(t, dut, ate)
+        t.Logf("Verify time taken to apply SET-AS-PATH to all routes in bgp rib.")
+        verifyBGPAsPath(t, dut, ate)
 }

--- a/feature/gnmi/otg_tests/drained_configuration_convergence_time/metadata.textproto
+++ b/feature/gnmi/otg_tests/drained_configuration_convergence_time/metadata.textproto
@@ -36,7 +36,7 @@ platform_exceptions: {
     missing_isis_interface_afi_safi_enable: true
     isis_interface_afi_unsupported: true
     isis_require_same_l1_metric_with_l2_metric: true
-    bgp_set_med_requires_equal_ospf_set_metric: true
+    same_afi_safi_and_peergroup_policies_unsupported: true
     isis_instance_enabled_required: true      
   }
 }

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1675,3 +1675,8 @@ func TelemetryNotSupportedForLowPriorityNh(dut *ondatra.DUTDevice) bool {
 func MatchAsPathSetUnsupported(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetMatchAsPathSetUnsupported()
 }
+
+// Same apply-policy under peer-group and peer-group/afi-safi
+func SameAfiSafiAndPeergroupPoliciesUnsupported(dut *ondatra.DUTDevice) bool {
+	return lookupDUTDeviations(dut).GetSameAfiSafiAndPeergroupPoliciesUnsupported()
+}

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -969,6 +969,10 @@ message Metadata {
     // Arista b/434583178
     bool match_as_path_set_unsupported = 333;
 
+    // Same apply-policy under peer-group and peer-group/afi-safi unsupported
+    // Arista b/413225712
+    bool same_afi_safi_and_peergroup_policies_unsupported = 334;
+    
     // Reserved field numbers and identifiers.
     reserved 84, 9, 28, 20, 38, 43, 90, 97, 55, 89, 19, 36, 35, 40, 113, 131, 141, 173, 234, 254, 231, 300;
   }


### PR DESCRIPTION
Add deviation for applying two different policies when applying the same import-polict for both the peer-group and that peer-group's afi-safi is unsupported. 