### PR TITLE
Update testbed for ipv4_guev1_decap_and_hashing_test

### DIFF
--- a/feature/policy_forwarding/decapsulation/otg_tests/ipv4_guev1_decap_and_hashing_test/metadata.textproto
+++ b/feature/policy_forwarding/decapsulation/otg_tests/ipv4_guev1_decap_and_hashing_test/metadata.textproto
@@ -4,7 +4,7 @@
 uuid:  "55c4eb1d-a363-44b9-94df-a9e73c9e1234"
 plan_id:  "PF-1.22"
 description:  "GUEv1 Decapsulation and ECMP test for IPv4 and IPv6 payload"
-testbed:  TESTBED_DUT_ATE_2LINKS
+testbed:  TESTBED_DUT_ATE_8LINKS
 platform_exceptions: {
   platform: {
     vendor: ARISTA


### PR DESCRIPTION
Update testbed for `ipv4_guev1_decap_and_hashing_test` as the test requires more than 4 ports.