### PR TITLE
Remove GUE decap test entries as dups of PF-1.19

### DIFF
--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -1711,30 +1711,7 @@ test: {
   readme: ""
   exec: " "
 }
-test: {
-  id: "TUN-2.11"
-  description: "Filter based GUE decap with IPv4 tunnel endpoints"
-  readme: ""
-  exec: " "
-}
-test: {
-  id: "TUN-2.12"
-  description: "Filter based GUE decap with IPv6 tunnel endpoints"
-  readme: ""
-  exec: " "
-}
-test: {
-  id: "TUN-2.13"
-  description: "Interface based GUE decap with IPv4 tunnel endpoints"
-  readme: ""
-  exec: " "
-}
-test: {
-  id: "TUN-2.14"
-  description: "Interface based GUE decap with IPv6 tunnel endpoints"
-  readme: ""
-  exec: " "
-}
+
 test: {
   id: "TUN-2.15"
   description: "Interface based GUE encapsulation with IPv4 outer header"


### PR DESCRIPTION
Remove TUN-2.11,12 as these tests are not implemented and based on their text descriptions in testregistry.textproto, they fully overlap with PF-1.19.

Remove TUN-2.13,14 as based on their text descriptions in testregistry.textproto, these tests were scoped to configure interface based GUE decap. But this is invalid as there is no feature to do policy forwarding decapsulation applied to an interface. There is only global decap policy.