### PR TITLE
AFT-1.1 AFTS Base: Using 1.7 M scale for all vendors

### DIFF
--- a/feature/afts/otg_tests/afts_base/afts_base_test.go
+++ b/feature/afts/otg_tests/afts_base/afts_base_test.go
@@ -69,8 +69,8 @@ const (
 	aftConvergenceTime        = 20 * time.Minute
 	bgpTimeout                = 2 * time.Minute
 	linkLocalAddress          = "fe80::200:2ff:fe02:202"
-	bgpRouteCountIPv4LowScale = 100000
-	bgpRouteCountIPv6LowScale = 100000
+	bgpRouteCountIPv4LowScale = 1200000
+	bgpRouteCountIPv6LowScale = 512000
 	bgpRouteCountIPv4Default  = 2000000
 	bgpRouteCountIPv6Default  = 1000000
 )

--- a/feature/afts/otg_tests/afts_base/metadata.textproto
+++ b/feature/afts/otg_tests/afts_base/metadata.textproto
@@ -12,6 +12,7 @@ platform_exceptions: {
     isis_single_topology_required: true
     skip_interface_name_check: true
     link_local_instead_of_nh: true
+    low_scale_aft: true
   }
 }
 platform_exceptions: {
@@ -24,6 +25,7 @@ platform_exceptions: {
     isis_interface_afi_unsupported: true
     interface_enabled: true
     bgp_missing_oc_max_prefixes_configuration: true
+    low_scale_aft: true
   }
 }
 platform_exceptions: {
@@ -33,5 +35,6 @@ platform_exceptions: {
   deviations: {
     isis_level_enabled: true
     multipath_unsupported_neighbor_or_afisafi: true
+    low_scale_aft: true
   }
 }


### PR DESCRIPTION
Reducing the scale to 1.2 M for IPV4 and 512K for IPV6 For all 3 vendors (Cisco, Arista, Juniper)
This is done as this is the highest supported scale currently. 