### PR TITLE
Fix error in AssertNextHopCount logic.

### DIFF
--- a/internal/telemetry/aftcache/aft_cache.go
+++ b/internal/telemetry/aftcache/aft_cache.go
@@ -425,9 +425,10 @@ type aftSubscriptionResponse struct {
 
 // aftSubscribe subscribes to a gNMI client and creates a channel to read from the subscription
 // stream asynchronously.
-// TODO: This is somewhat bad practice. I was surprised that this function spawned a goroutine.
+// TODO: Split out the watching logic into a blocking function.
+// This is somewhat bad practice. I was surprised that this function spawned a goroutine.
 // Functions should not return if they spawn goroutines. (Assume the caller will cancel the context
-// on return.) Split out the watching logic into a blocking function.
+// on return.)
 func aftSubscribe(ctx context.Context, t *testing.T, c gnmipb.GNMIClient, dut *ondatra.DUTDevice) <-chan *aftSubscriptionResponse {
 	sub, err := c.Subscribe(ctx)
 	if err != nil {
@@ -798,6 +799,7 @@ func AssertNextHopCount(t *testing.T, dut *ondatra.DUTDevice, wantPrefixes map[s
 
 // VerifyAtomicFlagHook returns a NotificationHook which verifies that the atomic flag is set to true.
 func VerifyAtomicFlagHook(t *testing.T) NotificationHook {
+	t.Helper()
 	return NotificationHook{
 		Description: "Atomic update hook",
 		NotificationFunc: func(c *aftCache, n *gnmipb.SubscribeResponse) error {


### PR DESCRIPTION
Verified in https://github.com/openconfig/featureprofiles/pull/4703#issuecomment-3446861126.

If the next hop count is not (yet) equal to the
asserted quantity, we should just wait and not
error.

Also add TODO to change how goroutines are spaened for the AFT Cache.

===

This pull request introduces improvements to logging and code practices in the `internal/telemetry/aftcache/aft_cache.go` file, primarily focused on making test output more informative and clarifying function behavior. The most significant changes are enhancements to logging for debugging and verification, and a code quality note regarding goroutine usage.

**Logging improvements:**

* Added detailed logging for stale notifications, including timestamps, to aid in debugging cache updates.
* Improved logging in `AssertNextHopCount` by reporting the number of verified prefixes and the duration of next hop checks using deferred log statements.
* Changed the behavior when the next hop count is incorrect: now logs the mismatch instead of returning an error, making test output clearer and less disruptive.

**Code quality and documentation:**

* Added a TODO comment to `aftSubscribe` highlighting that spawning goroutines within a function that returns immediately is bad practice, and suggesting refactoring into a blocking function for better clarity and control.