### PR TITLE
Add ATE advertised routes helper function.

### DIFF
--- a/internal/otg_helpers/otg_config_helpers/otgrouteadvertise.go
+++ b/internal/otg_helpers/otg_config_helpers/otgrouteadvertise.go
@@ -143,9 +143,9 @@ func (ar *ATEAdvertiseRoutes) missingRoutesDefault() {
 }
 
 // ConfigureATEWithISISAndBGPRoutes builds an OTG config with Ethernet, IPv4/IPv6,
-// ISIS, and advertised BGP routes for the provided ports and pushes/starts it.
+// ISIS, and advertised BGP routes for the provided ports and returns it.
 // - ISIS routes are advertised only from the first port in ports slice to produce a single next-hop.
-func ConfigureATEWithISISAndBGPRoutes(t *testing.T, ateRoutes *ATEAdvertiseRoutes) {
+func ConfigureATEWithISISAndBGPRoutes(t *testing.T, ateRoutes *ATEAdvertiseRoutes) gosnappi.Config {
 	t.Helper()
 	config := gosnappi.NewConfig()
 
@@ -214,7 +214,5 @@ func ConfigureATEWithISISAndBGPRoutes(t *testing.T, ateRoutes *ATEAdvertiseRoute
 		AdvertiseBGPRoutes(dev, ipv4, ipv6, ateRoutes.BGPV4Routes, ateRoutes.BGPV6Routes)
 	}
 
-	otg := ate.OTG()
-	otg.PushConfig(t, config)
-	otg.StartProtocols(t)
+	return config
 }


### PR DESCRIPTION
Verified in https://github.com/openconfig/featureprofiles/pull/4703#issuecomment-3446861126.

To be used in https://github.com/openconfig/featureprofiles/pull/4703 and other AFT tests.

===

This pull request introduces a new utility package, `internal/cfgplugins/ate.go`, to centralize and simplify the configuration of ATE (Automated Test Equipment) devices for network protocol testing. The new code provides reusable functions and types for advertising ISIS and BGP routes, handling default values, and building complete OTG (Open Traffic Generator) configurations for test setups. This abstraction streamlines test code and improves maintainability.

**ATE configuration utilities:**

* Added the `AdvertisedRoutes` and `ATEAdvertiseRoutes` types to encapsulate route advertisement parameters for ISIS and BGP protocols, including default values and device/port attributes.
* Implemented the `AdvertiseBGPRoutes` and `AdvertiseISISRoutes` functions to programmatically configure BGP and ISIS route advertisements on ATE devices, supporting both IPv4 and IPv6.

**Default handling and configuration orchestration:**

* Added logic to automatically set default values for advertised routes when not provided, ensuring robust and predictable test setups.
* Introduced the `ConfigureATEWithISISAndBGPRoutes` function to build and push a complete OTG configuration, including Ethernet, IP, ISIS, and BGP protocols, with proper route advertisement and protocol startup.