### PR TITLE
Rt 1.5 Address flakiness in code

### DIFF
--- a/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
+++ b/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
@@ -662,6 +662,8 @@ func TestTrafficBGPPrefixLimit(t *testing.T) {
 	conf := configureATE(t, ate)
 
 	ate.OTG().StartProtocols(t)
+	otgutils.WaitForARP(t, ate.OTG(), conf, "IPv4")
+	otgutils.WaitForARP(t, ate.OTG(), conf, "IPv6")
 
 	withdrawBGPRoutes(t, conf, []string{r4UnderLimit,
 		r6UnderLimit,


### PR DESCRIPTION
Add WaitforARP function after otg push config to avoid flakiness in test result. 