### PR TITLE
TRANSCEIVER-7.2 & 9.2 fix

### DIFF
--- a/feature/platform/transceiver/tests/zrp_inventory_test/metadata.textproto
+++ b/feature/platform/transceiver/tests/zrp_inventory_test/metadata.textproto
@@ -22,3 +22,13 @@ platform_exceptions: {
     component_mfg_date_unsupported: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+  }
+  deviations: {
+    interface_enabled: true
+    explicit_dco_config: true
+    transceiver_config_enable_unsupported: true
+  }
+}

--- a/feature/platform/transceiver/tests/zrp_inventory_test/zrp_inventory_test.go
+++ b/feature/platform/transceiver/tests/zrp_inventory_test/zrp_inventory_test.go
@@ -67,14 +67,14 @@ func verifyAllInventoryValues(t *testing.T, pStreamsStr []*samplestream.SampleSt
 }
 
 func TestInventoryInterfaceFlap(t *testing.T) {
-	if operationalModeFlag != nil {
-		operationalMode = uint16(*operationalModeFlag)
-	} else {
-		t.Fatalf("Please specify the vendor-specific operational-mode flag")
-	}
 	dut := ondatra.DUT(t, "dut")
 	dp1 := dut.Port(t, "port1")
 	dp2 := dut.Port(t, "port2")
+	fptest.ConfigureDefaultNetworkInstance(t, dut)
+	operationalMode = uint16(*operationalModeFlag)
+	cfgplugins.InterfaceInitialize(t, dut, operationalMode)
+	cfgplugins.InterfaceConfig(t, dut, dp1)
+	cfgplugins.InterfaceConfig(t, dut, dp2)
 	tr1 := gnmi.Get(t, dut, gnmi.OC().Interface(dp1.Name()).Transceiver().State())
 	// tr2 := gnmi.Get(t, dut, gnmi.OC().Interface(dp2.Name()).Transceiver().State())
 	och1 := components.OpticalChannelComponentFromPort(t, dut, dp1)
@@ -137,75 +137,78 @@ func TestInventoryInterfaceFlap(t *testing.T) {
 }
 
 func TestInventoryTransceiverOnOff(t *testing.T) {
-	if operationalModeFlag != nil {
-		operationalMode = uint16(*operationalModeFlag)
-	} else {
-		t.Fatalf("Please specify the vendor-specific operational-mode flag")
-	}
 	dut := ondatra.DUT(t, "dut")
-	dp1 := dut.Port(t, "port1")
-	dp2 := dut.Port(t, "port2")
-	tr1 := gnmi.Get(t, dut, gnmi.OC().Interface(dp1.Name()).Transceiver().State())
-	tr2 := gnmi.Get(t, dut, gnmi.OC().Interface(dp2.Name()).Transceiver().State())
-	och1 := components.OpticalChannelComponentFromPort(t, dut, dp1)
-	och2 := components.OpticalChannelComponentFromPort(t, dut, dp2)
-	fptest.ConfigureDefaultNetworkInstance(t, dut)
-	cfgplugins.ConfigOpticalChannel(t, dut, och1, frequency, targetOutputPower, operationalMode)
-	cfgplugins.ConfigOpticalChannel(t, dut, och2, frequency, targetOutputPower, operationalMode)
+	if !deviations.TransceiverConfigEnableUnsupported(dut) {
+		dp1 := dut.Port(t, "port1")
+		dp2 := dut.Port(t, "port2")
+		fptest.ConfigureDefaultNetworkInstance(t, dut)
+		operationalMode = uint16(*operationalModeFlag)
+		cfgplugins.InterfaceInitialize(t, dut, operationalMode)
+		cfgplugins.InterfaceConfig(t, dut, dp1)
+		cfgplugins.InterfaceConfig(t, dut, dp2)
+		tr1 := gnmi.Get(t, dut, gnmi.OC().Interface(dp1.Name()).Transceiver().State())
+		//tr2 := gnmi.Get(t, dut, gnmi.OC().Interface(dp2.Name()).Transceiver().State())
+		och1 := components.OpticalChannelComponentFromPort(t, dut, dp1)
+		och2 := components.OpticalChannelComponentFromPort(t, dut, dp2)
+		cfgplugins.ConfigOpticalChannel(t, dut, och1, frequency, targetOutputPower, operationalMode)
+		cfgplugins.ConfigOpticalChannel(t, dut, och2, frequency, targetOutputPower, operationalMode)
 
-	// Uncomment once the Ondatra OC release version is fixed.
-	// if (dp1.PMD() != ondatra.PMD400GBASEZRP) || (dp2.PMD() != ondatra.PMD400GBASEZRP) {
-	// 	t.Fatalf("Transceivers types (%v, %v): (%v, %v) are not 400ZR_PLUS, expected %v", tr1, tr2, dp1.PMD(), dp2.PMD(), ondatra.PMD400GBASEZRP)
-	// }
-	component1 := gnmi.OC().Component(tr1)
+		// Uncomment once the Ondatra OC release version is fixed.
+		// if (dp1.PMD() != ondatra.PMD400GBASEZRP) || (dp2.PMD() != ondatra.PMD400GBASEZRP) {
+		// 	t.Fatalf("Transceivers types (%v, %v): (%v, %v) are not 400ZR_PLUS, expected %v", tr1, tr2, dp1.PMD(), dp2.PMD(), ondatra.PMD400GBASEZRP)
+		// }
+		component1 := gnmi.OC().Component(tr1)
 
-	// Wait for channels to be up.
-	gnmi.Await(t, dut, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), timeout, oc.Interface_OperStatus_UP)
-	gnmi.Await(t, dut, gnmi.OC().Interface(dp2.Name()).OperStatus().State(), timeout, oc.Interface_OperStatus_UP)
+		// Wait for channels to be up.
+		gnmi.Await(t, dut, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), timeout, oc.Interface_OperStatus_UP)
+		gnmi.Await(t, dut, gnmi.OC().Interface(dp2.Name()).OperStatus().State(), timeout, oc.Interface_OperStatus_UP)
 
-	var p1StreamsStr []*samplestream.SampleStream[string]
-	var p1StreamsUnion []*samplestream.SampleStream[oc.Component_Type_Union]
+		var p1StreamsStr []*samplestream.SampleStream[string]
+		var p1StreamsUnion []*samplestream.SampleStream[oc.Component_Type_Union]
 
-	// TODO: b/333021032 - Uncomment the description check from the test once the bug is fixed.
-	p1StreamsStr = append(p1StreamsStr,
-		samplestream.New(t, dut, component1.SerialNo().State(), samplingInterval),
-		samplestream.New(t, dut, component1.PartNo().State(), samplingInterval),
-		samplestream.New(t, dut, component1.MfgName().State(), samplingInterval),
-		samplestream.New(t, dut, component1.HardwareVersion().State(), samplingInterval),
-		samplestream.New(t, dut, component1.FirmwareVersion().State(), samplingInterval),
-		// samplestream.New(t, dut, component1.Description().State(), samplingInterval),
-	)
-	if !deviations.ComponentMfgDateUnsupported(dut) {
-		p1StreamsStr = append(p1StreamsStr, samplestream.New(t, dut, component1.MfgDate().State(), samplingInterval))
+		// TODO: b/333021032 - Uncomment the description check from the test once the bug is fixed.
+		p1StreamsStr = append(p1StreamsStr,
+			samplestream.New(t, dut, component1.SerialNo().State(), samplingInterval),
+			samplestream.New(t, dut, component1.PartNo().State(), samplingInterval),
+			samplestream.New(t, dut, component1.MfgName().State(), samplingInterval),
+			samplestream.New(t, dut, component1.HardwareVersion().State(), samplingInterval),
+			samplestream.New(t, dut, component1.FirmwareVersion().State(), samplingInterval),
+			// samplestream.New(t, dut, component1.Description().State(), samplingInterval),
+		)
+		if !deviations.ComponentMfgDateUnsupported(dut) {
+			p1StreamsStr = append(p1StreamsStr, samplestream.New(t, dut, component1.MfgDate().State(), samplingInterval))
+		}
+		p1StreamsUnion = append(p1StreamsUnion, samplestream.New(t, dut, component1.Type().State(), samplingInterval))
+
+		verifyAllInventoryValues(t, p1StreamsStr, p1StreamsUnion)
+
+		//  power off interface transceiver.
+		for _, p := range dut.Ports() {
+			// for transceiver disable, the input needs to be the transceiver name instead of the interface name
+			tr := gnmi.Get(t, dut, gnmi.OC().Interface(p.Name()).Transceiver().State())
+			gnmi.Update(t, dut, gnmi.OC().Component(p.Name()).Name().Config(), p.Name())
+			setConfigLeaf := gnmi.OC().Component(tr)
+			gnmi.Update(t, dut, setConfigLeaf.Config(), &oc.Component{
+				Name: ygot.String(tr),
+			})
+			gnmi.Update(t, dut, gnmi.OC().Component(tr).Transceiver().Enabled().Config(), false)
+		}
+		t.Logf("Interfaces are down: %v, %v", dp1.Name(), dp2.Name())
+		verifyAllInventoryValues(t, p1StreamsStr, p1StreamsUnion)
+
+		time.Sleep(3 * waitInterval)
+		//  power on interface transceiver.
+		gnmi.Update(t, dut, gnmi.OC().Component(dp1.Name()).Name().Config(), dp1.Name())
+		gnmi.Update(t, dut, gnmi.OC().Component(tr1).Transceiver().Enabled().Config(), true)
+		gnmi.Update(t, dut, gnmi.OC().Component(dp2.Name()).Name().Config(), dp2.Name())
+		//gnmi.Update(t, dut, gnmi.OC().Component(tr2).Transceiver().Enabled().Config(), true)
+		// Wait for channels to be up.
+		gnmi.Await(t, dut, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), timeout, oc.Interface_OperStatus_UP)
+		gnmi.Await(t, dut, gnmi.OC().Interface(dp2.Name()).OperStatus().State(), timeout, oc.Interface_OperStatus_UP)
+
+		t.Logf("Interfaces are up: %v, %v", dp1.Name(), dp2.Name())
+		verifyAllInventoryValues(t, p1StreamsStr, p1StreamsUnion)
+	} else {
+		t.Log("Skipping sub-test as transceiver Enable/Disable leaf not supported")
 	}
-	p1StreamsUnion = append(p1StreamsUnion, samplestream.New(t, dut, component1.Type().State(), samplingInterval))
-
-	verifyAllInventoryValues(t, p1StreamsStr, p1StreamsUnion)
-
-	//  power off interface transceiver.
-	for _, p := range dut.Ports() {
-		// for transceiver disable, the input needs to be the transceiver name instead of the interface name
-		tr := gnmi.Get(t, dut, gnmi.OC().Interface(p.Name()).Transceiver().State())
-		gnmi.Update(t, dut, gnmi.OC().Component(p.Name()).Name().Config(), p.Name())
-		setConfigLeaf := gnmi.OC().Component(tr)
-		gnmi.Update(t, dut, setConfigLeaf.Config(), &oc.Component{
-			Name: ygot.String(tr),
-		})
-		gnmi.Update(t, dut, gnmi.OC().Component(tr).Transceiver().Enabled().Config(), false)
-	}
-	t.Logf("Interfaces are down: %v, %v", dp1.Name(), dp2.Name())
-	verifyAllInventoryValues(t, p1StreamsStr, p1StreamsUnion)
-
-	time.Sleep(3 * waitInterval)
-	//  power on interface transceiver.
-	gnmi.Update(t, dut, gnmi.OC().Component(dp1.Name()).Name().Config(), dp1.Name())
-	gnmi.Update(t, dut, gnmi.OC().Component(tr1).Transceiver().Enabled().Config(), true)
-	gnmi.Update(t, dut, gnmi.OC().Component(dp2.Name()).Name().Config(), dp2.Name())
-	gnmi.Update(t, dut, gnmi.OC().Component(tr2).Transceiver().Enabled().Config(), true)
-	// Wait for channels to be up.
-	gnmi.Await(t, dut, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), timeout, oc.Interface_OperStatus_UP)
-	gnmi.Await(t, dut, gnmi.OC().Interface(dp2.Name()).OperStatus().State(), timeout, oc.Interface_OperStatus_UP)
-
-	t.Logf("Interfaces are up: %v, %v", dp1.Name(), dp2.Name())
-	verifyAllInventoryValues(t, p1StreamsStr, p1StreamsUnion)
 }

--- a/feature/platform/transceiver/tests/zrp_laser_bias_current_test/metadata.textproto
+++ b/feature/platform/transceiver/tests/zrp_laser_bias_current_test/metadata.textproto
@@ -16,3 +16,14 @@ platform_exceptions: {
     missing_zr_optical_channel_tunable_parameters_telemetry: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+  }
+  deviations: {
+    interface_enabled: true
+    explicit_dco_config: true
+    transceiver_config_enable_unsupported: true
+    missing_zr_optical_channel_tunable_parameters_telemetry: true
+  }
+}

--- a/feature/platform/transceiver/tests/zrp_laser_bias_current_test/zrp_laser_bias_current_test.go
+++ b/feature/platform/transceiver/tests/zrp_laser_bias_current_test/zrp_laser_bias_current_test.go
@@ -91,20 +91,15 @@ func verifyLaserBiasCurrentAll(t *testing.T, p1Stream *samplestream.SampleStream
 }
 
 func TestZRLaserBiasCurrentState(t *testing.T) {
-	if operationalModeFlag != nil {
-		operationalMode = uint16(*operationalModeFlag)
-	} else {
-		t.Fatalf("Please specify the vendor-specific operational-mode flag")
-	}
 	dut1 := ondatra.DUT(t, "dut")
 	dp1 := dut1.Port(t, "port1")
 	dp2 := dut1.Port(t, "port2")
 	t.Logf("dut1: %v", dut1)
 	t.Logf("dut1 dp1 name: %v", dp1.Name())
-	och1 := components.OpticalChannelComponentFromPort(t, dut1, dp1)
-	och2 := components.OpticalChannelComponentFromPort(t, dut1, dp2)
-	cfgplugins.ConfigOpticalChannel(t, dut1, och1, frequency, targetOutputPower, operationalMode)
-	cfgplugins.ConfigOpticalChannel(t, dut1, och2, frequency, targetOutputPower, operationalMode)
+	operationalMode = uint16(*operationalModeFlag)
+	operationalMode = cfgplugins.InterfaceInitialize(t, dut1, operationalMode)
+	cfgplugins.InterfaceConfig(t, dut1, dp1)
+	cfgplugins.InterfaceConfig(t, dut1, dp2)
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
 	// transceiverState := gnmi.Get(t, dut1, gnmi.OC().Interface(dp1.Name()).Transceiver().State())
 	// Uncomment once the Ondatra OC release version is fixed.
@@ -119,20 +114,16 @@ func TestZRLaserBiasCurrentState(t *testing.T) {
 }
 
 func TestZRLaserBiasCurrentStateInterfaceFlap(t *testing.T) {
-	if operationalModeFlag != nil {
-		operationalMode = uint16(*operationalModeFlag)
-	} else {
-		t.Fatalf("Please specify the vendor-specific operational-mode flag")
-	}
 	dut1 := ondatra.DUT(t, "dut")
 	dp1 := dut1.Port(t, "port1")
 	dp2 := dut1.Port(t, "port2")
 	t.Logf("dut1: %v", dut1)
 	t.Logf("dut1 dp1 name: %v", dp1.Name())
-	och1 := components.OpticalChannelComponentFromPort(t, dut1, dp1)
-	och2 := components.OpticalChannelComponentFromPort(t, dut1, dp2)
-	cfgplugins.ConfigOpticalChannel(t, dut1, och1, frequency, targetOutputPower, operationalMode)
-	cfgplugins.ConfigOpticalChannel(t, dut1, och2, frequency, targetOutputPower, operationalMode)
+	operationalMode = uint16(*operationalModeFlag)
+	operationalMode = cfgplugins.InterfaceInitialize(t, dut1, operationalMode)
+	cfgplugins.InterfaceConfig(t, dut1, dp1)
+	cfgplugins.InterfaceConfig(t, dut1, dp2)
+
 	// Check interface is up
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
 	// Check if TRANSCEIVER is of type 400ZR_PLUS
@@ -143,55 +134,59 @@ func TestZRLaserBiasCurrentStateInterfaceFlap(t *testing.T) {
 	// }
 	// Disable interface
 	cfgplugins.ToggleInterface(t, dut1, dp1.Name(), false)
+	t.Logf(" %v interface config disable initiated", dp1.Name())
 	componentName := components.OpticalChannelComponentFromPort(t, dut1, dp1)
 	component := gnmi.OC().Component(componentName)
 	p1Stream := samplestream.New(t, dut1, component.OpticalChannel().LaserBiasCurrent().State(), 10*time.Second)
 	defer p1Stream.Close()
+	t.Logf("%v operational status is: %v", dp1.Name(), gnmi.Get(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State()))
 	verifyLaserBiasCurrentAll(t, p1Stream, dut1)
 	// Wait 120 sec cooling-off period
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_DOWN)
+	t.Logf("%v operational status is: %v", dp1.Name(), gnmi.Get(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State()))
+	t.Log("Wait to update telemetry")
+	time.Sleep(80 * time.Second)
 	verifyLaserBiasCurrentAll(t, p1Stream, dut1)
 	// Enable interface
 	cfgplugins.ToggleInterface(t, dut1, dp1.Name(), true)
+	t.Logf("%v interface config enable initiated", dp1.Name())
 	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
+	t.Logf("%v operational status is: %v", dp1.Name(), gnmi.Get(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State()))
 	verifyLaserBiasCurrentAll(t, p1Stream, dut1)
 }
 
 func TestZRLaserBiasCurrentStateTransceiverOnOff(t *testing.T) {
-	if operationalModeFlag != nil {
-		operationalMode = uint16(*operationalModeFlag)
-	} else {
-		t.Fatalf("Please specify the vendor-specific operational-mode flag")
-	}
 	dut1 := ondatra.DUT(t, "dut")
-	dp1 := dut1.Port(t, "port1")
-	dp2 := dut1.Port(t, "port2")
-	t.Logf("dut1: %v", dut1)
-	t.Logf("dut1 dp1 name: %v", dp1.Name())
-	och1 := components.OpticalChannelComponentFromPort(t, dut1, dp1)
-	och2 := components.OpticalChannelComponentFromPort(t, dut1, dp2)
-	cfgplugins.ConfigOpticalChannel(t, dut1, och1, frequency, targetOutputPower, operationalMode)
-	cfgplugins.ConfigOpticalChannel(t, dut1, och2, frequency, targetOutputPower, operationalMode)
-	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
-	transceiverState := gnmi.Get(t, dut1, gnmi.OC().Interface(dp1.Name()).Transceiver().State())
-	// Check if TRANSCEIVER is of type 400ZR_PLUS
-	// Uncomment once the Ondatra OC release version is fixed.
-	// if dp1.PMD() != ondatra.PMD400GBASEZRP {
-	// 	t.Fatalf("%s Transceiver is not 400ZR_PLUS its of type: %v", transceiverState, dp1.PMD())
-	// }
-	componentName := components.OpticalChannelComponentFromPort(t, dut1, dp1)
-	component := gnmi.OC().Component(componentName)
-	p1Stream := samplestream.New(t, dut1, component.OpticalChannel().LaserBiasCurrent().State(), 10*time.Second)
-	defer p1Stream.Close()
-	verifyLaserBiasCurrentAll(t, p1Stream, dut1)
-	// power off interface transceiver
-	gnmi.Update(t, dut1, gnmi.OC().Component(transceiverState).Name().Config(), transceiverState)
-	// for transceiver disable, the input needs to be the transceiver name instead of the interface name
-	gnmi.Update(t, dut1, gnmi.OC().Component(transceiverState).Transceiver().Enabled().Config(), false)
-	// Cannot use Interface_OperStatus_DOWN here as the interface is "Not Present"
-	verifyLaserBiasCurrentAll(t, p1Stream, dut1)
-	// power on interface transceiver
-	gnmi.Update(t, dut1, gnmi.OC().Component(transceiverState).Transceiver().Enabled().Config(), true)
-	gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
-	verifyLaserBiasCurrentAll(t, p1Stream, dut1)
+	if !deviations.TransceiverConfigEnableUnsupported(dut1) {
+		dp1 := dut1.Port(t, "port1")
+		dp2 := dut1.Port(t, "port2")
+		t.Logf("dut1: %v", dut1)
+		t.Logf("dut1 dp1 name: %v", dp1.Name())
+		operationalMode = uint16(*operationalModeFlag)
+		operationalMode = cfgplugins.InterfaceInitialize(t, dut1, operationalMode)
+		cfgplugins.InterfaceConfig(t, dut1, dp1)
+		cfgplugins.InterfaceConfig(t, dut1, dp2)
+		gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
+		transceiverState := gnmi.Get(t, dut1, gnmi.OC().Interface(dp1.Name()).Transceiver().State())
+		// Check if TRANSCEIVER is of type 400ZR_PLUS
+		// Uncomment once the Ondatra OC release version is fixed.
+		// if dp1.PMD() != ondatra.PMD400GBASEZRP {
+		// 	t.Fatalf("%s Transceiver is not 400ZR_PLUS its of type: %v", transceiverState, dp1.PMD())
+		// }
+		componentName := components.OpticalChannelComponentFromPort(t, dut1, dp1)
+		component := gnmi.OC().Component(componentName)
+		p1Stream := samplestream.New(t, dut1, component.OpticalChannel().LaserBiasCurrent().State(), 10*time.Second)
+		defer p1Stream.Close()
+		verifyLaserBiasCurrentAll(t, p1Stream, dut1)
+		// power off interface transceiver
+		gnmi.Update(t, dut1, gnmi.OC().Component(transceiverState).Name().Config(), transceiverState)
+		// for transceiver disable, the input needs to be the transceiver name instead of the interface name
+		gnmi.Update(t, dut1, gnmi.OC().Component(transceiverState).Transceiver().Enabled().Config(), false)
+		// Cannot use Interface_OperStatus_DOWN here as the interface is "Not Present"
+		verifyLaserBiasCurrentAll(t, p1Stream, dut1)
+		// power on interface transceiver
+		gnmi.Update(t, dut1, gnmi.OC().Component(transceiverState).Transceiver().Enabled().Config(), true)
+		gnmi.Await(t, dut1, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
+		verifyLaserBiasCurrentAll(t, p1Stream, dut1)
+	}
 }


### PR DESCRIPTION
- Deviation `explicit_dco_config`, `transceiver_config_enable_unsupported` & `missing_zr_optical_channel_tunable_parameters_telemetry` added.
- TransceiveronOff sub-test is been skipped as Nokia dont support transceiver/config/enable leaf.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."