### PR TITLE
DP-1.12: Adding Queue management profile binding to the output interface

### DIFF
--- a/feature/qos/ecn/otg_tests/ecn_enabled_traffic_test/ecn_enabled_traffic_test.go
+++ b/feature/qos/ecn/otg_tests/ecn_enabled_traffic_test/ecn_enabled_traffic_test.go
@@ -38,7 +38,8 @@ import (
 )
 
 const (
-	v4PrefixLen = 31
+	v4PrefixLen            = 31
+	queueManagementProfile = "queueManagementProfile"
 )
 
 var (
@@ -818,7 +819,7 @@ func configureQoS(t *testing.T, dut *ondatra.DUTDevice) {
 		schedulerPolicy := output.GetOrCreateSchedulerPolicy()
 		schedulerPolicy.SetName(tc.scheduler)
 		queue := output.GetOrCreateQueue(tc.queueName)
-		queue.SetQueueManagementProfile("queueManagementProfile")
+		queue.SetQueueManagementProfile(queueManagementProfile)
 		queue.SetName(tc.queueName)
 		gnmi.Replace(t, dut, gnmi.OC().Qos().Config(), q)
 	}


### PR DESCRIPTION
DP-1.12: Adding Queue management profile binding to the output interface