### PR TITLE
add descriptions for DUT ports and refactor BGP configuration functions

### DIFF
--- a/feature/bgp/addpath/otg_tests/addpath_scale/metadata.textproto
+++ b/feature/bgp/addpath/otg_tests/addpath_scale/metadata.textproto
@@ -11,6 +11,7 @@ platform_exceptions: {
   }
   deviations: {
     ipv4_missing_enabled: true
+    bgp_conditions_match_community_set_unsupported: true
   }
 }
 platform_exceptions: {


### PR DESCRIPTION
adding code which resolves the IPv4 prefixes mismatch. 

IPv6 prefix mismatch still needs to be triaged further. 