### PR TITLE
Refactor MED validation logic in flow control tests

### DIFF
--- a/feature/bgp/policybase/otg_tests/actions_med_localpref_prepend_flow_control/actions_MED_LocPref_prepend_flow_control_test.go
+++ b/feature/bgp/policybase/otg_tests/actions_med_localpref_prepend_flow_control/actions_MED_LocPref_prepend_flow_control_test.go
@@ -815,7 +815,7 @@ func TestBGPPolicy(t *testing.T) {
 }
 
 // expectedMED returns the MED that should be verified considering device deviations.
-func expectedMED(t *testing.T,dut *ondatra.DUTDevice, requestedValue, deviatedValue uint32) uint32 {
+func expectedMED(t *testing.T, dut *ondatra.DUTDevice, requestedValue, deviatedValue uint32) uint32 {
 	t.Helper()
 	// If device cannot perform set-med or med-add actions, return base MED value.
 	if deviations.BGPSetMedActionUnsupported(dut) {


### PR DESCRIPTION
for cisco, since bgp_set_med_action_unsupported = true, the MED value verification for prefixes should be handled accordingly. 

This applies to the subtest "Configure eBGP increase MED Import Export Policy". 

verified that test passes locally.