### PR TITLE
PF1-6 change testbed type

### DIFF
--- a/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection/metadata.textproto
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection/metadata.textproto
@@ -4,7 +4,7 @@
 uuid:  "db187faa-0f6d-44f8-86d2-832df9c285fc"
 plan_id:  "PF-1.6"
 description:  "Policy based VRF selection for IPV4/IPV6"
-testbed:  TESTBED_DUT_ATE_2LINKS
+testbed:  TESTBED_DUT_ATE_4LINKS
 
 platform_exceptions:  {
   platform:  {


### PR DESCRIPTION
Change testbed type to dut-ate-4links in test PF-1.6 metadata as the test requires 3 ports.
Linked to https://partnerissuetracker.corp.google.com/issues/458890286