### PR TITLE
MGT-1 adding "label mode per-vrf"

### DIFF
--- a/feature/system/management/otg_tests/management_ha_test/management_ha_test.go
+++ b/feature/system/management/otg_tests/management_ha_test/management_ha_test.go
@@ -439,6 +439,7 @@ func getCiscoCLIRedisConfig(instanceName string, as uint32, vrf string) string {
 	cfg := fmt.Sprintf("router bgp %d instance %s\n", as, instanceName)
 	cfg = cfg + fmt.Sprintf(" vrf %s\n", vrf)
 	cfg = cfg + "  address-family ipv6 unicast\n"
+	cfg = cfg + "   label mode per-vrf\n"
 	cfg = cfg + "   redistribute connected\n"
 	return cfg
 }


### PR DESCRIPTION
The problem was caused by too many labels and resource conflicts when using BGP in a VRF on IOS XR.
Setting label mode per-vrf tells the router to use a single label for the VRF, which is more efficient and avoids the technical issues you experienced.
This is the recommended and supported approach for your scenario, and it will help ensure consistent and predictable network behavior.