### PR TITLE
update core file pattern matching for cisco

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -45,7 +45,7 @@ var (
 	}
 	vendorCoreFileNamePattern = map[opb.Device_Vendor]*regexp.Regexp{
 		opb.Device_JUNIPER: regexp.MustCompile(".*.tar.gz"),
-		opb.Device_CISCO:   regexp.MustCompile(`/misc/disk1(/coredumps)?/.*core.*\.(?:gz|lz4)$`),
+		opb.Device_CISCO:   regexp.MustCompile(`/misc/disk1(/coredumps)?/.*\bcore\b.*\.(?:gz|lz4|txt)$`),
 		opb.Device_NOKIA:   regexp.MustCompile("/var/core/coredump-.*"),
 		opb.Device_ARISTA:  regexp.MustCompile("/var/core/core.*"),
 	}


### PR DESCRIPTION
PR Description:

This PR updates the regular expression used to identify Cisco core dump files within the vendorCoreFileNamePattern map in internal/core/core.go.

Changes Introduced:

    Optional /coredumps directory: The regex now accounts for an optional /coredumps subdirectory within /misc/disk1, making the pattern more flexible for different Cisco device configurations.
    Support for compressed core dumps: The pattern has been extended to explicitly match core dump files ending with .gz or .lz4 extensions, which are common for compressed core dumps.


Motivation:

1. The previous regex (/misc/disk1/.*core.*) was less specific and could potentially miss valid core dump files that are compressed or located within the /coredumps subdirectory. This enhancement improves the accuracy and robustness of core dump detection for Cisco devices, ensuring that compressed core dumps are correctly identified and processed.

2. Some of the informative files inside coredumps folder is mistakenly treated as core file. This change will avoid detecting these two files as core file
```
=== RUN   TestMain
error notifying tests are done: errors running AfterTestsCallbacks: [error on callback "[github.com/openconfig/featureprofiles/internal/core.registerAfter](https://github.com/openconfig/featureprofiles/internal/core.registerAfter)": core file check found cores:

Delta Core Files by DUT:
DUT: R3-[10.85.84.51:2014](https://10.85.84.51:2014/)
/misc/disk1/coredumps/core_info
/misc/disk1/coredumps/last_core_timestamp]
```



Affected File:
internal/core/core.go