### PR TITLE
RT-1.15: Remove deprecated usage of match-set-options

### DIFF
--- a/feature/bgp/addpath/otg_tests/addpath_scale/addpath_scale_test.go
+++ b/feature/bgp/addpath/otg_tests/addpath_scale/addpath_scale_test.go
@@ -407,7 +407,6 @@ func createCommunitySet(t *testing.T, dut *ondatra.DUTDevice, cs communitySet, r
 			}
 		}
 		communitySet.SetCommunityMember(cm)
-		communitySet.SetMatchSetOptions(cs.matchSetOptions)
 	}
 	var communitySetCLIConfig string
 	if deviations.CommunityMemberRegexUnsupported(dut) && cs.name == communitySetNameRegex {


### PR DESCRIPTION
`match-set-options` under `defined-sets` for `community-sets` are deprecated. This change removes the usage from this test.