### PR TITLE
Add README for gRIBI to BGP Redistribution Test

### DIFF
--- a/feature/networkinstance/otg_tests/defaults_test/gribi_to_bgp_redistribution/README.md
+++ b/feature/networkinstance/otg_tests/defaults_test/gribi_to_bgp_redistribution/README.md
@@ -1,0 +1,254 @@
+# TestID-14.3: gRIBI to BGP Route Redistribution for IPv4
+
+## Summary
+
+This test validates the gRIBI route redistribution from gRIBI to BGP for IPv4 in a network instance.
+
+## Testbed type
+
+* Specify the .testbed topology file from the
+[TESTBED_DUT_ATE_2 LINKS](https://github.com/openconfig/featureprofiles/blob/main/topologies/topologies/atedut_2.testbed)
+
+## Procedure
+
+### Test environment setup
+
+* DUT and ATE ports will be connected and configured as following:
+  * DUT Port 1 (192.0.2.1/30) <> (192.0.2.2/30) ATE Port 1 
+  * DUT Port 2 (203.0.113.1/30) <> (203.0.113.2/30) ATE Port 2
+
+* VRFs: TEST_VRF (L3), DEFAULT
+* gRIBI: Enabled
+
+* DUT Port 2 <> ATE Port 2:
+  * DUT AS: 65500, ATE AS: 65502
+  * Import Policy (bgp-import-policy): (Same as DUT Port 1 Import)
+    * 198.51.100.0/26 & /32 & EF_ALL Community: Accept
+    * Default: Reject
+  * Export Policy (bgp-export-policy):
+    * Redistributed gRIBI routes matching (198.51.100.0/26 & /32 & EF_ALL Community): Accept
+    * Default: Reject
+      
+* Redistribution Policy (TEST_VRF):
+  * Source: gRIBI, Destination: BGP
+  * Import Policy:
+    * Prefixes within 198.51.100.0/26 with mask /32: Add Communities EF_ALL, NO-CORE, then Accept.
+    * Default: Reject
+
+### TestID-14.2.1 - gRIBI to BGP Redistribution
+
+* Step 1 - Generate DUT configuration
+  * Configure network-instance 'TEST_VRF' with DUT and ATE interfaces and IP addresses.
+  * Configure eBGP & multipath with import and export policies.
+  * Configure gRIBI to BGP redistribution policy and table connection.
+
+```json
+{
+  "table-connections": {
+    "table-connection": [
+      {
+        "src-protocol": "openconfig-policy-types:GRIBI",
+        "dst-protocol": "openconfig-policy-types:BGP",
+        "address-family": "openconfig-types:IPV4",
+        "config": {
+          "src-protocol": "openconfig-policy-types:GRIBI",
+          "dst-protocol": "openconfig-policy-types:BGP",
+          "address-family": "openconfig-types:IPV4",
+          "default-export-policy": "REJECT_ROUTE",
+          "export-policy": "GRIBI-TO-BGP"
+        }
+      }
+    ]
+  }
+}
+{
+  "policy-definitions": {
+    "policy-definition": [
+      {
+        "name": "GRIBI-TO-BGP",
+        "config": {
+          "name": "GRIBI-TO-BGP"
+        },
+        "statements": {
+          "statement": [
+            {
+              "name": "REDISTRIBUTE_GRIBI_IPV4",
+              "config": {
+                "name": "REDISTRIBUTE_GRIBI_IPV4"
+              },
+              "conditions": {
+                "match-prefix-set": {
+                  "config": {
+                    "prefix-set": "EF_AGG",
+                    "match-set-options": "ANY"
+                  }
+                }
+              },
+              "actions": {
+                "config": {
+                  "policy-result": "ACCEPT_ROUTE"
+                },
+                "openconfig-bgp-policy:bgp-actions": {
+                  "set-community": {
+                    "config": {
+                      "method": "REFERENCE",
+                      "options": "ADD"
+                    },
+                    "reference": {
+                      "config": {
+                        "community-set-refs": [
+                          "EF_ALL",
+                          "NO-CORE"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+```
+
+* Step 2 - Program a gRIBI route in TEST_VRF
+
+```yaml
+#gRIBI Entry using gribic: Redistribute gRIBI to BGP
+'operation: { op: ADD network_instance: "TEST_VRF" next_hop: { index: 1001 next_hop { ip_address: { value: "192.0.2.2" } } } }'
+'operation: { op: ADD network_instance: "TEST_VRF" next_hop_group: { id: 2001 next_hop_group { next_hop { index: 1001 weight: { value: 1 } } } } }'
+'operation: { op: ADD network_instance: "TEST_VRF" ipv4: { prefix: "198.51.100.1/32" ipv4_entry { next_hop_group: { value: 2001 } } } }'
+```
+* Step 3 - Verify gRIBI route '198.51.100.1/32' is received over eBGP session at ATE Port 2
+* Step 4 - Send Traffic from ATE port 2 to ATE 1 (towards destination address 198.51.100.1)
+* Step 5 - Validate traffice is received at ATE Port 2 without any loss.
+* Step 6 - Delete gRIBI route '198.51.100.1/32' from TEST_VRF
+
+```yaml
+'operation: { op: DELETE network_instance: "TEST_VRF" ipv4: { prefix: "198.51.100.1/32" } }'
+'operation: { op: DELETE network_instance: "TEST_VRF" next_hop_group: { id: 2001 } }'
+'operation: { op: DELETE network_instance: "TEST_VRF" next_hop: { index: 1001 } }'
+```
+* Step 7 - Verify gRIBI route '198.51.100.1/32' is deleted from TEST_VRF
+* Step 8 - Validate full traffic loss at ATE Port 2.
+
+
+### TestID-14.2.2 - Drain Policy Validation
+
+* Step 1 - Generate DUT configuration
+  * Configure and append a drain policy 'peer_drain' to existing bgp export policy towards ATE Port 2 BGP session.
+
+```json
+"routing-policy": {
+    "policy-definitions": {
+      "policy-definition": [
+        {
+          "name": "peer_drain",
+          "config": {
+            "name": "peer_drain"
+          },
+          "statements": {
+            "statement": [
+              {
+                "name": "DRAIN-ACTIONS",
+                "config": {
+                  "name": "DRAIN-ACTIONS"
+                },
+                "actions": {
+                  "config": {
+                    "policy-result": "NEXT_STATEMENT"
+                  },
+                  "bgp-actions": {
+                    "config": {
+                      "set-med": "+100",
+                    },
+                    "set-as-path-prepend": {
+                      "config": {
+                        "repeat-n": 5,
+                        "asn": 64701
+                      }
+                    },
+                    "set-community": {
+                      "config": {
+                         "options": "ADD"
+                      },
+                      "reference": {
+                        "config": {
+                          "community-set-refs": [
+                            "GSHUT-COMMUNITY"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+}
+```
+
+* Step 2 - Program a gRIBI route in TEST_VRF
+
+```yaml
+#gRIBI Entry using gribic: Redistribute gRIBI to BGP
+'operation: { op: ADD network_instance: "TEST_VRF" next_hop: { index: 1001 next_hop { ip_address: { value: "192.0.2.2" } } } }'
+'operation: { op: ADD network_instance: "TEST_VRF" next_hop_group: { id: 2001 next_hop_group { next_hop { index: 1001 weight: { value: 1 } } } } }'
+'operation: { op: ADD network_instance: "TEST_VRF" ipv4: { prefix: "198.51.100.1/32" ipv4_entry { next_hop_group: { value: 2001 } } } }'
+```
+* Step 3 - Verify gRIBI route '198.51.100.1/32' is received over eBGP session at ATE Port 2
+* Step 4 - Append drain policy 'peer_drain' to existing bgp export policy towards ATE Port 2 BGP session.
+* Step 5 - Verify route '198.51.100.1/32' is received with MED, appended AS numbers and GHUT community at ATE Port 2 
+* Step 5 - Delete drain policy 'peer_drain'
+* Step 3 - Verify route '198.51.100.1/32' BGP attributes are reverted back to orginial at ATE Port 2
+* Step 6 - Delete gRIBI route '198.51.100.1/32' from TEST_VRF and verify route is removed from RIB and FIB
+
+```yaml
+'operation: { op: DELETE network_instance: "TEST_VRF" ipv4: { prefix: "198.51.100.1/32" } }'
+'operation: { op: DELETE network_instance: "TEST_VRF" next_hop_group: { id: 2001 } }'
+'operation: { op: DELETE network_instance: "TEST_VRF" next_hop: { index: 1001 } }'
+```
+
+## OpenConfig Path and RPC Coverage
+
+This yaml stanza defines the OC paths intended to be covered by this test.  OC
+paths used for test environment setup are not required to be listed here. This
+content is parsed by automation to derive the test coverage.  If any new OC
+paths are required, they should also be included here as a TODO comment.
+
+```yaml
+paths:
+/network-instances/network-instance/table-connections/table-connection[src-protocol='GRIBI'][dst-protocol='BGP'][address-family='IPV4']/config/src-protocol
+/network-instances/network-instance/table-connections/table-connection[src-protocol='GRIBI'][dst-protocol='BGP'][address-family='IPV4']/config/dst-protocol
+/network-instances/network-instance/table-connections/table-connection[src-protocol='GRIBI'][dst-protocol='BGP'][address-family='IPV4']/config/address-family
+/network-instances/network-instance/table-connections/table-connection[src-protocol='GRIBI'][dst-protocol='BGP'][address-family='IPV4']/config/default-export-policy
+/network-instances/network-instance/table-connections/table-connection[src-protocol='GRIBI'][dst-protocol='BGP'][address-family='IPV4']/config/export-policy
+
+/routing-policy/policy-definitions/policy-definition[name='GRIBI-TO-BGP']/config/name
+/routing-policy/policy-definitions/policy-definition[name='GRIBI-TO-BGP']/statements/statement[name='REDISTRIBUTE_GRIBI_IPV4']/config/name
+/routing-policy/policy-definitions/policy-definition[name='GRIBI-TO-BGP']/statements/statement[name='REDISTRIBUTE_GRIBI_IPV4']/conditions/match-prefix-set/config/prefix-set
+/routing-policy/policy-definitions/policy-definition[name='GRIBI-TO-BGP']/statements/statement[name='REDISTRIBUTE_GRIBI_IPV4']/conditions/match-prefix-set/config/match-set-options
+/routing-policy/policy-definitions/policy-definition[name='GRIBI-TO-BGP']/statements/statement[name='REDISTRIBUTE_GRIBI_IPV4']/actions/config/policy-result
+/routing-policy/policy-definitions/policy-definition[name='GRIBI-TO-BGP']/statements/statement[name='REDISTRIBUTE_GRIBI_IPV4']/actions/openconfig-bgp-policy:bgp-actions/set-community/config/method
+/routing-policy/policy-definitions/policy-definition[name='GRIBI-TO-BGP']/statements/statement[name='REDISTRIBUTE_GRIBI_IPV4']/actions/openconfig-bgp-policy:bgp-actions/set-community/config/options
+/routing-policy/policy-definitions/policy-definition[name='GRIBI-TO-BGP']/statements/statement[name='REDISTRIBUTE_GRIBI_IPV4']/actions/openconfig-bgp-policy:bgp-actions/set-community/reference/config/community-set-refs
+
+rpcs:
+  gnmi:
+    gNMI.Set:
+      union_replace: true
+    gNMI.Subscribe:
+      on_change: true
+```
+
+## Required DUT platform
+
+* Specify the minimum DUT-type:
+  * FFF - fixed form factor


### PR DESCRIPTION
Add README for gRIBI to BGP route redistribution test, detailing setup, procedures, and expected outcomes.