### PR TITLE
Update gribi_scaling_test.go

### DIFF
--- a/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
+++ b/feature/gribi/otg_tests/gribi_scaling/gribi_scaling_test.go
@@ -317,7 +317,7 @@ func TestScaling(t *testing.T) {
 	t.Log("ARP resolved. Applying Forwarding Policy now")
 	dp1 := dut.Port(t, "port1")
 	applyForwardingPolicy(t, dp1.Name())
-	
+
 	var maxEntries int = 10000
 	for _, vrfConfig := range vrfConfigs {
 		entries := append(vrfConfig.NHs, vrfConfig.NHGs...)


### PR DESCRIPTION
TE-14.1 - Update the ordering of the code to avoid flakiness and correct WaitForARP function arguments. 