### PR TITLE
Update parent_component_validation_test.go

### DIFF
--- a/feature/platform/tests/parent_component_validation/parent_component_validation_test.go
+++ b/feature/platform/tests/parent_component_validation/parent_component_validation_test.go
@@ -54,12 +54,12 @@ func TestInterfaceParentComponent(t *testing.T) {
 		{
 			desc:    "Port1",
 			port:    "port1",
-			pattern: "^(SwitchChip(?:[0-9]/[0-9])?|NPU[0-9]|[0-9]/[0-9]/CPU[0-9]-NPU[0-9]|FPC[0-9]+:PIC[0-9]:NPU[0-9])$",
+			pattern: "^(SwitchChip(?:[0-9]+|[0-9]/[0-9])?|NPU[0-9]|[0-9]/[0-9]/CPU[0-9]-NPU[0-9]|FPC[0-9]+:PIC[0-9]:NPU[0-9])$",
 		},
 		{
 			desc:    "Port2",
 			port:    "port2",
-			pattern: "^(SwitchChip(?:[0-9]/[0-9])?|NPU[0-9]|[0-9]/[0-9]/CPU[0-9]-NPU[0-9]|FPC[0-9]+:PIC[0-9]:NPU[0-9])$",
+			pattern: "^(SwitchChip(?:[0-9]+|[0-9]/[0-9])?|NPU[0-9]|[0-9]/[0-9]/CPU[0-9]-NPU[0-9]|FPC[0-9]+:PIC[0-9]:NPU[0-9])$",
 		},
 	}
 


### PR DESCRIPTION
Regex is modified to accept parent component identified simply by an index ID eg SwitchChip0 and not just a slot/port format eg SwitchChip0/1