### PR TITLE
Fixed tcam profile and DSCP issues for existing DP1.16 ingress traffic classification  test

### DIFF
--- a/feature/qos/otg_tests/ingress_traffic_classification_and_rewrite_test/ingress_traffic_classification_and_rewrite_test.go
+++ b/feature/qos/otg_tests/ingress_traffic_classification_and_rewrite_test/ingress_traffic_classification_and_rewrite_test.go
@@ -605,12 +605,12 @@ func rewriteIpv6PktsWithDscp(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.
 	finalpacket5 := verify_classifier_packets(t, dut, oc.Input_Classifier_Type_IPV6, "4")
 	finalpacket6 := verify_classifier_packets(t, dut, oc.Input_Classifier_Type_IPV6, "6")
 
-	compare_counters(t, dut, intialpacket1, finalpacket1)
-	compare_counters(t, dut, intialpacket2, finalpacket2)
-	compare_counters(t, dut, intialpacket3, finalpacket3)
-	compare_counters(t, dut, intialpacket4, finalpacket4)
-	compare_counters(t, dut, intialpacket5, finalpacket5)
-	compare_counters(t, dut, intialpacket6, finalpacket6)
+	compare_counters(t, intialpacket1, finalpacket1)
+	compare_counters(t, intialpacket2, finalpacket2)
+	compare_counters(t, intialpacket3, finalpacket3)
+	compare_counters(t, intialpacket4, finalpacket4)
+	compare_counters(t, intialpacket5, finalpacket5)
+	compare_counters(t, intialpacket6, finalpacket6)
 }
 
 func rewriteIpv4PktsWithDscp(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice, topo gosnappi.Config, greTest bool, gueTest bool) {
@@ -740,12 +740,12 @@ func rewriteIpv4PktsWithDscp(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.
 	finalpacket5 := verify_classifier_packets(t, dut, oc.Input_Classifier_Type_IPV4, "4")
 	finalpacket6 := verify_classifier_packets(t, dut, oc.Input_Classifier_Type_IPV4, "6")
 
-	compare_counters(t, dut, intialpacket1, finalpacket1)
-	compare_counters(t, dut, intialpacket2, finalpacket2)
-	compare_counters(t, dut, intialpacket3, finalpacket3)
-	compare_counters(t, dut, intialpacket4, finalpacket4)
-	compare_counters(t, dut, intialpacket5, finalpacket5)
-	compare_counters(t, dut, intialpacket6, finalpacket6)
+	compare_counters(t, intialpacket1, finalpacket1)
+	compare_counters(t, intialpacket2, finalpacket2)
+	compare_counters(t, intialpacket3, finalpacket3)
+	compare_counters(t, intialpacket4, finalpacket4)
+	compare_counters(t, intialpacket5, finalpacket5)
+	compare_counters(t, intialpacket6, finalpacket6)
 
 }
 
@@ -1145,20 +1145,13 @@ func verify_classifier_packets(t *testing.T, dut *ondatra.DUTDevice, classifier 
 	return matchpackets
 }
 
-func compare_counters(t *testing.T, dut *ondatra.DUTDevice, intialpacket uint64, finalpacket uint64) {
+func compare_counters(t *testing.T, intialpacket uint64, finalpacket uint64) {
 	t.Logf("Classifier counters Before Traffic %v", intialpacket)
 	t.Logf("Classifier counters After Traffic %v", finalpacket)
-	// Deviation: classifier counters not supported
-	if deviations.ClassifierCountersOCUnsupported(dut) {
-		if dut.Vendor() == ondatra.ARISTA {
-			t.Logf("Deviation: classifier matched-packets counters not supported on %s", dut.Vendor())
-		}
+	if finalpacket > intialpacket {
+		t.Logf("Pass : Classifier counters got incremented after start and stop traffic")
 	} else {
-		if finalpacket > intialpacket {
-			t.Logf("Pass : Classifier counters got incremented after start and stop traffic")
-		} else {
-			t.Errorf("Fail : Classifier counters not incremented after start and stop traffic. Refer BUG ID 419618177")
-		}
+		t.Errorf("Fail : Classifier counters not incremented after start and stop traffic. Refer BUG ID 419618177")
 	}
 }
 

--- a/feature/qos/otg_tests/ingress_traffic_classification_and_rewrite_test/metadata.textproto
+++ b/feature/qos/otg_tests/ingress_traffic_classification_and_rewrite_test/metadata.textproto
@@ -16,6 +16,5 @@ platform_exceptions: {
     static_mpls_lsp_oc_unsupported: true
     policy_forwarding_to_next_hop_oc_unsupported: true
     policy_forwarding_gre_encapsulation_oc_unsupported: true
-    classifier_counters_oc_unsupported: true
   }
 }

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1899,9 +1899,3 @@ func CiscoxrTransceiverFt(dut *ondatra.DUTDevice) string {
 func TransceiverStateUnsupported(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetTransceiverStateUnsupported()
 }
-
-// ClassifierCountersOCUnsupported returns true if the device does not support classifiers counters.
-// Arista b/419618177
-func ClassifierCountersOCUnsupported(dut *ondatra.DUTDevice) bool {
-	return lookupDUTDeviations(dut).GetClassifierCountersOcUnsupported()
-}

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -1136,10 +1136,6 @@ message Metadata {
     // Device does not support transceiver state leaf.
     bool transceiver_state_unsupported = 374;
 
-    // Arista b/419618177
-    // Device does not  support the classifiers counters.
-    bool classifier_counters_oc_unsupported = 375;
-
     // Reserved field numbers and identifiers.
     reserved 84, 9, 28, 20, 38, 43, 90, 97, 55, 89, 19, 36, 35, 40, 113, 131, 141, 173, 234, 254, 231, 300;
   }

--- a/proto/metadata_go_proto/metadata.pb.go
+++ b/proto/metadata_go_proto/metadata.pb.go
@@ -1300,11 +1300,8 @@ type Metadata_Deviations struct {
 	CiscoxrTransceiverFt string `protobuf:"bytes,373,opt,name=ciscoxr_transceiver_ft,json=ciscoxrTransceiverFt,proto3" json:"ciscoxr_transceiver_ft,omitempty"`
 	// Device does not support transceiver state leaf.
 	TransceiverStateUnsupported bool `protobuf:"varint,374,opt,name=transceiver_state_unsupported,json=transceiverStateUnsupported,proto3" json:"transceiver_state_unsupported,omitempty"`
-	// Arista b/419618177
-	// Device does not  support the classifiers counters.
-	ClassifierCountersOcUnsupported bool `protobuf:"varint,375,opt,name=classifier_counters_oc_unsupported,json=classifierCountersOcUnsupported,proto3" json:"classifier_counters_oc_unsupported,omitempty"`
-	unknownFields                   protoimpl.UnknownFields
-	sizeCache                       protoimpl.SizeCache
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *Metadata_Deviations) Reset() {
@@ -3724,13 +3721,6 @@ func (x *Metadata_Deviations) GetTransceiverStateUnsupported() bool {
 	return false
 }
 
-func (x *Metadata_Deviations) GetClassifierCountersOcUnsupported() bool {
-	if x != nil {
-		return x.ClassifierCountersOcUnsupported
-	}
-	return false
-}
-
 type Metadata_PlatformExceptions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Platform      *Metadata_Platform     `protobuf:"bytes,1,opt,name=platform,proto3" json:"platform,omitempty"`
@@ -3787,7 +3777,7 @@ var File_metadata_proto protoreflect.FileDescriptor
 
 const file_metadata_proto_rawDesc = "" +
 	"\n" +
-	"\x0emetadata.proto\x12\x12openconfig.testing\x1a1github.com/openconfig/ondatra/proto/testbed.proto\"\xa2\xd0\x01\n" +
+	"\x0emetadata.proto\x12\x12openconfig.testing\x1a1github.com/openconfig/ondatra/proto/testbed.proto\"\xd4\xcf\x01\n" +
 	"\bMetadata\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\x12\x17\n" +
 	"\aplan_id\x18\x02 \x01(\tR\x06planId\x12 \n" +
@@ -3799,7 +3789,7 @@ const file_metadata_proto_rawDesc = "" +
 	"\bPlatform\x12.\n" +
 	"\x06vendor\x18\x01 \x01(\x0e2\x16.ondatra.Device.VendorR\x06vendor\x120\n" +
 	"\x14hardware_model_regex\x18\x03 \x01(\tR\x12hardwareModelRegex\x124\n" +
-	"\x16software_version_regex\x18\x04 \x01(\tR\x14softwareVersionRegexJ\x04\b\x02\x10\x03R\x0ehardware_model\x1a\x8e\xc6\x01\n" +
+	"\x16software_version_regex\x18\x04 \x01(\tR\x14softwareVersionRegexJ\x04\b\x02\x10\x03R\x0ehardware_model\x1a\xc0\xc5\x01\n" +
 	"\n" +
 	"Deviations\x120\n" +
 	"\x14ipv4_missing_enabled\x18\x01 \x01(\bR\x12ipv4MissingEnabled\x129\n" +
@@ -4145,8 +4135,7 @@ const file_metadata_proto_rawDesc = "" +
 	"-interface_ethernet_inblock_errors_unsupported\x18\xf3\x02 \x01(\bR)interfaceEthernetInblockErrorsUnsupported\x12?\n" +
 	"\x1cretain_gnmi_cfg_after_reboot\x18\xf4\x02 \x01(\bR\x18retainGnmiCfgAfterReboot\x125\n" +
 	"\x16ciscoxr_transceiver_ft\x18\xf5\x02 \x01(\tR\x14ciscoxrTransceiverFt\x12C\n" +
-	"\x1dtransceiver_state_unsupported\x18\xf6\x02 \x01(\bR\x1btransceiverStateUnsupported\x12L\n" +
-	"\"classifier_counters_oc_unsupported\x18\xf7\x02 \x01(\bR\x1fclassifierCountersOcUnsupportedJ\x04\bT\x10UJ\x04\b\t\x10\n" +
+	"\x1dtransceiver_state_unsupported\x18\xf6\x02 \x01(\bR\x1btransceiverStateUnsupportedJ\x04\bT\x10UJ\x04\b\t\x10\n" +
 	"J\x04\b\x1c\x10\x1dJ\x04\b\x14\x10\x15J\x04\b&\x10'J\x04\b+\x10,J\x04\bZ\x10[J\x04\ba\x10bJ\x04\b7\x108J\x04\bY\x10ZJ\x04\b\x13\x10\x14J\x04\b$\x10%J\x04\b#\x10$J\x04\b(\x10)J\x04\bq\x10rJ\x06\b\x83\x01\x10\x84\x01J\x06\b\x8d\x01\x10\x8e\x01J\x06\b\xad\x01\x10\xae\x01J\x06\b\xea\x01\x10\xeb\x01J\x06\b\xfe\x01\x10\xff\x01J\x06\b\xe7\x01\x10\xe8\x01J\x06\b\xac\x02\x10\xad\x02\x1a\xa0\x01\n" +
 	"\x12PlatformExceptions\x12A\n" +
 	"\bplatform\x18\x01 \x01(\v2%.openconfig.testing.Metadata.PlatformR\bplatform\x12G\n" +


### PR DESCRIPTION
**Readme:** https://github.com/openconfig/featureprofiles/blob/main/feature/qos/otg_tests/ingress_traffic_classification_and_rewrite_test/README.md

Fixed the TCAM Profile and DSCP issue (434618050), still failing a few test cases (failing 6 outoff 11) due to the issue 419618177.

Please find the latest logs here https://partnerissuetracker.corp.google.com/u/1/issues/415458482

A few test cases are failing due to the counters issue (Defect: 419677). I’m unable to access the defect. Please let me know once the issue is fixed (mention the image version). I will validate and update accordingly.