### PR TITLE
Update holddown_timers_test.go

### DIFF
--- a/feature/interface/holdtime/otg_tests/holdtime_test/holddown_timers_test.go
+++ b/feature/interface/holdtime/otg_tests/holdtime_test/holddown_timers_test.go
@@ -363,7 +363,7 @@ func verifyPortsStatus(t *testing.T, dut *ondatra.DUTDevice, portState string, w
 		want = oc.Interface_OperStatus_UP
 		gnmi.Await(t, dut,
 			gnmi.OC().Interface(aggID).OperStatus().State(),
-			time.Second*waitTime,
+			waitTime,
 			oc.Interface_OperStatus_UP)
 	} else {
 		switch dut.Vendor() {
@@ -374,7 +374,7 @@ func verifyPortsStatus(t *testing.T, dut *ondatra.DUTDevice, portState string, w
 		}
 		gnmi.Await(t, dut,
 			gnmi.OC().Interface(aggID).OperStatus().State(),
-			time.Second*waitTime,
+			waitTime,
 			want)
 	}
 
@@ -431,7 +431,7 @@ func TestHoldTimeConfig(t *testing.T) {
 			}
 			return present
 		}).Await(t)
-		verifyPortsStatus(t, dut, "UP", 20)
+		verifyPortsStatus(t, dut, "UP", 20*time.Second)
 	})
 
 }
@@ -495,7 +495,7 @@ func TestTC2LongDown(t *testing.T) {
 	t.Run("Bring back UP OTG Interface", func(t *testing.T) {
 		OTGInterfaceUP(t, ate)
 		t.Logf("Verifying port status for %s", aggID)
-		verifyPortsStatus(t, dut, "UP", 45)
+		verifyPortsStatus(t, dut, "UP", 45*time.Second)
 	})
 
 	t.Run("Verify test results", func(t *testing.T) {
@@ -515,7 +515,7 @@ func TestTC3ShortUP(t *testing.T) {
 
 		// shutting down OTG interface to emulate the RF
 		OTGInterfaceDOWN(t, ate, dut)
-		verifyPortsStatus(t, dut, "DOWN", 2)
+		verifyPortsStatus(t, dut, "DOWN", 2*time.Second)
 		oper1 := gnmi.Get(t, dut, gnmi.OC().Interface(aggID).OperStatus().State())
 		change1 := gnmi.Get(t, dut, gnmi.OC().Interface(aggID).LastChange().State())
 		t.Log(oper1)
@@ -531,7 +531,7 @@ func TestTC3ShortUP(t *testing.T) {
 		change2 := gnmi.Get(t, dut, gnmi.OC().Interface(aggID).LastChange().State())
 
 		// ensure the LAG interface is still down
-		verifyPortsStatus(t, dut, "DOWN", 4)
+		verifyPortsStatus(t, dut, "DOWN", 4*time.Second)
 		t.Log(oper2)
 
 		change1Time := time.Unix(0, int64(change1)).UTC()
@@ -547,7 +547,7 @@ func TestTC3ShortUP(t *testing.T) {
 		// bring OTG port back up
 		OTGInterfaceUP(t, ate)
 		// verify interface is up for next test case
-		verifyPortsStatus(t, dut, "UP", 45)
+		verifyPortsStatus(t, dut, "UP", 45*time.Second)
 
 	})
 
@@ -569,7 +569,7 @@ func TestTC4SLongUP(t *testing.T) {
 		// bring port back up for 4 seconds below the 5000 ms hold up timer
 		OTGInterfaceUP(t, ate)
 		// ensure the LAG interface is still down
-		verifyPortsStatus(t, dut, "UP", 45)
+		verifyPortsStatus(t, dut, "UP", 45*time.Second)
 
 		// Collecting time stamp of interface up
 		change2 := gnmi.Get(t, dut, gnmi.OC().Interface(aggID).LastChange().State())
@@ -617,7 +617,7 @@ func TestTC5ShortDOWN(t *testing.T) {
 	t.Run("Flap OTG Interfaces", func(t *testing.T) {
 
 		t.Log("Verify Interface State before TC Start")
-		verifyPortsStatus(t, dut, "UP", 10)
+		verifyPortsStatus(t, dut, "UP", 10*time.Second)
 		// shutting down OTG interface to emulate the RF
 		t.Log("Shutdown OTG Interface")
 		change1 = gnmi.Get(t, dut, gnmi.OC().Interface(aggID).State())
@@ -671,7 +671,7 @@ func TestTC5ShortDOWN(t *testing.T) {
 
 	t.Run("Verify port status UP", func(t *testing.T) {
 		t.Log("re-verify that the interface state is still up")
-		verifyPortsStatus(t, dut, "UP", 30)
+		verifyPortsStatus(t, dut, "UP", 30*time.Second)
 
 	})
 }


### PR DESCRIPTION
Increase wait time for initial port state verification. This is to avoid test flakiness. 