### PR TITLE
Container-1: add delay between Create/Push and List operations.

### DIFF
--- a/feature/container/containerz/tests/container_lifecycle/containerz_test.go
+++ b/feature/container/containerz/tests/container_lifecycle/containerz_test.go
@@ -59,7 +59,9 @@ func startContainer(ctx context.Context, t *testing.T) (*client.Client, func()) 
 		PollForRunningState: false,
 		PollInterval:        5 * time.Second,
 	}
-	return containerztest.Setup(ctx, t, dut, opts)
+	c, cleanup := containerztest.Setup(ctx, t, dut, opts)
+	time.Sleep(5 * time.Second) // Allow time for container to stabilize.
+	return c, cleanup
 }
 
 // TestDeployAndStartContainer implements CNTR-1.1 validating that it is

--- a/internal/containerztest/containerztest.go
+++ b/internal/containerztest/containerztest.go
@@ -155,6 +155,9 @@ func DeployAndStart(ctx context.Context, t *testing.T, cli *client.Client, opts 
 		}
 	}
 
+	// Allow some time for the image to be fully registered.
+	time.Sleep(5 * time.Second)
+
 	// 4. Verify the image exists after push.
 	t.Logf("Verifying image %s:%s exists after push.", opts.ImageName, opts.ImageTag)
 	imgListCh, err := cli.ListImage(ctx, 0, map[string][]string{"name": {opts.ImageName}, "tag": {opts.ImageTag}})


### PR DESCRIPTION
The current tests push invokes the ListImage directly following PushImage. Similarly, the tests invoke ListContainer immediately following StartContainer.

This PR adds a delay following StartContainer/PushImage that allows the DUT internal state to update before invoking the List* RPC.