### PR TITLE
fixing bgp_remote_private_as_test for arista

### DIFF
--- a/feature/bgp/otg_tests/bgp_remove_private_as/bgp_remove_private_as_test.go
+++ b/feature/bgp/otg_tests/bgp_remove_private_as/bgp_remove_private_as_test.go
@@ -36,19 +36,6 @@ func TestMain(m *testing.M) {
 	fptest.RunTests(m)
 }
 
-// The testbed consists of ate:port1 -> dut:port1 and
-// dut:port2 -> ate:port2.  The first pair is called the "source"
-// pair, and the second the "destination" pair.
-//
-// Source: ate:port1 -> dut:port1 subnet 192.0.2.0/30
-// Destination: dut:port2 -> ate:port2 subnet 192.0.2.4/30
-//
-// Note that the first (.0, .3) and last (.4, .7) IPv4 addresses are
-// reserved from the subnet for broadcast, so a /30 leaves exactly 2
-// usable addresses. This does not apply to IPv6 which allows /127
-// for point to point links, but we use /126 so the numbering is
-// consistent with IPv4.
-
 const (
 	advertisedRoutesv4Net    = "203.0.113.1"
 	advertisedRoutesv4Prefix = 32
@@ -56,7 +43,6 @@ const (
 	peerGrpName2             = "BGP-PEER-GROUP2"
 	routeCount               = 254
 	dutAS                    = 500
-	ateAS1                   = 100
 	ateAS2                   = 200
 	plenIPv4                 = 30
 	plenIPv6                 = 126
@@ -65,6 +51,7 @@ const (
 )
 
 var (
+	ateAS1 = uint32(500)
 	dutSrc = attrs.Attributes{
 		Desc:    "DUT to ATE source",
 		IPv4:    "192.0.2.1",
@@ -218,14 +205,14 @@ func verifyBGPTelemetry(t *testing.T, dut *ondatra.DUTDevice) {
 	}
 }
 
-// verifyPrefixesTelemetry confirms that the dut shows the correct numbers of installed,
-// sent and received IPv4 prefixes.
-func verifyPrefixesTelemetry(t *testing.T, dut *ondatra.DUTDevice, nbr string, wantInstalled, wantSent uint32) {
+// verifyPrefixesTelemetry confirms that the dut shows the correct numbers of sent and received IPv4
+// prefixes.
+func verifyPrefixesTelemetry(t *testing.T, dut *ondatra.DUTDevice, nbr string, wantReceived, wantSent uint32) {
 	t.Helper()
 	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	prefixesv4 := statePath.Neighbor(nbr).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Prefixes()
-	if gotInstalled := gnmi.Get(t, dut, prefixesv4.Installed().State()); gotInstalled != wantInstalled {
-		t.Errorf("Installed prefixes mismatch: got %v, want %v", gotInstalled, wantInstalled)
+	if gotReceived := gnmi.Get(t, dut, prefixesv4.Received().State()); gotReceived != wantReceived {
+		t.Errorf("Received prefixes mismatch: got %v, want %v", gotReceived, wantReceived)
 	}
 	if gotSent := gnmi.Get(t, dut, prefixesv4.Sent().State()); gotSent != wantSent {
 		t.Errorf("Sent prefixes mismatch: got %v, want %v", gotSent, wantSent)
@@ -234,7 +221,7 @@ func verifyPrefixesTelemetry(t *testing.T, dut *ondatra.DUTDevice, nbr string, w
 
 // configureOTG configures the interfaces and BGP protocols on an ATE, including
 // advertising some(faked) networks over BGP.
-func configureOTG(t *testing.T, otg *otg.OTG, asSeg []uint32, asSEQMode bool) gosnappi.Config {
+func configureOTG(t *testing.T, dut *ondatra.DUTDevice, otg *otg.OTG, asSeg []uint32, asSEQMode bool) gosnappi.Config {
 	t.Helper()
 	config := gosnappi.NewConfig()
 	port1 := config.Ports().Add().SetName("port1")
@@ -258,7 +245,12 @@ func configureOTG(t *testing.T, otg *otg.OTG, asSeg []uint32, asSEQMode bool) go
 
 	iDut1Bgp := iDut1Dev.Bgp().SetRouterId(iDut1Ipv4.Address())
 	iDut1Bgp4Peer := iDut1Bgp.Ipv4Interfaces().Add().SetIpv4Name(iDut1Ipv4.Name()).Peers().Add().SetName(ateSrc.Name + ".BGP4.peer")
-	iDut1Bgp4Peer.SetPeerAddress(dutSrc.IPv4).SetAsNumber(ateAS1).SetAsType(gosnappi.BgpV4PeerAsType.EBGP)
+	switch dut.Vendor() {
+	case ondatra.ARISTA:
+		iDut1Bgp4Peer.SetPeerAddress(dutSrc.IPv4).SetAsNumber(ateAS1).SetAsType(gosnappi.BgpV4PeerAsType.IBGP)
+	default:
+		iDut1Bgp4Peer.SetPeerAddress(dutSrc.IPv4).SetAsNumber(ateAS1).SetAsType(gosnappi.BgpV4PeerAsType.EBGP)
+	}
 	iDut1Bgp4Peer.LearnedInformationFilter().SetUnicastIpv4Prefix(true).SetUnicastIpv6Prefix(true)
 
 	iDut2Bgp := iDut2Dev.Bgp().SetRouterId(iDut2Ipv4.Address())
@@ -330,14 +322,21 @@ func verifyOTGBGPTelemetry(t *testing.T, otg *otg.OTG, c gosnappi.Config, state 
 }
 
 // verifyBGPAsPath is to Validate AS Path attribute using bgp rib telemetry on ATE.
-func verifyBGPAsPath(t *testing.T, otg *otg.OTG, config gosnappi.Config, asSeg []uint32, removeASPath bool) {
+func verifyBGPAsPath(t *testing.T, dut *ondatra.DUTDevice, otg *otg.OTG, config gosnappi.Config, asSeg []uint32, removeASPath bool) {
 	t.Helper()
 	_, ok := gnmi.WatchAll(t, otg, gnmi.OTG().BgpPeer(ateDst.Name+".BGP4.peer").UnicastIpv4PrefixAny().State(),
 		time.Minute, func(v *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv4Prefix]) bool {
 			return v.IsPresent()
 		}).Await(t)
 
-	var wantASSeg = []uint32{dutAS, ateAS1}
+	var wantASSeg []uint32
+	switch dut.Vendor() {
+	case ondatra.ARISTA:
+		wantASSeg = []uint32{dutAS}
+
+	default:
+		wantASSeg = []uint32{dutAS, ateAS1}
+	}
 	if removeASPath {
 		for _, as := range asSeg {
 			if as < 64512 {
@@ -371,7 +370,12 @@ func TestRemovePrivateAS(t *testing.T) {
 	ate := ondatra.ATE(t, "ate")
 	otg := ate.OTG()
 	var otgConfig gosnappi.Config
-
+	switch dut.Vendor() {
+	case ondatra.ARISTA:
+		ateAS1 = dutAS
+	default:
+		ateAS1 = 100
+	}
 	t.Run("Configure DUT interfaces", func(t *testing.T) {
 		configureDUT(t, dut)
 	})
@@ -418,7 +422,7 @@ func TestRemovePrivateAS(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Logf("Start OTG Config.")
-			otgConfig = configureOTG(t, otg, tc.asSeg, tc.asSEQMode)
+			otgConfig = configureOTG(t, dut, otg, tc.asSeg, tc.asSEQMode)
 
 			t.Log("Verifying port status.")
 			verifyPortsUp(t, dut.Device)
@@ -431,13 +435,13 @@ func TestRemovePrivateAS(t *testing.T) {
 			verifyPrefixesTelemetry(t, dut, ateDst.IPv4, 0, routeCount)
 
 			t.Log("Verify AS Path list received at ate Port2 including private AS number.")
-			verifyBGPAsPath(t, otg, otgConfig, tc.asSeg, !removeASPath)
+			verifyBGPAsPath(t, dut, otg, otgConfig, tc.asSeg, !removeASPath)
 
 			t.Log("Configure remove private AS on DUT.")
 			gnmi.Update(t, dut, dutConfPath.Bgp().PeerGroup(peerGrpName2).RemovePrivateAs().Config(), oc.Bgp_RemovePrivateAsOption_PRIVATE_AS_REMOVE_ALL)
 
 			t.Log("Private AS numbers should be stripped off while advertising BGP routes into public AS.")
-			verifyBGPAsPath(t, otg, otgConfig, tc.asSeg, removeASPath)
+			verifyBGPAsPath(t, dut, otg, otgConfig, tc.asSeg, removeASPath)
 
 			otg.StopProtocols(t)
 			time.Sleep(30 * time.Second)


### PR DESCRIPTION
Modify the test to use an iBGP session between ateSrc and dutSrc. This change will allow routes with private AS numbers to be accepted by the DUT, after which they can be advertised to ateDst via an eBGP session, allowing the remove-private-as feature to be properly tested.

update ateAS1 to match dutAS, configure OTG to use iBGP for the session with dutSrc, and adjust verifyBGPAsPath to correctly validate the AS path for iBGP.
