### PR TITLE
Mgt 1 - Fix flakiness

### DIFF
--- a/feature/interface/singleton/otg_tests/flow_control/flow_control_test.go
+++ b/feature/interface/singleton/otg_tests/flow_control/flow_control_test.go
@@ -80,11 +80,16 @@ func configureDUTInterface(t *testing.T, dut *ondatra.DUTDevice, a *attrs.Attrib
 	s := duti1.GetOrCreateSubinterface(0)
 	_ = s.GetOrCreateIpv4()
 	_ = s.GetOrCreateIpv6()
-	duti1.GetOrCreateEthernet().EnableFlowControl = ygot.Bool(flowControlMode)
 	di1 := d.Interface(p1.Name())
 	fptest.LogQuery(t, p1.String(), di1.Config(), duti1)
+	gnmi.Replace(t, dut, di1.Config(), duti1)
 
-	gnmi.Update(t, dut, di1.Config(), duti1)
+	flowControl := d.Interface(p1.Name()).Ethernet().EnableFlowControl()
+	if flowControlMode {
+		gnmi.Replace(t, dut, flowControl.Config(), true)
+	} else {
+		gnmi.Replace(t, dut, flowControl.Config(), false)
+	}
 }
 
 func verifyFlowControl(t *testing.T, dut *ondatra.DUTDevice, flowControlMode bool) {


### PR DESCRIPTION
Add a reset function before the start of each sub-test to ensure that all ports are UP and bgp is established to avoid flakiness in code. 