### PR TITLE
RT-1.3: fix otg telemetry

### DIFF
--- a/feature/bgp/addpath/otg_tests/route_propagation_test/route_propagation_test.go
+++ b/feature/bgp/addpath/otg_tests/route_propagation_test/route_propagation_test.go
@@ -324,11 +324,13 @@ func checkOTGBGP4Prefix(t *testing.T, otg *otg.OTG, config gosnappi.Config, expe
 	t.Helper()
 	start := time.Now()
 	for time.Since(start) < 2*time.Minute {
-		bgpPrefixes := gnmi.GetAll(t, otg, gnmi.OTG().BgpPeer(expectedOTGBGPPrefix.PeerName).UnicastIpv4PrefixAny().State())
+		bgpPrefixes := gnmi.LookupAll(t, otg, gnmi.OTG().BgpPeer(expectedOTGBGPPrefix.PeerName).UnicastIpv4PrefixAny().State())
 		for _, bgpPrefix := range bgpPrefixes {
-			if bgpPrefix.Address != nil && bgpPrefix.GetAddress() == expectedOTGBGPPrefix.Address &&
-				bgpPrefix.PrefixLength != nil && bgpPrefix.GetPrefixLength() == expectedOTGBGPPrefix.PrefixLength {
-				return true
+			if val, ok := bgpPrefix.Val(); ok {
+				if val.Address != nil && val.GetAddress() == expectedOTGBGPPrefix.Address &&
+					val.PrefixLength != nil && val.GetPrefixLength() == expectedOTGBGPPrefix.PrefixLength {
+					return true
+				}
 			}
 		}
 	}
@@ -339,11 +341,13 @@ func checkOTGBGP6Prefix(t *testing.T, otg *otg.OTG, config gosnappi.Config, expe
 	t.Helper()
 	start := time.Now()
 	for time.Since(start) < 2*time.Minute {
-		bgpPrefixes := gnmi.GetAll(t, otg, gnmi.OTG().BgpPeer(expectedOTGBGPPrefix.PeerName).UnicastIpv6PrefixAny().State())
+		bgpPrefixes := gnmi.LookupAll(t, otg, gnmi.OTG().BgpPeer(expectedOTGBGPPrefix.PeerName).UnicastIpv6PrefixAny().State())
 		for _, bgpPrefix := range bgpPrefixes {
-			if bgpPrefix.Address != nil && bgpPrefix.GetAddress() == expectedOTGBGPPrefix.Address &&
-				bgpPrefix.PrefixLength != nil && bgpPrefix.GetPrefixLength() == expectedOTGBGPPrefix.PrefixLength {
-				return true
+			if val, ok := bgpPrefix.Val(); ok {
+				if val.Address != nil && val.GetAddress() == expectedOTGBGPPrefix.Address &&
+					val.PrefixLength != nil && val.GetPrefixLength() == expectedOTGBGPPrefix.PrefixLength {
+					return true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Use `gnmi.LookupAll` instead of `gnmi.GetAll` for otg telemetry to avoid failing the test fatally if prefixes not yet received

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."