### PR TITLE
Fixed aggregate_interface_counters_test for Nokia

### DIFF
--- a/feature/gnmi/otg_tests/aggregate_interface_counters_test/aggregate_interface_counters_test.go
+++ b/feature/gnmi/otg_tests/aggregate_interface_counters_test/aggregate_interface_counters_test.go
@@ -205,6 +205,11 @@ func (tc *testCase) clearAggregate(t *testing.T) {
 		t.Logf("Deleting the aggregate on the device")
 		agg := &oc.Interface{Name: ygot.String(tc.aggID)}
 		agg.Type = ieee8023adLag
+		if deviations.ExplicitInterfaceInDefaultVRF(tc.dut) {
+			interfaceID := fmt.Sprintf("%s.%d", tc.aggID, 0)
+			niName := deviations.DefaultNetworkInstance(tc.dut)
+			gnmi.Delete(t, tc.dut, gnmi.OC().NetworkInstance(niName).Interface(interfaceID).Config())
+		}
 		gnmi.Delete(t, tc.dut, gnmi.OC().Interface(tc.aggID).Config())
 		gnmi.Update(t, tc.dut, gnmi.OC().Interface(tc.aggID).Config(), agg)
 


### PR DESCRIPTION
The test is failing for Nokia because interface lag3 was still referenced by network-instance DEFAULT when gnmi.Delete is called. 
To fix this, we need to first delete the interface from the network-instance, then delete the interface itself.
