### PR TITLE
gNMI-1.15: Add delay after RootOp config push to ensure device completes config processing.

### DIFF
--- a/feature/gnmi/tests/gnmi_set_test/gnmi_set_test.go
+++ b/feature/gnmi/tests/gnmi_set_test/gnmi_set_test.go
@@ -133,7 +133,11 @@ func TestGetSet(t *testing.T) {
 
 	forEachPushOp(t, dut, func(t *testing.T, op pushOp, config *oc.Root) {
 		op.push(t, dut, config, scope)
-		// TODO: after push, do a get again to check the config diff.
+		// Wait after RootOp for device to finish processing the large config
+		// before the next test starts.
+		if op.string() == "RootOp" {
+			time.Sleep(5 * time.Second)
+		}
 	})
 }
 


### PR DESCRIPTION
TestGetSet's RootOp pushes the entire config to the device. The gNMI set response returns successfully, but the device continues processing the configuration internally. When the next testcase starts immediately after, the device is still busy processing the previous config, causing the testcase to fail.


This is a timing issue where the gNMI acknowledgment doesn't guarantee the device has finished internal processing. I've added a 5-second sleep after RootOp in TestGetSet to allow the device to complete internal processing before the next test begins.