### PR TITLE
Increase gNMI sample timeout to 60 seconds in RT-1.24

### DIFF
--- a/feature/bgp/otg_tests/bgp_2byte_4byte_asn_policy_test/bgp_2byte_4byte_asn_policy_test.go
+++ b/feature/bgp/otg_tests/bgp_2byte_4byte_asn_policy_test/bgp_2byte_4byte_asn_policy_test.go
@@ -51,6 +51,7 @@ const (
 	prefixSubnetRangeV4 = "30..32"
 	prefixSubnetRangeV6 = "126..128"
 	globalAsNumber      = 999
+	gnmiSampleTimeout   = 60 * time.Second
 )
 
 var prefixV4 = []string{"198.51.100.0/30", "198.51.100.4/30", "198.51.100.8/30"}
@@ -412,7 +413,7 @@ func verifyPrefixesTelemetryV4(t *testing.T, dut *ondatra.DUTDevice, wantInstall
 	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	prefixesv4 := statePath.Neighbor(ateSrc.IPv4).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).Prefixes()
 
-	gotInstalled, ok := gnmi.Watch(t, dut, prefixesv4.Installed().State(), 15*time.Second, func(val *ygnmi.Value[uint32]) bool {
+	gotInstalled, ok := gnmi.Watch(t, dut, prefixesv4.Installed().State(), gnmiSampleTimeout, func(val *ygnmi.Value[uint32]) bool {
 		gotInstalled, _ := val.Val()
 		return gotInstalled == wantInstalled
 	}).Await(t)
@@ -428,7 +429,7 @@ func verifyPrefixesTelemetryV6(t *testing.T, dut *ondatra.DUTDevice, wantInstall
 	statePath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	prefixesv6 := statePath.Neighbor(ateSrc.IPv6).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).Prefixes()
 
-	gotInstalledv6, ok := gnmi.Watch(t, dut, prefixesv6.Installed().State(), 15*time.Second, func(val *ygnmi.Value[uint32]) bool {
+	gotInstalledv6, ok := gnmi.Watch(t, dut, prefixesv6.Installed().State(), gnmiSampleTimeout, func(val *ygnmi.Value[uint32]) bool {
 		gotInstalledv6, _ := val.Val()
 		return gotInstalledv6 == wantInstalledv6
 	}).Await(t)


### PR DESCRIPTION
1. Brief description and need for this PR
When `gnmi.Watch()` is called without an explicit subscription mode, it defaults to **TARGET_DEFINED** mode. On IOS-XR, TARGET_DEFINED defaults to **SAMPLE mode with a 30-second interval** for BGP state paths.

This means:
- The client receives an **initial sync** immediately with the current value
- Subsequent updates arrive only every **30 seconds**

With a 15-second timeout:
- The test receives only **1 sample** (the initial sync)
- If the initial sync contains the old/stale value (before the policy took effect), the test **times out** before the next sample arrives
- Whether the test passes or fails depends on **only the first sample**

gnmiSampleTimeout is the timeout for gNMI Watch/Await operations.
The ondatra gnmi.Watch uses TARGET_DEFINED subscription mode which defaults to SAMPLE mode in IOS-XR
with a 30-second interval. To reliably receive at least 2 samples (initial
sync + one update), we need a timeout greater than 30 seconds. Using 60
seconds provides sufficient margin to avoid flaky test failures.

### Example Case

**Test Case 5: Establish iBGP connection between ATE (2-byte) - DUT (4-byte < 65535) for ipv4 peers**

| Policy | Action | Want | Got | Elapsed (ms) | Status |
|--------|--------|------|-----|--------------|--------|
| REJECT-PREFIX | apply | 2 | 2 | 31053 | PASS |
| REJECT-PREFIX | delete | 3 | 3 | 137 | PASS |
| REJECT-COMMUNITY | apply | 2 | 2 | 31048 | PASS |
| REJECT-COMMUNITY | delete | 3 | 3 | 105 | PASS |
| REJECT-AS-PATH | apply | 2 | 2 | 1042 | PASS |

2. Proposed changes
Increase all gnmi.Watch() timeouts from 15 seconds to 60 seconds to ensure reliable test execution regardless of subscription timing.

Example of similar usage in the public repo - https://github.com/openconfig/featureprofiles/blob/main/feature/policy_forwarding/otg_tests/match_dscp_indirect_next_hop/match_dscp_indirect_next_hop_test.go#L432
