### PR TITLE
RT-1.15: Enhance addpath scale test with additional port descriptions and BGP session verification

### DIFF
--- a/feature/bgp/addpath/otg_tests/addpath_scale/addpath_scale_test.go
+++ b/feature/bgp/addpath/otg_tests/addpath_scale/addpath_scale_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/openconfig/featureprofiles/internal/attrs"
+	"github.com/openconfig/featureprofiles/internal/cfgplugins"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/featureprofiles/internal/helpers"
@@ -60,6 +61,7 @@ var (
 	dutPort1 = attributes{
 		Attributes: &attrs.Attributes{
 			Name:    "port1",
+			Desc:    "port1",
 			IPv4:    "192.0.2.1",
 			IPv4Len: plenIPv4,
 			IPv6:    "2001:0db8::192:0:2:1",
@@ -70,6 +72,7 @@ var (
 	dutPort2 = attributes{
 		Attributes: &attrs.Attributes{
 			Name:    "port2",
+			Desc:    "port2",
 			IPv4:    "192.0.2.5",
 			IPv4Len: plenIPv4,
 			IPv6:    "2001:0db8::192:0:2:5",
@@ -81,6 +84,7 @@ var (
 	dutPort3 = attributes{
 		Attributes: &attrs.Attributes{
 			Name:    "port3",
+			Desc:    "port3",
 			IPv4:    "192.0.2.9",
 			IPv4Len: plenIPv4,
 			IPv6:    "2001:0db8::192:0:2:9",
@@ -92,6 +96,7 @@ var (
 	dutPort4 = attributes{
 		Attributes: &attrs.Attributes{
 			Name:    "port4",
+			Desc:    "port4",
 			IPv4:    "200.0.0.1", // 192.0.2.13
 			IPv4Len: 24,
 			IPv6:    "1000::200:0:0:1", // 2001:0db8::192:0:2:d
@@ -224,7 +229,8 @@ func TestAddPathScale(t *testing.T) {
 	}
 	ate.OTG().PushConfig(t, top)
 	ate.OTG().StartProtocols(t)
-
+	otgutils.WaitForARP(t, ate.OTG(), top, "IPv4")
+	otgutils.WaitForARP(t, ate.OTG(), top, "IPv6")
 	configureDUT(t, dut)
 	configureRoutePolicy(t, dut, "ALLOW", oc.RoutingPolicy_PolicyResultType_ACCEPT_ROUTE)
 
@@ -241,6 +247,14 @@ func TestAddPathScale(t *testing.T) {
 		advertiseRoutesWithEBGP(t, top)
 		ate.OTG().PushConfig(t, top)
 		ate.OTG().StartProtocols(t)
+		time.Sleep(2 * time.Minute)
+		otgutils.WaitForARP(t, ate.OTG(), top, "IPv4")
+		otgutils.WaitForARP(t, ate.OTG(), top, "IPv6") // check ipv6 show commands
+		t.Logf("Verify OTG BGP sessions up")
+		cfgplugins.VerifyOTGBGPEstablished(t, ate)
+		t.Logf("Verify DUT BGP sessions up")
+		cfgplugins.VerifyDUTBGPEstablished(t, dut)
+
 	})
 
 	testCases := []struct {
@@ -303,6 +317,14 @@ func TestAddPathScaleWithRoutePolicy(t *testing.T) {
 		advertiseRoutesWithEBGPWithCommunities(t, top)
 		ate.OTG().PushConfig(t, top)
 		ate.OTG().StartProtocols(t)
+		time.Sleep(2 * time.Minute)
+		t.Logf("Verify OTG BGP sessions up")
+		cfgplugins.VerifyOTGBGPEstablished(t, ate)
+		t.Logf("Verify DUT BGP sessions up")
+		cfgplugins.VerifyDUTBGPEstablished(t, dut)
+		// // time.Sleep(1 * time.Minute)
+		// otgutils.WaitForARP(t, ate.OTG(), top, "IPv4")
+		// otgutils.WaitForARP(t, ate.OTG(), top, "IPv6")
 	})
 
 	createTrafficFlow(t, top, ate)

--- a/feature/platform/fabric/otg_tests/fabric_redundancy_test/metadata.textproto
+++ b/feature/platform/fabric/otg_tests/fabric_redundancy_test/metadata.textproto
@@ -1,4 +1,4 @@
-# proto-file: github.com/openconfig/featureprofiles/proto/metadata.proto
+g# proto-file: github.com/openconfig/featureprofiles/proto/metadata.proto
 # proto-message: Metadata
 
 uuid: "261d317f-9bcc-43f9-a412-295ae6c008cf"

--- a/feature/platform/fabric/otg_tests/fabric_redundancy_test/metadata.textproto
+++ b/feature/platform/fabric/otg_tests/fabric_redundancy_test/metadata.textproto
@@ -1,4 +1,4 @@
-g# proto-file: github.com/openconfig/featureprofiles/proto/metadata.proto
+# proto-file: github.com/openconfig/featureprofiles/proto/metadata.proto
 # proto-message: Metadata
 
 uuid: "261d317f-9bcc-43f9-a412-295ae6c008cf"


### PR DESCRIPTION
draft code for debugging IXIA issues for RT-1.15

Facing these errors:
I0204 17:46:48.943748   14738 gnmi.go:285] Received gNMI SyncResponse.
    arp.go:29: Did not receive OTG Neighbor entry for interface port1.Eth, last got: <nil>
--- FAIL: TestAddPathScale (144.10s)

