### PR TITLE
Added changes to ensure the ports are up before pushing the config

### DIFF
--- a/feature/gnoi/os/tests/osinstall/osinstall_test.go
+++ b/feature/gnoi/os/tests/osinstall/osinstall_test.go
@@ -41,6 +41,7 @@ import (
 	spb "github.com/openconfig/gnoi/system"
 )
 
+
 var packageReader = func(ctx context.Context) (io.ReadCloser, uint64, error) {
 	f, err := os.Open(*osFile)
 	if err != nil {
@@ -93,6 +94,7 @@ var (
 const (
 	ipv4PrefixLen = 30
 	ipv6PrefixLen = 126
+	waitTime             = 10 * time.Minute
 )
 
 type bgpAttrs struct {
@@ -433,6 +435,10 @@ func watchStatus(t *testing.T, ic ospb.OS_InstallClient, standby bool) error {
 func TestPushAndVerifyInterfaceConfig(t *testing.T) {
 
 	dut := ondatra.DUT(t, "dut")
+        // Wait for streaming telemetry to report the interfaces as up.
+	for _, p := range dut.Ports() {
+        	gnmi.Await(t, dut, gnmi.OC().Interface(p.Name()).OperStatus().State(), waitTime, oc.Interface_OperStatus_UP)
+	}
 	t.Logf("Create and push interface config to the DUT")
 	dutPort := dut.Port(t, "port1")
 	dutPortName := dutPort.Name()

--- a/feature/platform/tests/parent_component_validation/parent_component_validation_test.go
+++ b/feature/platform/tests/parent_component_validation/parent_component_validation_test.go
@@ -46,7 +46,7 @@ func checkParentComponent(t *testing.T, dut *ondatra.DUTDevice, entity string) s
 // TestInterfaceParentComponent tests that the parent component of any given interface is a Switch Chip.
 func TestInterfaceParentComponent(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
-	parentComponentRegex := regexp.MustCompile("^(SwitchChip(?:[0-9]+|[0-9]/[0-9])?|NPU[0-9]|[0-9]/(?:[0-9]|RP[0-9])/CPU[0-9]-NPU[0-9]|FPC[0-9]+:PIC[0-9]:NPU[0-9]+)$")
+	parentComponentRegex := regexp.MustCompile("^(SwitchChip(?:[0-9]+|[0-9]/[0-9])?|NPU[0-9]|[0-9]/(?:[0-9]|RP[0-9])/CPU[0-9]-NPU[0-9]|FPC[0-9]+:PIC[0-9]:NPU[0-9]+|CHASSIS0:FPC[0-9]+:PIC[0-9]:NPU[0-9]+)$")
 	cases := []struct {
 		desc string
 		port string


### PR DESCRIPTION
Issue the script has failed when pusing config as the ports were not up after the reboot.
Added a check to ensure the ports are up before pushing the config.
No deviation required.