### PR TITLE
Update test registry

### DIFF
--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -1534,7 +1534,7 @@ test: {
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/gribi/otg_tests/fib_failed_due_to_hw_res_exhaust_test/README.md"
 }
 test: {
-  id: "PF-1.25"
+  id: "PF-1.25" 
   description: "MPLS based forwarding Static LSP"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/mpls/otg_tests/static_lsp_test/README.md"
 }


### PR DESCRIPTION
Adding SR-1.1
Updating the test registry for static_lsp test plan ID from TE-9.2 to PF-1.25