### PR TITLE
Update required_approvals.yml

### DIFF
--- a/.github/workflows/required_approvals.yml
+++ b/.github/workflows/required_approvals.yml
@@ -22,3 +22,4 @@ jobs:
         approval_mode: ALL
         pr_number: ${{ github.event.pull_request.number }}
         require_all_approvals_latest_commit: false
+        limit_org_teams_to_codeowners_file: true


### PR DESCRIPTION
Set limit_org_teams_to_codeowners_file to true to avoid the below PR approval workflow failure

  request: {
    method: 'GET',
    url: 'https://api.github.com/orgs/openconfig/teams/ent%3Afog-security/members',
    headers: {
      accept: 'application/vnd.github.v3+json',
      'user-agent': 'octokit-rest.js/19.0.7 octokit-core.js/4.2.0 Node.js/20.19.6 (linux; x64)',
      authorization: 'token [REDACTED]'
    },
    request: { hook: [Function: bound bound register] }