### PR TITLE
Fixing control_card_redundancy test for Fixed chassis

### DIFF
--- a/feature/platform/controllercard/tests/controller_card_redundancy_test/controller_card_redundancy_test.go
+++ b/feature/platform/controllercard/tests/controller_card_redundancy_test/controller_card_redundancy_test.go
@@ -464,7 +464,12 @@ func TestControllerCards(t *testing.T) {
 	}
 
 	if got, want := len(controllerCards), 2; got < want {
-		t.Errorf("Not enough controller cards for the test on %v: got %v, want at least %v", dut.Model(), got, want)
+		t.Skipf("Not enough controller cards for the test on %v: got %v, want at least %v: Check the Vendor model it could be fixed form factor device", dut.Model(), got, want)
+	}
+
+	// Skip the test if there are more than 2 controller cards.
+	if len(controllerCards) > 2 {
+		t.Skipf("Skipping the test as there are more than 2 controller cards on %v: Check the Vendor model it could be fixed form factor device", dut.Model())
 	}
 
 	// Test cases.


### PR DESCRIPTION
This tests were failing for the devices with no controller_card specifically the Fixed form factor chassis.
