### PR TITLE
Update holddown_timers_test.go

### DIFF
--- a/feature/interface/holdtime/otg_tests/holdtime_test/holddown_timers_test.go
+++ b/feature/interface/holdtime/otg_tests/holdtime_test/holddown_timers_test.go
@@ -519,7 +519,7 @@ func TestTC3ShortUP(t *testing.T) {
 
 		// shutting down OTG interface to emulate the RF
 		OTGInterfaceDOWN(t, ate, dut)
-		verifyPortsStatus(t, dut, "DOWN", 2*time.Second)
+		verifyPortsStatus(t, dut, "DOWN", 15*time.Second)
 		oper1 := gnmi.Get(t, dut, gnmi.OC().Interface(aggID).OperStatus().State())
 		change1 := gnmi.Get(t, dut, gnmi.OC().Interface(aggID).LastChange().State())
 		t.Log(oper1)
@@ -535,7 +535,7 @@ func TestTC3ShortUP(t *testing.T) {
 		change2 := gnmi.Get(t, dut, gnmi.OC().Interface(aggID).LastChange().State())
 
 		// ensure the LAG interface is still down
-		verifyPortsStatus(t, dut, "DOWN", 4*time.Second)
+		verifyPortsStatus(t, dut, "DOWN", 15*time.Second)
 		t.Log(oper2)
 
 		change1Time := time.Unix(0, int64(change1)).UTC()


### PR DESCRIPTION
Increase timeouts while verifying interface status. 