### PR TITLE
Fix GNMI-1.18 for Arista

### DIFF
--- a/feature/platform/fabric/otg_tests/sampled_backplane_capacity_counters_test/sampled_backplane_capacity_counters_test.go
+++ b/feature/platform/fabric/otg_tests/sampled_backplane_capacity_counters_test/sampled_backplane_capacity_counters_test.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	icPattern = map[ondatra.Vendor]string{
-		ondatra.ARISTA:  "^SwitchChip",
+		ondatra.ARISTA:  `^SwitchChip\d+(?:/\d+)?$`,
 		ondatra.CISCO:   "^[0-9]/[0-9]/CPU[0-9]-NPU[0-9]",
 		ondatra.JUNIPER: "NPU[0-9]$",
 		ondatra.NOKIA:   "^SwitchChip",


### PR DESCRIPTION
The fix updates the regex for identifying IC components in Arista devices so that the enttries for per fap components such as "SwitchChip2/0.1", "SwitchChip3/1.4" are skipped.