### PR TITLE
Fixed password_console_login_test for Juniper

### DIFF
--- a/feature/gnsi/credentialz/tests/password_console_login/password_console_login_test.go
+++ b/feature/gnsi/credentialz/tests/password_console_login/password_console_login_test.go
@@ -52,6 +52,19 @@ func TestCredentialz(t *testing.T) {
 			  	 authentication protocol password
 				 `
 		helpers.GnmiCLIConfig(t, dut, cliConfig)
+	case ondatra.JUNIPER:
+		t.Logf("Juniper vendor, adding CLI config to enable ssh services and allow root login")
+		cliConfig := `
+			system {
+					services {
+							ssh {
+									root-login allow;
+							}
+					}
+					authentication-order password;
+			}
+			`
+		helpers.GnmiCLIConfig(t, dut, cliConfig)
 	default:
 		t.Logf("Vendor %s, does not need CLI configuration in this test", dut.Vendor())
 	}


### PR DESCRIPTION
The test was failing for Juniper specifically as it was not having the required ssh service configuration on the device
This PR addresses this issue 