### PR TITLE
RT-1.26: Basic static route support-Removing deviation

### DIFF
--- a/feature/staticroute/otg_tests/basic_static_route_support_test/metadata.textproto
+++ b/feature/staticroute/otg_tests/basic_static_route_support_test/metadata.textproto
@@ -42,7 +42,6 @@ platform_exceptions: {
     vendor: JUNIPER
   }
   deviations: {
-    ipv6_static_route_with_ipv4_nh_unsupported: true
     skip_static_nexthop_check: true
     isis_level_enabled: true
     interface_ref_interface_id_format: true


### PR DESCRIPTION
Removed deviation ipv6_static_route_with_ipv4_nh_unsupported for juniper