### PR TITLE
Fixing host_certificate test for Cisco,Arista

### DIFF
--- a/internal/security/credz/credz.go
+++ b/internal/security/credz/credz.go
@@ -695,8 +695,11 @@ func GetConfiguredHostKey(t *testing.T, dut *ondatra.DUTDevice, algo string, fqd
 		if lastErr != nil {
 			t.Logf("Failed to get public keys from DUT: %v", lastErr)
 		}
-		t.Logf("Available public keys: %+v", response.PublicKeys)
-		t.Fatalf("Failed to find host key for algorithm %s on DUT. Available keys and their types can be inspected via logs.", algo)
+		if response != nil {
+			t.Logf("Available public keys: %+v", response.PublicKeys)
+		} else {
+			t.Fatalf("Failed to find host key for algorithm %s on DUT. Available keys and their types can be inspected via logs.", algo)
+		}
 	}
 
 	return algo + " " + matchingKey


### PR DESCRIPTION
-Replaced `ssh-keyscan` subprocess with a robust gNSI `GetPublicKeys` RPC call for host key verification. This change directly addresses the `getaddrinfo` failures by leveraging the existing gRPC channel managed by Ondatra, eliminating the need for DNS resolution or separate SSH connectivity into the DUT
-Added a polling loop (10 attempts, 5s delay) in `GetConfiguredHostKey` to wait for the host key to be available after a rotation.

-Consolidated the gNSI `KeyType` to SSH algorithm mapping into `sshAlgo` and ensured it covers `RSA_3072` and `ECDSA_P_384`.
-Added `sshKey` to detect binary wire-format public keys and automatically encode them to base64.
-Added more logging for debug
    - Logged the exact public key contents being written for certification.
    - Logged the gNSI response and the constructed SSH public key line.
    - Added a log of the `ssh-keygen` command being executed.