### PR TITLE
RT-1.1 Adding 50 extra seconds to account for the following variables:

### DIFF
--- a/feature/bgp/otg_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
+++ b/feature/bgp/otg_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
@@ -435,7 +435,7 @@ func TestPassword(t *testing.T) {
 
 	}
 	t.Log("Wait till hold time expires: BGP should not be in ESTABLISHED state when passwords do not match.")
-	_, ok := gnmi.Watch(t, dut, nbrPath.SessionState().State(), (dutHoldTime+60)*time.Second, func(val *ygnmi.Value[oc.E_Bgp_Neighbor_SessionState]) bool {
+	_, ok := gnmi.Watch(t, dut, nbrPath.SessionState().State(), (dutHoldTime+2*dutKeepaliveTime)*time.Second, func(val *ygnmi.Value[oc.E_Bgp_Neighbor_SessionState]) bool {
 		state, ok := val.Val()
 		return ok && state != oc.Bgp_Neighbor_SessionState_ESTABLISHED
 	}).Await(t)

--- a/feature/bgp/otg_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
+++ b/feature/bgp/otg_tests/base_bgp_session_parameters/base_bgp_session_parameters_test.go
@@ -435,7 +435,7 @@ func TestPassword(t *testing.T) {
 
 	}
 	t.Log("Wait till hold time expires: BGP should not be in ESTABLISHED state when passwords do not match.")
-	_, ok := gnmi.Watch(t, dut, nbrPath.SessionState().State(), (dutHoldTime+10)*time.Second, func(val *ygnmi.Value[oc.E_Bgp_Neighbor_SessionState]) bool {
+	_, ok := gnmi.Watch(t, dut, nbrPath.SessionState().State(), (dutHoldTime+60)*time.Second, func(val *ygnmi.Value[oc.E_Bgp_Neighbor_SessionState]) bool {
 		state, ok := val.Val()
 		return ok && state != oc.Bgp_Neighbor_SessionState_ESTABLISHED
 	}).Await(t)


### PR DESCRIPTION
This provides a 60-second margin over the hold timer, easily accommodating the propagation pipeline. Formula: timeout ≥ hold_timer + keepalive_interval + 30s_margin = 90 + 30 + 30 = 150s.