### PR TITLE
Fixed ssh_password_login_disallowed test for Juniper

### DIFF
--- a/feature/gnsi/credentialz/tests/ssh_password_login_disallowed/ssh_password_login_disallowed_test.go
+++ b/feature/gnsi/credentialz/tests/ssh_password_login_disallowed/ssh_password_login_disallowed_test.go
@@ -39,7 +39,7 @@ const (
 	username        = "testuser"
 	userPrincipal   = "my_principal"
 	command         = "show version"
-	maxSSHRetryTime = 30 // Unit is seconds.
+	maxSSHRetryTime = 120 // Unit is seconds.
 )
 
 func TestMain(m *testing.M) {
@@ -63,9 +63,14 @@ func TestCredentialz(t *testing.T) {
 		}
 	}(dir)
 
+	algo := "ed25519"
+	if dut.Vendor() == ondatra.JUNIPER {
+		algo = "rsa"
+	}
+
 	// Create ssh keys/certificates for CA & testuser.
-	credz.CreateSSHKeyPair(t, dir, "ca")
-	credz.CreateSSHKeyPair(t, dir, username)
+	credz.CreateSSHKeyPairAlgo(t, dir, "ca", algo)
+	credz.CreateSSHKeyPairAlgo(t, dir, username, algo)
 	credz.CreateUserCertificate(t, dir, userPrincipal)
 
 	// Setup user and password.
@@ -86,7 +91,7 @@ func TestCredentialz(t *testing.T) {
 		}
 
 		// Verify ssh with password fails as expected.
-		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
 		defer cancel()
 		startTime := time.Now()
 		for {
@@ -121,7 +126,7 @@ func TestCredentialz(t *testing.T) {
 		}
 
 		// Verify ssh with certificate succeeds.
-		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
 		defer cancel()
 		startTime := time.Now()
 		// var conn *ssh.Client
@@ -136,7 +141,7 @@ func TestCredentialz(t *testing.T) {
 			if uint64(time.Since(startTime).Seconds()) > maxSSHRetryTime {
 				t.Fatalf("Exceeded maxSSHRetryTime, dialing ssh failed, but we expected to succeed, error: %s", err)
 			}
-			t.Logf("Dialing ssh failed, retrying ...")
+			t.Logf("Dialing ssh failed: %v, retrying ...", err)
 			time.Sleep(5 * time.Second)
 		}
 

--- a/internal/security/credz/credz.go
+++ b/internal/security/credz/credz.go
@@ -262,7 +262,7 @@ func RotateTrustedUserCA(t *testing.T, dut *ondatra.DUTDevice, dir string) {
 		dataTypes := bytes.Fields(data)
 		keyType := keyTypeFromAlgo(string(dataTypes[0]))
 		if keyType == cpb.KeyType_KEY_TYPE_UNSPECIFIED {
-			keyType = cpb.KeyType_KEY_TYPE_ED25519
+			t.Fatalf("Unrecognized key type: %s", dataTypes[0])
 		}
 		pubKey := dataTypes[1]
 		if dut.Vendor() == ondatra.JUNIPER {

--- a/internal/security/credz/credz.go
+++ b/internal/security/credz/credz.go
@@ -219,10 +219,17 @@ func RotateAuthorizedKey(t *testing.T, dut *ondatra.DUTDevice, dir, username, ve
 			t.Fatalf("Failed reading private key contents, error: %s", err)
 		}
 		dataTypes := bytes.Fields(data)
+		keyType := keyTypeFromAlgo(string(dataTypes[0]))
+		if keyType == cpb.KeyType_KEY_TYPE_UNSPECIFIED {
+			keyType = cpb.KeyType_KEY_TYPE_ED25519
+		}
+		authKey := dataTypes[1]
+		if dut.Vendor() == ondatra.JUNIPER {
+			authKey = bytes.Join(dataTypes[:2], []byte(" "))
+		}
 		keyContents = append(keyContents, &cpb.AccountCredentials_AuthorizedKey{
-			// AuthorizedKey: data,
-			AuthorizedKey: dataTypes[1],
-			KeyType:       cpb.KeyType_KEY_TYPE_ED25519,
+			AuthorizedKey: authKey,
+			KeyType:       keyType,
 		})
 	}
 	request := &cpb.RotateAccountCredentialsRequest{
@@ -253,9 +260,17 @@ func RotateTrustedUserCA(t *testing.T, dut *ondatra.DUTDevice, dir string) {
 			t.Fatalf("Failed reading ca public key contents, error: %s", err)
 		}
 		dataTypes := bytes.Fields(data)
+		keyType := keyTypeFromAlgo(string(dataTypes[0]))
+		if keyType == cpb.KeyType_KEY_TYPE_UNSPECIFIED {
+			keyType = cpb.KeyType_KEY_TYPE_ED25519
+		}
+		pubKey := dataTypes[1]
+		if dut.Vendor() == ondatra.JUNIPER {
+			pubKey = bytes.Join(dataTypes[:2], []byte(" "))
+		}
 		keyContents = append(keyContents, &cpb.PublicKey{
-			PublicKey: dataTypes[1],
-			KeyType:   cpb.KeyType_KEY_TYPE_ED25519,
+			PublicKey: pubKey,
+			KeyType:   keyType,
 		})
 	}
 	request := &cpb.RotateHostParametersRequest{
@@ -424,21 +439,27 @@ func GetDutPublicKey(t *testing.T, dut *ondatra.DUTDevice, targetAlgo string) []
 	return []byte(keyLine)
 }
 
-// CreateSSHKeyPair creates ssh keypair with a filename of keyName in the specified directory.
-// Keypairs can be created for ca/dut/testuser as per individual credentialz test requirements.
-func CreateSSHKeyPair(t *testing.T, dir, keyName string) {
-	sshCmd := exec.Command(
-		"ssh-keygen",
-		"-t", "ed25519",
-		"-f", keyName,
-		"-C", keyName,
-		"-q", "-N", "",
-	)
+// CreateSSHKeyPairAlgo creates ssh keypair with a filename of keyName in the specified directory with the specified algo.
+func CreateSSHKeyPairAlgo(t *testing.T, dir, keyName, algo string) {
+	args := []string{
+		"-t", algo,
+	}
+	if algo == "rsa" {
+		args = append(args, "-b", "4096")
+	}
+	args = append(args, "-f", keyName, "-C", keyName, "-q", "-N", "")
+	sshCmd := exec.Command("ssh-keygen", args...)
 	sshCmd.Dir = dir
 	err := sshCmd.Run()
 	if err != nil {
 		t.Fatalf("Failed generating %s key pair, error: %s", keyName, err)
 	}
+}
+
+// CreateSSHKeyPair creates ssh keypair with a filename of keyName in the specified directory.
+// Keypairs can be created for ca/dut/testuser as per individual credentialz test requirements.
+func CreateSSHKeyPair(t *testing.T, dir, keyName string) {
+	CreateSSHKeyPairAlgo(t, dir, keyName, "ed25519")
 }
 
 // CreateUserCertificate creates ssh user certificate in the specified directory.
@@ -725,6 +746,23 @@ func GetConfiguredHostKey(t *testing.T, dut *ondatra.DUTDevice, algo string, fqd
 	}
 
 	return algo + " " + matchingKey
+}
+
+func keyTypeFromAlgo(algo string) cpb.KeyType {
+	switch algo {
+	case "ssh-rsa":
+		return cpb.KeyType_KEY_TYPE_RSA_4096
+	case "ecdsa-sha2-nistp256":
+		return cpb.KeyType_KEY_TYPE_ECDSA_P_256
+	case "ecdsa-sha2-nistp384":
+		return cpb.KeyType_KEY_TYPE_ECDSA_P_384
+	case "ecdsa-sha2-nistp521":
+		return cpb.KeyType_KEY_TYPE_ECDSA_P_521
+	case "ssh-ed25519":
+		return cpb.KeyType_KEY_TYPE_ED25519
+	default:
+		return cpb.KeyType_KEY_TYPE_UNSPECIFIED
+	}
 }
 
 func sshAlgo(t *testing.T, pk *cpb.PublicKey) string {


### PR DESCRIPTION
Juniper device's SSH daemon was probably not responding when the test applies the CA configurations hence failing the test. Following fixes were made to the test to pass this test.

-In RotateTrustedUserCA and RotateAuthorizedKey, the test extracts the public key from the generated .pub files and sends only the Base64 section (AAAA...), stripping the prefix (ssh-ed25519 or ssh-rsa). So with this change we now pass the Full OpenSSH public key string (e.g., ssh-rsa AAAA...) to the device instead of just the Base64 portion.

-Increased maxSSHRetryTime to 120 seconds, and updated the context timeouts in ssh_password_login_disallowed_test.go from 60 to 120 seconds. This is just to make sure that there is enough time given to Juniper in case there was some issue with the SSH daemon.
