### PR TITLE
Update Mount path

### DIFF
--- a/feature/container/containerz/tests/container_lifecycle/containerz_test.go
+++ b/feature/container/containerz/tests/container_lifecycle/containerz_test.go
@@ -492,8 +492,9 @@ func TestVolumes(t *testing.T) {
 		time.Sleep(5 * time.Second)
 
 		mountOpts := map[string]string{
+			"type":       "none",
 			"options":    "bind",
-			"mountpoint": "/some-path",
+			"mountpoint": "/tmp",
 		}
 
 		createdVolumeName, err := cli.CreateVolume(ctx, volumeName, "local", nil, mountOpts)
@@ -528,7 +529,7 @@ func TestVolumes(t *testing.T) {
 
 				// check options
 				wantOptions := map[string]string{
-					"device": "/some-path",
+					"device": "/tmp",
 					"o":      "bind",
 					"type":   "none",
 				}


### PR DESCRIPTION
## Changes Applied
- Added `"type": "none"` to `mountOpts`.
- Updated `mountOpts["mountpoint"]` from `"/some-path"` to `"/tmp"`.
- Updated expected list option `wantOptions["device"]` from `"/some-path"` to `"/tmp"`.

These updates keep the create-volume mount configuration and list-volume option verification aligned for a bind mount to `/tmp`.