### PR TITLE
RT-5.7 Fix

### DIFF
--- a/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/metadata.textproto
+++ b/feature/interface/aggregate/otg_tests/aggregate_all_not_viable_test/metadata.textproto
@@ -28,7 +28,6 @@ platform_exceptions: {
     wecmp_auto_unsupported: true
     isis_loopback_required: true
     weighted_ecmp_fixed_packet_verification: true
-    interface_ref_interface_id_format: true
   }
 }
 


### PR DESCRIPTION
RT-5.7 AGGREGATE ALL NOT VIABLE TEST - CODE CHANGES EXPLANATION

**CHANGE #1: VRF ASSIGNMENT FIX FOR CISCO LAG INTERFACES**

Location: aggregate_all_not_forwarding_viable_test.go, lines 529-537

Problem:
--------
The test was calling fptest.AssignToNetworkInstance() for all interfaces 
including LAG (Bundle-Ether) interfaces. On Cisco devices, LAG interfaces 
cannot be directly assigned to a VRF/Network Instance.

Error Message:
"'RSI' detected the 'warning' condition 'The specified interface type does not 
support VRFs'"

Code Change:
------------
BEFORE:
    fptest.AssignToNetworkInstance(t, dut, p.Name(), 
        deviations.DefaultNetworkInstance(dut), 0)

AFTER:
    // Assign the interface to the default network instance if not CISCO
    // Cisco LAG interfaces do not support VRF assignment
    if dut.Vendor() != ondatra.CISCO {
        fptest.AssignToNetworkInstance(t, dut, p.Name(), 
            deviations.DefaultNetworkInstance(dut), 0)
    }

Explanation:
------------
Cisco IOS-XR handles LAG interfaces differently from other vendors. Bundle-Ether
interfaces are implicitly part of the default network instance and cannot be 
explicitly assigned to a VRF. The fix adds a vendor check to skip this 
assignment for Cisco devices only.

**CHANGE #2: LOOPBACK INTERFACE CONFIGURATION FOR ISIS**

Location: aggregate_all_not_forwarding_viable_test.go, lines 561-564, 590-612

Problem:
--------
Cisco requires a loopback interface for ISIS to function properly. The test
was not configuring Loopback0 when the ISISLoopbackRequired deviation is true.

Code Added:
-----------
1. Conditional loopback configuration call:

    // Configure Loopback0 for Cisco where ISIS requires a loopback interface
    if deviations.ISISLoopbackRequired(dut) {
        configureLoopback(t, dut)
        aggIDs = append(aggIDs, "Loopback0")
    }

2. New configureLoopback function:

    func configureLoopback(t *testing.T, dut *ondatra.DUTDevice) {
        t.Helper()
        d := &oc.Root{}
        loopbackIntf := d.GetOrCreateInterface("Loopback0")
        loopbackIntf.Name = ygot.String("Loopback0")
        loopbackIntf.Description = ygot.String("Loopback for ISIS")
        loopbackIntf.Type = oc.IETFInterfaces_InterfaceType_softwareLoopback
        if deviations.InterfaceEnabled(dut) {
            loopbackIntf.Enabled = ygot.Bool(true)
        }
        s := loopbackIntf.GetOrCreateSubinterface(0)
        s4 := s.GetOrCreateIpv4()
        if deviations.InterfaceEnabled(dut) {
            s4.Enabled = ygot.Bool(true)
        }
        s4.GetOrCreateAddress(dutLoopback.IPv4).PrefixLength = ygot.Uint8(dutLoopback.IPv4Len)
        s6 := s.GetOrCreateIpv6()
        if deviations.InterfaceEnabled(dut) {
            s6.Enabled = ygot.Bool(true)
        }
        s6.GetOrCreateAddress(dutLoopback.IPv6).PrefixLength = ygot.Uint8(dutLoopback.IPv6Len)
        gnmi.Update(t, dut, gnmi.OC().Interface("Loopback0").Config(), loopbackIntf)
    }

Explanation:
------------
Cisco IOS-XR ISIS implementation requires a loopback interface to be configured
and included in ISIS for proper route advertisement. The Loopback0 interface:
- Uses IP 192.0.2.21/32 and 2001:db8::21/128
- Is added to the aggIDs list so it gets configured in ISIS
- Serves as the router-ID source for ISIS

**CHANGE #3: ISIS LOOPBACK INTERFACE HANDLING**

Location: aggregate_all_not_forwarding_viable_test.go, lines 801-840

Problem:
--------
The configureDUTISIS function was treating all interfaces the same:
1. Adding ".0" suffix to ALL interfaces when InterfaceRefInterfaceIDFormat is true
2. Setting CircuitType to POINT_TO_POINT for ALL interfaces
3. Not setting loopback interfaces as passive

This caused:
- Invalid interface name "Loopback0.0" (Cisco doesn't use this format)
- Loopback interfaces trying to form adjacencies (should be passive)

Code Change:
------------
BEFORE:
    for _, aggID := range aggIDs {
        isisIntf := isis.GetOrCreateInterface(aggID)
        if deviations.InterfaceRefInterfaceIDFormat(dut) {
            isisIntf = isis.GetOrCreateInterface(aggID + ".0")
        }
        // ... same treatment for all interfaces
        isisIntf.CircuitType = oc.Isis_CircuitType_POINT_TO_POINT

AFTER:
    for _, aggID := range aggIDs {
        isLoopback := strings.HasPrefix(strings.ToLower(aggID), "loopback")
        intfID := aggID
        // Only add .0 suffix for non-loopback interfaces
        // Loopback interfaces on Cisco do not use subinterface notation
        if deviations.InterfaceRefInterfaceIDFormat(dut) && !isLoopback {
            intfID = aggID + ".0"
        }
        isisIntf := isis.GetOrCreateInterface(intfID)
        // ...
        isisIntf.Enabled = ygot.Bool(true)
        // Loopback interfaces should be passive (they don't form ISIS adjacencies)
        if isLoopback {
            isisIntf.SetPassive(true)
        } else {
            isisIntf.CircuitType = oc.Isis_CircuitType_POINT_TO_POINT
        }

Explanation:
------------
1. Loopback Detection: strings.HasPrefix(strings.ToLower(aggID), "loopback")
   - Detects if the interface is a loopback interface
   
2. Skip ".0" suffix for loopback:
   - Cisco Loopback interfaces don't use subinterface notation
   - "Loopback0" is valid, "Loopback0.0" is NOT valid
   
3. Set Passive for loopback:
   - Loopback interfaces don't need to form ISIS adjacencies
   - They just advertise their routes into ISIS
   - SetPassive(true) tells ISIS to advertise the loopback subnet but not
     send/receive ISIS hello packets on this interface

4. CircuitType only for non-loopback:
   - POINT_TO_POINT circuit type is only for actual network interfaces
   - Loopback interfaces are internal and don't have a circuit type

**CHANGE** #4: ISIS ADJACENCY LOOKUP PATH FIX

Location: aggregate_all_not_forwarding_viable_test.go, lines 243-246, 396-399, 
          1253-1261

Problem:
--------
The awaitAdjacency function and direct gnmi.LookupAll calls were using the base
interface name (e.g., "Bundle-Ether2") to query ISIS adjacency state. However,
when InterfaceRefInterfaceIDFormat deviation is true, ISIS interface would be
configured as "Bundle-Ether2.0", causing lookups to fail.

Code Change:
------------
1. Modified awaitAdjacency function:

    func awaitAdjacency(t *testing.T, dut *ondatra.DUTDevice, intfName string, 
                        state []oc.E_Isis_IsisInterfaceAdjState) bool {
        isisIntfID := intfName
        // When InterfaceRefInterfaceIDFormat is true, ISIS interface ID has .0 suffix
        if deviations.InterfaceRefInterfaceIDFormat(dut) && 
           !strings.HasPrefix(strings.ToLower(intfName), "loopback") {
            isisIntfID = intfName + ".0"
        }
        isisPath := ocpath.Root().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
            Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, isisInstance).Isis()
        intf := isisPath.Interface(isisIntfID)
        // ...
    }

2. Fixed direct gnmi.LookupAll calls:

    if ok := awaitAdjacency(...); !ok {
        isisIntfID := aggIDs[1]
        if deviations.InterfaceRefInterfaceIDFormat(dut) {
            isisIntfID = aggIDs[1] + ".0"
        }
        if presence := gnmi.LookupAll(t, dut, ocpath.Root()...
            .Isis().Interface(isisIntfID).LevelAny()...); len(presence) > 0 {
            // ...
        }
    }

Explanation:
------------
The ISIS state query path must match the configured ISIS interface name. When
InterfaceRefInterfaceIDFormat deviation is enabled, the ISIS interface is
configured with ".0" suffix, so queries must also use the same suffix.

**CHANGE** #5: METADATA DEVIATION FIX (CRITICAL)

Location: metadata.textproto, Cisco platform_exceptions section

Problem:
--------
The test had `interface_ref_interface_id_format: true` deviation set for Cisco,
but comparing with WORKING Cisco ISIS tests revealed they don't use this deviation:

| Test                         | Uses interface_ref_interface_id_format |
|------------------------------|----------------------------------------|
| weighted_ecmp_test (WORKS)   | NO                                     |
| isis_drain_test (WORKS)      | NO                                     |
| aggregate_all_not_viable     | YES <-- PROBLEM                        |

This deviation was causing:
1. ISIS interface names to use ".0" suffix (Bundle-Ether2.0)
2. Mismatch between configured interface and ISIS adjacency lookup
3. ISIS adjacency never forming properly

Code Change:
------------
BEFORE:
    platform_exceptions: {
      platform: {
        vendor: CISCO
      }
      deviations: {
        interface_ref_config_unsupported:true
        wecmp_auto_unsupported: true
        isis_loopback_required: true
        weighted_ecmp_fixed_packet_verification: true
        interface_ref_interface_id_format: true   <-- REMOVED
      }
    }

AFTER:
    platform_exceptions: {
      platform: {
        vendor: CISCO
      }
      deviations: {
        interface_ref_config_unsupported:true
        wecmp_auto_unsupported: true
        isis_loopback_required: true
        weighted_ecmp_fixed_packet_verification: true
      }
    }

Explanation:
------------
The interface_ref_interface_id_format deviation is used for certain interfaces
that require subinterface notation in their configuration. However, for Cisco
LAG interfaces in ISIS, this is not needed. Working Cisco ISIS tests use only:
- interface_ref_config_unsupported: true (skip interface-ref in ISIS config)
- isis_loopback_required: true (configure Loopback0 for ISIS)

Removing this unnecessary deviation ensures ISIS interfaces are configured
with the correct names that match the actual interface names on the device.


**FILES MODIFIED**

1. aggregate_all_not_forwarding_viable_test.go
   - Added vendor check for VRF assignment (Change #1)
   - Added configureLoopback function (Change #2)
   - Modified configureDUTISIS for loopback handling (Change #3)
   - Modified awaitAdjacency and gnmi.LookupAll calls (Change #4)

2. metadata.textproto
   - Removed interface_ref_interface_id_format deviation (Change #5)
