### PR TITLE
Removed the missing_value_for_defaults deviation from RT-1.54 and RT-1.11

### DIFF
--- a/feature/bgp/otg_tests/bgp_override_as_path_split_horizon_test/metadata.textproto
+++ b/feature/bgp/otg_tests/bgp_override_as_path_split_horizon_test/metadata.textproto
@@ -12,7 +12,6 @@ platform_exceptions: {
   deviations: {
     explicit_interface_in_default_vrf: true
     interface_enabled: true
-    missing_value_for_defaults: true
     default_bgp_instance_name: "BGP"
   }
 }

--- a/feature/bgp/otg_tests/bgp_remove_private_as/metadata.textproto
+++ b/feature/bgp/otg_tests/bgp_remove_private_as/metadata.textproto
@@ -22,7 +22,6 @@ platform_exceptions: {
   deviations: {
     interface_enabled: true
     explicit_interface_in_default_vrf: true
-    missing_value_for_defaults: true
     default_bgp_instance_name: "BGP"
   }
 }


### PR DESCRIPTION
Updated metadata.textproto
- removed missing_value_for_defaults

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."