### PR TITLE
CNTR-3.8: Set restart policy to always in cold reboot persistence test

### DIFF
--- a/feature/container/failover/tests/supervisor_failover/failover_test.go
+++ b/feature/container/failover/tests/supervisor_failover/failover_test.go
@@ -445,6 +445,7 @@ func TestContainerPersistenceAfterColdReboot(t *testing.T) {
 		startOpts := []client.StartOption{
 			client.WithPorts([]string{"60061:60061"}),
 			client.WithVolumes([]string{fmt.Sprintf("%s:%s", volName, "/data")}),
+                        client.WithRestartPolicy("always"),
 		}
 		// Ensure container is removed before starting.
 		if err := cli.RemoveContainer(ctx, containerName, true); err != nil && status.Code(err) != codes.NotFound && status.Code(err) != codes.Unknown {

--- a/feature/container/failover/tests/supervisor_failover/failover_test.go
+++ b/feature/container/failover/tests/supervisor_failover/failover_test.go
@@ -445,7 +445,7 @@ func TestContainerPersistenceAfterColdReboot(t *testing.T) {
 		startOpts := []client.StartOption{
 			client.WithPorts([]string{"60061:60061"}),
 			client.WithVolumes([]string{fmt.Sprintf("%s:%s", volName, "/data")}),
-                        client.WithRestartPolicy("always"),
+			client.WithRestartPolicy("always"),
 		}
 		// Ensure container is removed before starting.
 		if err := cli.RemoveContainer(ctx, containerName, true); err != nil && status.Code(err) != codes.NotFound && status.Code(err) != codes.Unknown {


### PR DESCRIPTION
Fixes #5268

TestContainerPersistenceAfterColdReboot started container with default restart policy (none), so container did not restart after cold reboot.
Added client.WithRestartPolicy("always") in startOpts to align behavior with expected post-reboot RUNNING state.