### PR TITLE
Removing the authkey change specific to Juniper

### DIFF
--- a/internal/security/credz/credz.go
+++ b/internal/security/credz/credz.go
@@ -224,9 +224,6 @@ func RotateAuthorizedKey(t *testing.T, dut *ondatra.DUTDevice, dir, username, ve
 			keyType = cpb.KeyType_KEY_TYPE_ED25519
 		}
 		authKey := dataTypes[1]
-		if dut.Vendor() == ondatra.JUNIPER {
-			authKey = bytes.Join(dataTypes[:2], []byte(" "))
-		}
 		keyContents = append(keyContents, &cpb.AccountCredentials_AuthorizedKey{
 			AuthorizedKey: authKey,
 			KeyType:       keyType,


### PR DESCRIPTION
Remove the Juniper-specific special case in RotateAuthorizedKey that was adding the SSH algorithm prefix to the AuthorizedKey field. According to the gNSI Credentialz proto definition, this field should only contain the base64-encoded key.

