### PR TITLE
Removed juniper specific changes RotateAuthorizedKey

### DIFF
--- a/internal/security/credz/credz.go
+++ b/internal/security/credz/credz.go
@@ -262,9 +262,6 @@ func RotateTrustedUserCA(t *testing.T, dut *ondatra.DUTDevice, dir string) {
 			t.Fatalf("Unrecognized key type: %s", dataTypes[0])
 		}
 		pubKey := dataTypes[1]
-		if dut.Vendor() == ondatra.JUNIPER {
-			pubKey = bytes.Join(dataTypes[:2], []byte(" "))
-		}
 		keyContents = append(keyContents, &cpb.PublicKey{
 			PublicKey: pubKey,
 			KeyType:   keyType,


### PR DESCRIPTION
Remove the Juniper-specific special case in RotateTrustedUserCA that was adding the SSH algorithm prefix to the AuthorizedKey field. According to the gNSI Credentialz proto definition, this field should only contain the base64-encoded key.