### PR TITLE
[RT-7.9] Update wait times for convergence

### DIFF
--- a/feature/bgp/policybase/otg_tests/multipath_bgp_ecmp_protocol_nexthop/multipath_bgp_ecmp_protocol_nexthop_test.go
+++ b/feature/bgp/policybase/otg_tests/multipath_bgp_ecmp_protocol_nexthop/multipath_bgp_ecmp_protocol_nexthop_test.go
@@ -418,9 +418,9 @@ func enableMultipath(t *testing.T, dut *ondatra.DUTDevice, maxpaths uint32, ipv4
 	} else {
 		cliConfig := fmt.Sprintf("router bgp %v\nmaximum-paths %v\n", dutAS, maxpaths)
 		t.Logf("CLI config: \n%v", cliConfig)
-		t.Logf("Now applying CLI config on DUT, sleep for 30 seconds")
+		t.Logf("Now applying CLI config on DUT, sleep for 60 seconds")
 		helpers.GnmiCLIConfig(t, dut, cliConfig)
-		time.Sleep(30 * time.Second)
+		time.Sleep(60 * time.Second)
 	}
 }
 
@@ -649,7 +649,7 @@ func verifyBGPPrefixesTelemetry(t *testing.T, dut *ondatra.DUTDevice, nbrs []str
 		} else {
 			prefixPath = statePath.Neighbor(nbr).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).Prefixes()
 		}
-		if gotRx, ok := gnmi.Watch(t, dut, prefixPath.ReceivedPrePolicy().State(), 30*time.Second, func(val *ygnmi.Value[uint32]) bool {
+		if gotRx, ok := gnmi.Watch(t, dut, prefixPath.ReceivedPrePolicy().State(), 2*time.Minute, func(val *ygnmi.Value[uint32]) bool {
 			gotRx, ok := val.Val()
 			return ok && gotRx == wantRx
 		}).Await(t); !ok {


### PR DESCRIPTION
Increase gnmi.Watch timeout in verifyBGPPrefixesTelemetry from 30s to 2 minutes to allow sufficient time for initial BGP prefix advertisement over IS-IS loopback sessions to propagate to DUT telemetry.

Increase sleep in enableMultipath (Arista deviation path) from 30s to 60s to ensure EOS fully programs the 3-path ECMP FIB before traffic validation begins, preventing transient packet loss during hardware convergence.