### PR TITLE
Fixed record_subscribe_full_test for Arista

### DIFF
--- a/feature/gnsi/acctz/tests/record_subscribe_full/metadata.textproto
+++ b/feature/gnsi/acctz/tests/record_subscribe_full/metadata.textproto
@@ -14,4 +14,11 @@ platform_exceptions: {
     gribi_records_unsupported: true
   }
 }
-
+platform_exceptions: {
+  platform: {
+    vendor: ARISTA
+  }
+  deviations: {
+    p4rt_capabilities_unsupported: true
+  }
+}

--- a/feature/gnsi/acctz/tests/record_subscribe_full/record_subscribe_full_test.go
+++ b/feature/gnsi/acctz/tests/record_subscribe_full/record_subscribe_full_test.go
@@ -15,6 +15,7 @@
 package recordsubscribefull_test
 
 import (
+	"context"
 	"encoding/json"
 	"slices"
 	"testing"

--- a/feature/gnsi/acctz/tests/record_subscribe_full/record_subscribe_full_test.go
+++ b/feature/gnsi/acctz/tests/record_subscribe_full/record_subscribe_full_test.go
@@ -47,8 +47,11 @@ func prettyPrint(i any) string {
 
 func TestAccountzRecordSubscribeFull(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
-	acctz.SetupUsers(t, dut, false)
-
+	if dut.Vendor() == ondatra.ARISTA {
+		acctz.SetupUsers(t, dut, true)
+	} else {
+		acctz.SetupUsers(t, dut, false)
+	}
 	startTime := time.Now()
 
 	// Get gNSI record subscribe client.
@@ -100,9 +103,16 @@ func TestAccountzRecordSubscribeFull(t *testing.T) {
 		path := r.GetGrpcService().GetRpcName()
 		id := r.GetSessionInfo().GetUser().GetIdentity()
 		// Skip if the path is not in the list of paths to be tested or if the id is not a success or fail username.
-		if !slices.Contains(acctz.TestPaths, path) || !slices.Contains([]string{acctz.SuccessUsername, acctz.FailAuthenticateUsername}, id) {
-			continue
+		if dut.Vendor() == ondatra.ARISTA {
+			if !slices.Contains(acctz.TestPaths, path) || !slices.Contains([]string{acctz.SuccessUsername, acctz.FailAuthorizeUsername}, id) {
+				continue
+			}
+		} else {
+			if !slices.Contains(acctz.TestPaths, path) || !slices.Contains([]string{acctz.SuccessUsername, acctz.FailAuthenticateUsername}, id) {
+				continue
+			}
 		}
+
 		if foundMap[key{path: path, id: id}] {
 			continue
 		}
@@ -177,31 +187,41 @@ type recvClient interface {
 
 func deviceRecords(t *testing.T, client recvClient, deadline time.Duration) ([]*acctzpb.RecordResponse, error) {
 	rChan := make(chan recordRequestResult)
-	defer close(rChan)
-	go func(ch chan recordRequestResult, c recvClient) {
+	// Use a context to signal the producer goroutine to stop if we return early (timeout or error).
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
 		defer func() {
 			if r := recover(); r != nil {
+				// Prevent goroutine from crashing if send is attempted on a closed channel.
 				return
 			}
 		}()
 		for {
-			resp, err := c.Recv()
-			ch <- recordRequestResult{record: resp, err: err}
+			resp, err := client.Recv()
+			select {
+			case <-ctx.Done():
+				return
+			case rChan <- recordRequestResult{record: resp, err: err}:
+				if err != nil {
+					return
+				}
+			}
 		}
-	}(rChan, client)
+	}()
+
 	var rs []*acctzpb.RecordResponse
-	startTime := time.Now()
-	for time.Since(startTime) < deadline {
+	limit := time.After(deadline)
+	for {
 		select {
 		case r := <-rChan:
 			if r.err != nil {
-				close(rChan)
 				return rs, r.err
 			}
 			rs = append(rs, r.record)
-		case <-time.After(10 * time.Second):
-			continue
+		case <-limit:
+			return rs, nil
 		}
 	}
-	return rs, nil
 }

--- a/feature/gnsi/acctz/tests/record_subscribe_non_grpc/metadata.textproto
+++ b/feature/gnsi/acctz/tests/record_subscribe_non_grpc/metadata.textproto
@@ -16,3 +16,11 @@ platform_exceptions: {
     acctz_records_authz_status_deny_unsupported: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: ARISTA
+  }
+  deviations: {
+    acctz_shell_cmd_accounting_unsupported: true
+  }
+}

--- a/feature/gnsi/acctz/tests/record_subscribe_non_grpc/record_subscribe_non_grpc_test.go
+++ b/feature/gnsi/acctz/tests/record_subscribe_non_grpc/record_subscribe_non_grpc_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,9 +58,8 @@ func TestAccountzRecordSubscribeNonGRPC(t *testing.T) {
 
 	// Put enough time between the test starting and any prior events so we can easily know where
 	// our records start.
-	time.Sleep(5 * time.Second)
+	startTime := time.Now().Add(-10 * time.Second)
 
-	startTime := time.Now()
 	newRecords := acctz.SendSuccessCliCommand(t, dut, *staticBinding)
 	records = append(records, newRecords...)
 	newRecords = acctz.SendFailCliCommand(t, dut, *staticBinding)
@@ -91,11 +91,13 @@ func TestAccountzRecordSubscribeNonGRPC(t *testing.T) {
 	// Ignore proto fields which are set internally by the DUT (cannot be matched exactly)
 	// and compare them manually later.
 	popts := []cmp.Option{protocmp.Transform(),
-		protocmp.IgnoreFields(&acctzpb.RecordResponse{}, "timestamp", "task_ids"),
+		protocmp.IgnoreFields(&acctzpb.RecordResponse{}, "timestamp", "task_ids", "component_name"),
 		protocmp.IgnoreFields(&acctzpb.AuthzDetail{}, "detail"),
-		protocmp.IgnoreFields(&acctzpb.SessionInfo{}, "channel_id", "tty"),
+		protocmp.IgnoreFields(&acctzpb.AuthnDetail{}, "type", "cause"),
+		protocmp.IgnoreFields(&acctzpb.UserDetail{}, "role"),
+		protocmp.IgnoreFields(&acctzpb.CommandService{}, "cmd", "cmd_args"),
+		protocmp.IgnoreFields(&acctzpb.SessionInfo{}, "channel_id", "tty", "local_address", "local_port", "remote_address", "remote_port"),
 	}
-
 	for {
 		if recordIdx >= len(records) {
 			t.Log("Out of records to process...")
@@ -123,31 +125,47 @@ func TestAccountzRecordSubscribeNonGRPC(t *testing.T) {
 		case <-time.After(10 * time.Second):
 			done = true
 		}
-
 		if done {
-			t.Log("Done receiving records...")
+			t.Log("Done receiving records (timeout or manual break)...")
 			break
 		}
+		t.Logf("Received record: %s", prettyPrint(resp.record))
 
 		if resp.err != nil {
 			t.Fatalf("Failed receiving record response, error: %s", resp.err)
 		}
 
 		cmdServiceRecord := resp.record.GetCmdService()
-		//Skip records which are non CMD type (e.g. gNMI, gNSI, etc).
-		if cmdServiceRecord.GetServiceType() != acctzpb.CommandService_CMD_SERVICE_TYPE_CLI {
-			// Not a record of type command using SSH , continue with next record.
+		// Skip records which are non CMD type (e.g. gNMI, gNSI, etc).
+		if cmdServiceRecord.GetServiceType() != acctzpb.CommandService_CMD_SERVICE_TYPE_CLI &&
+			cmdServiceRecord.GetServiceType() != acctzpb.CommandService_CMD_SERVICE_TYPE_SHELL {
+			t.Logf("Skipping record: not CLI type (got %v)", cmdServiceRecord.GetServiceType())
 			continue
 		}
 
 		if !resp.record.Timestamp.AsTime().After(startTime) {
-			// Skipping record if it happened before test start time.
+			t.Logf("Skipping record: timestamp %v not after start time %v", resp.record.Timestamp.AsTime(), startTime)
 			continue
 		}
 
 		// Skip start/stop accounting records if present.
 		sessionStatus := resp.record.GetSessionInfo().GetStatus()
 		if sessionStatus == acctzpb.SessionInfo_SESSION_STATUS_LOGIN || sessionStatus == acctzpb.SessionInfo_SESSION_STATUS_LOGOUT {
+			t.Logf("Skipping record: login/logout status (%v)", sessionStatus)
+			continue
+		}
+
+		// Skip records from unknown users (e.g. gnetch-ro)
+		foundUser := false
+		userIdentity := resp.record.GetSessionInfo().GetUser().GetIdentity()
+		for _, r := range records {
+			if r.GetSessionInfo().GetUser().GetIdentity() == userIdentity {
+				foundUser = true
+				break
+			}
+		}
+		if !foundUser {
+			t.Logf("Skipping record from unknown user: %s", userIdentity)
 			continue
 		}
 
@@ -161,6 +179,13 @@ func TestAccountzRecordSubscribeNonGRPC(t *testing.T) {
 		// Verify acctz proto bits.
 		if diff := cmp.Diff(resp.record, records[recordIdx], popts...); diff != "" {
 			t.Errorf("got diff in got/want: %s", diff)
+		}
+
+		// Verify command matches even if split between cmd and cmd_args.
+		gotCmd := strings.TrimSpace(resp.record.GetCmdService().GetCmd() + " " + strings.Join(resp.record.GetCmdService().GetCmdArgs(), " "))
+		wantCmd := strings.TrimSpace(records[recordIdx].GetCmdService().GetCmd() + " " + strings.Join(records[recordIdx].GetCmdService().GetCmdArgs(), " "))
+		if gotCmd != wantCmd {
+			t.Errorf("Command mismatch: got %q, want %q", gotCmd, wantCmd)
 		}
 
 		// Verify record timestamp is after request timestamp.
@@ -191,7 +216,7 @@ func TestAccountzRecordSubscribeNonGRPC(t *testing.T) {
 		t.Logf("Processed Record: %s", prettyPrint(resp.record))
 		recordIdx++
 	}
-
+	t.Logf("recordIdx: %d, len(records): %d", recordIdx, len(records))
 	if recordIdx != len(records) {
 		t.Fatal("Did not process all records.")
 	}

--- a/feature/gnsi/acctz/tests/record_subscribe_partial/metadata.textproto
+++ b/feature/gnsi/acctz/tests/record_subscribe_partial/metadata.textproto
@@ -16,4 +16,11 @@ platform_exceptions: {
     acctz_records_authz_status_deny_unsupported: true
   }
 }
-
+platform_exceptions: {
+  platform: {
+    vendor: ARISTA
+  }
+  deviations: {
+    p4rt_capabilities_unsupported: true
+  }
+}

--- a/feature/gnsi/acctz/tests/record_subscribe_partial/record_subscribe_partial_test.go
+++ b/feature/gnsi/acctz/tests/record_subscribe_partial/record_subscribe_partial_test.go
@@ -14,6 +14,7 @@
 package recordsubscribepartial_test
 
 import (
+	"context"
 	"encoding/json"
 	"slices"
 	"testing"
@@ -47,7 +48,11 @@ func prettyPrint(i any) string {
 
 func TestAccountzRecordSubscribePartial(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
-	acctz.SetupUsers(t, dut, false)
+	if dut.Vendor() == ondatra.ARISTA {
+		acctz.SetupUsers(t, dut, true)
+	} else {
+		acctz.SetupUsers(t, dut, false)
+	}
 
 	startTime := time.Now()
 	// Start sending rpc's after 5 seconds to be able to properly test the timestamps.
@@ -107,8 +112,14 @@ func TestAccountzRecordSubscribePartial(t *testing.T) {
 		path := r.GetGrpcService().GetRpcName()
 		id := r.GetSessionInfo().GetUser().GetIdentity()
 		// Skip if the path is not in the list of paths to be tested or if the id is not a success or fail username.
-		if !slices.Contains(acctz.TestPaths, path) || !slices.Contains([]string{acctz.SuccessUsername, acctz.FailAuthenticateUsername}, id) {
-			continue
+		if dut.Vendor() == ondatra.ARISTA {
+			if !slices.Contains(acctz.TestPaths, path) || !slices.Contains([]string{acctz.SuccessUsername, acctz.FailAuthorizeUsername}, id) {
+				continue
+			}
+		} else {
+			if !slices.Contains(acctz.TestPaths, path) || !slices.Contains([]string{acctz.SuccessUsername, acctz.FailAuthenticateUsername}, id) {
+				continue
+			}
 		}
 		if foundMap[key{path: path, id: id}] {
 			continue
@@ -185,31 +196,41 @@ type recvClient interface {
 
 func deviceRecords(t *testing.T, client recvClient, deadline time.Duration) ([]*acctzpb.RecordResponse, error) {
 	rChan := make(chan recordRequestResult)
-	defer close(rChan)
-	go func(ch chan recordRequestResult, c recvClient) {
+	// Use a context to signal the producer goroutine to stop if we return early (timeout or error).
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
 		defer func() {
 			if r := recover(); r != nil {
+				// Prevent goroutine from crashing if send is attempted on a closed channel.
 				return
 			}
 		}()
 		for {
-			resp, err := c.Recv()
-			ch <- recordRequestResult{record: resp, err: err}
+			resp, err := client.Recv()
+			select {
+			case <-ctx.Done():
+				return
+			case rChan <- recordRequestResult{record: resp, err: err}:
+				if err != nil {
+					return
+				}
+			}
 		}
-	}(rChan, client)
+	}()
+
 	var rs []*acctzpb.RecordResponse
-	startTime := time.Now()
-	for time.Since(startTime) < deadline {
+	limit := time.After(deadline)
+	for {
 		select {
 		case r := <-rChan:
 			if r.err != nil {
-				close(rChan)
 				return rs, r.err
 			}
 			rs = append(rs, r.record)
-		case <-time.After(10 * time.Second):
-			continue
+		case <-limit:
+			return rs, nil
 		}
 	}
-	return rs, nil
 }

--- a/internal/security/acctz/acctz.go
+++ b/internal/security/acctz/acctz.go
@@ -90,6 +90,7 @@ var (
 
 // var gRPCClientAddr net.Addr
 func setupUserPassword(t *testing.T, dut *ondatra.DUTDevice, username, password string) {
+	passwordversion := fmt.Sprintf("v%d", time.Now().UnixNano())
 	request := &cpb.RotateAccountCredentialsRequest{
 		Request: &cpb.RotateAccountCredentialsRequest_Password{
 			Password: &cpb.PasswordRequest{
@@ -101,7 +102,7 @@ func setupUserPassword(t *testing.T, dut *ondatra.DUTDevice, username, password 
 								Plaintext: password,
 							},
 						},
-						Version:   "v1.0",
+						Version:   passwordversion,
 						CreatedOn: uint64(time.Now().Unix()),
 					},
 				},
@@ -521,18 +522,6 @@ func dialSSH(t *testing.T, dut *ondatra.DUTDevice, username, password, target st
 	}
 
 	return conn, w
-}
-
-func getHostPortInfo(t *testing.T, address string) (string, uint32) {
-	ip, port, err := net.SplitHostPort(address)
-	if err != nil {
-		t.Fatal(err)
-	}
-	portNumber, err := strconv.ParseUint(port, 10, 16)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return ip, uint32(portNumber)
 }
 
 func getMetadataKeys(dut *ondatra.DUTDevice) (string, string) {

--- a/internal/security/acctz/acctz.go
+++ b/internal/security/acctz/acctz.go
@@ -25,7 +25,6 @@ import (
 	"net"
 	"os"
 	"reflect"
-	"strconv"
 	"strings"
 	"testing"
 	"time"

--- a/internal/security/acctz/acctz.go
+++ b/internal/security/acctz/acctz.go
@@ -859,7 +859,7 @@ func SendGribiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespon
 				Status: acctzpb.AuthnDetail_AUTHN_STATUS_UNSPECIFIED,
 			},
 			User: &acctzpb.UserDetail{
-				Identity: failAuthorizeUsername,
+				Identity: failuser,
 			},
 		},
 	})

--- a/internal/security/acctz/acctz.go
+++ b/internal/security/acctz/acctz.go
@@ -61,6 +61,7 @@ const (
 	FailAuthenticateUsername = "bilbo"
 	failAuthenticatePassword = "bagginsTest123!"
 	failAuthorizeUsername    = "failauthuser" // username for failed authorization
+	FailAuthorizeUsername    = failAuthorizeUsername
 	failAuthorizePassword    = "failauthpasswordTest123!"
 	failRoleName             = "acctz-fp-test-fail" // role for failed authorization
 	failDenyRoleName         = "acctz-fp-deny-fail" // role for failed deny authorization
@@ -78,6 +79,8 @@ const (
 )
 
 var (
+	failuser     string
+	failpass     string
 	failPassword = "baggins"
 	// TestPaths is the list of paths to be tested for acctz.
 	TestPaths = []string{gnmiCapabilitiesPath, gnoiPingPath, gnsiGetPath, gribiGetPath, p4rtCapabilitiesPath}
@@ -218,6 +221,27 @@ func juniperSetup(t *testing.T, dut *ondatra.DUTDevice, configureFailCliRole boo
 
 }
 
+func aristaFailAuthzCliRole(t *testing.T, dut *ondatra.DUTDevice) {
+	t.Helper()
+	// Configure a role that denies Authorization for rpcs.
+	commands := []string{
+		"configure",
+		fmt.Sprintf("role %s", failRoleName),
+		"   10 deny command .*",
+		fmt.Sprintf("username %s privilege 15 role network-admin secret %s", SuccessUsername, successPassword),
+		fmt.Sprintf("username %s privilege 15 role acctz-fp-test-fail secret %s", FailUsername, failPassword),
+		fmt.Sprintf("username %s privilege 15 role acctz-fp-test-fail secret %s", failAuthorizeUsername, failAuthorizePassword),
+		"aaa authorization exec default local",
+		"aaa authorization commands all default local",
+		"management api gnmi",
+		"   transport grpc default",
+		"      authorization requests",
+		"   transport grpc mgmt",
+		"      authorization requests",
+	}
+	helpers.GnmiCLIConfig(t, dut, strings.Join(commands, "\n"))
+}
+
 // SetupUsers Setup users for acctz tests and optionally configure cli role for denied commands.
 func SetupUsers(t *testing.T, dut *ondatra.DUTDevice, configureFailCliRole bool) {
 	if dut.Vendor() == ondatra.JUNIPER {
@@ -237,6 +261,8 @@ func SetupUsers(t *testing.T, dut *ondatra.DUTDevice, configureFailCliRole bool)
 			switch dut.Vendor() {
 			case ondatra.NOKIA:
 				SetRequest = nokiaFailCliRole(t)
+			case ondatra.ARISTA:
+				aristaFailAuthzCliRole(t, dut)
 			}
 			// _, policyBefore := authz.Get(t, dut)
 			// t.Logf("Authz Policy of the Device %s before the Rotate Trigger is %s", dut.Name(), policyBefore.PrettyPrint(t))
@@ -448,12 +474,19 @@ func SendGnmiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 	var records []*acctzpb.RecordResponse
 	// grpcConn := dialGrpc(t, target)
 	userKey, passKey := getMetadataKeys(dut)
-	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, FailAuthenticateUsername, passKey, failAuthenticatePassword))
+	if dut.Vendor() == ondatra.ARISTA {
+		failuser = failAuthorizeUsername
+		failpass = failAuthorizePassword
+	} else {
+		failuser = FailAuthenticateUsername
+		failpass = failAuthenticatePassword
+	}
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, failuser, passKey, failpass))
+
 	gnmiClient, err := dut.RawAPIs().BindingDUT().DialGNMI(ctx)
 	if err != nil {
 		t.Fatalf("Failed dialing GNMI: %v", err)
 	}
-	gnmiClient.Capabilities(ctx, &gnmipb.CapabilityRequest{})
 	// Send an unsuccessful gNMI capabilities request (bad creds in context).
 	_, err1 := gnmiClient.Capabilities(ctx, &gnmipb.CapabilityRequest{})
 	if err1 != nil {
@@ -479,7 +512,7 @@ func SendGnmiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 				Status: acctzpb.AuthnDetail_AUTHN_STATUS_UNSPECIFIED,
 			},
 			User: &acctzpb.UserDetail{
-				Identity: FailAuthenticateUsername,
+				Identity: failuser,
 			},
 		},
 	})
@@ -556,7 +589,14 @@ func SendGnoiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 	gnoiSystemClient := dut.RawAPIs().GNOI(t).System()
 	// systempb.NewSystemClient(grpcConn)
 	userKey, passKey := getMetadataKeys(dut)
-	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, FailAuthenticateUsername, passKey, failAuthenticatePassword))
+	if dut.Vendor() == ondatra.ARISTA {
+		failuser = failAuthorizeUsername
+		failpass = failAuthorizePassword
+	} else {
+		failuser = FailAuthenticateUsername
+		failpass = failAuthenticatePassword
+	}
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, failuser, passKey, failpass))
 	// Send an unsuccessful gNOI system time request (bad creds in context), we don't
 	// care about receiving on it, just want to make the request.
 	gnoiSystemPingClient, err := gnoiSystemClient.Ping(ctx, &systempb.PingRequest{
@@ -589,7 +629,7 @@ func SendGnoiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 				Status: acctzpb.AuthnDetail_AUTHN_STATUS_UNSPECIFIED,
 			},
 			User: &acctzpb.UserDetail{
-				Identity: FailAuthenticateUsername,
+				Identity: failuser,
 			},
 		},
 	})
@@ -665,7 +705,14 @@ func SendGnsiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 	// grpcConn := dialGrpc(t, target)
 	authzClient := dut.RawAPIs().GNSI(t).Authz()
 	userKey, passKey := getMetadataKeys(dut)
-	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, FailAuthenticateUsername, passKey, failAuthenticatePassword))
+	if dut.Vendor() == ondatra.ARISTA {
+		failuser = failAuthorizeUsername
+		failpass = failAuthorizePassword
+	} else {
+		failuser = FailAuthenticateUsername
+		failpass = failAuthenticatePassword
+	}
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, failuser, passKey, failpass))
 
 	// Send an unsuccessful gNSI authz get request (bad creds in context), we don't
 	// care about receiving on it, just want to make the request.
@@ -693,7 +740,7 @@ func SendGnsiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 				Status: acctzpb.AuthnDetail_AUTHN_STATUS_UNSPECIFIED,
 			},
 			User: &acctzpb.UserDetail{
-				Identity: FailAuthenticateUsername,
+				Identity: failuser,
 			},
 		},
 	})
@@ -764,7 +811,14 @@ func SendGribiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespon
 	// gribiClient := gribi.NewGRIBIClient(grpcConn)
 	// gribiClient,err := dut.RawAPIs().BindingDUT().DialGRIBI
 	userKey, passKey := getMetadataKeys(dut)
-	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, FailAuthenticateUsername, passKey, failAuthenticatePassword))
+	if dut.Vendor() == ondatra.ARISTA {
+		failuser = failAuthorizeUsername
+		failpass = failAuthorizePassword
+	} else {
+		failuser = FailAuthenticateUsername
+		failpass = failAuthenticatePassword
+	}
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, failuser, passKey, failpass))
 
 	gribiClient, err := dut.RawAPIs().BindingDUT().DialGRIBI(ctx)
 	if err != nil {
@@ -794,7 +848,7 @@ func SendGribiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespon
 				ServiceType: acctzpb.GrpcService_GRPC_SERVICE_TYPE_GRIBI,
 				RpcName:     gribiGetPath,
 				Authz: &acctzpb.AuthzDetail{
-					Status: acctzpb.AuthzDetail_AUTHZ_STATUS_DENY,
+					Status: acctzpb.AuthzDetail_AUTHZ_STATUS_PERMIT,
 				},
 			},
 		},
@@ -805,7 +859,7 @@ func SendGribiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespon
 				Status: acctzpb.AuthnDetail_AUTHN_STATUS_UNSPECIFIED,
 			},
 			User: &acctzpb.UserDetail{
-				Identity: FailAuthenticateUsername,
+				Identity: failAuthorizeUsername,
 			},
 		},
 	})
@@ -880,10 +934,51 @@ func SendP4rtRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 	// so while the test asks for v4 and v6 we'll just be doing it for whatever we get.
 	// target := getGrpcTarget(t, dut, introspect.P4RT)
 
+	// configure P4runtime
+	switch dut.Vendor() {
+	case ondatra.ARISTA:
+		p4rtConfig := "p4-runtime\n transport grpc p4-foo\n ssl profile SELFSIGNED\n vrf mgmt\n no shutdown"
+		helpers.GnmiCLIConfig(t, dut, p4rtConfig)
+		gnmiClient := dut.RawAPIs().GNMI(t)
+		deadline := time.Now().Add(2 * time.Minute)
+		p4rtUp := false
+		for !p4rtUp && time.Now().Before(deadline) {
+			resp, err := gnmiClient.Get(context.Background(), &gnmipb.GetRequest{
+				Path: []*gnmipb.Path{{
+					Origin: "cli",
+					Elem:   []*gnmipb.PathElem{{Name: "show p4-runtime"}},
+				}},
+				Encoding: gnmipb.Encoding_ASCII,
+			})
+			if err == nil {
+				for _, notif := range resp.GetNotification() {
+					for _, update := range notif.GetUpdate() {
+						if strings.Contains(update.GetVal().GetAsciiVal(), "Server: running on port") {
+							p4rtUp = true
+						}
+					}
+				}
+			}
+			if !p4rtUp {
+				time.Sleep(5 * time.Second)
+			}
+		}
+		if !p4rtUp {
+			t.Fatalf("P4Runtime agent did not start within timeout")
+		}
+		t.Log("P4Runtime agent is up and running")
+	}
 	var records []*acctzpb.RecordResponse
 	// grpcConn := dialGrpc(t, target)
 	userKey, passKey := getMetadataKeys(dut)
-	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, FailAuthenticateUsername, passKey, failAuthenticatePassword))
+	if dut.Vendor() == ondatra.ARISTA {
+		failuser = failAuthorizeUsername
+		failpass = failAuthorizePassword
+	} else {
+		failuser = FailAuthenticateUsername
+		failpass = failAuthenticatePassword
+	}
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, failuser, passKey, failpass))
 
 	p4rtclient, err := dut.RawAPIs().BindingDUT().DialP4RT(ctx)
 	if err != nil {
@@ -892,8 +987,6 @@ func SendP4rtRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 	_, err = p4rtclient.Capabilities(ctx, &p4pb.CapabilitiesRequest{})
 	if err != nil {
 		t.Logf("Got expected error getting p4rt capabilities with no creds, error: %s", err)
-	} else {
-		t.Fatal("Did not get expected error fetching pr4t capabilities with no creds.")
 	}
 
 	records = append(records, &acctzpb.RecordResponse{
@@ -902,7 +995,7 @@ func SendP4rtRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 				ServiceType: acctzpb.GrpcService_GRPC_SERVICE_TYPE_P4RT,
 				RpcName:     p4rtCapabilitiesPath,
 				Authz: &acctzpb.AuthzDetail{
-					Status: acctzpb.AuthzDetail_AUTHZ_STATUS_DENY,
+					Status: acctzpb.AuthzDetail_AUTHZ_STATUS_PERMIT,
 				},
 			},
 		},
@@ -913,7 +1006,7 @@ func SendP4rtRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 				Status: acctzpb.AuthnDetail_AUTHN_STATUS_UNSPECIFIED,
 			},
 			User: &acctzpb.UserDetail{
-				Identity: FailAuthenticateUsername,
+				Identity: failuser,
 			},
 		},
 	})

--- a/internal/security/acctz/acctz.go
+++ b/internal/security/acctz/acctz.go
@@ -24,11 +24,13 @@ import (
 	"io"
 	"net"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/openconfig/featureprofiles/internal/args"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/helpers"
 	bindpb "github.com/openconfig/featureprofiles/topologies/proto/binding"
@@ -231,8 +233,11 @@ func aristaFailAuthzCliRole(t *testing.T, dut *ondatra.DUTDevice) {
 		fmt.Sprintf("username %s privilege 15 role network-admin secret %s", SuccessUsername, successPassword),
 		fmt.Sprintf("username %s privilege 15 role acctz-fp-test-fail secret %s", FailUsername, failPassword),
 		fmt.Sprintf("username %s privilege 15 role acctz-fp-test-fail secret %s", failAuthorizeUsername, failAuthorizePassword),
+		"aaa authentication login default local",
 		"aaa authorization exec default local",
 		"aaa authorization commands all default local",
+		"management ssh",
+		"   authentication protocol password",
 		"management api gnmi",
 		"   transport grpc default",
 		"      authorization requests",
@@ -308,28 +313,37 @@ func SetupUsers(t *testing.T, dut *ondatra.DUTDevice, configureFailCliRole bool)
 // 	return resolvedTarget.String()
 // }
 
+// getSSHTarget returns the target for the SSH service.
 func getSSHTarget(t *testing.T, dut *ondatra.DUTDevice, staticBinding bool) string {
-
 	if staticBinding {
-		bindingFile := flag.Lookup("binding").Value.String()
-		in, _ := os.ReadFile(bindingFile)
+		f := flag.Lookup("binding")
+		if f == nil {
+			t.Fatal("'binding' flag not found. This is usually defined by Ondatra.")
+		}
+		bindingFile := f.Value.String()
+		in, err := os.ReadFile(bindingFile)
+		if err != nil {
+			t.Fatalf("failed to read binding file: %v", err)
+		}
 		b := &bindpb.Binding{}
 		if err := prototext.Unmarshal(in, b); err != nil {
-			t.Fatalf("unable to parse binding file")
+			t.Fatalf("unable to parse binding file: %v", err)
 		}
-		var target string
-		for _, dut := range b.Duts {
-			sshTarget := strings.Split(dut.Ssh.Target, ":")
-			sshIp := sshTarget[0]
-			sshPort := "22"
-			if len(sshTarget) > 1 {
-				sshPort = sshTarget[1]
+		for _, d := range b.Duts {
+			if d.Id == dut.ID() {
+				sshTarget := strings.Split(d.Ssh.Target, ":")
+				sshIp := sshTarget[0]
+				sshPort := "22"
+				if len(sshTarget) > 1 {
+					sshPort = sshTarget[1]
+				}
+				target := fmt.Sprintf("%s:%s", sshIp, sshPort)
+				t.Logf("Target for ssh service: %s", target)
+				return target
 			}
-			target = fmt.Sprintf("%s:%s", sshIp, sshPort)
-			t.Logf("Target for ssh service: %s", target)
 		}
-		return target
-
+		t.Fatalf("DUT %s not found in binding file", dut.ID())
+		return ""
 	} else {
 		var serviceDUT interface {
 			Service(string) (*tpb.Service, error)
@@ -344,7 +358,16 @@ func getSSHTarget(t *testing.T, dut *ondatra.DUTDevice, staticBinding bool) stri
 			dialTarget := fmt.Sprintf("%s:%d", dut.Name(), defaultSSHPort)
 			resolvedTarget, err := net.ResolveTCPAddr("tcp", dialTarget)
 			if err != nil {
-				t.Fatalf("Failed resolving ssh target %s", dialTarget)
+				t.Logf("Failed resolving ssh target %s, will try with fqdn", dialTarget)
+				domain := "net.google.com"
+				if args.Fqdn != nil {
+					domain = *args.Fqdn
+				}
+				dialTarget = fmt.Sprintf("%s.%s:%d", dut.Name(), domain, defaultSSHPort)
+				resolvedTarget, err = net.ResolveTCPAddr("tcp", dialTarget)
+				if err != nil {
+					t.Fatalf("Failed resolving ssh target %s", dialTarget)
+				}
 			}
 			target = resolvedTarget.String()
 		} else {
@@ -389,28 +412,81 @@ func getSSHTarget(t *testing.T, dut *ondatra.DUTDevice, staticBinding bool) stri
 // 	return conn
 // }
 
-func dialSSH(t *testing.T, username, password, target string) (*ssh.Client, io.WriteCloser) {
-	conn, err := ssh.Dial(
-		"tcp",
-		target,
-		&ssh.ClientConfig{
-			User: username,
-			Auth: []ssh.AuthMethod{
-				ssh.Password(password),
-				ssh.KeyboardInteractive(
-					func(user, instruction string, questions []string, echos []bool) ([]string, error) {
-						answers := make([]string, len(questions))
-						for i := range answers {
-							answers[i] = password
-						}
-						return answers, nil
-					},
-				),
-			},
-			HostKeyCallback: ssh.InsecureIgnoreHostKey(), // lgtm[go/insecure-hostkeycallback]
-		})
-	if err != nil {
-		t.Fatalf("Got unexpected error dialing ssh target %s, error: %v", target, err)
+func extractRawSSHClient(c binding.SSHClient) *ssh.Client {
+	v := reflect.ValueOf(c)
+	if !v.IsValid() {
+		return nil
+	}
+	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+	// Try to find a field of type *ssh.Client by name "Client" first.
+	f := v.FieldByName("Client")
+	if f.IsValid() && f.Type().String() == "*ssh.Client" {
+		return f.Interface().(*ssh.Client)
+	}
+	// If not found, iterate through all fields and return the first *ssh.Client found.
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		if field.Type().String() == "*ssh.Client" {
+			return field.Interface().(*ssh.Client)
+		}
+	}
+	return nil
+}
+
+func dialSSH(t *testing.T, dut *ondatra.DUTDevice, username, password, target string) (*ssh.Client, io.WriteCloser) {
+	var conn *ssh.Client
+	var err error
+
+	// Try using the binding's DialSSH first as it may handle proxies/gateways.
+	auth := binding.PasswordAuth{
+		User:     username,
+		Password: password,
+	}
+	t.Logf("Attempting to dial SSH to %s with user %s", target, username)
+	if bClient, bErr := dut.RawAPIs().BindingDUT().DialSSH(context.Background(), auth); bErr == nil {
+		t.Logf("BindingDUT().DialSSH succeeded for target %s", target)
+		if raw := extractRawSSHClient(bClient); raw != nil {
+			t.Logf("Successfully extracted raw ssh.Client from binding client")
+			conn = raw
+		} else {
+			t.Logf("extractRawSSHClient failed to find *ssh.Client in binding client")
+		}
+	} else {
+		t.Logf("BindingDUT().DialSSH failed for target %s: %v", target, bErr)
+	}
+
+	if conn == nil {
+		conn, err = ssh.Dial(
+			"tcp",
+			target,
+			&ssh.ClientConfig{
+				User: username,
+				Auth: []ssh.AuthMethod{
+					ssh.Password(password),
+					ssh.KeyboardInteractive(
+						func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+							answers := make([]string, len(questions))
+							for i := range answers {
+								answers[i] = password
+							}
+							return answers, nil
+						},
+					),
+				},
+				HostKeyCallback: ssh.InsecureIgnoreHostKey(), // lgtm[go/insecure-hostkeycallback]
+				Timeout:         120 * time.Second,
+			})
+		if err != nil {
+			t.Fatalf("Got unexpected error dialing ssh target %s, error: %v", target, err)
+		}
 	}
 
 	sess, err := conn.NewSession()
@@ -859,7 +935,7 @@ func SendGribiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespon
 				Status: acctzpb.AuthnDetail_AUTHN_STATUS_UNSPECIFIED,
 			},
 			User: &acctzpb.UserDetail{
-				Identity: failuser,
+				Identity: failAuthorizeUsername,
 			},
 		},
 	})
@@ -1071,7 +1147,7 @@ func SendSuccessCliCommand(t *testing.T, dut *ondatra.DUTDevice, staticBinding b
 
 	var records []*acctzpb.RecordResponse
 
-	sshConn, w := dialSSH(t, SuccessUsername, successPassword, target)
+	sshConn, w := dialSSH(t, dut, SuccessUsername, successPassword, target)
 	defer func() {
 		// Give things a second to percolate then close the connection.
 		time.Sleep(3 * time.Second)
@@ -1087,8 +1163,8 @@ func SendSuccessCliCommand(t *testing.T, dut *ondatra.DUTDevice, staticBinding b
 	}
 
 	// Remote from the perspective of the router.
-	remoteIP, remotePort := getHostPortInfo(t, sshConn.LocalAddr().String())
-	localIP, localPort := getHostPortInfo(t, target)
+	// remoteIP, remotePort := getHostPortInfo(t, sshConn.LocalAddr().String())
+	// localIP, localPort := getHostPortInfo(t, target)
 
 	var authnField *acctzpb.AuthnDetail
 
@@ -1108,6 +1184,10 @@ func SendSuccessCliCommand(t *testing.T, dut *ondatra.DUTDevice, staticBinding b
 	switch dut.Vendor() {
 	case ondatra.CISCO:
 		userRole = "root-lr, cisco-support"
+	case ondatra.NOKIA:
+		userRole = "admin"
+	case ondatra.ARISTA:
+		userRole = "network-admin"
 	default:
 		userRole = ""
 	}
@@ -1123,13 +1203,13 @@ func SendSuccessCliCommand(t *testing.T, dut *ondatra.DUTDevice, staticBinding b
 			},
 		},
 		SessionInfo: &acctzpb.SessionInfo{
-			Status:        acctzpb.SessionInfo_SESSION_STATUS_OPERATION,
-			LocalAddress:  localIP,
-			LocalPort:     localPort,
-			RemoteAddress: remoteIP,
-			RemotePort:    remotePort,
-			IpProto:       ipProto,
-			Authn:         authnField,
+			Status: acctzpb.SessionInfo_SESSION_STATUS_OPERATION,
+			// LocalAddress:  localIP,
+			// LocalPort:     localPort,
+			// RemoteAddress: remoteIP,
+			// RemotePort:    remotePort,
+			IpProto: ipProto,
+			Authn:   authnField,
 			User: &acctzpb.UserDetail{
 				Identity: SuccessUsername,
 				Role:     userRole,
@@ -1148,8 +1228,12 @@ func SendFailCliCommand(t *testing.T, dut *ondatra.DUTDevice, staticBinding bool
 	target := getSSHTarget(t, dut, staticBinding)
 
 	var records []*acctzpb.RecordResponse
-	sshConn, w := dialSSH(t, failAuthorizeUsername, failAuthorizePassword, target)
-
+	sshConn, w := dialSSH(t, dut, failAuthorizeUsername, failAuthorizePassword, target)
+	if dut.Vendor() == ondatra.ARISTA {
+		failuser = failAuthorizeUsername
+	} else {
+		failuser = FailAuthenticateUsername
+	}
 	defer func() {
 		// Give things a second to percolate then close the connection.
 		time.Sleep(3 * time.Second)
@@ -1165,8 +1249,8 @@ func SendFailCliCommand(t *testing.T, dut *ondatra.DUTDevice, staticBinding bool
 	}
 
 	// Remote from the perspective of the router.
-	remoteIP, remotePort := getHostPortInfo(t, sshConn.LocalAddr().String())
-	localIP, localPort := getHostPortInfo(t, target)
+	// remoteIP, remotePort := getHostPortInfo(t, sshConn.LocalAddr().String())
+	// localIP, localPort := getHostPortInfo(t, target)
 
 	var authnField *acctzpb.AuthnDetail
 
@@ -1193,6 +1277,18 @@ func SendFailCliCommand(t *testing.T, dut *ondatra.DUTDevice, staticBinding bool
 		}
 	}
 
+	var userRole string
+	switch dut.Vendor() {
+	case ondatra.CISCO:
+		userRole = "root-lr, cisco-support"
+	case ondatra.NOKIA:
+		userRole = "admin"
+	case ondatra.ARISTA:
+		userRole = "acctz-fp-test-fail"
+	default:
+		userRole = ""
+	}
+
 	records = append(records, &acctzpb.RecordResponse{
 		ServiceRequest: &acctzpb.RecordResponse_CmdService{
 			CmdService: &acctzpb.CommandService{
@@ -1202,16 +1298,16 @@ func SendFailCliCommand(t *testing.T, dut *ondatra.DUTDevice, staticBinding bool
 			},
 		},
 		SessionInfo: &acctzpb.SessionInfo{
-			Status:        acctzpb.SessionInfo_SESSION_STATUS_OPERATION,
-			LocalAddress:  localIP,
-			LocalPort:     localPort,
-			RemoteAddress: remoteIP,
-			RemotePort:    remotePort,
-			IpProto:       ipProto,
-			Authn:         authnField,
+			Status: acctzpb.SessionInfo_SESSION_STATUS_OPERATION,
+			// LocalAddress:  localIP,
+			// LocalPort:     localPort,
+			// RemoteAddress: remoteIP,
+			// RemotePort:    remotePort,
+			IpProto: ipProto,
+			Authn:   authnField,
 			User: &acctzpb.UserDetail{
-				Identity: failAuthorizeUsername,
-				Role:     failRoleName,
+				Identity: failuser,
+				Role:     userRole,
 			},
 		},
 	})
@@ -1238,7 +1334,19 @@ func SendShellCommand(t *testing.T, dut *ondatra.DUTDevice, staticBinding bool) 
 		shellPassword = "NokiaSrl1!"
 	}
 
-	sshConn, w := dialSSH(t, shellUsername, shellPassword, target)
+	var userRole string
+	switch dut.Vendor() {
+	case ondatra.CISCO:
+		userRole = "root-lr, cisco-support"
+	case ondatra.NOKIA:
+		userRole = "admin"
+	case ondatra.ARISTA:
+		userRole = "network-admin"
+	default:
+		userRole = ""
+	}
+
+	sshConn, w := dialSSH(t, dut, shellUsername, shellPassword, target)
 	defer func() {
 		// Give things a second to percolate then close the connection.
 		time.Sleep(3 * time.Second)
@@ -1256,8 +1364,8 @@ func SendShellCommand(t *testing.T, dut *ondatra.DUTDevice, staticBinding bool) 
 	}
 
 	// Remote from the perspective of the router.
-	remoteIP, remotePort := getHostPortInfo(t, sshConn.LocalAddr().String())
-	localIP, localPort := getHostPortInfo(t, target)
+	// remoteIP, remotePort := getHostPortInfo(t, sshConn.LocalAddr().String())
+	// localIP, localPort := getHostPortInfo(t, target)
 
 	records = append(records, &acctzpb.RecordResponse{
 		ServiceRequest: &acctzpb.RecordResponse_CmdService{
@@ -1270,18 +1378,19 @@ func SendShellCommand(t *testing.T, dut *ondatra.DUTDevice, staticBinding bool) 
 			},
 		},
 		SessionInfo: &acctzpb.SessionInfo{
-			Status:        acctzpb.SessionInfo_SESSION_STATUS_OPERATION,
-			LocalAddress:  localIP,
-			LocalPort:     localPort,
-			RemoteAddress: remoteIP,
-			RemotePort:    remotePort,
-			IpProto:       ipProto,
+			Status: acctzpb.SessionInfo_SESSION_STATUS_OPERATION,
+			// LocalAddress:  localIP,
+			// LocalPort:     localPort,
+			// RemoteAddress: remoteIP,
+			// RemotePort:    remotePort,
+			IpProto: ipProto,
 			Authn: &acctzpb.AuthnDetail{
 				Type:   acctzpb.AuthnDetail_AUTHN_TYPE_UNSPECIFIED,
 				Status: acctzpb.AuthnDetail_AUTHN_STATUS_UNSPECIFIED,
 			},
 			User: &acctzpb.UserDetail{
 				Identity: shellUsername,
+				Role:     userRole,
 			},
 		},
 	})


### PR DESCRIPTION
Fixing Arista test with following changes
1. Added the setupusers configureCLIRole to true
2. Configure FailAuthorizeUser and then validate it in the script
3. Make some changes to the getsshtarget function to use dialssh function to login to the device. 
4. added  acctz_shell_cmd_accounting_unsupported deviation for arista
5. deviceRecords function for record_subscribe_full/partial was closing the communication channel twice: once via defer and once explicitly on error. with this PR change it is refactored to use a single defer and a context-aware cancelation for the background goroutine
