### PR TITLE
RT-3.1 and FP-1.1

### DIFF
--- a/feature/platform/tests/power_admin_down_up_test/power_admin_down_up_test.go
+++ b/feature/platform/tests/power_admin_down_up_test/power_admin_down_up_test.go
@@ -142,6 +142,9 @@ func powerDownUp(t *testing.T, dut *ondatra.DUTDevice, name string, cType oc.E_P
 	t.Logf("Starting %s POWER_DISABLE", name)
 	gnmi.Replace(t, dut, config, oc.Platform_ComponentPowerType_POWER_DISABLED)
 
+	// Wait time for control plan to stabilize and redial grpc connection
+	time.Sleep(30 * time.Second)
+
 	power, ok := gnmi.Await(t, dut, state, timeout, oc.Platform_ComponentPowerType_POWER_DISABLED).Val()
 	if !ok {
 		t.Errorf("Component %s, power-admin-state got: %v, want: %v", name, power, oc.Platform_ComponentPowerType_POWER_DISABLED)

--- a/feature/policy_forwarding/vrf_selection/otg_tests/base_vrf_selection/base_vrf_selection_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/base_vrf_selection/base_vrf_selection_test.go
@@ -379,6 +379,8 @@ func sendTraffic(t *testing.T, ate *ondatra.ATEDevice) {
 	time.Sleep(trafficDuration)
 	t.Logf("*** Stop traffic ...")
 	ate.OTG().StopTraffic(t)
+	// Wait for counters to be updated.
+	time.Sleep(20 * time.Second)
 }
 
 func captureTrafficStats(t *testing.T, ate *ondatra.ATEDevice, flowName string, wantLoss bool) {


### PR DESCRIPTION
base_vrf_selection_test.go - Add 20s wait time for counters to be updated and address flakiness. 
power_admin_down_up_test - Wait time of 30s for control plan to stabilize following a LC reboot. 
