### PR TITLE
CNTR-1: fix stale gNOI connection post reboot + Implement PushConfig for static bind.

### DIFF
--- a/feature/container/containerz/tests/container_lifecycle/containerz_test.go
+++ b/feature/container/containerz/tests/container_lifecycle/containerz_test.go
@@ -991,15 +991,43 @@ func TestContainerPersistenceAfterColdReboot(t *testing.T) {
 
 	t.Run("VerifyPersistence", func(t *testing.T) {
 		t.Log("Waiting for DUT to reboot and reconnect...")
+
 		// Wait for reboot.
-		time.Sleep(8 * time.Minute)
+		maxRebootTime := 8 * time.Minute
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		timeout := time.After(maxRebootTime)
+		var deviceWentDown bool
+
+	rebootLoop:
+		for {
+			select {
+			case <-timeout:
+				t.Fatalf("Timeout exceeded: DUT did not reboot within %v seconds.", maxRebootTime)
+			case <-ticker.C:
+				// use GNOI to refresh the stale cached connection post reboot.
+				sysClient := dut.RawAPIs().GNOI(t).System()
+				_, err := sysClient.Time(ctx, &gspb.TimeRequest{})
+				if err != nil {
+					if !deviceWentDown {
+						t.Logf("Device is now unreachable. Waiting for it to come back up.")
+						deviceWentDown = true
+					}
+				} else {
+					if deviceWentDown {
+						t.Logf("Device rebooted successfully.")
+						break rebootLoop
+					}
+					t.Logf("Device is still reachable; reboot hasn't started yet.")
+				}
+			}
+		}
 
 		// Poll for container state.
 		cli = containerztest.Client(t, dut)
 
 		// Use a generous timeout for the device to come back up and the container to start.
-		timeout := 5 * time.Minute
-		if err := containerztest.WaitForRunning(ctx, t, cli, instanceName, timeout); err != nil {
+		if err := containerztest.WaitForRunning(ctx, t, cli, instanceName, 5*time.Minute); err != nil {
 			t.Errorf("Container persistence failed: %v", err)
 		}
 

--- a/topologies/binding/binding.go
+++ b/topologies/binding/binding.go
@@ -175,6 +175,40 @@ func (d *staticDUT) reset(ctx context.Context) error {
 	return resetGRIBI(ctx, d)
 }
 
+func (d *staticDUT) PushConfig(ctx context.Context, config string, reset bool) error {
+	if reset {
+		if err := resetGNMI(ctx, d); err != nil {
+			return err
+		}
+	}
+	if config == "" {
+		return nil
+	}
+
+	setRequest := &gpb.SetRequest{Update: []*gpb.Update{
+		{
+			Path: &gpb.Path{
+				Origin: "cli",
+			},
+			Val: &gpb.TypedValue{
+				Value: &gpb.TypedValue_AsciiVal{
+					AsciiVal: config,
+				},
+			},
+		},
+	}}
+
+	gnmiClient, err := d.DialGNMI(ctx)
+	if err != nil {
+		return err
+	}
+	if _, err := gnmiClient.Set(ctx, setRequest); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (d *staticDUT) DialGNMI(ctx context.Context, opts ...grpc.DialOption) (gpb.GNMIClient, error) {
 	conn, err := dialConn(ctx, d, introspect.GNMI, opts)
 	if err != nil {


### PR DESCRIPTION
Currently, first containerZ call post reboot fails with 'connection reset by peer error' due to the stale connection handle cached by Ondatra. This PR waits for the device to come back up post reboot by polling the device state (instead of the current arbitrary sleep), and polls the device using gNOI (instead of the usual gNMI) to ensure the connection handle is proper post reboot.

The PR also implements PushConfig for static binding as it required to create a new containerZ client for certain vendors.