### PR TITLE
[deviations] Remove deprecated_vlan_id usage from ARISTA devaitions

### DIFF
--- a/feature/bgp/ate_tests/bgp_long_lived_graceful_restart/metadata.textproto
+++ b/feature/bgp/ate_tests/bgp_long_lived_graceful_restart/metadata.textproto
@@ -41,7 +41,6 @@ platform_exceptions: {
   deviations: {
     omit_l2_mtu: true
     interface_config_vrf_before_address: true
-    deprecated_vlan_id: true
     interface_enabled: true
     require_routed_subinterface_0: true
     default_network_instance: "default"

--- a/feature/interface/aggregate/otg_tests/aggregate_subinterface_test/metadata.textproto
+++ b/feature/interface/aggregate/otg_tests/aggregate_subinterface_test/metadata.textproto
@@ -13,7 +13,6 @@ platform_exceptions: {
   deviations: {
     interface_enabled: true
     default_network_instance: "default"
-    deprecated_vlan_id: true
     require_routed_subinterface_0: true
   }
 }

--- a/feature/p4rt/otg_tests/traceroute_packetin_with_vrf_selection_test/metadata.textproto
+++ b/feature/p4rt/otg_tests/traceroute_packetin_with_vrf_selection_test/metadata.textproto
@@ -11,7 +11,6 @@ platform_exceptions: {
   }
   deviations: {
     gnoi_subcomponent_path:  true
-    deprecated_vlan_id:  true
     interface_enabled:  true
     static_protocol_name: "STATIC"
     default_network_instance:  "default"


### PR DESCRIPTION
EOS supports the newer single-tagged vlan-id leaf which means deprecated_vlan_id should not be used anymore. The deviation affected RT-5.14, P4RT-5.3, and RT-1.14.