### PR TITLE
certz/test_data: suppress EC PARAMETERS in key file

### DIFF
--- a/feature/gnsi/certz/test_data/mk_cas.sh
+++ b/feature/gnsi/certz/test_data/mk_cas.sh
@@ -36,7 +36,7 @@ for d in ${DIRS[@]} ; do
           ;;
         ecdsa)
           openssl ecparam -name ${CURVE} \
-            -out ca-${d}/ca-${OFFSET}-${t}-key.pem -genkey
+            -out ca-${d}/ca-${OFFSET}-${t}-key.pem -genkey -noout
           ;;
       esac
       # Create a cert with the fresh key, require it to be a CA certificate.
@@ -83,7 +83,7 @@ for  d in ${DIRS[@]}; do
             ;;
           ecdsa)
             openssl ecparam -name ${CURVE} \
-              -out ca-${d}/${cs}-${t}-${g}-key.pem -genkey
+              -out ca-${d}/${cs}-${t}-${g}-key.pem -genkey -noout
             ;;
         esac
       done


### PR DESCRIPTION
the key file for ECDSA keys was being created
with an additional pem block specifying
EC PARAMETERS, which is not required.