### PR TITLE
cisco: Add AAA authorization config for non-gRPC record subscribe test

### DIFF
--- a/feature/gnsi/acctz/tests/record_subscribe_non_grpc/record_subscribe_non_grpc_test.go
+++ b/feature/gnsi/acctz/tests/record_subscribe_non_grpc/record_subscribe_non_grpc_test.go
@@ -234,7 +234,7 @@ func setupVendorSpecificAcctzConfig(t *testing.T, dut *ondatra.DUTDevice) {
 	switch dut.Vendor() {
 	case ondatra.CISCO:
 		// Enable CLI command accounting to ensure records are generated for CLI commands.
-		helpers.GnmiCLIConfig(t, dut, "aaa accounting commands default start-stop local\n")
+		helpers.GnmiCLIConfig(t, dut, "aaa accounting commands default start-stop local\naaa authorization commands default none\n")
 		// Increase gRPC accounting queue size to avoid record loss
 		// during longer test executions with background activity.
 		helpers.GnmiCLIConfig(t, dut, "grpc\n aaa accounting queue-size 512\n")


### PR DESCRIPTION
The change adds an AAA authorization configuration (aaa authorization commands default none) alongside the existing AAA accounting command. This disables command authorization checks so that command execution is only logged (accounted) but not gated by an authorization policy, which is likely needed to allow the ACCTZ record subscribe test to execute CLI commands without authorization blocking them.