### PR TITLE
[Health-1.1] Update TestInterfacesubIntfs to pass

### DIFF
--- a/feature/system/health/tests/system_generic_health_check/metadata.textproto
+++ b/feature/system/health/tests/system_generic_health_check/metadata.textproto
@@ -4,7 +4,7 @@
 uuid: "a01b6e65-3b45-4e0c-a71d-f451c07fec6b"
 plan_id: "Health-1.1"
 description: "Generic Health Check"
-testbed: TESTBED_DUT
+testbed: TESTBED_DUT_2LINKS
 platform_exceptions: {
   platform: {
     vendor: JUNIPER
@@ -37,11 +37,13 @@ platform_exceptions: {
   deviations: {
     interface_ethernet_inblock_errors_unsupported: true
     interface_counters_in_unknown_protos_unsupported: true
+    interface_counters_in_fcs_errors_unsupported: true
     no_queue_drop_unsupported: true
     linecard_cpu_utilization_unsupported: true
     linecard_memory_utilization_unsupported: true
     secondary_controller_card_cpu_utilization_unsupported: true
     secondary_controller_card_memory_utilization_unsupported: true
+    subinterface_0_state_unsupported: true
   }
 }
 tags: TAGS_AGGREGATION

--- a/feature/system/health/tests/system_generic_health_check/system_generic_health_check_test.go
+++ b/feature/system/health/tests/system_generic_health_check/system_generic_health_check_test.go
@@ -717,7 +717,9 @@ func TestInterfaceStatus(t *testing.T) {
 			} else {
 				t.Logf("INFO: Counter OutErrors: %d", root.GetCounters().GetOutErrors())
 			}
-			if root.GetCounters().InFcsErrors == nil {
+			if deviations.InterfaceCountersInFcsErrorsUnsupported(dut) {
+				t.Logf("Skipping InFcsErrors check due to InterfaceCountersInFcsErrorsUnsupported devaiation.")
+			} else if root.GetCounters().InFcsErrors == nil {
 				t.Errorf("ERROR: Counter InFcsErrors is not present")
 			} else {
 				t.Logf("INFO: Counter InFcsErrors: %d", root.GetCounters().GetInFcsErrors())
@@ -739,42 +741,51 @@ func TestInterfacesubIntfs(t *testing.T) {
 				if !present {
 					t.Fatalf("ERROR: subIntf index value doesn't exist")
 				}
+
 				subIntfPath := gnmi.OC().Interface(intf).Subinterface(subIntfIndex)
-				IntfPath := gnmi.OC().Interface(intf)
+				intfPath := gnmi.OC().Interface(intf)
 				subIntfState := gnmi.Get(t, dut, subIntfPath.State())
 				subIntf := subIntfState.GetName()
 
 				t.Run(subIntf, func(t *testing.T) {
-					intfState := gnmi.Get(t, dut, gnmi.OC().Interface(intf).State())
-					if subIntfState.OperStatus == oc.Interface_OperStatus_NOT_PRESENT {
-						t.Errorf("ERROR: Oper status is not up")
-					} else {
-						t.Logf("INFO: Oper status: %s", subIntfState.GetOperStatus())
-					}
+					t.Run("OperStatus", func(t *testing.T) {
+						if deviations.Subinterface0StateUnsupported(dut) && subIntfIndex == 0 {
+							t.Skipf("Skipping test due to deviation subinterface_0_state_unsupported")
+						} else {
+							if subIntfState.OperStatus == oc.Interface_OperStatus_NOT_PRESENT {
+								t.Errorf("ERROR: Oper status is not up")
+							} else {
+								t.Logf("INFO: Oper status: %s", subIntfState.GetOperStatus())
+							}
+						}
+					})
 
-					if subIntfState.AdminStatus == oc.Interface_AdminStatus_UNSET {
-						t.Errorf("ERROR: Admin status is not up")
-					} else {
-						t.Logf("INFO: Admin status: %s", subIntfState.GetAdminStatus())
-					}
+					t.Run("AdminStatus", func(t *testing.T) {
+						if deviations.Subinterface0StateUnsupported(dut) && subIntfIndex == 0 {
+							t.Skipf("Skipping test due to deviation subinterface_0_state_unsupported")
+						} else {
+							if subIntfState.AdminStatus == oc.Interface_AdminStatus_UNSET {
+								t.Errorf("ERROR: Admin status is not up")
+							} else {
+								t.Logf("INFO: Admin status: %s", subIntfState.GetAdminStatus())
+							}
+						}
+					})
 
-					if subIntfState.Description == nil {
-						t.Errorf("ERROR: Description is not present")
-					} else {
-						t.Logf("INFO: Description: %s", subIntfState.GetDescription())
-					}
+					t.Run("Description", func(t *testing.T) {
+						if deviations.Subinterface0StateUnsupported(dut) && subIntfIndex == 0 {
+							t.Skipf("Skipping test due to deviation subinterface_0_state_unsupported")
+						} else {
+							if subIntfState.Description == nil {
+								t.Errorf("ERROR: Description is not present")
+							} else {
+								t.Logf("INFO: Description: %s", subIntfState.GetDescription())
+							}
+						}
+					})
 
-					if subIntfState.GetCounters().OutOctets == nil && intfState.GetCounters().OutOctets == nil {
-						t.Errorf("ERROR: Counter OutOctets is not present on interface %s, %s", subIntf, intf)
-					}
-
-					if subIntfState.GetCounters().InMulticastPkts == nil && intfState.GetCounters().InMulticastPkts == nil {
-						t.Errorf("ERROR: Counter InMulticastPkts is not present on interface %s, %s", subIntf, intf)
-					}
-
-					counters := IntfPath.Counters()
-					parentCounters := gnmi.OC().Interface(intf).Counters()
-
+					subIntfCounterPath := subIntfPath.Counters()
+					intfCounterPath := intfPath.Counters()
 					cases := []struct {
 						desc          string
 						counter       ygnmi.SingletonQuery[uint64]
@@ -782,33 +793,43 @@ func TestInterfacesubIntfs(t *testing.T) {
 					}{
 						{
 							desc:          "InDiscards",
-							counter:       counters.InDiscards().State(),
-							parentCounter: parentCounters.InDiscards().State(),
+							counter:       subIntfCounterPath.InDiscards().State(),
+							parentCounter: intfCounterPath.InDiscards().State(),
 						},
 						{
 							desc:          "InErrors",
-							counter:       counters.InErrors().State(),
-							parentCounter: parentCounters.InErrors().State(),
+							counter:       subIntfCounterPath.InErrors().State(),
+							parentCounter: intfCounterPath.InErrors().State(),
 						},
 						{
 							desc:          "InUnknownProtos",
-							counter:       counters.InUnknownProtos().State(),
-							parentCounter: parentCounters.InUnknownProtos().State(),
+							counter:       subIntfCounterPath.InUnknownProtos().State(),
+							parentCounter: intfCounterPath.InUnknownProtos().State(),
+						},
+						{
+							desc:          "InMulticastPkts",
+							counter:       subIntfCounterPath.InMulticastPkts().State(),
+							parentCounter: intfCounterPath.InMulticastPkts().State(),
 						},
 						{
 							desc:          "OutDiscards",
-							counter:       counters.OutDiscards().State(),
-							parentCounter: parentCounters.OutDiscards().State(),
+							counter:       subIntfCounterPath.OutDiscards().State(),
+							parentCounter: intfCounterPath.OutDiscards().State(),
 						},
 						{
 							desc:          "OutErrors",
-							counter:       counters.OutErrors().State(),
-							parentCounter: parentCounters.OutErrors().State(),
+							counter:       subIntfCounterPath.OutErrors().State(),
+							parentCounter: intfCounterPath.OutErrors().State(),
+						},
+						{
+							desc:          "OutOctets",
+							counter:       subIntfCounterPath.OutOctets().State(),
+							parentCounter: intfCounterPath.OutOctets().State(),
 						},
 						{
 							desc:          "InFcsErrors",
-							counter:       counters.InFcsErrors().State(),
-							parentCounter: parentCounters.InFcsErrors().State(),
+							counter:       subIntfCounterPath.InFcsErrors().State(),
+							parentCounter: intfCounterPath.InFcsErrors().State(),
 						},
 					}
 					t.Logf("Verifying counters for Interfaces: %s", interfaces)
@@ -816,6 +837,8 @@ func TestInterfacesubIntfs(t *testing.T) {
 						t.Run(c.desc, func(t *testing.T) {
 							if c.desc == "InUnknownProtos" && deviations.InterfaceCountersInUnknownProtosUnsupported(dut) {
 								t.Skipf("INFO: Skipping test due to deviation interface_counters_in_unknown_protos_unsupported")
+							} else if c.desc == "InFcsErrors" && deviations.InterfaceCountersInFcsErrorsUnsupported(dut) {
+								t.Skipf("INFO: Skipping test due to deviation interface_counters_in_fcs_errors_unsupported")
 							}
 							if val, present := gnmi.Lookup(t, dut, c.counter).Val(); present {
 								t.Logf("INFO: %s: %d", c.counter, val)

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -2147,3 +2147,9 @@ func SecondaryControllerCardCpuUtilizationUnsupported(dut *ondatra.DUTDevice) bo
 func SecondaryControllerCardMemoryUtilizationUnsupported(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetSecondaryControllerCardMemoryUtilizationUnsupported()
 }
+
+// Device does not support interface counters in fcs errors
+// Arista: https://issuetracker.google.com/issues/508304903
+func InterfaceCountersInFcsErrorsUnsupported(dut *ondatra.DUTDevice) bool {
+	return lookupDUTDeviations(dut).GetInterfaceCountersInFcsErrorsUnsupported()
+}

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -1307,6 +1307,10 @@ message Metadata {
     // Arista: https://issuetracker.google.com/issues/508656197
     bool secondary_controller_card_memory_utilization_unsupported = 417;
 
+    // Device does not support interface counters in fcs errors
+    // Arista: https://issuetracker.google.com/issues/508304903
+    bool interface_counters_in_fcs_errors_unsupported = 418;
+
     // Reserved field numbers and identifiers.
     reserved 84, 9, 28, 20, 38, 43, 90, 97, 55, 89, 19, 36, 35, 40, 113, 131, 141, 173, 234, 254, 231, 300, 241, 49;
   }

--- a/proto/metadata_go_proto/metadata.pb.go
+++ b/proto/metadata_go_proto/metadata.pb.go
@@ -1393,7 +1393,7 @@ type Metadata_Deviations struct {
 	// Device does not populate state on subinterface 0
 	// that is implicitly created.
 	// Arista: https://partnerissuetracker.corp.google.com/issues/456175792
-	// Cisco: https://partnerissuetracker.corp.google.com/u/0/issues/509766094
+	// Cisco: https://partnerissuetracker.corp.google.com/issues/509766094
 	Subinterface_0StateUnsupported bool `protobuf:"varint,405,opt,name=subinterface_0_state_unsupported,json=subinterface0StateUnsupported,proto3" json:"subinterface_0_state_unsupported,omitempty"`
 	// Device does not support fragment punt drops.
 	// Arista: https://partnerissuetracker.corp.google.com/issues/502413665
@@ -1432,8 +1432,11 @@ type Metadata_Deviations struct {
 	// Device does not support secondary controller card memory telemetry
 	// Arista: https://issuetracker.google.com/issues/508656197
 	SecondaryControllerCardMemoryUtilizationUnsupported bool `protobuf:"varint,417,opt,name=secondary_controller_card_memory_utilization_unsupported,json=secondaryControllerCardMemoryUtilizationUnsupported,proto3" json:"secondary_controller_card_memory_utilization_unsupported,omitempty"`
-	unknownFields                                       protoimpl.UnknownFields
-	sizeCache                                           protoimpl.SizeCache
+	// Device does not support interface counters in fcs errors
+	// Arista: https://issuetracker.google.com/issues/508304903
+	InterfaceCountersInFcsErrorsUnsupported bool `protobuf:"varint,418,opt,name=interface_counters_in_fcs_errors_unsupported,json=interfaceCountersInFcsErrorsUnsupported,proto3" json:"interface_counters_in_fcs_errors_unsupported,omitempty"`
+	unknownFields                           protoimpl.UnknownFields
+	sizeCache                               protoimpl.SizeCache
 }
 
 func (x *Metadata_Deviations) Reset() {
@@ -4140,6 +4143,13 @@ func (x *Metadata_Deviations) GetSecondaryControllerCardMemoryUtilizationUnsuppo
 	return false
 }
 
+func (x *Metadata_Deviations) GetInterfaceCountersInFcsErrorsUnsupported() bool {
+	if x != nil {
+		return x.InterfaceCountersInFcsErrorsUnsupported
+	}
+	return false
+}
+
 type Metadata_PlatformExceptions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Platform      *Metadata_Platform     `protobuf:"bytes,1,opt,name=platform,proto3" json:"platform,omitempty"`
@@ -4196,7 +4206,7 @@ var File_metadata_proto protoreflect.FileDescriptor
 
 const file_metadata_proto_rawDesc = "" +
 	"\n" +
-	"\x0emetadata.proto\x12\x12openconfig.testing\x1a1github.com/openconfig/ondatra/proto/testbed.proto\"\xb2\xe8\x01\n" +
+	"\x0emetadata.proto\x12\x12openconfig.testing\x1a1github.com/openconfig/ondatra/proto/testbed.proto\"\x92\xe9\x01\n" +
 	"\bMetadata\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\x12\x17\n" +
 	"\aplan_id\x18\x02 \x01(\tR\x06planId\x12 \n" +
@@ -4208,7 +4218,7 @@ const file_metadata_proto_rawDesc = "" +
 	"\bPlatform\x12.\n" +
 	"\x06vendor\x18\x01 \x01(\x0e2\x16.ondatra.Device.VendorR\x06vendor\x120\n" +
 	"\x14hardware_model_regex\x18\x03 \x01(\tR\x12hardwareModelRegex\x124\n" +
-	"\x16software_version_regex\x18\x04 \x01(\tR\x14softwareVersionRegexJ\x04\b\x02\x10\x03R\x0ehardware_model\x1a\xfe\xdd\x01\n" +
+	"\x16software_version_regex\x18\x04 \x01(\tR\x14softwareVersionRegexJ\x04\b\x02\x10\x03R\x0ehardware_model\x1a\xde\xde\x01\n" +
 	"\n" +
 	"Deviations\x120\n" +
 	"\x14ipv4_missing_enabled\x18\x01 \x01(\bR\x12ipv4MissingEnabled\x129\n" +
@@ -4596,7 +4606,8 @@ const file_metadata_proto_rawDesc = "" +
 	"\x12macsec_counters_ft\x18\x9e\x03 \x01(\tR\x10macsecCountersFt\x12E\n" +
 	"\x1fenable_mpls_static_on_interface\x18\x9f\x03 \x01(\bR\x1benableMplsStaticOnInterface\x12p\n" +
 	"5secondary_controller_card_cpu_utilization_unsupported\x18\xa0\x03 \x01(\bR0secondaryControllerCardCpuUtilizationUnsupported\x12v\n" +
-	"8secondary_controller_card_memory_utilization_unsupported\x18\xa1\x03 \x01(\bR3secondaryControllerCardMemoryUtilizationUnsupportedJ\x04\bT\x10UJ\x04\b\t\x10\n" +
+	"8secondary_controller_card_memory_utilization_unsupported\x18\xa1\x03 \x01(\bR3secondaryControllerCardMemoryUtilizationUnsupported\x12^\n" +
+	",interface_counters_in_fcs_errors_unsupported\x18\xa2\x03 \x01(\bR'interfaceCountersInFcsErrorsUnsupportedJ\x04\bT\x10UJ\x04\b\t\x10\n" +
 	"J\x04\b\x1c\x10\x1dJ\x04\b\x14\x10\x15J\x04\b&\x10'J\x04\b+\x10,J\x04\bZ\x10[J\x04\ba\x10bJ\x04\b7\x108J\x04\bY\x10ZJ\x04\b\x13\x10\x14J\x04\b$\x10%J\x04\b#\x10$J\x04\b(\x10)J\x04\bq\x10rJ\x06\b\x83\x01\x10\x84\x01J\x06\b\x8d\x01\x10\x8e\x01J\x06\b\xad\x01\x10\xae\x01J\x06\b\xea\x01\x10\xeb\x01J\x06\b\xfe\x01\x10\xff\x01J\x06\b\xe7\x01\x10\xe8\x01J\x06\b\xac\x02\x10\xad\x02J\x06\b\xf1\x01\x10\xf2\x01J\x04\b1\x102\x1a\xa0\x01\n" +
 	"\x12PlatformExceptions\x12A\n" +
 	"\bplatform\x18\x01 \x01(\v2%.openconfig.testing.Metadata.PlatformR\bplatform\x12G\n" +


### PR DESCRIPTION
TestInterfacesubIntfs under Health-1.1 needs a few changes to pass on EOS:
* in-fcs-errors is not supported, deviation interface_counters_in_fcs_errors_unsupported added
* testbed should contain at least 1 link to allow the test to setup the test with active interfaces
* subinterface_0_state_unsupported added to check the parent interface if subinterface 0 is used and deviation is enabled
* update the logic to avoid getting the counters multiple times