### PR TITLE
gNMI-1.25: deviation subinterface_0_state_unsupported for Cisco

### DIFF
--- a/feature/interface/otg_tests/telemetry_interface_last_change_test/metadata.textproto
+++ b/feature/interface/otg_tests/telemetry_interface_last_change_test/metadata.textproto
@@ -11,6 +11,7 @@ platform_exceptions: {
   }
   deviations: {
     ipv4_missing_enabled: true
+    subinterface_0_state_unsupported: true
   }
 }
 platform_exceptions: {

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -1256,6 +1256,7 @@ message Metadata {
     // Device does not populate state on subinterface 0
     // that is implicitly created.
     // Arista: https://partnerissuetracker.corp.google.com/issues/456175792
+    // Cisco: https://partnerissuetracker.corp.google.com/u/0/issues/509766094
     bool subinterface_0_state_unsupported = 405;
 
     // Device does not support fragment punt drops.

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -1256,7 +1256,7 @@ message Metadata {
     // Device does not populate state on subinterface 0
     // that is implicitly created.
     // Arista: https://partnerissuetracker.corp.google.com/issues/456175792
-    // Cisco: https://partnerissuetracker.corp.google.com/u/0/issues/509766094
+    // Cisco: https://partnerissuetracker.corp.google.com/issues/509766094
     bool subinterface_0_state_unsupported = 405;
 
     // Device does not support fragment punt drops.

--- a/proto/metadata_go_proto/metadata.pb.go
+++ b/proto/metadata_go_proto/metadata.pb.go
@@ -1393,6 +1393,7 @@ type Metadata_Deviations struct {
 	// Device does not populate state on subinterface 0
 	// that is implicitly created.
 	// Arista: https://partnerissuetracker.corp.google.com/issues/456175792
+	// Cisco: https://partnerissuetracker.corp.google.com/u/0/issues/509766094
 	Subinterface_0StateUnsupported bool `protobuf:"varint,405,opt,name=subinterface_0_state_unsupported,json=subinterface0StateUnsupported,proto3" json:"subinterface_0_state_unsupported,omitempty"`
 	// Device does not support fragment punt drops.
 	// Arista: https://partnerissuetracker.corp.google.com/issues/502413665


### PR DESCRIPTION
Context of the sub-interface indexing issue: https://partnerissuetracker.corp.google.com/issues/502419972
Deviation tracking bug: https://partnerissuetracker.corp.google.com/u/0/issues/509766094

Per Google's preference, we are reusing the existing deviation subinterface_0_state_unsupported instead of creating a new one for index=1 which would also require readme and test changes.