### PR TITLE
Modifying test to include post switchover validation

### DIFF
--- a/feature/gribi/otg_tests/supervisor_failure_test/README.md
+++ b/feature/gribi/otg_tests/supervisor_failure_test/README.md
@@ -22,16 +22,15 @@ Ensure that gRIBI entries are persisted over supervisor failure.
 make it become leader. Ensure that no error is reported from the gRIBI
 server.
 
-* Add 100 `IPv4Entry`s for prefixes (e.g., `203.0.113.0/24` through `203.0.113.99/24`) pointing to ATE port-2 via
-`gRIBI-A`. Ensure that the entries are active through AFT telemetry and correct
-ACKs are received.
+* Add 50 `IPv4Entry`s (starting at `203.0.113.1/32`) and 50 `IPv6Entry`s
+(starting at `2001:db8:203:0:113::1/128`) pointing to ATE port-2 via
+`gRIBI-A`. Ensure that the entries are active through AFT telemetry and correct ACK is received.
 
-* Send traffic from ATE port-1 to the 100 prefixes, and ensure traffic
+* Send traffic from ATE port-1 to the 100 prefixes (50 IPv4 and 50 IPv6), and ensure traffic
 flows 100% and reaches ATE port-2.
 
-* Validate: Traffic continues to be forwarded between ATE port-1 and ATE
-port-2 during supervisor switchover triggered using gNOI
-`SwitchControlProcessor`.
+* Validate: Supervisor switchover is triggered using gNOI `SwitchControlProcessor`.
+Ensure gRIBI entries persist over switchover and traffic contniues to be forwarded.
 
 * Following reconnection of a gRIBI client to the new master supervisor, ensure
 the 100 prefixes pointing to ATE port-2 are present and traffic
@@ -39,9 +38,12 @@ flows 100% from ATE port-1 to ATE port-2.
 
 ### TE-8.2.2 - Post Switchover FIB Programming Validation
 
-* Add another 100 `IPv4Entry`s for new prefixes (e.g., `203.0.114.0/24` through `203.0.114.99/24`) pointing to ATE port-2. Ensure that these new entries are active through AFT telemetry and correct ACKs are received.
+* Add another 50 `IPv4Entry`s (starting at `203.0.114.1/32`) and 50
+`IPv6Entry`s (starting at `2001:db8:203:0:114::1/128`) pointing to ATE
+port-2. Ensure that these new entries are active through AFT telemetry and correct ACKs are received.
 
-* Send traffic from ATE port-1 to the additional 100 prefixes, and ensure traffic flows 100% and reaches ATE port-2 to verify that the FIB is programmed correctly after the switchover.
+* Send traffic to all 200 prefixes (100 initial + 100 post-switchover) and
+ensure traffic flows 100% from ATE port-1 to ATE port-2.
 
 ## OpenConfig Path and RPC Coverage
 

--- a/feature/gribi/otg_tests/supervisor_failure_test/README.md
+++ b/feature/gribi/otg_tests/supervisor_failure_test/README.md
@@ -4,30 +4,44 @@
 
 Ensure that gRIBI entries are persisted over supervisor failure.
 
+## Testbed type
+
+* https://github.com/openconfig/featureprofiles/blob/main/topologies/atedut_2.testbed
+
 ## Procedure
 
-*   Connect DUT port-1 to ATE port-1, DUT port-2 to ATE port-2. Assign IPv4
-    addresses to all ports.
+### Test environment setup:
 
-*   Connect gRIBI client to DUT specifying persistence mode PRESERVE,
-    `SINGLE_PRIMARY` client redundancy in the SessionParameters request, and
-    make it become leader. Ensure that no error is reported from the gRIBI
-    server.
+* Connect DUT port-1 to ATE port-1, DUT port-2 to ATE port-2.
+* Assign IPv4 addresses to all ports.
 
-*   Add an `IPv4Entry` for prefix `203.0.113.0/24` pointing to ATE port-2 via
-    `gRIBI-A`. Ensure that the entry is active through AFT telemetry and correct
-    ACK is received.
+### TE-8.2.1 - FIB Programming and Switchover Validation
 
-*   Send traffic from ATE port-1 to prefix `203.0.113.0/24`, and ensure traffic
-    flows 100% and reaches ATE port-2.
+* Connect gRIBI client to DUT specifying persistence mode PRESERVE,
+`SINGLE_PRIMARY` client redundancy in the SessionParameters request, and
+make it become leader. Ensure that no error is reported from the gRIBI
+server.
 
-*   Validate: Traffic continues to be forwarded between ATE port-1 and ATE
-    port-2 during supervisor switchover triggered using gNOI
-    `SwitchControlProcessor`.
+* Add 100 `IPv4Entry`s for prefixes (e.g., `203.0.113.0/24` through `203.0.113.99/24`) pointing to ATE port-2 via
+`gRIBI-A`. Ensure that the entries are active through AFT telemetry and correct
+ACKs are received.
 
-    Following reconnection of a gRIBI client to new master supervisor , ensure
-    the prefix `203.0.113.0/24` pointing to ATE port-2 is present and traffic
-    flows 100% from ATE port-1 to ATE port-2.
+* Send traffic from ATE port-1 to the 100 prefixes, and ensure traffic
+flows 100% and reaches ATE port-2.
+
+* Validate: Traffic continues to be forwarded between ATE port-1 and ATE
+port-2 during supervisor switchover triggered using gNOI
+`SwitchControlProcessor`.
+
+* Following reconnection of a gRIBI client to the new master supervisor, ensure
+the 100 prefixes pointing to ATE port-2 are present and traffic
+flows 100% from ATE port-1 to ATE port-2.
+
+### TE-8.2.2 - Post Switchover FIB Programming Validation
+
+* Add another 100 `IPv4Entry`s for new prefixes (e.g., `203.0.114.0/24` through `203.0.114.99/24`) pointing to ATE port-2. Ensure that these new entries are active through AFT telemetry and correct ACKs are received.
+
+* Send traffic from ATE port-1 to the additional 100 prefixes, and ensure traffic flows 100% and reaches ATE port-2 to verify that the FIB is programmed correctly after the switchover.
 
 ## OpenConfig Path and RPC Coverage
 
@@ -63,7 +77,7 @@ rpcs:
 
 ## Minimum DUT Required
 
-vRX - Virtual Router Device
+* MFF
 
 
 ## Canonical OC


### PR DESCRIPTION
Modifying test to include post switchover validation and increasing the count from 1 entry to 100 entries

AI Prompt that was used to modify the Readme:
`Modify the readme to add 100 IPv4Entries not just 1 IPv4Entry. Modify the traffic test to include the 100 IPv4Entries. Also add a step after supervisor switchover to add another 100 IPv4Entries to ensure that FIB is programmed correctly after the switchover`