### PR TITLE
PF-1.22: fixes for ipv4_guev1_decap_and_hashing_test

### DIFF
--- a/feature/policy_forwarding/decapsulation/otg_tests/ipv4_guev1_decap_and_hashing_test/ipv4_guev1_decap_and_hashing_test.go
+++ b/feature/policy_forwarding/decapsulation/otg_tests/ipv4_guev1_decap_and_hashing_test/ipv4_guev1_decap_and_hashing_test.go
@@ -54,7 +54,7 @@ const (
 	dutAreaAddress       = "49.0001"
 	dutSysID             = "1920.0000.2001"
 	ateSysID             = "64000000000"
-	UDPSrcPort           = 5996
+	UDPSrcPort           = 1000
 	UDPDstPort           = 6080
 	UDPDstPortNeg        = 6085
 	testSrcPort          = 14
@@ -363,6 +363,9 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) []string {
 	cfgplugins.SetupStaticAggregateAtomically(t, dut, aggrBatch, cfgplugins.StaticAggregateConfig{AggID: aggID2, DutLag: dutLag2, AggPorts: dutAggPorts2})
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 	cfgplugins.ConfigureLoadbalance(t, dut)
+	// Routing Policy (ALLOW) must be defined before BGP references it
+	rpPolicy := cfgplugins.ConfigureCommonBGPPolicies(t, dut)
+	gnmi.Update(t, dut, gnmi.OC().RoutingPolicy().Config(), rpPolicy)
 	// ISIS Configuration
 	cfgISIS := cfgplugins.ISISConfigBasic{
 		InstanceName: isisInstance,
@@ -700,7 +703,7 @@ func configureFlows(t *testing.T, otgConfig gosnappi.Config, macAddress string, 
 	if immediateHeader {
 		udpOuter.SrcPort().SetValue(UDPSrcPort)
 	} else {
-		udpOuter.SrcPort().Increment().SetStart(UDPSrcPort).SetStep(1).SetCount(10)
+		udpOuter.SrcPort().Increment().SetStart(UDPSrcPort).SetStep(1).SetCount(1000)
 	}
 	if incr == 13 || incr == 14 {
 		udpOuter.DstPort().SetValue(UDPDstPortNeg)
@@ -723,7 +726,7 @@ func configureFlows(t *testing.T, otgConfig gosnappi.Config, macAddress string, 
 		if immediateHeader {
 			udpMiddle.SrcPort().SetValue(UDPSrcPort - 1)
 		} else {
-			udpMiddle.SrcPort().Increment().SetStart(UDPSrcPort - 1).SetStep(1).SetCount(10)
+			udpMiddle.SrcPort().Increment().SetStart(UDPSrcPort - 1).SetStep(1).SetCount(1000)
 		}
 		udpMiddle.DstPort().SetValue(UDPDstPort)
 
@@ -770,7 +773,7 @@ func configureFlows(t *testing.T, otgConfig gosnappi.Config, macAddress string, 
 			ipInner.Dst().SetValue(constH4v6)
 		}
 		udp := flow.Packet().Add().Udp()
-		udp.SrcPort().Increment().SetStart(UDPSrcPort - 1).SetStep(1).SetCount(10)
+		udp.SrcPort().Increment().SetStart(UDPSrcPort - 1).SetStep(1).SetCount(1000)
 		udp.DstPort().SetValue(UDPSrcPort - 2)
 	case 8, 10:
 		ipInner := flow.Packet().Add().Ipv6()

--- a/feature/policy_forwarding/decapsulation/otg_tests/ipv4_guev1_decap_and_hashing_test/ipv4_guev1_decap_and_hashing_test.go
+++ b/feature/policy_forwarding/decapsulation/otg_tests/ipv4_guev1_decap_and_hashing_test/ipv4_guev1_decap_and_hashing_test.go
@@ -54,7 +54,7 @@ const (
 	dutAreaAddress       = "49.0001"
 	dutSysID             = "1920.0000.2001"
 	ateSysID             = "64000000000"
-	UDPSrcPort           = 5996
+	UDPSrcPort           = 1000
 	UDPDstPort           = 6080
 	UDPDstPortNeg        = 6085
 	testSrcPort          = 14
@@ -708,7 +708,7 @@ func configureFlows(t *testing.T, otgConfig gosnappi.Config, macAddress string, 
 	if immediateHeader {
 		udpOuter.SrcPort().SetValue(UDPSrcPort)
 	} else {
-		udpOuter.SrcPort().Increment().SetStart(UDPSrcPort).SetStep(1).SetCount(10)
+		udpOuter.SrcPort().Increment().SetStart(UDPSrcPort).SetStep(1).SetCount(1000)
 	}
 	if incr == 13 || incr == 14 {
 		udpOuter.DstPort().SetValue(UDPDstPortNeg)
@@ -731,7 +731,7 @@ func configureFlows(t *testing.T, otgConfig gosnappi.Config, macAddress string, 
 		if immediateHeader {
 			udpMiddle.SrcPort().SetValue(UDPSrcPort - 1)
 		} else {
-			udpMiddle.SrcPort().Increment().SetStart(UDPSrcPort - 1).SetStep(1).SetCount(10)
+			udpMiddle.SrcPort().Increment().SetStart(UDPSrcPort - 1).SetStep(1).SetCount(1000)
 		}
 		udpMiddle.DstPort().SetValue(UDPDstPort)
 
@@ -778,7 +778,7 @@ func configureFlows(t *testing.T, otgConfig gosnappi.Config, macAddress string, 
 			ipInner.Dst().SetValue(constH4v6)
 		}
 		udp := flow.Packet().Add().Udp()
-		udp.SrcPort().Increment().SetStart(UDPSrcPort - 1).SetStep(1).SetCount(10)
+		udp.SrcPort().Increment().SetStart(UDPSrcPort - 1).SetStep(1).SetCount(1000)
 		udp.DstPort().SetValue(UDPSrcPort - 2)
 	case 8, 10:
 		ipInner := flow.Packet().Add().Ipv6()


### PR DESCRIPTION
Flow-9 and Flow-10 were failing because they happened to be load balancing with a distribution of 200,000/800,000. This distribution depends on the random load balancing polynomial on the device, and since today the test only sends packets with 10 UDP source ports, there is not enough entropy. It would be better to increase the number of UDP src ports to even the distribution and get the test to pass more consistently.

I've attached the log from a passing test run:
[pf-1_22.txt](https://github.com/user-attachments/files/27603406/pf-1_22.txt)
