### PR TITLE
SYS-1.1 Add strata platform support to default_copp_test

### DIFF
--- a/feature/system/control_plane_traffic/otg_tests/default_copp_test/default_copp_test.go
+++ b/feature/system/control_plane_traffic/otg_tests/default_copp_test/default_copp_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openconfig/featureprofiles/internal/attrs"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/featureprofiles/internal/helpers"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
@@ -94,6 +95,7 @@ type flowParameters struct {
 type commonEntities struct {
 	dut        *ondatra.DUTDevice
 	ate        *ondatra.ATEDevice
+	platCfg    *platformConfig
 	gnmiClient gpb.GNMIClient
 	ctx        context.Context
 }
@@ -103,6 +105,50 @@ type coppSystemTestcase struct {
 	flowParams         flowParameters
 	increasedDropCount bool
 	counters           []string
+}
+
+const (
+	coppCounterPrefix    = "arista-platform-control-plane-traffic-counters:"
+	counterL3LpmOverflow = "l3LpmOverflow"
+	counterL2Unicast     = "l2Unicast"
+	counterIPUnicast     = "ipUnicast"
+	counterL2Broadcast   = "l2Broadcast"
+	counterLACP          = "lacp"
+)
+
+type platformConfig struct {
+	platformName string            // "sand" or "strata"
+	counterNames map[string]string // logical key -> actual counter name
+}
+
+var platformCounterNames = map[string]map[string]string{
+	"sand": {
+		counterL3LpmOverflow: "l3-lpm-overflow",
+		counterL2Unicast:     "l2-unicast",
+		counterIPUnicast:     "ip-unicast",
+		counterL2Broadcast:   "l2-broadcast",
+		counterLACP:          "lacp",
+	},
+	"strata": {
+		counterL3LpmOverflow: "glean",
+		counterL2Unicast:     "switched-tc3-tc5",
+		counterIPUnicast:     "self-ip",
+		counterL2Broadcast:   "other",
+		counterLACP:          "lacp",
+	},
+}
+
+func getPlatformConfig(t *testing.T, dut *ondatra.DUTDevice) *platformConfig {
+	t.Helper()
+	platform := helpers.AristaPlatform(t, dut)
+	counters, ok := platformCounterNames[platform]
+	if !ok {
+		t.Fatalf("getPlatformConfig: detected platform %q has no counter mapping", platform)
+	}
+	return &platformConfig{
+		platformName: platform,
+		counterNames: counters,
+	}
 }
 
 // configInterfaceDUT configures the interface with the Addrs.
@@ -317,25 +363,47 @@ func removeAfterLastSlash(str string) string {
 	return str[:lastSlashIndex]
 }
 
+func (ce *commonEntities) getComponentKey(t *testing.T) string {
+	t.Helper()
+
+	p1 := ce.dut.Port(t, dutIncomingPort)
+	pName := removeAfterLastSlash(p1.Name())
+
+	// COPP counters are owned by the switching ASIC in the Component hierarchy.
+	// Search starts from the Ethernet port to identify the proper ASIC for
+	// multichip systems.
+	cur := pName
+	componentKey := cur
+	for {
+		parent := gnmi.Get(t, ce.dut, gnmi.OC().Component(cur).Parent().State())
+		parentType := gnmi.Get(t, ce.dut, gnmi.OC().Component(parent).Type().State())
+		if parentType == oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_INTEGRATED_CIRCUIT {
+			componentKey = parent
+			break
+		}
+		cur = parent
+	}
+
+	return componentKey
+}
+
 // getDroppedPktCounts returns the dropped packet counts for the given counters.
 func (ce *commonEntities) getDroppedPktCounts(t *testing.T, counters []string) []float64 {
 	t.Helper()
-	p1 := ce.dut.Port(t, dutIncomingPort)
-	pName := removeAfterLastSlash(p1.Name())
-	ethernetPort := gnmi.Get(t, ce.dut, gnmi.OC().Component(pName).Parent().State())
-	switchName := gnmi.Get(t, ce.dut, gnmi.OC().Component(ethernetPort).Parent().State())
+
+	componentKey := ce.getComponentKey(t)
 
 	getResponse, err := ce.gnmiClient.Get(context.Background(), &gpb.GetRequest{
 		Path: []*gpb.Path{{
 			Elem: []*gpb.PathElem{
 				{Name: "components"},
-				{Name: "component", Key: map[string]string{"name": switchName}},
+				{Name: "component", Key: map[string]string{"name": componentKey}},
 				{Name: "integrated-circuit"},
 				{Name: "pipeline-counters"},
 				{Name: "control-plane-traffic"},
 				{Name: "vendor"},
 				{Name: "arista"},
-				{Name: "sand"},
+				{Name: ce.platCfg.platformName},
 				{Name: "state"},
 			},
 		}},
@@ -448,14 +516,18 @@ func TestCoppSystem(t *testing.T) {
 		return
 	}
 
+	platCfg := getPlatformConfig(t, dut)
+
 	ce := &commonEntities{
 		dut:        dut,
 		ate:        ate,
+		platCfg:    platCfg,
 		gnmiClient: gnmiClient,
 		ctx:        ctx,
 	}
 
 	ce.configureDUT(t)
+
 	// TODO [https://github.com/openconfig/featureprofiles/issues/4171]: Add test cases for BGP, LDP and LLDP traffic.
 	// Add test case for arista-platform-control-plane-traffic-counters:l3-destination-miss.
 	testCases := []coppSystemTestcase{
@@ -463,61 +535,61 @@ func TestCoppSystem(t *testing.T) {
 			name:               "CoppSystemL3LpmOverflowExceedingLimitTest",
 			flowParams:         flowParameters{pps: 20000, packetSize: 512, trafficLayer: 3, trafficType: "l3LpmOverflow"},
 			increasedDropCount: true,
-			counters:           []string{"arista-platform-control-plane-traffic-counters:l3-lpm-overflow"},
+			counters:           []string{coppCounterPrefix + platCfg.counterNames[counterL3LpmOverflow]},
 		},
 		{
 			name:               "CoppSystemL3LpmOverflowInLimitTest",
 			flowParams:         flowParameters{pps: 200, packetSize: 512, trafficLayer: 3, trafficType: "l3LpmOverflow"},
 			increasedDropCount: false,
-			counters:           []string{"arista-platform-control-plane-traffic-counters:l3-lpm-overflow"},
+			counters:           []string{coppCounterPrefix + platCfg.counterNames[counterL3LpmOverflow]},
 		},
 		{
 			name:               "CoppSystemL2UcastExceedingLimitTest",
 			flowParams:         flowParameters{pps: 600000, packetSize: 512, trafficLayer: 2},
 			increasedDropCount: true,
-			counters:           []string{"arista-platform-control-plane-traffic-counters:l2-unicast"},
+			counters:           []string{coppCounterPrefix + platCfg.counterNames[counterL2Unicast]},
 		},
 		{
 			name:               "CoppSystemL2UcastInLimitTest",
 			flowParams:         flowParameters{pps: 600, packetSize: 512, trafficLayer: 2},
 			increasedDropCount: false,
-			counters:           []string{"arista-platform-control-plane-traffic-counters:l2-unicast"},
+			counters:           []string{coppCounterPrefix + platCfg.counterNames[counterL2Unicast]},
 		},
 		{
 			name:               "CoppSystemIpUcastExceedingLimitTest",
 			flowParams:         flowParameters{pps: 600000, packetSize: 512, trafficLayer: 3, trafficType: "ipUcast", dstIPAddress: dutSrc.IPv4},
 			increasedDropCount: true,
-			counters:           []string{"arista-platform-control-plane-traffic-counters:ip-unicast"},
+			counters:           []string{coppCounterPrefix + platCfg.counterNames[counterIPUnicast]},
 		},
 		{
 			name:               "CoppSystemIpUcastInLimitTest",
 			flowParams:         flowParameters{pps: 600, packetSize: 512, trafficLayer: 3, trafficType: "ipUcast", dstIPAddress: dutSrc.IPv4},
 			increasedDropCount: false,
-			counters:           []string{"arista-platform-control-plane-traffic-counters:ip-unicast"},
+			counters:           []string{coppCounterPrefix + platCfg.counterNames[counterIPUnicast]},
 		},
 		{
 			name:               "CoppSystemL2BcastExceedingLimitTest",
 			flowParams:         flowParameters{pps: 600000, packetSize: 512, trafficLayer: 2, trafficType: "l2Bcast", dstMACAddress: broadcastMAC},
 			increasedDropCount: true,
-			counters:           []string{"arista-platform-control-plane-traffic-counters:l2-broadcast"},
+			counters:           []string{coppCounterPrefix + platCfg.counterNames[counterL2Broadcast]},
 		},
 		{
 			name:               "CoppSystemL2BcastInLimitTest",
 			flowParams:         flowParameters{pps: 600, packetSize: 512, trafficLayer: 2, trafficType: "l2Bcast", dstMACAddress: broadcastMAC},
 			increasedDropCount: false,
-			counters:           []string{"arista-platform-control-plane-traffic-counters:l2-broadcast"},
+			counters:           []string{coppCounterPrefix + platCfg.counterNames[counterL2Broadcast]},
 		},
 		{
 			name:               "CoppSystemLacpExceedingLimitTest",
 			flowParams:         flowParameters{pps: 600000, packetSize: 512, trafficLayer: 2, trafficType: "lacp"},
 			increasedDropCount: true,
-			counters:           []string{"arista-platform-control-plane-traffic-counters:lacp"},
+			counters:           []string{coppCounterPrefix + platCfg.counterNames[counterLACP]},
 		},
 		{
 			name:               "CoppSystemLacpInLimitTest",
 			flowParams:         flowParameters{pps: 600, packetSize: 512, trafficLayer: 2, trafficType: "lacp"},
 			increasedDropCount: false,
-			counters:           []string{"arista-platform-control-plane-traffic-counters:lacp"},
+			counters:           []string{coppCounterPrefix + platCfg.counterNames[counterLACP]},
 		},
 	}
 


### PR DESCRIPTION
The default_copp_test hardcodes "sand" in the OpenConfig vendor path and uses sand-specific counter names. Strata platform devices (e.g. DCS-7050CX4M-48D8-F) require different counter names and a different vendor path element. This change detects the platform dynamically from the gNMI response and selects the appropriate counter mapping.

* (M) feature/system/control_plane_traffic/otg_tests/default_copp_test/default_copp_test.go
  - Add platformConfig struct and counter name maps for sand vs strata.
  - Replace hardcoded "sand" path element with detected platform name.