### PR TITLE
Update tools/gap-analyzer Gemini model from '3.1-pro-preview' to '3-flash-preview'

### DIFF
--- a/tools/gap-analyzer/read_fnttests.go
+++ b/tools/gap-analyzer/read_fnttests.go
@@ -99,7 +99,7 @@ var (
 	// apiKey specifies the API Key for Gemini API.
 	apiKey = flag.String("api-key", os.Getenv("GEMINI_API_KEY"), "API Key for Google AI Gemini API. Can also be set via GEMINI_API_KEY env var.")
 	// model specifies the Gemini model to use for gap analysis.
-	model = flag.String("model", "gemini-3.1-pro-preview", "The public Gemini model to use.")
+	model = flag.String("model", "gemini-3-flash-preview", "The public Gemini model to use.")
 	// featureprofilesRoot specifies the root directory for searching feature profiles tests.
 	featureprofilesRoot = flag.String("featureprofiles-root", ".", "Root directory for searching tests (e.g., '.' for repo root).")
 	// changedFilesStr specifies a comma-separated list of changed files to analyze.


### PR DESCRIPTION
3.1-pro-preview has high demand due to which the tool would exit with a failure. We have decided to move to a lighter model with less demand as a replacement