### PR TITLE
 TestID-16.4: Fixes for export policy, drain policy, and prefix validation

### DIFF
--- a/feature/gribi/otg_tests/gribi_to_bgp_redistribution/gribi_to_bgp_redistribution_test.go
+++ b/feature/gribi/otg_tests/gribi_to_bgp_redistribution/gribi_to_bgp_redistribution_test.go
@@ -245,10 +245,10 @@ func configureRoutingPolicies(t *testing.T, dut *ondatra.DUTDevice) {
 	// ----------------------------
 	// ATTACH EXPORT POLICY TO BGP
 	// ----------------------------
-	policy := root.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp().GetOrCreateNeighbor(atePort2.IPv4).GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).GetOrCreateApplyPolicy()
+	policy := root.GetOrCreateNetworkInstance(vrfName).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp().GetOrCreateNeighbor(atePort2.IPv4).GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).GetOrCreateApplyPolicy()
 	policy.SetExportPolicy([]string{bgpExportPol})
 	policy.SetDefaultExportPolicy(oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE)
-	path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().Neighbor(atePort2.IPv4).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
+	path := gnmi.OC().NetworkInstance(vrfName).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().Neighbor(atePort2.IPv4).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
 
 	gnmi.BatchReplace(batch, path.Config(), policy)
 
@@ -316,7 +316,7 @@ func appendDrainPolicyToExport(t *testing.T, dut *ondatra.DUTDevice) {
 	t.Helper()
 	nbrPath := gnmi.OC().NetworkInstance(vrfName).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().Neighbor(atePort2.IPv4).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
 	exportPolicies := []string{drainPolicy, bgpExportPol}
-	gnmi.Update(t, dut, nbrPath.ExportPolicy().Config(), exportPolicies)
+	gnmi.Replace(t, dut, nbrPath.ExportPolicy().Config(), exportPolicies)
 }
 
 // removeDrainPolicyFromExport removes the drain policy from the BGP export chain.
@@ -511,7 +511,10 @@ func validateRoutingPolicyV4(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.
 	for _, bgpPrefix := range bgpPrefixes {
 		t.Logf("Received prefix %s/%d", bgpPrefix.GetAddress(), bgpPrefix.GetPrefixLength())
 
-		if bgpPrefix.Address != nil && bgpPrefix.GetAddress() == v4RoutePrefix && bgpPrefix.PrefixLength != nil && bgpPrefix.GetPrefixLength() == v4RoutePrefixLen {
+		parts := strings.Split(routePrefix, "/")
+		prefixAddr := parts[0]
+		prefixLen, _ := strconv.Atoi(parts[1])
+		if bgpPrefix.Address != nil && bgpPrefix.GetAddress() == prefixAddr && bgpPrefix.PrefixLength != nil && bgpPrefix.GetPrefixLength() == uint32(prefixLen) {
 
 			found = true
 
@@ -548,7 +551,7 @@ func validateRoutingPolicyV4(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.
 	}
 
 	if !found {
-		msg := fmt.Sprintf("prefix %s/%d not received on OTG", v4RoutePrefix, v4RoutePrefixLen)
+		msg := fmt.Sprintf("prefix %s not received on OTG", routePrefix)
 		errMsg += msg
 	}
 

--- a/feature/gribi/otg_tests/gribi_to_bgp_redistribution/gribi_to_bgp_redistribution_test.go
+++ b/feature/gribi/otg_tests/gribi_to_bgp_redistribution/gribi_to_bgp_redistribution_test.go
@@ -116,7 +116,6 @@ type OTGBGPPrefix struct {
 func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	t.Helper()
 	batch := &gnmi.SetBatch{}
-	configureHardwareInit(t, dut)
 	fptest.ConfigureDefaultNetworkInstance(t, dut)
 	p1 := dut.Port(t, "port1")
 	p2 := dut.Port(t, "port2")
@@ -484,21 +483,6 @@ func verifyOTGBGPEstablished(t *testing.T, ate *ondatra.ATEDevice) {
 		t.Fatalf("BGP sessions not established: got %v", val)
 	}
 	t.Log("OTG BGP sessions established")
-}
-
-// configureHardwareInit sets up the initial hardware configuration on the DUT. It pushes hardware initialization configs for VRF Selection Extended feature and Policy Forwarding feature.
-func configureHardwareInit(t *testing.T, dut *ondatra.DUTDevice) {
-	t.Helper()
-	features := []cfgplugins.FeatureType{
-		cfgplugins.FeatureVrfSelectionExtended,
-		cfgplugins.FeaturePolicyForwarding,
-	}
-	for _, feature := range features {
-		hardwareInitCfg := cfgplugins.NewDUTHardwareInit(t, dut, feature)
-		if hardwareInitCfg != "" {
-			cfgplugins.PushDUTHardwareInitConfig(t, dut, hardwareInitCfg)
-		}
-	}
 }
 
 // validateRoutingPolicyV4 verifies the correctness of the IPv4 BGP export routing policy applied on the DUT and its effects observed on the ATE.

--- a/feature/gribi/otg_tests/gribi_to_bgp_redistribution/gribi_to_bgp_redistribution_test.go
+++ b/feature/gribi/otg_tests/gribi_to_bgp_redistribution/gribi_to_bgp_redistribution_test.go
@@ -507,13 +507,12 @@ func validateRoutingPolicyV4(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.
 	bgpPrefixes := gnmi.GetAll[*otgtelemetry.BgpPeer_UnicastIpv4Prefix](t, ate.OTG(), gnmi.OTG().BgpPeer("atePort2.BGP4.peer").UnicastIpv4PrefixAny().State())
 	found := false
 	var errMsg string
+	parts := strings.Split(routePrefix, "/")
+	prefixAddr := parts[0]
+	prefixLen, _ := strconv.Atoi(parts[1])
 
 	for _, bgpPrefix := range bgpPrefixes {
 		t.Logf("Received prefix %s/%d", bgpPrefix.GetAddress(), bgpPrefix.GetPrefixLength())
-
-		parts := strings.Split(routePrefix, "/")
-		prefixAddr := parts[0]
-		prefixLen, _ := strconv.Atoi(parts[1])
 		if bgpPrefix.Address != nil && bgpPrefix.GetAddress() == prefixAddr && bgpPrefix.PrefixLength != nil && bgpPrefix.GetPrefixLength() == uint32(prefixLen) {
 
 			found = true

--- a/feature/gribi/otg_tests/gribi_to_bgp_redistribution/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_to_bgp_redistribution/metadata.textproto
@@ -14,7 +14,7 @@ platform_exceptions: {
     default_network_instance: "default"
     omit_l2_mtu: true
     interface_config_vrf_before_address: true
-    table_connections_unsupported: true
+    table_connections_unsupported: false
   }
 }
 

--- a/feature/gribi/otg_tests/gribi_to_bgp_redistribution/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_to_bgp_redistribution/metadata.textproto
@@ -14,7 +14,6 @@ platform_exceptions: {
     default_network_instance: "default"
     omit_l2_mtu: true
     interface_config_vrf_before_address: true
-    table_connections_unsupported: false
   }
 }
 


### PR DESCRIPTION
This PR adds a few fixes for export policy, drain policy, and prefix validation in the gRIBI to BGP redistribution fpt.
 - Apply BGP export policy to TEST_VRF instead of DEFAULT network instance, so the policy is attached to the actual BGP neighbor
 - Use gnmi.Replace instead of gnmi.Update when prepending drain policy to the export chain, since Update merges with the existing leaf-list and preserves the original policy ordering
 - Match validated prefix against the actual gRIBI route (198.51.100.1/32) instead of the aggregate prefix-set (198.51.100.0/26). This is similar to what is done on lines 641-643 in the function  "TestGRIBIBGPRedistribution".