### PR TITLE
Update gNMI-1.17

### DIFF
--- a/feature/platform/controllercard/tests/controller_card_redundancy_test/controller_card_redundancy_test.go
+++ b/feature/platform/controllercard/tests/controller_card_redundancy_test/controller_card_redundancy_test.go
@@ -279,6 +279,10 @@ func testControllerCardInventory(t *testing.T, dut *ondatra.DUTDevice, controlle
 
 func testControllerCardRedundancy(t *testing.T, dut *ondatra.DUTDevice, controllerCards []string) {
 
+	if deviations.SkipControllerCardPowerAdmin(dut) {
+		t.Skipf("Skipping test for controller card redundancy test as the device does not support controller card power up/down")
+	}
+	
 	// Collect active and standby controller cards before the switchover
 	rpStandbyBeforeSwitch, rpActiveBeforeSwitch := components.FindStandbyControllerCard(t, dut, controllerCards)
 
@@ -443,6 +447,14 @@ func testControllerCardLastRebootTime(t *testing.T, dut *ondatra.DUTDevice, cont
 	}
 	t.Logf("Standby controller boot time: %.2f seconds", time.Since(startReboot).Seconds())
 
+	// Wait for the telemetry agent to populate the last-reboot-time leaf
+	watchTime := gnmi.Watch(t, dut, lastRebootTime.State(), 5*time.Minute, func(val *ygnmi.Value[uint64]) bool {
+		return val.IsPresent()
+	})
+	if val, ok := watchTime.Await(t); !ok {
+		t.Fatalf("last-reboot-time was not populated within 5 minutes: got %v", val)
+	}
+	
 	// Get the last reboot time of the standby controller card after the reboot
 	lastRebootTimeAfter := gnmi.Get(t, dut, lastRebootTime.State())
 

--- a/feature/platform/controllercard/tests/controller_card_redundancy_test/controller_card_redundancy_test.go
+++ b/feature/platform/controllercard/tests/controller_card_redundancy_test/controller_card_redundancy_test.go
@@ -282,7 +282,7 @@ func testControllerCardRedundancy(t *testing.T, dut *ondatra.DUTDevice, controll
 	if deviations.SkipControllerCardPowerAdmin(dut) {
 		t.Skipf("Skipping test for controller card redundancy test as the device does not support controller card power up/down")
 	}
-	
+
 	// Collect active and standby controller cards before the switchover
 	rpStandbyBeforeSwitch, rpActiveBeforeSwitch := components.FindStandbyControllerCard(t, dut, controllerCards)
 
@@ -454,7 +454,7 @@ func testControllerCardLastRebootTime(t *testing.T, dut *ondatra.DUTDevice, cont
 	if val, ok := watchTime.Await(t); !ok {
 		t.Fatalf("last-reboot-time was not populated within 5 minutes: got %v", val)
 	}
-	
+
 	// Get the last reboot time of the standby controller card after the reboot
 	lastRebootTimeAfter := gnmi.Get(t, dut, lastRebootTime.State())
 

--- a/feature/platform/controllercard/tests/controller_card_redundancy_test/metadata.textproto
+++ b/feature/platform/controllercard/tests/controller_card_redundancy_test/metadata.textproto
@@ -14,3 +14,11 @@ platform_exceptions: {
     gnoi_subcomponent_reboot_status_unsupported: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
+  }
+  deviations: {
+    skip_controller_card_power_admin: true
+  }
+}


### PR DESCRIPTION
1. Adding the existing deviation skip_controller_card_power_admin to skip ControllerCardSwitchover subtest as it is not supported. 
2. Add gnmi.Watch over gnmi.Get to accomodate delays in telemetry leaf population. 