### PR TITLE
Increase HTTP client timeout to 300 seconds

### DIFF
--- a/tools/gap-analyzer/read_fnttests.go
+++ b/tools/gap-analyzer/read_fnttests.go
@@ -251,7 +251,7 @@ Result in JSON format:
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 60 * time.Second}
+	client := &http.Client{Timeout: 300 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		return false, "", fmt.Errorf("http request failed: %w", err)


### PR DESCRIPTION
Ensure any delay from the Gemini API, which is currently seeing extremely high traffic so requests might get queued, is accounted for.