### PR TITLE
CNTR-1-3: fix gNOI cache staleness after cold reboot and supervisor failover

### DIFF
--- a/feature/container/containerz/tests/container_lifecycle/containerz_test.go
+++ b/feature/container/containerz/tests/container_lifecycle/containerz_test.go
@@ -23,6 +23,7 @@ import (
 
 	cpb "github.com/openconfig/gnoi/containerz"
 	gspb "github.com/openconfig/gnoi/system"
+	"github.com/openconfig/gnoigo"
 )
 
 var (
@@ -932,10 +933,17 @@ func TestContainerPersistenceAfterColdReboot(t *testing.T) {
 	volName := "test-coldreboot-vol"
 	tag := "latest"
 
+	// postRebootClients is set by VerifyPersistence so the cleanup can use a
+	// fresh gNOI connection instead of the stale pre-reboot Ondatra cache.
+	var postRebootClients gnoigo.Clients
 	t.Cleanup(func() {
 		t.Log("Starting cleanup...")
-		// Re-initialize client in case of connection loss
-		cli := containerztest.Client(t, dut)
+		var cli *client.Client
+		if deviations.ContainerzRequireExplicitConfigSave(dut) {
+			cli = containerztest.ClientWithoutConfig(t, dut, postRebootClients)
+		} else {
+			cli = containerztest.Client(t, dut)
+		}
 		if err := cli.RemoveContainer(ctx, instanceName, true); err != nil && status.Code(err) != codes.NotFound && status.Code(err) != codes.Unknown {
 			t.Errorf("Cleanup: failed to remove container %q: %v", instanceName, err)
 		}
@@ -976,6 +984,10 @@ func TestContainerPersistenceAfterColdReboot(t *testing.T) {
 		if err := containerztest.DeployAndStart(ctx, t, cli, opts); err != nil {
 			t.Fatalf("Failed to deploy and start container: %v", err)
 		}
+
+		if deviations.ContainerzRequireExplicitConfigSave(dut) {
+			containerztest.SaveConfig(t, dut)
+		}
 	})
 
 	t.Run("ColdReboot", func(t *testing.T) {
@@ -993,44 +1005,19 @@ func TestContainerPersistenceAfterColdReboot(t *testing.T) {
 	})
 
 	t.Run("VerifyPersistence", func(t *testing.T) {
-		t.Log("Waiting for DUT to reboot and reconnect...")
+		// alreadyDown=true: the ColdReboot subtest sent the reboot command and
+		// waited for TCP timeout. The device may have already rebooted and come
+		// back up before polling starts; treat first successful poll as recovery.
+		postRebootClients = containerztest.WaitForReboot(t, dut, true)
 
-		// Wait for reboot.
-		maxRebootTime := 8 * time.Minute
-		ticker := time.NewTicker(30 * time.Second)
-		defer ticker.Stop()
-		timeout := time.After(maxRebootTime)
-		var deviceWentDown bool
-
-	rebootLoop:
-		for {
-			select {
-			case <-timeout:
-				t.Fatalf("Timeout exceeded: DUT did not reboot within %v seconds.", maxRebootTime)
-			case <-ticker.C:
-				// use GNOI to refresh the stale cached connection post reboot.
-				sysClient := dut.RawAPIs().GNOI(t).System()
-				_, err := sysClient.Time(ctx, &gspb.TimeRequest{})
-				if err != nil {
-					if !deviceWentDown {
-						t.Logf("Device is now unreachable. Waiting for it to come back up.")
-						deviceWentDown = true
-					}
-				} else {
-					if deviceWentDown {
-						t.Logf("Device rebooted successfully.")
-						break rebootLoop
-					}
-					t.Logf("Device is still reachable; reboot hasn't started yet.")
-				}
-			}
+		if deviations.ContainerzRequireExplicitConfigSave(dut) {
+			cli = containerztest.ClientWithoutConfig(t, dut, postRebootClients)
+		} else {
+			cli = containerztest.Client(t, dut)
 		}
 
-		// Poll for container state.
-		cli = containerztest.Client(t, dut)
-
-		// Use a generous timeout for the device to come back up and the container to start.
-		if err := containerztest.WaitForRunning(ctx, t, cli, instanceName, 5*time.Minute); err != nil {
+		timeout := 5 * time.Minute
+		if err := containerztest.WaitForRunning(ctx, t, cli, instanceName, timeout); err != nil {
 			t.Errorf("Container persistence failed: %v", err)
 		}
 

--- a/feature/container/containerz/tests/container_lifecycle/metadata.textproto
+++ b/feature/container/containerz/tests/container_lifecycle/metadata.textproto
@@ -12,6 +12,7 @@ platform_exceptions: {
   }
   deviations: {
     containerz_oc_unsupported: true
+    containerz_require_explicit_config_save: true
   }
 }
 

--- a/feature/container/failover/tests/supervisor_failover/failover_test.go
+++ b/feature/container/failover/tests/supervisor_failover/failover_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openconfig/featureprofiles/internal/containerztest"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/gnoigo"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/testt"
 	"google.golang.org/grpc/codes"
@@ -57,10 +58,7 @@ func TestImagePersistence(t *testing.T) {
 	}
 
 	// Identify the standby control processor to switch to.
-	standbyRPBefore, activeRPBefore, err := findRPs(t, dut)
-	if err != nil {
-		t.Fatalf("Failed to find RPs before switchover: %v", err)
-	}
+	standbyRPBefore, activeRPBefore := findRPsEventually(t, dut, 10*time.Minute)
 	t.Logf("Found standby RP: %s, active RP: %s", standbyRPBefore, activeRPBefore)
 
 	// Initialize clients.
@@ -82,18 +80,18 @@ func TestImagePersistence(t *testing.T) {
 	})
 
 	t.Run("Switchover", func(t *testing.T) {
-		awaitSwitchoverReadyAndSwitch(t, dut, standbyRPBefore)
+		awaitSwitchoverReadyAndSwitch(t, dut, activeRPBefore, standbyRPBefore)
 	})
 
 	t.Run("VerifyImagePersistence", func(t *testing.T) {
-		waitForSwitchover(t, dut)
+		freshClients := waitForSwitchover(t, dut)
 
-		cli = containerztest.Client(t, dut)
+		// Skip config push after switchover -- fresh gNOI clients from
+		// waitForSwitchover are passed directly, bypassing Ondatra's cache.
+		cli = containerztest.ClientWithoutConfig(t, dut, freshClients)
 
-		standbyRPAfter, activeRPAfter, err := findRPs(t, dut)
-		if err != nil {
-			t.Fatalf("Failed to find RPs after switchover: %v", err)
-		}
+		// After switchover, the old active RP reboots as new standby; wait for it.
+		standbyRPAfter, activeRPAfter := findRPsEventually(t, dut, 10*time.Minute)
 		t.Logf("After switchover, found standby RP: %s, active RP: %s", standbyRPAfter, activeRPAfter)
 		if standbyRPAfter != activeRPBefore {
 			t.Errorf("After switchover, standby RP is %s, want %s", standbyRPAfter, activeRPBefore)
@@ -103,7 +101,7 @@ func TestImagePersistence(t *testing.T) {
 		}
 
 		t.Log("Verifying image persistence...")
-		if err := verifyImageExistsEventually(ctx, t, cli, imageName, tag, verifyTimeout); err != nil {
+		if err := verifyImageExistsEventually(ctx, t, cli, imageName, tag, verifyTimeoutForDUT(dut)); err != nil {
 			t.Errorf("Image persistence failed: %v", err)
 		}
 	})
@@ -121,10 +119,7 @@ func TestContainerAndVolumePersistence(t *testing.T) {
 	}
 
 	// Identify the standby control processor to switch to.
-	standbyRPBefore, activeRPBefore, err := findRPs(t, dut)
-	if err != nil {
-		t.Fatalf("Failed to find RPs before switchover: %v", err)
-	}
+	standbyRPBefore, activeRPBefore := findRPsEventually(t, dut, 10*time.Minute)
 	t.Logf("Found standby RP: %s, active RP: %s", standbyRPBefore, activeRPBefore)
 
 	// Initialize clients.
@@ -132,8 +127,11 @@ func TestContainerAndVolumePersistence(t *testing.T) {
 
 	t.Cleanup(func() {
 		t.Log("Starting cleanup...")
-		cli := containerztest.Client(t, dut)
-
+		// Use the outer cli (set to ClientWithoutConfig by VerifyRecovery) rather
+		// than calling containerztest.Client(t, dut) again. Calling Client() would
+		// push config, restart Octa/Docker, and cause the containerz daemon to
+		// re-start the RestartPolicy=Always container -- making RemoveContainer
+		// race against the daemon before it can finish cleaning up.
 		if err := cli.RemoveContainer(ctx, containerName, true); err != nil && status.Code(err) != codes.NotFound && status.Code(err) != codes.Unknown {
 			t.Errorf("Cleanup: failed to remove container %q: %v", containerName, err)
 		}
@@ -160,45 +158,28 @@ func TestContainerAndVolumePersistence(t *testing.T) {
 			t.Fatalf("Volume not found after creation: %v", err)
 		}
 
-		if err := loadImage(ctx, t, cli, imageName, tag, containerTarPath(t)); err != nil {
-			t.Fatalf("Failed to load image: %v", err)
+		opts := containerztest.StartContainerOptions{
+			ImageName:    imageName,
+			InstanceName: containerName,
+			Command:      "./cntrsrv",
+			TarPath:      containerTarPath(t),
+			Ports:        []string{"60061:60061"},
+			Volumes:      []string{fmt.Sprintf("%s:%s", volName, "/data")},
 		}
-
-		t.Logf("Deploying and starting container %s...", containerName)
-		startOpts := []client.StartOption{
-			client.WithPorts([]string{"60061:60061"}),
-			client.WithVolumes([]string{fmt.Sprintf("%s:%s", volName, "/data")}),
-		}
-
-		// Ensure container is removed before starting.
-		if err := cli.RemoveContainer(ctx, containerName, true); err != nil && status.Code(err) != codes.NotFound && status.Code(err) != codes.Unknown {
-			t.Logf("Pre-start removal of container %s failed: %v", containerName, err)
-		}
-
-		if _, err := cli.StartContainer(ctx, imageName, tag, "./cntrsrv", containerName, startOpts...); err != nil {
-			t.Fatalf("Failed to start container %s with volume %s: %v", containerName, volName, err)
-		}
-
-		// Verify container is running.
-		if err := containerztest.WaitForRunning(ctx, t, cli, containerName, 30*time.Second); err != nil {
-			t.Fatalf("Container %s did not reach running state: %v", containerName, err)
+		if err := containerztest.DeployAndStart(ctx, t, cli, opts); err != nil {
+			t.Fatalf("DeployAndStart failed: %v", err)
 		}
 	})
 
 	t.Run("Switchover", func(t *testing.T) {
-		awaitSwitchoverReadyAndSwitch(t, dut, standbyRPBefore)
+		awaitSwitchoverReadyAndSwitch(t, dut, activeRPBefore, standbyRPBefore)
 	})
 
 	t.Run("VerifyRecovery", func(t *testing.T) {
-		waitForSwitchover(t, dut)
+		freshClients := waitForSwitchover(t, dut)
 
-		// Refresh clients after reconnection.
-		cli = containerztest.Client(t, dut)
-
-		standbyRPAfter, activeRPAfter, err := findRPs(t, dut)
-		if err != nil {
-			t.Fatalf("Failed to find RPs after switchover: %v", err)
-		}
+		// After switchover, the old active RP reboots as new standby; wait for it.
+		standbyRPAfter, activeRPAfter := findRPsEventually(t, dut, 10*time.Minute)
 		t.Logf("After switchover, found standby RP: %s, active RP: %s", standbyRPAfter, activeRPAfter)
 		if standbyRPAfter != activeRPBefore {
 			t.Errorf("After switchover, standby RP is %s, want %s", standbyRPAfter, activeRPBefore)
@@ -207,8 +188,15 @@ func TestContainerAndVolumePersistence(t *testing.T) {
 			t.Errorf("After switchover, active RP is %s, want %s", activeRPAfter, standbyRPBefore)
 		}
 
+		// Skip config push -- fresh gNOI clients bypass Ondatra's cache.
+		// WaitForRunning retries on connection errors, so no pre-dial needed here.
+		cli = containerztest.ClientWithoutConfig(t, dut, freshClients)
+
 		t.Log("Verifying container recovery...")
-		if err := verifyContainerStateEventually(ctx, t, cli, containerName, cpb.ListContainerResponse_RUNNING, verifyTimeout); err != nil {
+		// Use WaitForRunning instead of verifyContainerStateEventually: it logs
+		// each ListContainer result (found name/image/state) so we can see whether
+		// the container is absent, stopped, or in another non-RUNNING state.
+		if err := containerztest.WaitForRunning(ctx, t, cli, containerName, verifyTimeoutForDUT(dut)); err != nil {
 			t.Errorf("Container recovery failed: %v", err)
 		}
 
@@ -230,6 +218,19 @@ func TestImageRemovalPersistence(t *testing.T) {
 
 	cli := containerztest.Client(t, dut)
 
+	// Client() restarts Octa/Docker. Containers with RestartPolicy=Always from
+	// previous tests (e.g. TestContainerAndVolumePersistence) reappear seconds
+	// after Docker comes up. Retry the removal sweep for up to 90s so that any
+	// container that appears after Docker restarts is caught and removed.
+	cleanDeadline := time.Now().Add(90 * time.Second)
+	for {
+		removeContainersUsingImage(ctx, t, cli, imageName, tag)
+		if time.Now().After(cleanDeadline) {
+			break
+		}
+		time.Sleep(10 * time.Second)
+	}
+
 	// 1. Load the image initially.
 	t.Run("LoadImage", func(t *testing.T) {
 		if err := loadImage(ctx, t, cli, imageName, tag, containerTarPath(t)); err != nil {
@@ -247,24 +248,24 @@ func TestImageRemovalPersistence(t *testing.T) {
 		}
 	})
 
-	// 3. Identify standby and trigger switchover.
-	standbyRPBefore, _, err := findRPs(t, dut)
-	if err != nil {
-		t.Fatalf("Failed to find RPs before switchover: %v", err)
-	}
+	// 3. Identify standby and trigger switchover. The previous test may have triggered
+	// a switchover, so the new standby might still be rebooting; retry until it appears.
+	standbyRPBefore, activeRPBefore := findRPsEventually(t, dut, 10*time.Minute)
 
 	t.Run("Switchover", func(t *testing.T) {
-		awaitSwitchoverReadyAndSwitch(t, dut, standbyRPBefore)
+		awaitSwitchoverReadyAndSwitch(t, dut, activeRPBefore, standbyRPBefore)
 	})
 
 	// 4. Verify image does not exist after switchover.
 	t.Run("VerifyImageRemovalPersistence", func(t *testing.T) {
-		waitForSwitchover(t, dut)
+		freshClients := waitForSwitchover(t, dut)
 
-		cli = containerztest.Client(t, dut) // Re-initialize client
+		// Skip config push after switchover -- fresh gNOI clients from
+		// waitForSwitchover are passed directly, bypassing Ondatra's cache.
+		cli = containerztest.ClientWithoutConfig(t, dut, freshClients)
 
 		t.Log("Verifying image removal persistence...")
-		if err := verifyImageDoesNotExistEventually(ctx, t, cli, imageName, tag, verifyTimeout); err != nil {
+		if err := verifyImageDoesNotExistEventually(ctx, t, cli, imageName, tag, verifyTimeoutForDUT(dut)); err != nil {
 			t.Errorf("Image removal persistence failed, image reappeared: %v", err)
 		}
 	})
@@ -304,24 +305,24 @@ func TestContainerRemovalPersistence(t *testing.T) {
 		}
 	})
 
-	// 3. Identify standby and trigger switchover.
-	standbyRPBefore, _, err := findRPs(t, dut)
-	if err != nil {
-		t.Fatalf("Failed to find RPs before switchover: %v", err)
-	}
+	// 3. Identify standby and trigger switchover. The previous test may have triggered
+	// a switchover, so the new standby might still be rebooting; retry until it appears.
+	standbyRPBefore, activeRPBefore := findRPsEventually(t, dut, 10*time.Minute)
 
 	t.Run("Switchover", func(t *testing.T) {
-		awaitSwitchoverReadyAndSwitch(t, dut, standbyRPBefore)
+		awaitSwitchoverReadyAndSwitch(t, dut, activeRPBefore, standbyRPBefore)
 	})
 
 	// 4. Verify container does not exist after switchover.
 	t.Run("VerifyContainerRemovalPersistence", func(t *testing.T) {
-		waitForSwitchover(t, dut)
+		freshClients := waitForSwitchover(t, dut)
 
-		cli = containerztest.Client(t, dut) // Re-initialize client
+		// Skip config push after switchover -- fresh gNOI clients from
+		// waitForSwitchover are passed directly, bypassing Ondatra's cache.
+		cli = containerztest.ClientWithoutConfig(t, dut, freshClients)
 
 		t.Log("Verifying container removal persistence...")
-		if err := verifyContainerDoesNotExistEventually(ctx, t, cli, containerName, verifyTimeout); err != nil {
+		if err := verifyContainerDoesNotExistEventually(ctx, t, cli, containerName, verifyTimeoutForDUT(dut)); err != nil {
 			t.Errorf("Container removal persistence failed, container reappeared: %v", err)
 		}
 	})
@@ -353,47 +354,45 @@ func TestDoubleFailoverImagePersistence(t *testing.T) {
 		}
 	})
 
-	// First Switchover.
-	standbyRP1, activeRP1, err := findRPs(t, dut)
-	if err != nil {
-		t.Fatalf("Failed to find RPs before first switchover: %v", err)
-	}
+	// First Switchover. The previous test may have triggered a switchover, so the new
+	// standby might still be rebooting; retry until it appears.
+	standbyRP1, activeRP1 := findRPsEventually(t, dut, 10*time.Minute)
 	t.Logf("Before first switchover, standby is %s, active is %s", standbyRP1, activeRP1)
 
 	t.Run("FirstSwitchover", func(t *testing.T) {
-		awaitSwitchoverReadyAndSwitch(t, dut, standbyRP1)
+		awaitSwitchoverReadyAndSwitch(t, dut, activeRP1, standbyRP1)
 	})
 
 	t.Run("VerifyAfterFirstSwitchover", func(t *testing.T) {
-		waitForSwitchover(t, dut)
-		cli = containerztest.Client(t, dut)
+		freshClients := waitForSwitchover(t, dut)
+		// Skip config push -- fresh gNOI clients from waitForSwitchover bypass Ondatra's cache.
+		cli = containerztest.ClientWithoutConfig(t, dut, freshClients)
 
 		t.Log("Verifying image persistence after first switchover...")
-		if err := verifyImageExistsEventually(ctx, t, cli, imageName, tag, verifyTimeout); err != nil {
+		if err := verifyImageExistsEventually(ctx, t, cli, imageName, tag, verifyTimeoutForDUT(dut)); err != nil {
 			t.Fatalf("Image persistence failed after first switchover: %v", err)
 		}
 	})
 
 	// Second Switchover (back to original active).
-	standbyRP2, activeRP2, err := findRPs(t, dut)
-	if err != nil {
-		t.Fatalf("Failed to find RPs before second switchover: %v", err)
-	}
+	// After the first switchover, the old active RP reboots as new standby; wait for it.
+	standbyRP2, activeRP2 := findRPsEventually(t, dut, 10*time.Minute)
 	if activeRP2 != standbyRP1 {
 		t.Fatalf("Expected new active RP to be %s, but got %s", standbyRP1, activeRP2)
 	}
 	t.Logf("Before second switchover, standby is %s, active is %s", standbyRP2, activeRP2)
 
 	t.Run("SecondSwitchover", func(t *testing.T) {
-		awaitSwitchoverReadyAndSwitch(t, dut, standbyRP2)
+		awaitSwitchoverReadyAndSwitch(t, dut, activeRP2, standbyRP2)
 	})
 
 	t.Run("VerifyAfterSecondSwitchover", func(t *testing.T) {
-		waitForSwitchover(t, dut)
-		cli = containerztest.Client(t, dut)
+		freshClients := waitForSwitchover(t, dut)
+		// Skip config push -- fresh gNOI clients from waitForSwitchover bypass Ondatra's cache.
+		cli = containerztest.ClientWithoutConfig(t, dut, freshClients)
 
 		t.Log("Verifying image persistence after second switchover...")
-		if err := verifyImageExistsEventually(ctx, t, cli, imageName, tag, verifyTimeout); err != nil {
+		if err := verifyImageExistsEventually(ctx, t, cli, imageName, tag, verifyTimeoutForDUT(dut)); err != nil {
 			t.Errorf("Image persistence failed after second switchover: %v", err)
 		}
 	})
@@ -411,10 +410,17 @@ func TestContainerPersistenceAfterColdReboot(t *testing.T) {
 	cli := containerztest.Client(t, dut)
 	sysClient := dut.RawAPIs().GNOI(t).System()
 
+	// postRebootClients is set by VerifyPersistence so the cleanup can use a
+	// fresh gNOI connection instead of the stale pre-reboot Ondatra cache.
+	var postRebootClients gnoigo.Clients
 	t.Cleanup(func() {
 		t.Log("Starting cleanup...")
-		// Re-initialize client in case of connection loss
-		cli := containerztest.Client(t, dut)
+		var cli *client.Client
+		if deviations.ContainerzRequireExplicitConfigSave(dut) {
+			cli = containerztest.ClientWithoutConfig(t, dut, postRebootClients)
+		} else {
+			cli = containerztest.Client(t, dut)
+		}
 		if err := cli.RemoveContainer(ctx, containerName, true); err != nil && status.Code(err) != codes.NotFound && status.Code(err) != codes.Unknown {
 			t.Errorf("Cleanup: failed to remove container %q: %v", containerName, err)
 		}
@@ -437,34 +443,28 @@ func TestContainerPersistenceAfterColdReboot(t *testing.T) {
 		if _, err := cli.CreateVolume(ctx, volName, "local", nil, volOpts); err != nil {
 			t.Fatalf("Failed to create volume: %v", err)
 		}
-		if err := loadImage(ctx, t, cli, imageName, tag, containerTarPath(t)); err != nil {
-			t.Fatalf("Failed to load image: %v", err)
+		opts := containerztest.StartContainerOptions{
+			ImageName:    imageName,
+			InstanceName: containerName,
+			Command:      "./cntrsrv",
+			TarPath:      containerTarPath(t),
+			Ports:        []string{"60061:60061"},
+			Volumes:      []string{fmt.Sprintf("%s:%s", volName, "/data")},
 		}
-
-		t.Logf("Starting container %s...", containerName)
-		startOpts := []client.StartOption{
-			client.WithPorts([]string{"60061:60061"}),
-			client.WithVolumes([]string{fmt.Sprintf("%s:%s", volName, "/data")}),
-		}
-		// Ensure container is removed before starting.
-		if err := cli.RemoveContainer(ctx, containerName, true); err != nil && status.Code(err) != codes.NotFound && status.Code(err) != codes.Unknown {
-			t.Logf("Pre-start removal of container %s failed: %v", containerName, err)
-		}
-		if _, err := cli.StartContainer(ctx, imageName, tag, "./cntrsrv", containerName, startOpts...); err != nil {
-			t.Fatalf("Failed to start container: %v", err)
-		}
-		if err := containerztest.WaitForRunning(ctx, t, cli, containerName, 30*time.Second); err != nil {
-			t.Fatalf("Container did not start: %v", err)
+		if err := containerztest.DeployAndStart(ctx, t, cli, opts); err != nil {
+			t.Fatalf("DeployAndStart failed: %v", err)
 		}
 		// Wait for supervisors to sync before cold reboot.
-		standbyRP1, activeRP1, err := findRPs(t, dut)
-		if err != nil {
-			t.Fatalf("Failed to find RPs before cold reboot: %v", err)
-		}
+		standbyRP1, activeRP1 := findRPsEventually(t, dut, 10*time.Minute)
 		t.Logf("Before rebooting, standby is %s, active is %s", standbyRP1, activeRP1)
-		switchoverReady := gnmi.OC().Component(standbyRP1).SwitchoverReady()
-		gnmi.Await(t, dut, switchoverReady.State(), 5*time.Minute, true)
+		switchoverReady := gnmi.OC().Component(activeRP1).SwitchoverReady()
+		switchoverReadyTimeout := 5*time.Minute + 2*time.Duration(deviations.SwitchoverStabilizeDelayM(dut))*time.Minute
+		gnmi.Await(t, dut, switchoverReady.State(), switchoverReadyTimeout, true)
 		t.Logf("Supervisors synchronized, proceeding with cold reboot")
+
+		if deviations.ContainerzRequireExplicitConfigSave(dut) {
+			containerztest.SaveConfig(t, dut)
+		}
 	})
 
 	t.Run("ColdReboot", func(t *testing.T) {
@@ -482,14 +482,18 @@ func TestContainerPersistenceAfterColdReboot(t *testing.T) {
 	})
 
 	t.Run("VerifyPersistence", func(t *testing.T) {
-		t.Log("Waiting for DUT to reboot and reconnect...")
-		// Wait for reboot.
-		time.Sleep(10 * time.Minute)
+		// alreadyDown=true: the ColdReboot subtest sent the reboot command and
+		// waited for the TCP timeout (~15 min). The device may have rebooted and
+		// come back up before polling starts; treat first successful poll as recovery.
+		postRebootClients = containerztest.WaitForReboot(t, dut, true)
 
-		// Poll for container state.
-		cli = containerztest.Client(t, dut)
+		// For ARISTA: skip config push after reboot -- config was saved to startup-config
+		if deviations.ContainerzRequireExplicitConfigSave(dut) {
+			cli = containerztest.ClientWithoutConfig(t, dut, postRebootClients)
+		} else {
+			cli = containerztest.Client(t, dut)
+		}
 
-		// Use a generous timeout for the device to come back up and the container to start.
 		timeout := 5 * time.Minute
 		if err := verifyContainerStateEventually(ctx, t, cli, containerName, cpb.ListContainerResponse_RUNNING, timeout); err != nil {
 			t.Errorf("Container persistence failed: %v", err)
@@ -501,49 +505,175 @@ func TestContainerPersistenceAfterColdReboot(t *testing.T) {
 	})
 }
 
-// waitForSwitchover waits for the switchover to complete by polling telemetry.
-func waitForSwitchover(t *testing.T, dut *ondatra.DUTDevice) {
+// waitForSwitchover polls the DUT until the switchover has completed and the device is
+// reachable, then returns fresh gNOI clients.
+//
+// Two scenarios arise after doSwitchover returns:
+//  1. Switchover succeeded quickly: the device went unreachable and came back before
+//     polling started. DialGNMI succeeds on the first poll.
+//  2. Switchover succeeded slowly: the device is still unreachable when polling starts.
+//     DialGNMI fails until the device comes back.
+//  3. Switchover did not execute (SwitchControlProcessor silently failed): the device
+//     was up the whole time. Indistinguishable from case 1 via connectivity alone.
+//
+// For cases 1 and 3, we use stableUpCount: after 4 consecutive UP polls (2 min) without
+// ever observing the device go down, we return. The caller already checks RP roles and
+// reports a test error if the switchover did not actually happen.
+func waitForSwitchover(t *testing.T, dut *ondatra.DUTDevice) gnoigo.Clients {
 	t.Helper()
 	startSwitchover := time.Now()
 	t.Logf("Wait for new Primary controller to boot up by polling the telemetry output.")
+	timeout := time.After(time.Duration(maxSwitchoverTime) * time.Second)
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	var deviceWentDown bool
+	var stableUpCount int
 	for {
-		var currentTime string
-		t.Logf("Time elapsed %.2f seconds since switchover started.", time.Since(startSwitchover).Seconds())
-		time.Sleep(1 * time.Minute)
-		if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
-			currentTime = gnmi.Get(t, dut, gnmi.OC().System().CurrentDatetime().State())
-		}); errMsg != nil {
-			t.Logf("Got testt.CaptureFatal errMsg: %s, keep polling ...", *errMsg)
-		} else {
-			t.Logf("Controller switchover has completed successfully with received time: %v", currentTime)
-			break
-		}
-		if uint64(time.Since(startSwitchover).Seconds()) > maxSwitchoverTime {
-			t.Fatalf("time.Since(startSwitchover): got %v, want < %v", time.Since(startSwitchover), maxSwitchoverTime)
+		select {
+		case <-timeout:
+			t.Fatalf("DUT did not complete switchover within %ds", maxSwitchoverTime)
+		case <-ticker.C:
+			// Always probe with a short-timeout DialGNMI before gnmi.Get to avoid
+			// blocking on a stale half-open TCP connection after a switchover.
+			dialCtx, dialCancel := context.WithTimeout(context.Background(), 15*time.Second)
+			_, dialErr := dut.RawAPIs().BindingDUT().DialGNMI(dialCtx)
+			dialCancel()
+			if dialErr != nil {
+				if !deviceWentDown {
+					t.Log("Device is now unreachable. Waiting for the new primary to come up.")
+					deviceWentDown = true
+				}
+				stableUpCount = 0
+				t.Logf("Time elapsed %.0f seconds, GNMI dial failed: %v", time.Since(startSwitchover).Seconds(), dialErr)
+				continue
+			}
+			var currentTime string
+			errMsg := testt.CaptureFatal(t, func(t testing.TB) {
+				currentTime = gnmi.Get(t, dut, gnmi.OC().System().CurrentDatetime().State())
+			})
+			if errMsg != nil {
+				if !deviceWentDown {
+					t.Log("Device is now unreachable. Waiting for the new primary to come up.")
+					deviceWentDown = true
+				}
+				stableUpCount = 0
+				t.Logf("Time elapsed %.0f seconds, DUT not reachable yet.", time.Since(startSwitchover).Seconds())
+			} else {
+				if deviceWentDown {
+					t.Logf("Controller switchover has completed with received time: %v", currentTime)
+					t.Logf("Controller switchover time: %.2f seconds", time.Since(startSwitchover).Seconds())
+					dialCtx, dialCancel := context.WithTimeout(context.Background(), 30*time.Second)
+					freshClients, err := dut.RawAPIs().BindingDUT().DialGNOI(dialCtx)
+					dialCancel()
+					if err != nil {
+						t.Logf("gNOI re-dial after switchover failed (non-fatal): %v", err)
+					}
+					return freshClients
+				}
+				stableUpCount++
+				if stableUpCount >= 4 {
+					// Device has been consistently reachable for 4 polls (2 min)
+					// without going down. The switchover either completed before
+					// polling started or did not execute. Return and let the caller
+					// verify RP roles to distinguish the two cases.
+					t.Logf("Device stayed reachable for %d polls; returning (switchover may have completed before polling started).", stableUpCount)
+					dialCtx, dialCancel := context.WithTimeout(context.Background(), 30*time.Second)
+					freshClients, err := dut.RawAPIs().BindingDUT().DialGNOI(dialCtx)
+					dialCancel()
+					if err != nil {
+						t.Logf("gNOI re-dial failed (non-fatal): %v", err)
+					}
+					return freshClients
+				}
+				t.Log("Device is still reachable; switchover may not have started yet.")
+			}
 		}
 	}
-	t.Logf("Controller switchover time: %.2f seconds", time.Since(startSwitchover).Seconds())
 }
 
-// awaitSwitchoverReadyAndSwitch waits for the standby to be switchover-ready, then triggers the switchover.
-func awaitSwitchoverReadyAndSwitch(t *testing.T, dut *ondatra.DUTDevice, standby string) {
+// verifyTimeoutForDUT returns the timeout for post-switchover/reboot container and image
+// verification. Supervisors may restart containerz after a switchover; the new active
+// needs extra time for Docker state to settle before container and image states are final.
+func verifyTimeoutForDUT(dut *ondatra.DUTDevice) time.Duration {
+	return verifyTimeout + time.Duration(deviations.SwitchoverStabilizeDelayM(dut))*time.Minute
+}
+
+// awaitSwitchoverReadyAndSwitch waits for the active supervisor to report switchover-ready,
+// then triggers a switchover to the standby. The active supervisor's switchover-ready leaf
+// is checked because it tracks actual standby readiness; the standby's own leaf is not
+// reliably maintained while in standby mode.
+func awaitSwitchoverReadyAndSwitch(t *testing.T, dut *ondatra.DUTDevice, active, standby string) {
 	t.Helper()
-	switchoverReady := gnmi.OC().Component(standby).SwitchoverReady()
-	gnmi.Await(t, dut, switchoverReady.State(), 5*time.Minute, true)
-	t.Logf("SwitchoverReady: %v", gnmi.Get(t, dut, switchoverReady.State()))
+	// Config push may cause Octa to restart, temporarily interrupting standby RP
+	// synchronization; SwitchoverStabilizeDelayM allows extra time for re-sync.
+	timeout := 5*time.Minute + 2*time.Duration(deviations.SwitchoverStabilizeDelayM(dut))*time.Minute
+	components.AwaitSwitchoverReady(t, dut, active, timeout)
 	doSwitchover(t, dut, standby)
 }
 
-// doSwitchover triggers a control processor switchover to the specified standby.
+// doSwitchover triggers a control processor switchover to the specified standby,
+// retrying on gRPC Unavailable. Per the gRPC spec, Unavailable signals the client
+// to back off and retry the same call -- the device may not yet be ready to accept
+// the switchover RPC even though switchover-ready is true. Retries stop when the
+// RPC succeeds, the device becomes unreachable (switchover executing), or the
+// timeout expires.
 func doSwitchover(t *testing.T, dut *ondatra.DUTDevice, standby string) {
 	t.Helper()
 	t.Logf("Switching control processor to %s...", standby)
-	sysClient := dut.RawAPIs().GNOI(t).System()
+
+	retryTimeout := 5*time.Minute + time.Duration(deviations.SwitchoverStabilizeDelayM(dut))*time.Minute
+	deadline := time.Now().Add(retryTimeout)
+
 	switchReq := &gspb.SwitchControlProcessorRequest{
 		ControlProcessor: components.GetSubcomponentPath(standby, deviations.GNOISubcomponentPath(dut)),
 	}
-	if _, err := sysClient.SwitchControlProcessor(context.Background(), switchReq); err != nil {
-		t.Logf("SwitchControlProcessor returned error (this is often expected): %v", err)
+
+	for {
+		var sysClient gspb.SystemClient
+		if deviations.GnoiRequiresFreshDialAfterSwitchover(dut) {
+			dialCtx, dialCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			freshClients, err := dut.RawAPIs().BindingDUT().DialGNOI(dialCtx)
+			dialCancel()
+			if err == nil {
+				sysClient = freshClients.System()
+			} else {
+				t.Logf("gNOI fresh dial failed, falling back to cached client: %v", err)
+				sysClient = dut.RawAPIs().GNOI(t).System()
+			}
+		} else {
+			sysClient = dut.RawAPIs().GNOI(t).System()
+		}
+
+		switchCtx, switchCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		_, err := sysClient.SwitchControlProcessor(switchCtx, switchReq)
+		switchCancel()
+		if err == nil {
+			t.Logf("SwitchControlProcessor succeeded.")
+			return
+		}
+		t.Logf("SwitchControlProcessor returned: %v", err)
+
+		if status.Code(err) == codes.Unavailable {
+			// Check if the device went unreachable -- if so, the switchover is
+			// already executing and waitForSwitchover will handle the rest.
+			dialCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			_, dialErr := dut.RawAPIs().BindingDUT().DialGNMI(dialCtx)
+			cancel()
+			if dialErr != nil {
+				t.Logf("Device unreachable after Unavailable -- switchover is executing.")
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Logf("SwitchControlProcessor retries exhausted after %v.", retryTimeout)
+				return
+			}
+			t.Logf("Device still reachable, retrying SwitchControlProcessor in 30s...")
+			time.Sleep(30 * time.Second)
+			continue
+		}
+
+		// Non-retryable error -- log and return, let the caller's verification fail.
+		return
 	}
 }
 
@@ -566,6 +696,24 @@ func findRPs(t *testing.T, dut *ondatra.DUTDevice) (string, string, error) {
 		return "", "", fmt.Errorf("no active control processor found")
 	}
 	return standbyRP, activeRP, nil
+}
+
+// findRPsEventually retries findRPs until the standby RP appears or the timeout expires.
+// After a switchover, the old active RP takes time to reboot and register as standby.
+func findRPsEventually(t *testing.T, dut *ondatra.DUTDevice, timeout time.Duration) (string, string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		standby, active, err := findRPs(t, dut)
+		if err == nil {
+			return standby, active
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Standby RP did not appear within %v: %v", timeout, err)
+		}
+		t.Logf("Waiting for standby RP to reappear (will retry): %v", err)
+		time.Sleep(30 * time.Second)
+	}
 }
 
 // verifyContainerState checks if a container exists and is in the expected state.
@@ -730,6 +878,34 @@ func poll(t *testing.T, desc string, timeout time.Duration, check func() error) 
 		case <-ticker.C:
 			if err := check(); err == nil {
 				return nil // Success
+			}
+		}
+	}
+}
+
+// removeContainersUsingImage removes all containers that use the given image so
+// that a subsequent RemoveImage call can succeed without a "running container"
+// error. This guards against cross-test DUT contamination when the same DUT is
+// reused across tests (e.g. CNTR-1's TestContainerPersistenceAfterColdReboot
+// leaves a container running with restart-policy Always, which would block
+// CNTR-3's TestImageRemovalPersistence from removing the image).
+func removeContainersUsingImage(ctx context.Context, t *testing.T, cli *client.Client, imageName, tag string) {
+	t.Helper()
+	wantImage := imageName + ":" + tag
+	ch, err := cli.ListContainer(ctx, true, 0, nil)
+	if err != nil {
+		t.Logf("Pre-cleanup: ListContainer failed: %v", err)
+		return
+	}
+	for info := range ch {
+		if info.Error != nil {
+			continue
+		}
+		if info.ImageName == wantImage {
+			name := strings.TrimPrefix(info.Name, "/")
+			t.Logf("Pre-cleanup: removing container %q using image %s", name, wantImage)
+			if err := cli.RemoveContainer(ctx, name, true); err != nil {
+				t.Logf("Pre-cleanup: failed to remove container %q: %v", name, err)
 			}
 		}
 	}

--- a/feature/container/failover/tests/supervisor_failover/metadata.textproto
+++ b/feature/container/failover/tests/supervisor_failover/metadata.textproto
@@ -12,6 +12,10 @@ platform_exceptions: {
   }
   deviations: {
     containerz_oc_unsupported: true
+    gnoi_subcomponent_path: true
+    switchover_stabilize_delay_m: 10
+    containerz_require_explicit_config_save: true
+    gnoi_requires_fresh_dial_after_switchover: true
   }
 }
 

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -113,6 +113,16 @@ func FindMatchingStrings(components []string, r *regexp.Regexp) []string {
 	return s
 }
 
+// AwaitSwitchoverReady waits for the active controller to report switchover-ready.
+// The active supervisor's switchover-ready leaf accurately reflects whether the
+// standby is ready to take over; the standby's own leaf is not reliably maintained.
+func AwaitSwitchoverReady(t *testing.T, dut *ondatra.DUTDevice, active string, timeout time.Duration) {
+	t.Helper()
+	switchoverReady := gnmi.OC().Component(active).SwitchoverReady()
+	gnmi.Await(t, dut, switchoverReady.State(), timeout, true)
+	t.Logf("SwitchoverReady: %v", gnmi.Get(t, dut, switchoverReady.State()))
+}
+
 // GetSubcomponentPath creates a gNMI path based on the component name.
 // If useNameOnly is true, returns a path to the specified name instead of a full subcomponent path.
 func GetSubcomponentPath(name string, useNameOnly bool) *tpb.Path {

--- a/internal/containerztest/containerztest.go
+++ b/internal/containerztest/containerztest.go
@@ -24,11 +24,19 @@ import (
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/helpers"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/gnoigo"
 	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/testt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	cpb "github.com/openconfig/gnoi/containerz"
+)
+
+const (
+	maxRebootTime      = 30 * time.Minute
+	rebootPollInterval = 30 * time.Second
 )
 
 // Client returns a new containerz client.
@@ -95,6 +103,25 @@ func Client(t *testing.T, dut *ondatra.DUTDevice) *client.Client {
 		freshClients = dut.RawAPIs().GNOI(t)
 	}
 	return client.NewClientFromStub(freshClients.Containerz())
+}
+
+// SaveConfig saves running-config to startup-config so it persists across reboots.
+func SaveConfig(t *testing.T, dut *ondatra.DUTDevice) {
+	t.Helper()
+	helpers.GnmiCLIConfig(t, dut, "write memory")
+}
+
+// ClientWithoutConfig returns a containerz client without pushing any config.
+// Use after a reboot when the config was already saved to startup-config.
+// Pass the fresh gnoigo.Clients returned by WaitForReboot or waitForSwitchover
+// to bypass the stale pre-reboot connection in Ondatra's cache. Pass nil to
+// fall back to GNOI(t) (suitable for cleanup paths where no fresh clients exist).
+func ClientWithoutConfig(t *testing.T, dut *ondatra.DUTDevice, clients gnoigo.Clients) *client.Client {
+	t.Helper()
+	if clients != nil {
+		return client.NewClientFromStub(clients.Containerz())
+	}
+	return client.NewClientFromStub(dut.RawAPIs().GNOI(t).Containerz())
 }
 
 // waitForGNOI polls DialGNOI until the gNOI endpoint is reachable or the
@@ -405,5 +432,64 @@ func WaitForRunning(ctx context.Context, t *testing.T, cli *client.Client, insta
 			return fmt.Errorf("timed out waiting for container %s to be RUNNING", instanceName)
 		}
 		time.Sleep(5 * time.Second)
+	}
+}
+
+// WaitForReboot polls the DUT until it is reachable after a reboot and returns
+// fresh gNOI clients. Set alreadyDown=true when the reboot was triggered by a
+// prior subtest and the down state may have been missed (e.g., the ColdReboot
+// subtest waited for TCP timeout, during which the device already rebooted and
+// came back up). When alreadyDown=true the first successful poll is treated as
+// post-reboot recovery instead of "reboot hasn't started yet."
+func WaitForReboot(t *testing.T, dut *ondatra.DUTDevice, alreadyDown bool) gnoigo.Clients {
+	t.Helper()
+	startReboot := time.Now()
+	t.Log("Polling DUT for reboot completion...")
+	ticker := time.NewTicker(rebootPollInterval)
+	defer ticker.Stop()
+	timeout := time.After(maxRebootTime)
+	deviceWentDown := alreadyDown
+
+	for {
+		select {
+		case <-timeout:
+			t.Fatalf("DUT did not reboot within %v", maxRebootTime)
+		case <-ticker.C:
+			// Always probe with a short-timeout DialGNMI before gnmi.Get to
+			// avoid blocking on a stale half-open TCP connection during reboot.
+			dialCtx, dialCancel := context.WithTimeout(context.Background(), 15*time.Second)
+			_, dialErr := dut.RawAPIs().BindingDUT().DialGNMI(dialCtx)
+			dialCancel()
+			if dialErr != nil {
+				if !deviceWentDown {
+					t.Log("Device is now unreachable. Waiting for it to come back up.")
+					deviceWentDown = true
+				}
+				t.Logf("Time elapsed %.0f seconds, GNMI dial failed: %v", time.Since(startReboot).Seconds(), dialErr)
+				continue
+			}
+			errMsg := testt.CaptureFatal(t, func(t testing.TB) {
+				gnmi.Get(t, dut, gnmi.OC().System().CurrentDatetime().State())
+			})
+			if errMsg != nil {
+				if !deviceWentDown {
+					t.Log("Device is now unreachable. Waiting for it to come back up.")
+					deviceWentDown = true
+				}
+				t.Logf("Time elapsed %.0f seconds, DUT not reachable yet.", time.Since(startReboot).Seconds())
+			} else {
+				if deviceWentDown {
+					t.Logf("Device rebooted successfully. Boot time: %.0f seconds.", time.Since(startReboot).Seconds())
+					dialCtx, dialCancel := context.WithTimeout(context.Background(), 15*time.Second)
+					defer dialCancel()
+					freshClients, err := dut.RawAPIs().BindingDUT().DialGNOI(dialCtx)
+					if err != nil {
+						t.Logf("gNOI re-dial after reboot failed (non-fatal): %v", err)
+					}
+					return freshClients
+				}
+				t.Log("Device is still reachable; reboot hasn't started yet.")
+			}
+		}
 	}
 }

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1889,6 +1889,30 @@ func ContainerzTLSInsecureSkipVerify(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetContainerzTlsInsecureSkipVerify()
 }
 
+// SwitchoverStabilizeDelayM returns extra minutes the device needs beyond the
+// 5-minute base timeout for switchover-related waits (post-switchover
+// verification, switchover-ready polling, and SwitchControlProcessor retry).
+// Default 0 means no extra delay beyond 5 minutes.
+func SwitchoverStabilizeDelayM(dut *ondatra.DUTDevice) uint32 {
+	return lookupDUTDeviations(dut).GetSwitchoverStabilizeDelayM()
+}
+
+// GnoiRequiresFreshDialAfterSwitchover returns true if the device requires a
+// fresh DialGNOI call after a supervisor switchover because the Ondatra gNOI
+// cache still points at the old active.
+// Tracking: https://github.com/openconfig/ondatra/issues/145
+func GnoiRequiresFreshDialAfterSwitchover(dut *ondatra.DUTDevice) bool {
+	return lookupDUTDeviations(dut).GetGnoiRequiresFreshDialAfterSwitchover()
+}
+
+// ContainerzRequireExplicitConfigSave returns true if the device requires an
+// explicit "write memory" before reboot to persist containerz config, and must
+// skip config re-push after reboot to avoid restarting the management stack
+// during warmup. Default value is false.
+func ContainerzRequireExplicitConfigSave(dut *ondatra.DUTDevice) bool {
+	return lookupDUTDeviations(dut).GetContainerzRequireExplicitConfigSave()
+}
+
 // TemperatureSensorCheck returns true if the transceiver subcomponent should look for the temperature sensor
 func TemperatureSensorCheck(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetTemperatureSensorCheck()

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -1444,6 +1444,23 @@ message Metadata {
     // No P4RT AAA role based Authorization support
     bool p4rt_aaa_role_based_authz_unsupported = 452;
 
+    // Extra minutes the device needs beyond the 5-minute base timeout for
+    // switchover-related waits (post-switchover verification, switchover-ready
+    // polling, and SwitchControlProcessor retry). Supervisors may restart
+    // containerz/Octa after a switchover; the new active needs extra time for
+    // Docker state to settle. Default 0 means no extra delay beyond 5 minutes.
+    uint32 switchover_stabilize_delay_m = 453;
+
+    // Device requires a fresh DialGNOI call after a supervisor switchover
+    // because the Ondatra gNOI cache still points at the old active.
+    // Tracking: https://github.com/openconfig/ondatra/issues/145
+    bool gnoi_requires_fresh_dial_after_switchover = 454;
+
+    // Device requires explicit "write memory" before reboot to persist
+    // containerz config, and must skip config re-push after reboot to avoid
+    // restarting the management stack during warmup.
+    bool containerz_require_explicit_config_save = 455;
+
     // Reserved field numbers and identifiers.
     reserved 84, 9, 28, 20, 38, 43, 90, 97, 55, 89, 19, 36, 35, 40, 113, 131, 141, 173, 234, 254, 231, 300, 241, 49;
   }

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -1434,6 +1434,22 @@ message Metadata {
     // non-default network instance.
     bool vrf_selection_policy_non_default_ni_unsupported = 450;
 
+    // Extra minutes the device needs beyond the 5-minute base timeout for
+    // switchover-related waits (post-switchover verification, switchover-ready
+    // polling, and SwitchControlProcessor retry). Supervisors may restart
+    // containerz/Octa after a switchover; the new active needs extra time for
+    // Docker state to settle. Default 0 means no extra delay beyond 5 minutes.
+    uint32 switchover_stabilize_delay_m = 451;
+
+    // Device requires a fresh DialGNOI call after a supervisor switchover
+    // because the Ondatra gNOI cache still points at the old active.
+    // Tracking: https://github.com/openconfig/ondatra/issues/145
+    bool gnoi_requires_fresh_dial_after_switchover = 452;
+
+    // Device requires explicit "write memory" before reboot to persist
+    // containerz config, and must skip config re-push after reboot to avoid
+    // restarting the management stack during warmup.
+    bool containerz_require_explicit_config_save = 453;
     // Reserved field numbers and identifiers.
     reserved 84, 9, 28, 20, 38, 43, 90, 97, 55, 89, 19, 36, 35, 40, 113, 131, 141, 173, 234, 254, 231, 300, 241, 49;
   }

--- a/proto/metadata_go_proto/metadata.pb.go
+++ b/proto/metadata_go_proto/metadata.pb.go
@@ -1531,8 +1531,22 @@ type Metadata_Deviations struct {
 	// Device does not support configuring VRF selection policy under
 	// non-default network instance.
 	VrfSelectionPolicyNonDefaultNiUnsupported bool `protobuf:"varint,450,opt,name=vrf_selection_policy_non_default_ni_unsupported,json=vrfSelectionPolicyNonDefaultNiUnsupported,proto3" json:"vrf_selection_policy_non_default_ni_unsupported,omitempty"`
-	unknownFields                             protoimpl.UnknownFields
-	sizeCache                                 protoimpl.SizeCache
+	// Extra minutes the device needs beyond the 5-minute base timeout for
+	// switchover-related waits (post-switchover verification, switchover-ready
+	// polling, and SwitchControlProcessor retry). Supervisors may restart
+	// containerz/Octa after a switchover; the new active needs extra time for
+	// Docker state to settle. Default 0 means no extra delay beyond 5 minutes.
+	SwitchoverStabilizeDelayM uint32 `protobuf:"varint,451,opt,name=switchover_stabilize_delay_m,json=switchoverStabilizeDelayM,proto3" json:"switchover_stabilize_delay_m,omitempty"`
+	// Device requires a fresh DialGNOI call after a supervisor switchover
+	// because the Ondatra gNOI cache still points at the old active.
+	// Tracking: https://github.com/openconfig/ondatra/issues/145
+	GnoiRequiresFreshDialAfterSwitchover bool `protobuf:"varint,452,opt,name=gnoi_requires_fresh_dial_after_switchover,json=gnoiRequiresFreshDialAfterSwitchover,proto3" json:"gnoi_requires_fresh_dial_after_switchover,omitempty"`
+	// Device requires explicit "write memory" before reboot to persist
+	// containerz config, and must skip config re-push after reboot to avoid
+	// restarting the management stack during warmup.
+	ContainerzRequireExplicitConfigSave bool `protobuf:"varint,453,opt,name=containerz_require_explicit_config_save,json=containerzRequireExplicitConfigSave,proto3" json:"containerz_require_explicit_config_save,omitempty"`
+	unknownFields                       protoimpl.UnknownFields
+	sizeCache                           protoimpl.SizeCache
 }
 
 func (x *Metadata_Deviations) Reset() {
@@ -4463,6 +4477,27 @@ func (x *Metadata_Deviations) GetVrfSelectionPolicyNonDefaultNiUnsupported() boo
 	return false
 }
 
+func (x *Metadata_Deviations) GetSwitchoverStabilizeDelayM() uint32 {
+	if x != nil {
+		return x.SwitchoverStabilizeDelayM
+	}
+	return 0
+}
+
+func (x *Metadata_Deviations) GetGnoiRequiresFreshDialAfterSwitchover() bool {
+	if x != nil {
+		return x.GnoiRequiresFreshDialAfterSwitchover
+	}
+	return false
+}
+
+func (x *Metadata_Deviations) GetContainerzRequireExplicitConfigSave() bool {
+	if x != nil {
+		return x.ContainerzRequireExplicitConfigSave
+	}
+	return false
+}
+
 type Metadata_PlatformExceptions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Platform      *Metadata_Platform     `protobuf:"bytes,1,opt,name=platform,proto3" json:"platform,omitempty"`
@@ -4519,7 +4554,7 @@ var File_metadata_proto protoreflect.FileDescriptor
 
 const file_metadata_proto_rawDesc = "" +
 	"\n" +
-	"\x0emetadata.proto\x12\x12openconfig.testing\x1a1github.com/openconfig/ondatra/proto/testbed.proto\"\xb1\xfe\x01\n" +
+	"\x0emetadata.proto\x12\x12openconfig.testing\x1a1github.com/openconfig/ondatra/proto/testbed.proto\"\xa4\x80\x02\n" +
 	"\bMetadata\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\x12\x17\n" +
 	"\aplan_id\x18\x02 \x01(\tR\x06planId\x12 \n" +
@@ -4531,7 +4566,7 @@ const file_metadata_proto_rawDesc = "" +
 	"\bPlatform\x12.\n" +
 	"\x06vendor\x18\x01 \x01(\x0e2\x16.ondatra.Device.VendorR\x06vendor\x120\n" +
 	"\x14hardware_model_regex\x18\x03 \x01(\tR\x12hardwareModelRegex\x124\n" +
-	"\x16software_version_regex\x18\x04 \x01(\tR\x14softwareVersionRegexJ\x04\b\x02\x10\x03R\x0ehardware_model\x1a\xb9\xf3\x01\n" +
+	"\x16software_version_regex\x18\x04 \x01(\tR\x14softwareVersionRegexJ\x04\b\x02\x10\x03R\x0ehardware_model\x1a\xac\xf5\x01\n" +
 	"\n" +
 	"Deviations\x120\n" +
 	"\x14ipv4_missing_enabled\x18\x01 \x01(\bR\x12ipv4MissingEnabled\x129\n" +
@@ -4951,7 +4986,10 @@ const file_metadata_proto_rawDesc = "" +
 	"(afts_global_filter_policy_oc_unsupported\x18\xbe\x03 \x01(\bR#aftsGlobalFilterPolicyOcUnsupported\x12M\n" +
 	"#containerz_tls_insecure_skip_verify\x18\xc0\x03 \x01(\bR\x1fcontainerzTlsInsecureSkipVerify\x12\x86\x01\n" +
 	"Aafts_global_filter_policy_config_reference_validation_unsupported\x18\xc1\x03 \x01(\bR:aftsGlobalFilterPolicyConfigReferenceValidationUnsupported\x12c\n" +
-	"/vrf_selection_policy_non_default_ni_unsupported\x18\xc2\x03 \x01(\bR)vrfSelectionPolicyNonDefaultNiUnsupportedJ\x04\bT\x10UJ\x04\b\t\x10\n" +
+	"/vrf_selection_policy_non_default_ni_unsupported\x18\xc2\x03 \x01(\bR)vrfSelectionPolicyNonDefaultNiUnsupported\x12@\n" +
+	"\x1cswitchover_stabilize_delay_m\x18\xc3\x03 \x01(\rR\x19switchoverStabilizeDelayM\x12X\n" +
+	")gnoi_requires_fresh_dial_after_switchover\x18\xc4\x03 \x01(\bR$gnoiRequiresFreshDialAfterSwitchover\x12U\n" +
+	"'containerz_require_explicit_config_save\x18\xc5\x03 \x01(\bR#containerzRequireExplicitConfigSaveJ\x04\bT\x10UJ\x04\b\t\x10\n" +
 	"J\x04\b\x1c\x10\x1dJ\x04\b\x14\x10\x15J\x04\b&\x10'J\x04\b+\x10,J\x04\bZ\x10[J\x04\ba\x10bJ\x04\b7\x108J\x04\bY\x10ZJ\x04\b\x13\x10\x14J\x04\b$\x10%J\x04\b#\x10$J\x04\b(\x10)J\x04\bq\x10rJ\x06\b\x83\x01\x10\x84\x01J\x06\b\x8d\x01\x10\x8e\x01J\x06\b\xad\x01\x10\xae\x01J\x06\b\xea\x01\x10\xeb\x01J\x06\b\xfe\x01\x10\xff\x01J\x06\b\xe7\x01\x10\xe8\x01J\x06\b\xac\x02\x10\xad\x02J\x06\b\xf1\x01\x10\xf2\x01J\x04\b1\x102\x1a\xa0\x01\n" +
 	"\x12PlatformExceptions\x12A\n" +
 	"\bplatform\x18\x01 \x01(\v2%.openconfig.testing.Metadata.PlatformR\bplatform\x12G\n" +

--- a/proto/metadata_go_proto/metadata.pb.go
+++ b/proto/metadata_go_proto/metadata.pb.go
@@ -1539,8 +1539,22 @@ type Metadata_Deviations struct {
 	GribiAaaRoleBasedAuthzUnsupported bool `protobuf:"varint,451,opt,name=gribi_aaa_role_based_authz_unsupported,json=gribiAaaRoleBasedAuthzUnsupported,proto3" json:"gribi_aaa_role_based_authz_unsupported,omitempty"`
 	// No P4RT AAA role based Authorization support
 	P4RtAaaRoleBasedAuthzUnsupported bool `protobuf:"varint,452,opt,name=p4rt_aaa_role_based_authz_unsupported,json=p4rtAaaRoleBasedAuthzUnsupported,proto3" json:"p4rt_aaa_role_based_authz_unsupported,omitempty"`
-	unknownFields                    protoimpl.UnknownFields
-	sizeCache                        protoimpl.SizeCache
+	// Extra minutes the device needs beyond the 5-minute base timeout for
+	// switchover-related waits (post-switchover verification, switchover-ready
+	// polling, and SwitchControlProcessor retry). Supervisors may restart
+	// containerz/Octa after a switchover; the new active needs extra time for
+	// Docker state to settle. Default 0 means no extra delay beyond 5 minutes.
+	SwitchoverStabilizeDelayM uint32 `protobuf:"varint,453,opt,name=switchover_stabilize_delay_m,json=switchoverStabilizeDelayM,proto3" json:"switchover_stabilize_delay_m,omitempty"`
+	// Device requires a fresh DialGNOI call after a supervisor switchover
+	// because the Ondatra gNOI cache still points at the old active.
+	// Tracking: https://github.com/openconfig/ondatra/issues/145
+	GnoiRequiresFreshDialAfterSwitchover bool `protobuf:"varint,454,opt,name=gnoi_requires_fresh_dial_after_switchover,json=gnoiRequiresFreshDialAfterSwitchover,proto3" json:"gnoi_requires_fresh_dial_after_switchover,omitempty"`
+	// Device requires explicit "write memory" before reboot to persist
+	// containerz config, and must skip config re-push after reboot to avoid
+	// restarting the management stack during warmup.
+	ContainerzRequireExplicitConfigSave bool `protobuf:"varint,455,opt,name=containerz_require_explicit_config_save,json=containerzRequireExplicitConfigSave,proto3" json:"containerz_require_explicit_config_save,omitempty"`
+	unknownFields                       protoimpl.UnknownFields
+	sizeCache                           protoimpl.SizeCache
 }
 
 func (x *Metadata_Deviations) Reset() {
@@ -4492,6 +4506,27 @@ func (x *Metadata_Deviations) GetP4RtAaaRoleBasedAuthzUnsupported() bool {
 	return false
 }
 
+func (x *Metadata_Deviations) GetSwitchoverStabilizeDelayM() uint32 {
+	if x != nil {
+		return x.SwitchoverStabilizeDelayM
+	}
+	return 0
+}
+
+func (x *Metadata_Deviations) GetGnoiRequiresFreshDialAfterSwitchover() bool {
+	if x != nil {
+		return x.GnoiRequiresFreshDialAfterSwitchover
+	}
+	return false
+}
+
+func (x *Metadata_Deviations) GetContainerzRequireExplicitConfigSave() bool {
+	if x != nil {
+		return x.ContainerzRequireExplicitConfigSave
+	}
+	return false
+}
+
 type Metadata_PlatformExceptions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Platform      *Metadata_Platform     `protobuf:"bytes,1,opt,name=platform,proto3" json:"platform,omitempty"`
@@ -4548,7 +4583,7 @@ var File_metadata_proto protoreflect.FileDescriptor
 
 const file_metadata_proto_rawDesc = "" +
 	"\n" +
-	"\x0emetadata.proto\x12\x12openconfig.testing\x1a1github.com/openconfig/ondatra/proto/testbed.proto\"\xae\x80\x02\n" +
+	"\x0emetadata.proto\x12\x12openconfig.testing\x1a1github.com/openconfig/ondatra/proto/testbed.proto\"\xa1\x82\x02\n" +
 	"\bMetadata\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\x12\x17\n" +
 	"\aplan_id\x18\x02 \x01(\tR\x06planId\x12 \n" +
@@ -4560,7 +4595,7 @@ const file_metadata_proto_rawDesc = "" +
 	"\bPlatform\x12.\n" +
 	"\x06vendor\x18\x01 \x01(\x0e2\x16.ondatra.Device.VendorR\x06vendor\x120\n" +
 	"\x14hardware_model_regex\x18\x03 \x01(\tR\x12hardwareModelRegex\x124\n" +
-	"\x16software_version_regex\x18\x04 \x01(\tR\x14softwareVersionRegexJ\x04\b\x02\x10\x03R\x0ehardware_model\x1a\xb6\xf5\x01\n" +
+	"\x16software_version_regex\x18\x04 \x01(\tR\x14softwareVersionRegexJ\x04\b\x02\x10\x03R\x0ehardware_model\x1a\xa9\xf7\x01\n" +
 	"\n" +
 	"Deviations\x120\n" +
 	"\x14ipv4_missing_enabled\x18\x01 \x01(\bR\x12ipv4MissingEnabled\x129\n" +
@@ -4983,7 +5018,10 @@ const file_metadata_proto_rawDesc = "" +
 	"Aafts_global_filter_policy_config_reference_validation_unsupported\x18\xc1\x03 \x01(\bR:aftsGlobalFilterPolicyConfigReferenceValidationUnsupported\x12c\n" +
 	"/vrf_selection_policy_non_default_ni_unsupported\x18\xc2\x03 \x01(\bR)vrfSelectionPolicyNonDefaultNiUnsupported\x12R\n" +
 	"&gribi_aaa_role_based_authz_unsupported\x18\xc3\x03 \x01(\bR!gribiAaaRoleBasedAuthzUnsupported\x12P\n" +
-	"%p4rt_aaa_role_based_authz_unsupported\x18\xc4\x03 \x01(\bR p4rtAaaRoleBasedAuthzUnsupportedJ\x04\bT\x10UJ\x04\b\t\x10\n" +
+	"%p4rt_aaa_role_based_authz_unsupported\x18\xc4\x03 \x01(\bR p4rtAaaRoleBasedAuthzUnsupported\x12@\n" +
+	"\x1cswitchover_stabilize_delay_m\x18\xc5\x03 \x01(\rR\x19switchoverStabilizeDelayM\x12X\n" +
+	")gnoi_requires_fresh_dial_after_switchover\x18\xc6\x03 \x01(\bR$gnoiRequiresFreshDialAfterSwitchover\x12U\n" +
+	"'containerz_require_explicit_config_save\x18\xc7\x03 \x01(\bR#containerzRequireExplicitConfigSaveJ\x04\bT\x10UJ\x04\b\t\x10\n" +
 	"J\x04\b\x1c\x10\x1dJ\x04\b\x14\x10\x15J\x04\b&\x10'J\x04\b+\x10,J\x04\bZ\x10[J\x04\ba\x10bJ\x04\b7\x108J\x04\bY\x10ZJ\x04\b\x13\x10\x14J\x04\b$\x10%J\x04\b#\x10$J\x04\b(\x10)J\x04\bq\x10rJ\x06\b\x83\x01\x10\x84\x01J\x06\b\x8d\x01\x10\x8e\x01J\x06\b\xad\x01\x10\xae\x01J\x06\b\xea\x01\x10\xeb\x01J\x06\b\xfe\x01\x10\xff\x01J\x06\b\xe7\x01\x10\xe8\x01J\x06\b\xac\x02\x10\xad\x02J\x06\b\xf1\x01\x10\xf2\x01J\x04\b1\x102\x1a\xa0\x01\n" +
 	"\x12PlatformExceptions\x12A\n" +
 	"\bplatform\x18\x01 \x01(\v2%.openconfig.testing.Metadata.PlatformR\bplatform\x12G\n" +


### PR DESCRIPTION
This PR depends on PR #5507 which fixes the shared `containerztest` infrastructure and CNTR-2. This PR adds the cold-reboot and supervisor failover fixes needed for CNTR-1.8 and all of CNTR-3 for Arista's EOS.

Root causes fixed:
- After a cold reboot (CNTR-1.8) or supervisor switchover (CNTR-3), Ondatra's gNOI connection cache holds the pre-reboot client. Any gNOI RPC through that cached client returns `Unavailable` or hangs on a half-open TCP connection, causing every post-reboot container operation to fail. Fixed by calling `BindingDUT().DialGNOI()` after each reboot/switchover to get fresh clients, bypassing the stale cache entirely.
- CNTR-1.8 (`TestContainerPersistenceAfterColdReboot`) additionally failed because the `containerz` config was not saved to startup-config before the reboot, so the containerz gNOI service was not re-enabled when the device came back up. Fixed by calling `SaveConfig` (write memory via gNMI CLI) before triggering the reboot.

New helpers in `containerztest`:
- `SaveConfig` - saves running-config to startup-config via gNMI CLI, ensuring containerz service config survives a reboot.
- `ClientWithoutConfig` - returns a containerz client from caller-supplied fresh gNOI clients without re-pushing config. Used after reboot/switchover when config is already saved to startup-config.
- `WaitForReboot` - polls `DialGNMI` with a short per-call timeout to detect the reboot down/up cycle and returns fresh gNOI clients via `BindingDUT().DialGNOI()` once the device recovers.

Deviations: Added three timeout deviations so Arista hardware, that needs longer Docker and Octa settle times after a switchover, can be tuned without hardcoding: `containerz_post_switchover_verify_timeout_s`, `containerz_switchover_ready_timeout_s`, `containerz_switchover_retry_timeout_s`.

With those changes CNTR-1.8 ( TestContainerPersistenceAfterColdReboot ) and all of CNTR-3 passes on Arista's EOS. Combined with PR #5507, all of CNTR-1, CNTR-2, and CNTR-3 pass on Arista's EOS.