### PR TITLE
onboard: register new functional tests for physical loopback prober

### DIFF
--- a/feature/interface/ip/otg_tests/link_local_reuse_across_vrfs/README.md
+++ b/feature/interface/ip/otg_tests/link_local_reuse_across_vrfs/README.md
@@ -1,0 +1,136 @@
+# RT-5.16: Link-Local Subnet Reuse Across VRFs
+
+## Summary
+
+Verify that the device correctly supports assigning identical IPv4/IPv6 link-local addresses to multiple interfaces, provided they are isolated within different Virtual Routing and Forwarding (VRF) instances. This is a fundamental networking requirement for physical loopback prober designs to establish Layer 3 adjacency without consuming multiple public subnets.
+
+## Testbed type
+
+* dut.testbed: Single DUT with a physical fiber loop connecting two ports (e.g., Port 1 and Port 2).
+
+## Procedure
+
+### Test environment setup
+
+* Configure the DUT with two independent network-instances (type L3VRF) named vrf-primary and vrf-secondary.
+* Ensure physical loopback is present between two ports.
+
+### RT-5.16.1 - Positive: Overlapping Subnets in Different VRFs
+
+Verify that the device successfully applies overlapping link-local IPs when the target interfaces reside in different VRFs.
+
+#### Step 1 - Generate DUT configuration
+
+#### Canonical OC
+
+```json
+{
+  "network-instances": {
+    "network-instance": [
+      {
+        "config": { "name": "vrf-primary", "type": "L3VRF" },
+        "name": "vrf-primary",
+        "interfaces": {
+          "interface": [
+            {
+              "config": { "id": "Port-Channel6.100", "interface": "Port-Channel6.100", "subinterface": 100 },
+              "id": "Port-Channel6.100"
+            }
+          ]
+        }
+      },
+      {
+        "config": { "name": "vrf-secondary", "type": "L3VRF" },
+        "name": "vrf-secondary",
+        "interfaces": {
+          "interface": [
+            {
+              "config": { "id": "Port-Channel7.100", "interface": "Port-Channel7.100", "subinterface": 100 },
+              "id": "Port-Channel7.100"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "interfaces": {
+    "interface": [
+      {
+        "config": { "name": "Port-Channel6.100" },
+        "name": "Port-Channel6.100",
+        "subinterfaces": {
+          "subinterface": [
+            {
+              "index": 100,
+              "ipv4": {
+                "addresses": {
+                  "address": [
+                    { "config": { "ip": "169.254.0.1", "prefix-length": 30 }, "ip": "169.254.0.1" }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "config": { "name": "Port-Channel7.100" },
+        "name": "Port-Channel7.100",
+        "subinterfaces": {
+          "subinterface": [
+            {
+              "index": 100,
+              "ipv4": {
+                "addresses": {
+                  "address": [
+                    { "config": { "ip": "169.254.0.1", "prefix-length": 30 }, "ip": "169.254.0.1" }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+* Step 2 - Push configuration to DUT using gnmi.Set.
+* Step 3 - Verify control-plane reachability (e.g., ping between subinterfaces).
+* Step 4 - Validation:
+    * Interface State: Both interfaces report OPER_UP.
+    * IP State: The identical IP address is confirmed present in telemetry for both independent VRFs.
+    * Connectivity: The ping initiated in Step 3 reports 0% packet loss.
+    * Adjacency: The device's neighbor table (ARP/ND) confirms that the MAC address for the peer IP matches the secondary port, proving the packet physically traversed the fiber loop.
+
+### RT-5.16.2 - Negative: Collision Within the Same VRF
+
+Verify that the system rejects identical link-local subnets if they reside in the same VRF or Global context.
+
+* Step 1 - Configure Interface 1 in vrf-shared with 169.254.0.1/30.
+* Step 2 - Attempt to configure Interface 2 in the same vrf-shared with 169.254.0.2/30.
+* Step 3 - Validation: The system MUST reject the second configuration. The gNMI Set request must return a gRPC error indicating a configuration conflict.
+
+## OpenConfig Path and RPC Coverage
+
+```yaml
+paths:
+  /network-instances/network-instance/config/name:
+  /network-instances/network-instance/config/type:
+  /interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/config/ip:
+  /interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/config/prefix-length:
+  /interfaces/interface/state/oper-status:
+  /network-instances/network-instance/ipv4/neighbors/neighbor/state/link-layer-address:
+
+rpcs:
+  gnmi:
+    gNMI.Set:
+      union_replace: true
+    gNMI.Subscribe:
+      on_change: true
+```
+
+## Required DUT platform
+
+* FFF (Fixed Form Factor) or MFF (Modular Form Factor) with support for multiple VRFs.

--- a/feature/policy_forwarding/otg_tests/physical_loopback_fidelity/README.md
+++ b/feature/policy_forwarding/otg_tests/physical_loopback_fidelity/README.md
@@ -1,0 +1,108 @@
+# PF-1.27: Physical Loopback Dataplane Fidelity
+
+## Summary
+
+Verify the ASIC dataplane fidelity for traffic physically re-entering the device via loopback. This test confirms that the ASIC correctly handles packets in its ingress pipeline after they have traversed an external physical link. It specifically validates the handling of control plane packets (TTL=1) requiring Policy-Based Routing (PBR) redirection and standard data plane probes following a routing lookup.
+
+## Testbed type
+
+* dut.testbed: Single DUT with physical fiber loop connected between a Primary port and a Secondary port.
+
+## Procedure
+
+### Test environment setup
+
+* Configure subinterfaces on both loopback ports with a specific VLAN ID (e.g., VLAN 100) and identical link-local subnets.
+* Configure independent VRFs on each of them (vrf-primary and vrf-secondary) and bind the subinterfaces to them.
+* Configure the DUT to decapsulate incoming ATE traffic (e.g., MPLSoUDPv6) on primary interface and egress the native IP payload to the loopback port.
+* Apply policy-forwarding configuration on the secondary subinterface to redirect specific traffic (TTL=1) to an encapsulation next-hop group.
+
+### PF-1.27.1 - Ingress Redirection for Looped TTL=1 Packets
+
+Verify that the ASIC ingress pipeline correctly identifies packets re-entering from the loop with TTL=1 and redirects them via PBR to the Encapsulation Next-Hop Group (NHG).
+
+#### Step 1 - Generate DUT configuration
+
+Configure the Traffic Policy (PBR) to match the TTL=1 traffic on the receiving interface.
+
+#### Canonical OC
+
+```json
+{
+  "network-instances": {
+    "network-instance": [
+      {
+        "name": "vrf-secondary",
+        "policy-forwarding": {
+          "interfaces": {
+            "interface": [
+              {
+                "config": {
+                  "apply-forwarding-policy": "LOOPBACK_REDIRECTION",
+                  "interface-id": "Port-Channel7.100"
+                },
+                "interface-id": "Port-Channel7.100"
+              }
+            ]
+          },
+          "policies": {
+            "policy": [
+              {
+                "config": { "policy-id": "LOOPBACK_REDIRECTION" },
+                "policy-id": "LOOPBACK_REDIRECTION",
+                "rules": {
+                  "rule": [
+                    {
+                      "config": { "sequence-id": 1 },
+                      "ipv4": {
+                        "config": {
+                          "hop-limit": 1,
+                          "protocol": 6
+                        }
+                      },
+                      "action": {
+                        "config": {
+                          "network-instance": "DEFAULT",
+                          "next-hop-group": "ENCAPSULATION_NHG",
+                          "set-ttl": 1
+                        }
+                      },
+                      "sequence-id": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+* Step 2 - Push configuration to DUT.
+* Step 3 - Inject a BGP Hello packet (TTL=1) from ATE to DUT. DUT decaps & does label lookup to egress from the primary-side router & re-enter to the secondary-side peer IP across the loop.
+* Step 4 - Validation: The secondary-side vrf interface receives the packet, matches on the PBR for TTL=1 rule & redirects to the Encapsulation NHG with TTL=1. 0 packet loss observed.
+
+## OpenConfig Path and RPC Coverage
+
+```yaml
+paths:
+  /network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/config/next-hop-group:
+  /network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/ipv4/config/hop-limit:
+  /network-instances/network-instance/policy-forwarding/interfaces/interface/config/apply-forwarding-policy:
+  /network-instances/network-instance/policy-forwarding/policies/policy/rules/rule/action/config/set-ttl:
+  /network-instances/network-instance/next-hop-groups/next-hop-group/state/id:
+
+rpcs:
+  gnmi:
+    gNMI.Set:
+      union_replace: true
+    gNMI.Subscribe:
+      on_change: true
+```
+
+## Required DUT platform
+
+* FFF (Fixed Form Factor) or MFF (Modular Form Factor) with support for multiple VRFs.

--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -1205,6 +1205,12 @@ test: {
   exec: " "
 }
 test: {
+  id: "RT-5.16"
+  description: "Link-Local Subnet Reuse Across VRFs"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/interface/ip/otg_tests/link_local_reuse_across_vrfs/README.md"
+  exec: " "
+}
+test: {
   id: "RT-6.1"
   description: "Core LLDP TLV Population"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/lldp/otg_tests/core_lldp_tlv_population_test/README.md"
@@ -2579,5 +2585,11 @@ test: {
   id: "PF-1.26"
   description: "Double GUE Decapsulation"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/policy_forwarding/otg_tests/double_gue_decap/README.md"
+  exec: " "
+}
+test: {
+  id: "PF-1.27"
+  description: "Physical Loopback Dataplane Fidelity"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/policy_forwarding/otg_tests/physical_loopback_fidelity/README.md"
   exec: " "
 }


### PR DESCRIPTION
This Pull Request registers two new feature profiles in the test registry and adds their corresponding READMEs. These tests support the validation of devices used in physical loopback prober designs.

New Feature Profiles:

1. RT-5.16: Link-Local Subnet Reuse Across VRFs 

- Objective: Verifies that the device correctly supports assigning identical IPv4/IPv6 link-local addresses to multiple interfaces, provided they are isolated within independent Virtual Routing and Forwarding (VRF) instances

- Coverage: Includes positive tests for cross-VRF overlap and negative tests for collision within the same routing context 

2. PF-1.27: Physical Loopback Dataplane Fidelit

- Objective: Verifies ASIC dataplane fidelity for traffic physically re-entering the device via loopback

- Coverage: Validates the ingress pipeline's ability to handle looped control plane packets (TTL=1) requiring Policy-Based Routing (PBR) redirection and standard data plane probes following a routing lookup

Changes:

- Updated testregistry.textproto to add entries for RT-5.16 and PF-1.27.
- Added README.md for RT-5.16 in feature/interface/ip/otg_tests/link_local_reuse_across_vrfs/
- Added README.md for PF-1.27 in feature/policy_forwarding/otg_tests/physical_loopback_fidelity/

Label: enhancement