### PR TITLE
gNMI-1.17: Fix gNOI RPCs to be called on active supervisor

### DIFF
--- a/feature/platform/controllercard/tests/controller_card_redundancy_test/controller_card_redundancy_test.go
+++ b/feature/platform/controllercard/tests/controller_card_redundancy_test/controller_card_redundancy_test.go
@@ -67,48 +67,24 @@ func waitForSwitchover(t *testing.T, dut *ondatra.DUTDevice) {
 	t.Logf("RP switchover time: %.2f seconds", time.Since(startSwitchover).Seconds())
 }
 
+// awaitSwitchoverReadyAndSwitch waits for the active supervisor to report switchover-ready,
+// then triggers a switchover to the standby. The active supervisor's switchover-ready leaf
+// is checked because it tracks actual standby readiness; the standby's own leaf is not
+// reliably maintained while in standby mode.
+func awaitSwitchoverReadyAndSwitch(t *testing.T, dut *ondatra.DUTDevice, active, standby string) {
+	t.Helper()
+	timeout := 30 * time.Minute
+	components.AwaitSwitchoverReady(t, dut, active, timeout)
+	components.DoSwitchover(t, dut, standby)
+}
+
 func testControllerCardSwitchover(t *testing.T, dut *ondatra.DUTDevice, controllerCards []string) {
 	// Collect active and standby controller cards before the switchover
 	rpStandbyBeforeSwitch, rpActiveBeforeSwitch := components.FindStandbyControllerCard(t, dut, controllerCards)
 	t.Logf("Detected rpStandby: %v, rpActive: %v", rpStandbyBeforeSwitch, rpActiveBeforeSwitch)
 
-	// Check if active RP is ready for switchover
-	switchoverReady := gnmi.OC().Component(rpActiveBeforeSwitch).SwitchoverReady()
-	gnmi.Await(t, dut, switchoverReady.State(), 10*time.Minute, true)
-	t.Logf("SwitchoverReady().Get(t): %v", gnmi.Get(t, dut, switchoverReady.State()))
-	if got, want := gnmi.Get(t, dut, switchoverReady.State()), true; got != want {
-		t.Errorf("switchoverReady.Get(t): got %v, want %v", got, want)
-	}
-
-	// Initiate a RP switchover
-	gnoiClient := dut.RawAPIs().GNOI(t)
-	useNameOnly := deviations.GNOISubcomponentPath(dut)
-	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: components.GetSubcomponentPath(rpStandbyBeforeSwitch, useNameOnly),
-	}
-	t.Logf("switchoverRequest: %v", switchoverRequest)
-	switchoverResponse, err := gnoiClient.System().SwitchControlProcessor(context.Background(), switchoverRequest)
-	if err != nil {
-		t.Fatalf("Failed to perform control processor switchover with unexpected err: %v", err)
-	}
-	t.Logf("gnoiClient.System().SwitchControlProcessor() response: %v, err: %v", switchoverResponse, err)
-
-	want := rpStandbyBeforeSwitch
-	got := ""
-	if deviations.GNOISubcomponentPath(dut) {
-		got = switchoverResponse.GetControlProcessor().GetElem()[0].GetName()
-	} else {
-		got = switchoverResponse.GetControlProcessor().GetElem()[1].GetKey()["name"]
-	}
-	if got != want {
-		t.Fatalf("switchoverResponse.GetControlProcessor().GetElem()[0].GetName(): got %v, want %v", got, want)
-	}
-	if got, want := switchoverResponse.GetVersion(), ""; got == want {
-		t.Errorf("switchoverResponse.GetVersion(): got %v, want non-empty version", got)
-	}
-	if got := switchoverResponse.GetUptime(); got == 0 {
-		t.Errorf("switchoverResponse.GetUptime(): got %v, want > 0", got)
-	}
+	// Wait for active RP to be switchover-ready, then trigger switchover with retry.
+	awaitSwitchoverReadyAndSwitch(t, dut, rpActiveBeforeSwitch, rpStandbyBeforeSwitch)
 	// Waiting for device to be stable after the switchover.
 	waitForSwitchover(t, dut)
 
@@ -150,7 +126,7 @@ func testControllerCardSwitchover(t *testing.T, dut *ondatra.DUTDevice, controll
 	switchoverReadyStandbyrp := gnmi.OC().Component(rpStandbyAfterSwitch).SwitchoverReady()
 	gnmi.Await(t, dut, switchoverReadyActiverp.State(), 30*time.Minute, true)
 	gnmi.Await(t, dut, switchoverReadyStandbyrp.State(), 30*time.Minute, true)
-	t.Logf("SwitchoverReady().Get(t): %v", gnmi.Get(t, dut, switchoverReady.State()))
+	t.Logf("SwitchoverReady().Get(t): %v", gnmi.Get(t, dut, switchoverReadyActiverp.State()))
 	if got, want := gnmi.Get(t, dut, switchoverReadyActiverp.State()), true; got != want {
 		t.Errorf("switchoverReady.Get(t): got %v, want %v", got, want)
 	}
@@ -286,26 +262,8 @@ func testControllerCardRedundancy(t *testing.T, dut *ondatra.DUTDevice, controll
 	// Collect active and standby controller cards before the switchover
 	rpStandbyBeforeSwitch, rpActiveBeforeSwitch := components.FindStandbyControllerCard(t, dut, controllerCards)
 
-	// Check if active RP is ready for switchover
-	switchoverReady := gnmi.OC().Component(rpActiveBeforeSwitch).SwitchoverReady()
-	gnmi.Await(t, dut, switchoverReady.State(), 10*time.Minute, true)
-	t.Logf("SwitchoverReady().Get(t): %v", gnmi.Get(t, dut, switchoverReady.State()))
-	if got, want := gnmi.Get(t, dut, switchoverReady.State()), true; got != want {
-		t.Errorf("switchoverReady.Get(t): got %v, want %v", got, want)
-	}
-
-	// Initiate a RP switchover
-	gnoiClient := dut.RawAPIs().GNOI(t)
-	useNameOnly := deviations.GNOISubcomponentPath(dut)
-	switchoverRequest := &spb.SwitchControlProcessorRequest{
-		ControlProcessor: components.GetSubcomponentPath(rpStandbyBeforeSwitch, useNameOnly),
-	}
-	t.Logf("switchoverRequest: %v", switchoverRequest)
-	switchoverResponse, err := gnoiClient.System().SwitchControlProcessor(context.Background(), switchoverRequest)
-	if err != nil {
-		t.Fatalf("Failed to perform control processor switchover with unexpected err: %v", err)
-	}
-	t.Logf("gnoiClient.System().SwitchControlProcessor() response: %v, err: %v", switchoverResponse, err)
+	// Wait for active RP to be switchover-ready, then trigger switchover with retry.
+	awaitSwitchoverReadyAndSwitch(t, dut, rpActiveBeforeSwitch, rpStandbyBeforeSwitch)
 	// Polling the device to verify the stability of the device.
 	waitForSwitchover(t, dut)
 	rpStandbyAfterSwitch, rpActiveAfterSwitch := components.FindStandbyControllerCard(t, dut, controllerCards)
@@ -315,21 +273,11 @@ func testControllerCardRedundancy(t *testing.T, dut *ondatra.DUTDevice, controll
 	gnmi.Await(t, dut, switchoverReadyStandbyrp.State(), 30*time.Minute, true)
 	t.Logf("SwitchoverReady for active RP: %v, standby RP: %v", gnmi.Get(t, dut, switchoverReadyActiverp.State()), gnmi.Get(t, dut, switchoverReadyStandbyrp.State()))
 
-	want := rpStandbyBeforeSwitch
-	got := ""
-	if deviations.GNOISubcomponentPath(dut) {
-		got = switchoverResponse.GetControlProcessor().GetElem()[0].GetName()
-	} else {
-		got = switchoverResponse.GetControlProcessor().GetElem()[1].GetKey()["name"]
-	}
-	if got != want {
-		t.Fatalf("switchoverResponse.GetControlProcessor().GetElem()[0].GetName(): got %v, want %v", got, want)
-	}
-	if got, want := switchoverResponse.GetVersion(), ""; got == want {
-		t.Errorf("switchoverResponse.GetVersion(): got %v, want non-empty version", got)
-	}
-	if got := switchoverResponse.GetUptime(); got == 0 {
-		t.Errorf("switchoverResponse.GetUptime(): got %v, want > 0", got)
+	// Dial a fresh gNOI connection to the new active before issuing reboot requests.
+	useNameOnly := deviations.GNOISubcomponentPath(dut)
+	gnoiClient, err := dut.RawAPIs().BindingDUT().DialGNOI(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to dial gNOI for powerdown: %v", err)
 	}
 
 	// PowerDown the standby RP
@@ -419,8 +367,12 @@ func testControllerCardLastRebootTime(t *testing.T, dut *ondatra.DUTDevice, cont
 	// Get the last reboot time of the standby controller card before the reboot
 	lastRebootTime := gnmi.OC().Component(rpStandby).LastRebootTime()
 	lastRebootTimeBefore := gnmi.Get(t, dut, lastRebootTime.State())
-	// Reboot the standby controller card
-	gnoiClient := dut.RawAPIs().GNOI(t)
+	// Reboot the standby controller card using a fresh gNOI connection so we reach
+	// the current active (not a cached connection from a prior testlet's switchover).
+	gnoiClient, err := dut.RawAPIs().BindingDUT().DialGNOI(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to dial gNOI for reboot: %v", err)
+	}
 	useNameOnly := deviations.GNOISubcomponentPath(dut)
 	rebootControllerCardRequest := &spb.RebootRequest{
 		Method: spb.RebootMethod_COLD,

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -23,12 +23,15 @@ import (
 	"time"
 
 	"github.com/openconfig/featureprofiles/internal/deviations"
+	spb "github.com/openconfig/gnoi/system"
 	tpb "github.com/openconfig/gnoi/types"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
 	"github.com/openconfig/ondatra/gnmi/oc/ocpath"
 	"github.com/openconfig/ygnmi/ygnmi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -111,6 +114,80 @@ func FindMatchingStrings(components []string, r *regexp.Regexp) []string {
 		}
 	}
 	return s
+}
+
+// AwaitSwitchoverReady waits for the active controller to report switchover-ready.
+// The active supervisor's switchover-ready leaf accurately reflects whether the
+// standby is ready to take over; the standby's own leaf is not reliably maintained.
+func AwaitSwitchoverReady(t *testing.T, dut *ondatra.DUTDevice, active string, timeout time.Duration) {
+	t.Helper()
+	switchoverReady := gnmi.OC().Component(active).SwitchoverReady()
+	gnmi.Await(t, dut, switchoverReady.State(), timeout, true)
+	t.Logf("SwitchoverReady: %v", gnmi.Get(t, dut, switchoverReady.State()))
+}
+
+// DoSwitchover triggers a control processor switchover to the specified standby,
+// retrying on gRPC Unavailable. Per the gRPC spec, Unavailable signals the client
+// to back off and retry the same call -- the device may not yet be ready to accept
+// the switchover RPC even though switchover-ready is true. Retries stop when the
+// RPC succeeds, the device becomes unreachable (switchover executing), or the
+// timeout expires.
+func DoSwitchover(t *testing.T, dut *ondatra.DUTDevice, standby string) {
+	t.Helper()
+	t.Logf("Switching control processor to %s...", standby)
+
+	retryTimeout := 5 * time.Minute
+	deadline := time.Now().Add(retryTimeout)
+
+	switchReq := &spb.SwitchControlProcessorRequest{
+		ControlProcessor: GetSubcomponentPath(standby, deviations.GNOISubcomponentPath(dut)),
+	}
+
+	for {
+		var sysClient spb.SystemClient
+		if dut.Vendor() == ondatra.ARISTA {
+			// Fresh dial on every attempt: after a prior switchover the Ondatra gNOI
+			// cache may point to the old active (now standby). A fresh dial always
+			// reaches the current active.
+			if freshClients, err := dut.RawAPIs().BindingDUT().DialGNOI(context.Background()); err == nil {
+				sysClient = freshClients.System()
+			} else {
+				t.Logf("gNOI fresh dial failed, falling back to cached client: %v", err)
+				sysClient = dut.RawAPIs().GNOI(t).System()
+			}
+		} else {
+			sysClient = dut.RawAPIs().GNOI(t).System()
+		}
+
+		_, err := sysClient.SwitchControlProcessor(context.Background(), switchReq)
+		if err == nil {
+			t.Logf("SwitchControlProcessor succeeded.")
+			return
+		}
+		t.Logf("SwitchControlProcessor returned: %v", err)
+
+		if status.Code(err) == codes.Unavailable {
+			// Check if the device went unreachable -- if so, the switchover is
+			// already executing and the caller's waitForSwitchover will handle the rest.
+			dialCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			_, dialErr := dut.RawAPIs().BindingDUT().DialGNMI(dialCtx)
+			cancel()
+			if dialErr != nil {
+				t.Logf("Device unreachable after Unavailable -- switchover is executing.")
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Logf("SwitchControlProcessor retries exhausted after %v.", retryTimeout)
+				return
+			}
+			t.Logf("Device still reachable, retrying SwitchControlProcessor in 30s...")
+			time.Sleep(30 * time.Second)
+			continue
+		}
+
+		// Non-retryable error -- log and return, let the caller's verification fail.
+		return
+	}
 }
 
 // GetSubcomponentPath creates a gNMI path based on the component name.

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -145,17 +145,13 @@ func DoSwitchover(t *testing.T, dut *ondatra.DUTDevice, standby string) {
 
 	for {
 		var sysClient spb.SystemClient
-		if dut.Vendor() == ondatra.ARISTA {
-			// Fresh dial on every attempt: after a prior switchover the Ondatra gNOI
-			// cache may point to the old active (now standby). A fresh dial always
-			// reaches the current active.
-			if freshClients, err := dut.RawAPIs().BindingDUT().DialGNOI(context.Background()); err == nil {
-				sysClient = freshClients.System()
-			} else {
-				t.Logf("gNOI fresh dial failed, falling back to cached client: %v", err)
-				sysClient = dut.RawAPIs().GNOI(t).System()
-			}
+		// Fresh dial on every attempt: after a prior switchover the Ondatra gNOI
+		// cache may point to the old active (now standby). A fresh dial always
+		// reaches the current active.
+		if freshClients, err := dut.RawAPIs().BindingDUT().DialGNOI(context.Background()); err == nil {
+			sysClient = freshClients.System()
 		} else {
+			t.Logf("gNOI fresh dial failed, falling back to cached client: %v", err)
 			sysClient = dut.RawAPIs().GNOI(t).System()
 		}
 
@@ -177,7 +173,7 @@ func DoSwitchover(t *testing.T, dut *ondatra.DUTDevice, standby string) {
 				return
 			}
 			if time.Now().After(deadline) {
-				t.Logf("SwitchControlProcessor retries exhausted after %v.", retryTimeout)
+				t.Fatalf("SwitchControlProcessor retries exhausted after %v: %v", retryTimeout, err)
 				return
 			}
 			t.Logf("Device still reachable, retrying SwitchControlProcessor in 30s...")
@@ -185,8 +181,8 @@ func DoSwitchover(t *testing.T, dut *ondatra.DUTDevice, standby string) {
 			continue
 		}
 
-		// Non-retryable error -- log and return, let the caller's verification fail.
-		return
+		// Non-retryable error
+		t.Fatalf("SwitchControlProcessor failed with non-retryable error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Issue:

1) The testControllerCardSwitchover and testControllerCardRedundancy testlets used Ondatra's cached gNOI client (dut.RawAPIs().GNOI(t)) to issue SwitchControlProcessor RPCs. After a prior switchover, this cache points to the old active (now standby), causing the RPC to time out or fail.

2) Sometimes the switchover-ready state of the current active sup stays False within the current timeout window of 10 minutes.

3) gRPC switchover call returning with an unavailable response.

Fix:

1) Dial a fresh gNOI connection on every attempt to always reach the current active supervisor.

2) Increased the timeout for checking switchover-ready state on active supervisor is true to 30 minutes, as the sync between active and standby could take time.

3) Retry switchover request if the response is unavailable with a timeout.