### PR TITLE
TE-18.1: Enabling required deviation in metadata

### DIFF
--- a/feature/gribi/mpls_in_udp/otg_tests/mpls_in_udp/metadata.textproto
+++ b/feature/gribi/mpls_in_udp/otg_tests/mpls_in_udp/metadata.textproto
@@ -28,3 +28,13 @@ platform_exceptions:  {
     default_network_instance:  "default"
   }
 }
+platform_exceptions:  {
+  platform:  {
+    vendor:  NOKIA
+  }
+  deviations:  {
+    interface_enabled:  true
+    static_protocol_name:  "STATIC"
+    explicit_interface_in_default_vrf: true
+  }
+}


### PR DESCRIPTION
Adding required deviations for vendor Nokia in metadata.textproto.

“This code is a Contribution to the OpenConfig Feature Profiles project (“Work”) made under the Google Software Grant and Corporate Contributor License Agreement (“CLA”) and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia’s intellectual property are granted for any other purpose. This code is provided on an “as is” basis without any warranties of any kind.”