### PR TITLE
Update DP-1.17

### DIFF
--- a/feature/qos/ecn/otg_tests/dscp_transparency_test/metadata.textproto
+++ b/feature/qos/ecn/otg_tests/dscp_transparency_test/metadata.textproto
@@ -32,3 +32,11 @@ platform_exceptions: {
     qos_queue_requires_id: true
   }
 }
+platform_exceptions: {
+  platform: {
+    vendor: CISCO
+  }
+  deviations: {
+    qos_queue_requires_id: true
+  }
+}


### PR DESCRIPTION
1. qos_queue_requires_id is a required deviation for Cisco and is also present already for other tests. 