### PR TITLE
[RT-1.25] Fix configuration order

### DIFF
--- a/feature/staticroute/tests/static_route_test/metadata.textproto
+++ b/feature/staticroute/tests/static_route_test/metadata.textproto
@@ -7,6 +7,16 @@ description:  "Management network-instance default static route"
 testbed:  TESTBED_DUT_ATE_2LINKS
 platform_exceptions: {
   platform: {
+    vendor: ARISTA
+  }
+  deviations: {
+    interface_enabled: true
+    static_protocol_name: "STATIC"
+    interface_config_vrf_before_address: true
+  }
+}
+platform_exceptions: {
+  platform: {
     vendor: CISCO
   }
   deviations: {

--- a/feature/staticroute/tests/static_route_test/static_route_test.go
+++ b/feature/staticroute/tests/static_route_test/static_route_test.go
@@ -124,11 +124,17 @@ func configureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 		{"port2", &dutDst},
 	} {
 		port := dut.Port(t, p.portName)
+		if deviations.InterfaceConfigVRFBeforeAddress(dut) {
+			t.Logf("Configuring VRF on interface %s", port.Name())
+			configureInterfaceVRF(t, dut, port.Name())
+		}
 		i := &oc.Interface{Name: ygot.String(port.Name())}
 		i.Enabled = ygot.Bool(true)
 		gnmi.Update(t, dut, d.Interface(port.Name()).Config(), configInterfaceDUT(i, p.attrs, dut))
-		t.Logf("Configuring VRF on interface %s", port.Name())
-		configureInterfaceVRF(t, dut, port.Name())
+		if !deviations.InterfaceConfigVRFBeforeAddress(dut) {
+			t.Logf("Configuring VRF on interface %s", port.Name())
+			configureInterfaceVRF(t, dut, port.Name())
+		}
 	}
 
 }


### PR DESCRIPTION
The configuration for interface should be placed in the VRF before configuring IP address.