### PR TITLE
Encap into transit tunnels

### DIFF
--- a/internal/cfgplugins/gribifullscale.go
+++ b/internal/cfgplugins/gribifullscale.go
@@ -131,7 +131,6 @@ const (
 	TransitVRF222PrefixStart = "101.0.0.1"
 	RepairNHPrefixStart      = "102.0.0.1"
 	RepairIPv4PrefixStart    = "103.0.0.1"
-	EncapNHTunnelStart       = "198.18.128.1"
 
 	// Common prefix step used across multiple VRF builders.
 	CommonPrefixStep     = "0.0.0.1"
@@ -734,7 +733,7 @@ func BuildEncapDecapVRFs(t *testing.T, dut *ondatra.DUTDevice, ctx context.Conte
 	t.Helper()
 	allEntries := []fluent.GRIBIEntry{}
 	wantPrefixes := make(map[string][]string)
-	tunnelDsts, err := iputil.GenerateIPsWithStep(EncapNHTunnelStart, numUniqueEncapNH, CommonPrefixStep)
+	tunnelDsts, err := iputil.GenerateIPsWithStep(TransitVRF111PrefixStart, numUniqueEncapNH, CommonPrefixStep)
 	if err != nil {
 		t.Fatalf("BuildEncapDecapVRFs: generate encap NH tunnel dsts: %v", err)
 	}


### PR DESCRIPTION
The encapsulated traffic is dropped as the encapsulation sets as outer destination ip unspecified IP (EncapHTunnelStart =  "198.18.128.1"), instead of pointing to tunnel entries in the TE_VRF_111 transit vrf, specifically starting with TransitVRF111PrefixStart = "100.0.0.1".