### PR TITLE
Update gribi_route_test

### DIFF
--- a/feature/gribi/otg_tests/gribi_route_test/gribi_route_test.go
+++ b/feature/gribi/otg_tests/gribi_route_test/gribi_route_test.go
@@ -244,6 +244,9 @@ func TestGRIBIFailover(t *testing.T) {
 	})
 
 	t.Run("RT-14.2.4: Traffic Match to Transit_Vrf, noMatch Tunnel Prefix Egress to Port3", func(t *testing.T) {
+		if deviations.DecapNHWithNextHopNIUnsupported(dut) {
+			t.Skip("Skipping because Decap NH with NextHop Network Instance is unsupported")
+		}
 		flow := createFlow(&flowArgs{flowName: "flow4in4",
 			outHdrSrcIP: ipv4OuterSrc111, outHdrDstIP: ipv4OuterDst222,
 			InnHdrSrcIP: ipv4OuterSrc111, InnHdrDstIP: ipv4InnerDst, isIPInIP: true}, dstMac)
@@ -427,10 +430,13 @@ func configureVrfSelectionPolicyC(t *testing.T, dut *ondatra.DUTDevice) {
 
 func configureGribiRoute(t *testing.T, dut *ondatra.DUTDevice, tcArgs *testArgs) {
 	t.Helper()
+	decapNH := fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(tcArgs.dut)).
+		WithIndex(uint64(1)).WithDecapsulateHeader(fluent.IPinIP)
+	if !deviations.DecapNHWithNextHopNIUnsupported(dut) {
+		decapNH.WithNextHopNetworkInstance(deviations.DefaultNetworkInstance(dut))
+	}
 	tcArgs.client.Modify().AddEntry(t,
-		fluent.NextHopEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(tcArgs.dut)).
-			WithIndex(uint64(1)).WithDecapsulateHeader(fluent.IPinIP).
-			WithNextHopNetworkInstance(deviations.DefaultNetworkInstance(dut)),
+		decapNH,
 		fluent.NextHopGroupEntry().WithNetworkInstance(deviations.DefaultNetworkInstance(tcArgs.dut)).
 			WithID(uint64(1)).AddNextHop(uint64(1), uint64(1)),
 

--- a/feature/gribi/otg_tests/gribi_route_test/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_route_test/metadata.textproto
@@ -48,6 +48,7 @@ platform_exceptions: {
     missing_value_for_defaults: true
     max_ecmp_paths: true
     explicit_interface_in_default_vrf: false
+    decap_nh_with_nexthop_ni_unsupported: true
   }
 }
 tags: TAGS_TRANSIT

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1096,6 +1096,7 @@ func Ipv6RouterAdvertisementIntervalUnsupported(dut *ondatra.DUTDevice) bool {
 }
 
 // DecapNHWithNextHopNIUnsupported returns true if Decap NH with NextHopNetworkInstance is unsupported
+// Arista: https://issuetracker.google.com/512135230
 func DecapNHWithNextHopNIUnsupported(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetDecapNhWithNexthopNiUnsupported()
 }


### PR DESCRIPTION
1. Adding deviation decap_nh_with_nexthop_ni_unsupported
2. Skipping subtest RT-14.2.4 as per b/512135230 with deviation DecapNHWithNextHopNIUnsupported. 
3. Update issue tracker ID for the deviation.
