### PR TITLE
Improve Readme and add negative test case for controller card

### DIFF
--- a/feature/platform/tests/power_admin_down_up_test/README.md
+++ b/feature/platform/tests/power_admin_down_up_test/README.md
@@ -2,34 +2,60 @@
 
 ## Summary
 
-Validate ability to set power-admin-state for Fabric, Linecard and
-ControllerCard.
+Validate the ability to toggle the power-admin-state for Fabric, Linecard, and ControllerCard components. Including negative scenario for attempting to power down both controller cards.
 
-## Procedure
 
-*   For each of the non empty Fabric, Linecard and ControllerCard component:
-    *   Verify /components/component/state/oper-status is ACTIVE.
-    *   Update
-        /components/component/{fabric|linecard|controller-card}/config/power-admin-state
-        to POWER_DISABLED.
-    *   Verify
-        /components/component/{fabric|linecard|controller-card}/state/power-admin-state
-        changes to POWER_DISABLED.
-    *   Verify /components/component/state/oper-status is DISABLED.
-    *   Update
-        /components/component/{fabric|linecard|controller-card}/config/power-admin-state
-        to POWER_ENABLED.
-    *   Verify /components/component/state/oper-status returns to ACTIVE.
+## FP-1.1.1: Powering down Linecard and Fabric Card.
 
-## Minumum DUT platform requirement
-vRX
+1. **Test Setup**:
+    *  Verify `/components/component/state/oper-status` is `ACTIVE` for all installed Linecards and Fabric Cards.
+2. **Test Logic**:
+    *  Select one linecard and one fabric card.
+    *  Update `/components/component/config/power-admin-state` to `POWER_DISABLED` for the selected linecard and fabric card.
+    *  Verify `/components/component/state/power-admin-state` changes to `POWER_DISABLED` for the selected linecard and fabric card.
+    *  Verify `/components/component/state/oper-status` is `DISABLED` for the selected linecard and fabric card.
+    *  Update `/components/component/config/power-admin-state` to `POWER_ENABLED` for the selected linecard and fabric card.
+    *  Verify `/components/component/state/oper-status` returns to `ACTIVE` for the selected linecard and fabric card.
 
-## Config Parameter coverage
-    *   /components/component/{fabric|linecard|controller-card}/config/power-admin-state
+## FP-1.1.2: Attempting to power down both controller cards
 
-## Telemetry Parameter coverage
-    *   /components/component/state/oper-status
-    *   /components/component/{fabric|linecard|controller-card}/state/power-admin-state
+1.  **Test Setup**:
+    *   Connect to the DUT via gNMI and retrieve the list of all available controller cards by checking components of type `CONTROLLER_CARD`.
+    *   Ensure there are at least two controller cards available on the DUT to perform this test.
+    *   Verify that the `/components/component/state/oper-status` is `ACTIVE` for both the controller cards.
+    *   Verify that the `/components/component/state/switchover-ready` is `true` for both the controller cards.
+2.  **Test Logic**:
+    *   Find out the `PRIMARY` Controller Card using `/components/component/state/redundant-role`.
+    *   Using gNMI Set, attempt to update `/components/component/controller-card/config/power-admin-state` to `POWER_DISABLED` for the `PRIMARY` controller card.
+    *   Wait until the switchover happens and the `SECONDARY` becomes `PRIMARY`.
+    *   Verify that the `/components/component/state/oper-status` of the disabled Controller Card is now `DISABLED`.
+    *   Using gNMI Set, attempt to update `/components/component/controller-card/config/power-admin-state` to `POWER_DISABLED` for the newly elected `PRIMARY` controller card.
+    *   The device should either:
+        *   Reject the configuration to `POWER_DISABLED` the controller card OR
+        *   Automatically enable the previously `POWER_DISABLED` Controller Card and then `POWER_DISABLED` the requested Controller Card.
+    *   In any case the device should not become unresponsive, unreachable or lose connectivity.
+    *   Restore the `/components/component/controller-card/config/power-admin-state` for the disabled controller card back to `POWER_ENABLED` via gNMI Set.
+3.  **Verification**:
+    *   Verify the operational status and redundant roles of the controller cards post-recovery.
+
+### Canonical OC
+
+```json
+{
+  "openconfig-platform:components": {
+    "component": [
+      {
+        "name": "RE0",
+        "openconfig-platform-controller-card:controller-card": {
+          "config": {
+            "power-admin-state": "POWER_DISABLED"
+          }
+        }
+      }
+    ]
+  }
+}
+```
 
 ## OpenConfig Path and RPC Coverage
 
@@ -51,8 +77,14 @@ paths:
     platform_type: [LINECARD]
   /components/component/state/oper-status:
     platform_type: [CONTROLLER_CARD, FABRIC, LINECARD]
+  /components/component/state/redundant-role:
+    platform_type: [CONTROLLER_CARD]
+  /components/component/state/switchover-ready:
+    platform_type: [CONTROLLER_CARD]
 rpcs:
   gnmi:
+    gNMI.Get:
     gNMI.Set:
-    gNMI.Subscribe:
 ```
+## Minumum DUT platform requirement
+*   MFF

--- a/feature/platform/tests/power_admin_down_up_test/README.md
+++ b/feature/platform/tests/power_admin_down_up_test/README.md
@@ -8,14 +8,14 @@ Validate the ability to toggle the power-admin-state for Fabric, Linecard, and C
 ## FP-1.1.1: Powering down Linecard and Fabric Card.
 
 1. **Test Setup**:
-    *  Verify `/components/component/state/oper-status` is `ACTIVE` for all installed Linecards and Fabric Cards.
+    *  Verify `/components/component/{linecard|fabric}/state/oper-status` is `ACTIVE` for all installed Linecards and Fabric Cards.
 2. **Test Logic**:
     *  Select one linecard and one fabric card.
-    *  Update `/components/component/config/power-admin-state` to `POWER_DISABLED` for the selected linecard and fabric card.
-    *  Verify `/components/component/state/power-admin-state` changes to `POWER_DISABLED` for the selected linecard and fabric card.
-    *  Verify `/components/component/state/oper-status` is `DISABLED` for the selected linecard and fabric card.
-    *  Update `/components/component/config/power-admin-state` to `POWER_ENABLED` for the selected linecard and fabric card.
-    *  Verify `/components/component/state/oper-status` returns to `ACTIVE` for the selected linecard and fabric card.
+    *  Update `/components/component/{linecard|fabric}/config/power-admin-state` to `POWER_DISABLED` for the selected linecard and fabric card.
+    *  Verify `/components/component/{linecard|fabric}/state/power-admin-state` changes to `POWER_DISABLED` for the selected linecard and fabric card.
+    *  Verify `/components/component/{linecard|fabric}/state/oper-status` is `DISABLED` for the selected linecard and fabric card.
+    *  Update `/components/component/{linecard|fabric}/config/power-admin-state` to `POWER_ENABLED` for the selected linecard and fabric card.
+    *  Verify `/components/component/{linecard|fabric}/state/oper-status` returns to `ACTIVE` for the selected linecard and fabric card.
 
 ## FP-1.1.2: Attempting to power down both controller cards
 
@@ -85,6 +85,7 @@ rpcs:
   gnmi:
     gNMI.Get:
     gNMI.Set:
+    gNMI.Subscribe:
 ```
-## Minumum DUT platform requirement
+## Minimum DUT platform requirement
 *   MFF


### PR DESCRIPTION
- Validate the device's ability to transition the power-admin-state between POWER_DISABLED and POWER_ENABLED for Fabric, Linecard, and ControllerCard components.
- This includes verifying that the device gracefully handles negative scenarios, such as attempting to power down all available controller cards without entering an unrecoverable state.
