### PR TITLE
gRIBI scale: dedicated configuration for vrf selection pollicy

### DIFF
--- a/internal/cfgplugins/gribifullscale.go
+++ b/internal/cfgplugins/gribifullscale.go
@@ -371,9 +371,9 @@ func ConfigureDUT(t *testing.T, dut *ondatra.DUTDevice) {
 	// Configure sub-interfaces on port1 (1 VLAN) and port2 (640 VLANs).
 	ConfigureDUTSubinterfaces(t, vrfBatch, new(oc.Root), dut, dp1, DUTPort1IPv4Start, DUTPort1IPv6Start, StartVLANPort1, NumPort1VLANs)
 	ConfigureDUTSubinterfaces(t, vrfBatch, new(oc.Root), dut, dp2, DUTPort2IPv4Start, DUTPort2IPv6Start, StartVLANPort2, NumPort2VLANs)
-	ConfigureCLIDecapVRFMode(t, dut)
-	ConfigureVRFSelectionPolicyOC(t, dut, vrfBatch)
 	vrfBatch.Set(t, dut)
+	ConfigureCLIDecapVRFMode(t, dut)
+	ConfigureVRFSelectionPolicyOC(t, dut)
 }
 
 // ConfigureDUTSubinterfaces creates multiple VLAN-tagged sub-interfaces on dut port, deriving IPv4/IPv6 addresses from the provided prefixes.

--- a/internal/cfgplugins/policyforwarding.go
+++ b/internal/cfgplugins/policyforwarding.go
@@ -1463,7 +1463,7 @@ func ConfigureTrafficPolicyACL(t *testing.T, dut *ondatra.DUTDevice, params ACLT
 }
 
 // ConfigureVRFSelectionPolicyOC configures vrf_selection_policy_c on DUT port1.
-func ConfigureVRFSelectionPolicyOC(t *testing.T, dut *ondatra.DUTDevice, vrfBatch *gnmi.SetBatch) {
+func ConfigureVRFSelectionPolicyOC(t *testing.T, dut *ondatra.DUTDevice) {
 	t.Helper()
 	p1 := dut.Port(t, "port1")
 	defaultVRF := deviations.DefaultNetworkInstance(dut)
@@ -1544,7 +1544,7 @@ func ConfigureVRFSelectionPolicyOC(t *testing.T, dut *ondatra.DUTDevice, vrfBatc
 	if deviations.InterfaceRefConfigUnsupported(dut) {
 		intf.InterfaceRef = nil
 	}
-	gnmi.BatchUpdate(vrfBatch, gnmi.OC().NetworkInstance(defaultVRF).PolicyForwarding().Config(), pf)
+	gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(defaultVRF).PolicyForwarding().Config(), pf)
 }
 
 // ConfigureCLIDecapVRFMode enables next-hop decapsulation VRF mode required for VRF selection policy decapsulation forwarding.


### PR DESCRIPTION
When re-running the test on a device with existing vrf selection policy, the batched approach fails with: "failed to apply: Both ipv4 and ipv6 configs may not be present together"