### PR TITLE
Improving the P4RT device down test and adding negative/corner cases

### DIFF
--- a/feature/p4rt/tests/p4rt_device_down_test/README.md
+++ b/feature/p4rt/tests/p4rt_device_down_test/README.md
@@ -97,7 +97,7 @@ paths:
   /interfaces/interface/config/id:
   /components/component/state/oper-status:
     platform_type: ["LINECARD", "INTEGRATED_CIRCUIT"]
-  /components/component/config/power-admin-state:
+  /components/component/linecard/config/power-admin-state:
     platform_type: ["LINECARD"]
 
 rpcs:

--- a/feature/p4rt/tests/p4rt_device_down_test/README.md
+++ b/feature/p4rt/tests/p4rt_device_down_test/README.md
@@ -96,6 +96,8 @@ paths:
     platform_type: ["INTEGRATED_CIRCUIT"]
   /interfaces/interface/config/id:
   /components/component/state/oper-status:
+    platform_type: ["LINECARD", "INTEGRATED_CIRCUIT"]
+  /components/component/config/power-admin-state:
     platform_type: ["LINECARD"]
 
 rpcs:

--- a/feature/p4rt/tests/p4rt_device_down_test/README.md
+++ b/feature/p4rt/tests/p4rt_device_down_test/README.md
@@ -105,11 +105,6 @@ rpcs:
     gNMI.Get:
     gNMI.Set:
     gNMI.Subscribe:
-  p4rt:
-    P4Runtime.StreamChannel:
-    P4Runtime.SetForwardingPipelineConfig:
-    P4Runtime.Write:
-    P4Runtime.Read:
 ```
 
 ## Required DUT platform

--- a/feature/p4rt/tests/p4rt_device_down_test/README.md
+++ b/feature/p4rt/tests/p4rt_device_down_test/README.md
@@ -1,8 +1,8 @@
-# P4RT-1.3: P4RT behavior when a device/node is dowm
+# P4RT-1.3: P4RT behavior when a device/node is down
 
 ## Summary
 
-Verify that the P4RT server handles Read/Write RPCs for a device/node as follows:
+Verify that the P4RT server handles StreamChannel, Read, and Write RPCs for a device/node as follows:
 - Accepts them when the device is available and
 - Returns a `NOT_FOUND` error when it is unavailable or down [Point-1 P4RT Spec](https://p4.org/p4-spec/docs/p4runtime-spec-working-draft-html-version.html#_setforwardingpipelineconfig_rpc)
 
@@ -12,24 +12,81 @@ Verify that the P4RT server handles Read/Write RPCs for a device/node as follows
 
 ## Procedure
 
-### Initial Setup
+### Test environment setup
 
 *   Connect ATE port-1 and port-2 to DUT port-1 and port-2 respectively.
-*   Configure P4RT id and node-id (device_id) with two interfaces on different LineCards.
+*   Configure P4RT id and node-id (device_id) with two interfaces on different integrated circuits (LineCards or forwarding NPUs).
     * 1st Linecard `device_id = 111`
     * 2nd Linecard `device_id = 222`
-*   Disable the Linecard 2 with `device_id = 222`
+*   Verify via gNMI that the `oper-status` of both components is `ACTIVE`.
 
-### P4RT-1.3.1 - Verify that the P4RT server handles Read/Write RPCs as below:
+### P4RT-1.3.1 - Verify that the P4RT server handles StreamChannel and RPCs for a down device
 
-*   For both `device_id = 111` and `device_id = 222`
-    *   Send the WBB P4Info via the SetForwardingPipelineConfig
-    *   Send RPC Write to install the `AclWbbIngressTableEntry` for LLDP (ethertype: 0x88CC)
-*   Verify that the write RPC is successful for `device_id = 111`
-*   Validate Verify that the write RPC returns `NOT_FOUND` for `device_id = 222`
-*   Send RPC Read to read back the installed table entries. 
-*   Verify that the read RPC is successful for `device_id = 111`
-*   Validate Verify that the read RPC returns `NOT_FOUND` for `device_id = 222` 
+* Step 1 - Disable Linecard 2 and verify status
+    *   Disable the Linecard 2 with `device_id = 222` using gNMI (e.g., by setting the component's `power-admin-state` to `POWER_DISABLED` or using a platform-specific method to simulate a down state).
+    *   Verify via gNMI that the `oper-status` of the component for `device_id = 222` transitions to `DISABLED` or `INACTIVE`.
+
+* Step 2 - Send MasterArbitrationUpdate and Pipeline Config
+    *   Attempt to establish a `StreamChannel` and send a `MasterArbitrationUpdate` for `device_id = 222`. Verify it is rejected or returns `NOT_FOUND`.
+    *   Send the WBB P4Info via the `SetForwardingPipelineConfig` for both `device_id = 111` and `device_id = 222`.
+    *   Verify that `SetForwardingPipelineConfig` is successful for `device_id = 111`.
+    *   Verify that `SetForwardingPipelineConfig` returns `NOT_FOUND` for `device_id = 222`.
+
+* Step 3 - Send Write RPC
+    *   Send RPC Write to install the `AclWbbIngressTableEntry` for LLDP (ethertype: 0x88CC) for both `device_id = 111` and `device_id = 222`.
+    *   Verify that the write RPC is successful for `device_id = 111`.
+    *   Verify that the write RPC returns `NOT_FOUND` for `device_id = 222`.
+
+* Step 4 - Send Read RPC
+    *   Send RPC Read to read back the installed table entries for both `device_id = 111` and `device_id = 222`. 
+    *   Verify that the read RPC is successful for `device_id = 111`.
+    *   Verify that the read RPC returns `NOT_FOUND` for `device_id = 222`. 
+
+* Step 5 - Verify PacketOut to Down Device
+    *   Send a `PacketOut` message over the `StreamChannel` destined for `device_id = 222`. 
+    *   Verify the server drops it or returns an error.
+
+* Step 6 - Invalid Device ID
+    *   Attempt to send MasterArbitrationUpdate, SetForwardingPipelineConfig, Write, and Read RPCs to an entirely unconfigured `device_id` (e.g., `device_id = 999`).
+    *   Verify they all return `NOT_FOUND`.
+
+#### Canonical OC
+
+```json
+{
+  "components": {
+    "component": [
+      {
+        "name": "NPU1",
+        "integrated-circuit": {
+          "config": {
+            "node-id": "111"
+          }
+        }
+      },
+      {
+        "name": "NPU2",
+        "integrated-circuit": {
+          "config": {
+            "node-id": "222"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+### P4RT-1.3.2 - Verify P4RT server behavior when device state transitions
+
+* Step 1 - State Transition (Down to Up)
+    *   Re-enable Linecard 2 with `device_id = 222` via gNMI.
+    *   Verify via gNMI that the `oper-status` of the component transitions back to `ACTIVE`.
+    *   Verify that the P4RT server now accepts Mastership, `SetForwardingPipelineConfig`, `Write`, and `Read` for `device_id = 222`.
+
+* Step 2 - Device goes down mid-operation (Up to Down)
+    *   While `device_id = 222` is up, disable the Linecard 2 via gNMI.
+    *   Verify that subsequent `Read` and `Write` RPCs to `device_id = 222` now fail with `NOT_FOUND`.
 
 ## OpenConfig Path and RPC Coverage
 
@@ -38,15 +95,21 @@ paths:
   /components/component/integrated-circuit/config/node-id:
     platform_type: ["INTEGRATED_CIRCUIT"]
   /interfaces/interface/config/id:
+  /components/component/state/oper-status:
+    platform_type: ["LINECARD"]
 
 rpcs:
   gnmi:
     gNMI.Get:
     gNMI.Set:
     gNMI.Subscribe:
+  p4rt:
+    P4Runtime.StreamChannel:
+    P4Runtime.SetForwardingPipelineConfig:
+    P4Runtime.Write:
+    P4Runtime.Read:
 ```
 
 ## Required DUT platform
 
 * MFF
-

--- a/feature/p4rt/tests/p4rt_device_down_test/metadata.textproto
+++ b/feature/p4rt/tests/p4rt_device_down_test/metadata.textproto
@@ -3,7 +3,7 @@
 
 uuid: "95b352ee-b17a-4ac5-a49d-315424f56c3d"
 plan_id: "P4RT-1.3"
-description: "P4RT behavior when a device/node is dowm"
+description: "P4RT behavior when a device/node is down"
 testbed: TESTBED_DUT_ATE_4LINKS
 platform_exceptions: {
   platform: {


### PR DESCRIPTION
- Included prerequisites for StreamChannel mastership arbitration.
- Specified the disablement via power-admin-state for MFF linecards.
- Added a Canonical OC block representing the config payload.
- Incorporated the negative test cases (sending PacketOut and invalid device IDs).
- Structured the file into subtests (1.3.1 and 1.3.2) covering both the down-state and the state transitions (up-to-down / down-to-up).