### PR TITLE
gRIBI scale: configure switch for extended scale and save config before reboot

### DIFF
--- a/internal/cfgplugins/dut_initialize.go
+++ b/internal/cfgplugins/dut_initialize.go
@@ -47,6 +47,7 @@ const (
 	FeatureACLCounters
 	FeatureAnPF
 	FeatureIngressARP
+	FeatureOptimizeFIBAndCounters
 
 	aristaTcamProfileMplsTracking = `
 hardware counter feature traffic-policy in
@@ -348,8 +349,21 @@ hardware tcam
 	  !
 	system profile vrf-selection-with-ip6-sip
 `
+
+	aristaOptimizeFIBAndCounters = `
+   ip hardware fib next-hop weight-deviation 2.0
+   ip hardware fib programmed error action preserved
+   hardware fec programmed all
+   no hardware counter feature acl out ipv4
+   no hardware counter feature acl in
+   hardware counter feature ip-in-ip tunnel
+   hardware counter feature ip out layer3
+   hardware counter feature ip in layer3
+   hardware counter feature route ipv4
+   `
+
 	aristaTcamProfilePolicyForwarding = `
-    hardware tcam
+hardware tcam
   	profile tcam-policy-forwarding
       feature traffic-policy port ipv4
          port qualifier size 12 bits
@@ -1243,17 +1257,18 @@ hardware tcam
 
 var (
 	aristaTcamProfileMap = map[FeatureType]string{
-		FeatureMplsTracking:         aristaTcamProfileMplsTracking,
-		FeatureVrfSelectionExtended: aristaTcamProfileVrfSelectionExtended,
-		FeaturePolicyForwarding:     aristaTcamProfilePolicyForwarding,
-		FeatureQOSCounters:          aristaTcamProfileQOSCounters,
-		FeatureEnableAFTSummaries:   aristaEnableAFTSummaries,
-		FeatureNGPR:                 aristaNGPRTcamProfile,
-		FeatureTTLPolicyForwarding:  aristaTcamProfilePreserveTTL,
-		FeatureQOSIn:                aristaQOSTcamIn,
-		FeatureACLCounters:          aristaTCAMACLCounters,
-		FeatureAnPF:                 aristaAnPF,
-		FeatureIngressARP:           aristaIngressARP,
+		FeatureMplsTracking:           aristaTcamProfileMplsTracking,
+		FeatureVrfSelectionExtended:   aristaTcamProfileVrfSelectionExtended,
+		FeaturePolicyForwarding:       aristaTcamProfilePolicyForwarding,
+		FeatureQOSCounters:            aristaTcamProfileQOSCounters,
+		FeatureEnableAFTSummaries:     aristaEnableAFTSummaries,
+		FeatureNGPR:                   aristaNGPRTcamProfile,
+		FeatureTTLPolicyForwarding:    aristaTcamProfilePreserveTTL,
+		FeatureQOSIn:                  aristaQOSTcamIn,
+		FeatureACLCounters:            aristaTCAMACLCounters,
+		FeatureAnPF:                   aristaAnPF,
+		FeatureIngressARP:             aristaIngressARP,
+		FeatureOptimizeFIBAndCounters: aristaOptimizeFIBAndCounters,
 	}
 )
 

--- a/internal/cfgplugins/gribifullscale.go
+++ b/internal/cfgplugins/gribifullscale.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/featureprofiles/internal/gribi"
+	"github.com/openconfig/featureprofiles/internal/helpers"
 	"github.com/openconfig/featureprofiles/internal/iputil"
 	otgconfighelpers "github.com/openconfig/featureprofiles/internal/otg_helpers/otg_config_helpers"
 	otgvalidationhelpers "github.com/openconfig/featureprofiles/internal/otg_helpers/otg_validation_helpers"
@@ -442,12 +443,14 @@ func CreateDUTSubinterface(t *testing.T, vrfBatch *gnmi.SetBatch, d *oc.Root,
 func ConfigureHardwareInit(t *testing.T, dut *ondatra.DUTDevice) {
 	t.Helper()
 	hardwareVrfCfg := NewDUTHardwareInit(t, dut, FeatureVrfSelectionExtended)
-	hardwarePfCfg := NewDUTHardwareInit(t, dut, FeaturePolicyForwarding)
+	hardwarePfCfg := NewDUTHardwareInit(t, dut, FeatureOptimizeFIBAndCounters)
 	if hardwareVrfCfg == "" || hardwarePfCfg == "" {
 		return
 	}
 	PushDUTHardwareInitConfig(t, dut, hardwareVrfCfg)
 	PushDUTHardwareInitConfig(t, dut, hardwarePfCfg)
+	// Save the configurations before rebooting the chassis.
+	helpers.GnmiCLIConfig(t, dut, "write memory")
 }
 
 // CreateGRIBIScaleVRFs creates all non-default VRF network-instances plus the DEFAULT instance.  Uses deviations.DefaultNetworkInstance for the correct name.


### PR DESCRIPTION
The switch needs a special configuration to ensure it allocates enough space for all routes.

Crucially, the configurations must be saved before rebooting the device