### PR TITLE
RELAY-1.1: DHCP Relay functionality (Update)

### DIFF
--- a/feature/interface/helper_address/otg_tests/relay_agent_test/metadata.textproto
+++ b/feature/interface/helper_address/otg_tests/relay_agent_test/metadata.textproto
@@ -16,3 +16,11 @@ platform_exceptions:  {
     dhcp_relay_oc_unsupported: true
   }
 }
+platform_exceptions:  {
+  platform:  {
+    vendor:  CISCO
+  }
+  deviations:  {
+    ipv4_missing_enabled: true
+  }
+}

--- a/feature/interface/helper_address/otg_tests/relay_agent_test/relay_agent_test.go
+++ b/feature/interface/helper_address/otg_tests/relay_agent_test/relay_agent_test.go
@@ -326,12 +326,19 @@ func (tc *testCase) configureLAGInterface(t *testing.T, attrs *attrs.Attributes)
 	gnmi.Replace(t, tc.dut, aggPath.Config(), agg)
 
 	for _, port := range dutAggPorts {
-		holdTimeConfig := &oc.Interface_HoldTime{
-			Up:   ygot.Uint32(3000),
-			Down: ygot.Uint32(150),
+		memberIntf := &oc.Interface{
+			Name: ygot.String(port.Name()),
+			Type: oc.IETFInterfaces_InterfaceType_ethernetCsmacd,
 		}
+		if deviations.InterfaceEnabled(tc.dut) {
+			memberIntf.Enabled = ygot.Bool(true)
+		}
+		memberIntf.GetOrCreateEthernet().AggregateId = ygot.String(tc.aggID)
+		holdTime := memberIntf.GetOrCreateHoldTime()
+		holdTime.Up = ygot.Uint32(3000)
+		holdTime.Down = ygot.Uint32(150)
 		intfPath := gnmi.OC().Interface(port.Name())
-		gnmi.Update(t, tc.dut, intfPath.HoldTime().Config(), holdTimeConfig)
+		gnmi.Update(t, tc.dut, intfPath.Config(), memberIntf)
 	}
 
 	b := new(gnmi.SetBatch)
@@ -341,6 +348,7 @@ func (tc *testCase) configureLAGInterface(t *testing.T, attrs *attrs.Attributes)
 		IPv6HelperAddress: ateP3.IPv6,
 	}
 	cfgplugins.DhcpRelayConfig(t, tc.dut, b, dhcpRelayConfigParams)
+	b.Set(t, tc.dut)
 }
 
 // configureEthernetInterface sets up a standard ethernet interface with VLAN subinterface and applies DHCP relay CLI config.
@@ -398,6 +406,7 @@ func (tc *testCase) configureEthernetInterface(t *testing.T, attrs *attrs.Attrib
 		IPv6HelperAddress: ateP3.IPv6,
 	}
 	cfgplugins.DhcpRelayConfig(t, tc.dut, b, dhcpRelayConfigParams)
+	b.Set(t, tc.dut)
 }
 
 // configureDHCPRelay dispatches to the appropriate interface setup based on isLag.

--- a/internal/cfgplugins/dhcp.go
+++ b/internal/cfgplugins/dhcp.go
@@ -79,6 +79,7 @@ func DhcpRelayConfig(t *testing.T, dut *ondatra.DUTDevice, sb *gnmi.SetBatch, cf
 		// Enable relay-agent globally (DHCPv6) + enable on the interface.
 		gnmi.BatchReplace(sb, gnmi.OC().RelayAgent().Dhcpv6().EnableRelayAgent().Config(), true)
 		gnmi.BatchReplace(sb, gnmi.OC().RelayAgent().Dhcpv6().Interface(intfID).Enable().Config(), true)
+		gnmi.BatchReplace(sb, gnmi.OC().RelayAgent().Dhcpv6().Interface(intfID).Id().Config(), intfID)
 
 		if cfgParams.IPv6HelperAddress != "" {
 			gnmi.BatchReplace(


### PR DESCRIPTION
Updating test for RELAY-1.1: DHCP Relay functionality to support other Vendors

Readme Location: https://github.com/openconfig/featureprofiles/tree/main/feature/interface/helper_address/otg_tests/relay_agent_test

Logs:
https://partnerissuetracker.corp.google.com/issues/527694558