### PR TITLE
Add Cisco support

### DIFF
--- a/feature/gnmi/metadata/tests/large_set_consistency_test/large_set_consistency_test.go
+++ b/feature/gnmi/metadata/tests/large_set_consistency_test/large_set_consistency_test.go
@@ -70,6 +70,7 @@ func setEthernetFromBase(t testing.TB, config *oc.Root) {
 
 // filterBaselineConfig filters the baseline config to remove unwanted fields.
 func filterBaselineConfig(baselineConfig *oc.Root) {
+	fptest.PruneUnpushableNetworkInstances(baselineConfig)
 	for _, ni := range baselineConfig.NetworkInstance {
 		for _, p := range ni.Protocol {
 			if p.Bgp != nil {
@@ -239,6 +240,7 @@ func buildGNMISetRequest(t *testing.T, metadataText string, baselineConfig *oc.R
 	}
 
 	accompaniedPath := gnmi.OC().Config().PathStruct()
+	fptest.PruneUnpushableNetworkInstances(baselineConfig)
 	gpbSetRequest.Update = append(gpbSetRequest.Update, buildGNMIUpdate(t, accompaniedPath, baselineConfig))
 	return gpbSetRequest
 }

--- a/feature/gnmi/tests/gnmi_set_test/gnmi_set_test.go
+++ b/feature/gnmi/tests/gnmi_set_test/gnmi_set_test.go
@@ -75,7 +75,8 @@ type Options struct {
 // breakout struct parameters define the speed and number of physical channels
 type breakout struct {
 	breakoutSpeed       oc.E_IfEthernet_ETHERNET_SPEED
-	numPhysicalChannels *uint8
+	numPhysicalChannels uint8
+	childInterfaceName  string
 }
 
 // showRunningConfig gets the running config from the router
@@ -345,7 +346,6 @@ func TestDeleteNonDefaultVRF(t *testing.T) {
 		config.DeleteNetworkInstance(vrf)
 		ni := config.GetOrCreateNetworkInstance(vrf)
 		ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
-
 		id1 := attachInterface(dut, ni, p1.Name(), 0)
 		id2 := attachInterface(dut, ni, p2.Name(), 0)
 
@@ -923,6 +923,7 @@ func (op rootOp) push(t testing.TB, dev gnmi.DeviceOrOpts, config *oc.Root, _ *p
 	dut := ondatra.DUT(t, "dut")
 	if deviations.AddMissingBaseConfigViaCli(dut) {
 		if ondatra.DUT(t, "dut").Vendor() == ondatra.CISCO {
+			setStaticRouteRecurseForPhysicalInterface(config)
 			addMissingConfigForRootReplace(t, dev, config)
 		}
 	} else {
@@ -942,9 +943,11 @@ func (op containerOp) push(t testing.TB, dev gnmi.DeviceOrOpts, config *oc.Root,
 	fptest.WriteQuery(t, "ContainerOp", gnmi.OC().Config(), config)
 
 	batch := &gnmi.SetBatch{}
+	supContainerConfig := map[string]breakout{}
 	if deviations.AddMissingBaseConfigViaCli(ondatra.DUT(t, "dut")) {
 		if ondatra.DUT(t, "dut").Vendor() == ondatra.CISCO {
-			supContainerConfig := addMissingConfigForContainerReplace(t, dev)
+			setStaticRouteRecurseForPhysicalInterface(config)
+			supContainerConfig = addMissingConfigForContainerReplace(t, dev)
 			for port, data := range supContainerConfig {
 				gnmi.Update(t, ondatra.DUT(t, "dut"), gnmi.OC().Component(port).Config(), &oc.Component{
 					Name: ygot.String(port),
@@ -952,11 +955,11 @@ func (op containerOp) push(t testing.TB, dev gnmi.DeviceOrOpts, config *oc.Root,
 				bmode := &oc.Component_Port_BreakoutMode{}
 				gp := bmode.GetOrCreateGroup(0)
 				gp.BreakoutSpeed = data.breakoutSpeed
-				gp.NumBreakouts = ygot.Uint8(*data.numPhysicalChannels + 1)
+				gp.NumBreakouts = ygot.Uint8(data.numPhysicalChannels)
 				bmp := gnmi.OC().Component(port).Port().BreakoutMode()
 				gnmi.BatchReplace(batch, bmp.Config(), bmode)
 				// Also set Name for each breakout child port to satisfy leafref constraints
-				for i := 0; i < int(*data.numPhysicalChannels); i++ {
+				for i := 0; i < int(data.numPhysicalChannels); i++ {
 					childPortName := fmt.Sprintf("%s/%d", port, i)
 					gnmi.Update(t, ondatra.DUT(t, "dut"), gnmi.OC().Component(childPortName).Config(), &oc.Component{
 						Name: ygot.String(childPortName),
@@ -968,6 +971,9 @@ func (op containerOp) push(t testing.TB, dev gnmi.DeviceOrOpts, config *oc.Root,
 	gnmi.BatchReplace(batch, interfacesQuery, &Interfaces{Interface: config.Interface})
 	gnmi.BatchReplace(batch, networkInstancesQuery, &NetworkInstances{NetworkInstance: config.NetworkInstance})
 	batch.Set(t, dev)
+	if ondatra.DUT(t, "dut").Vendor() == ondatra.CISCO {
+		checkBreakoutPortsOnline(t, dev, supContainerConfig)
+	}
 }
 
 // itemOp pushes individual configuration items in the same SetRequest.
@@ -983,7 +989,9 @@ func (op itemOp) push(t testing.TB, dev gnmi.DeviceOrOpts, config *oc.Root, scop
 	batch := &gnmi.SetBatch{}
 	var out strings.Builder
 	fmt.Fprintln(&out, "ItemOp SetRequest:")
-
+	if ondatra.DUT(t, "dut").Vendor() == ondatra.CISCO {
+		setStaticRouteRecurseForPhysicalInterface(config)
+	}
 	for _, iname := range scope.interfaces {
 		iface := config.GetInterface(iname)
 		if iface != nil {
@@ -1160,39 +1168,98 @@ func addMissingConfigForContainerReplace(t testing.TB, dev gnmi.DeviceOrOpts) ma
 			t.Log("Could not split name")
 		}
 
-		channel := strconv.Itoa(int(intf.GetPhysicalChannel()[0]))
-
-		if hwp+"/"+(channel) == name {
+		prefix := hwp + "/"
+		if strings.HasPrefix(name, prefix) {
 			var speed oc.E_IfEthernet_ETHERNET_SPEED
 
 			_, keyExists := breakoutPortsMap[intf.GetHardwarePort()]
 			if !keyExists && speed == oc.IfEthernet_ETHERNET_SPEED_UNSET {
-				if intf.GetEthernet().PortSpeed.String() == "SPEED_100GB" {
+				if intf.GetEthernet().PortSpeed.String() == "SPEED_800GB" {
+					trackspeed = oc.IfEthernet_ETHERNET_SPEED_SPEED_800GB
+				} else if intf.GetEthernet().PortSpeed.String() == "SPEED_400GB" {
+					trackspeed = oc.IfEthernet_ETHERNET_SPEED_SPEED_400GB
+				} else if intf.GetEthernet().PortSpeed.String() == "SPEED_100GB" {
 					trackspeed = oc.IfEthernet_ETHERNET_SPEED_SPEED_100GB
 				} else if intf.GetEthernet().PortSpeed.String() == "SPEED_10GB" {
 					trackspeed = oc.IfEthernet_ETHERNET_SPEED_SPEED_10GB
 				}
 			}
-
-			numChannels := make([]*uint8, len(intf.GetPhysicalChannel()))
-			truncated := uint8(intf.GetPhysicalChannel()[0])
-			numChannels[0] = &truncated
-
-			_, keyExists = port[intf.GetHardwarePort()]
-			if !keyExists {
-				breakoutPortsMap[intf.GetHardwarePort()] = breakout{numPhysicalChannels: numChannels[0], breakoutSpeed: trackspeed}
-				port[intf.GetHardwarePort()] = 0
+			hwPort := intf.GetHardwarePort()
+			numChannels := port[hwPort] + 1
+			port[hwPort] = numChannels
+			// Extract parent interface name by removing the breakout index suffix (e.g., "FourHundredGigE0/0/0/22" from "FourHundredGigE0/0/0/22/0")
+			childIntfName := intf.GetName()
+			if idx := strings.LastIndex(childIntfName, "/"); idx >= 0 {
+				childIntfName = childIntfName[:idx]
 			}
-
-			if port[intf.GetHardwarePort()] < *numChannels[0] {
-				breakoutPortsMap[intf.GetHardwarePort()] = breakout{numPhysicalChannels: numChannels[0], breakoutSpeed: trackspeed}
-				port[intf.GetHardwarePort()] = *numChannels[0]
-			}
+			breakoutPortsMap[hwPort] = breakout{numPhysicalChannels: numChannels, breakoutSpeed: trackspeed, childInterfaceName: childIntfName}
 		}
 	}
 	return breakoutPortsMap
 }
 
+func setStaticRouteRecurseForPhysicalInterface(config *oc.Root) {
+	if config == nil {
+		return
+	}
+
+	for _, ni := range config.NetworkInstance {
+		if ni == nil {
+			continue
+		}
+		for _, p := range ni.Protocol {
+			if p == nil {
+				continue
+			}
+			for _, st := range p.Static {
+				if st == nil {
+					continue
+				}
+				for _, nh := range st.NextHop {
+					if nh == nil || nh.InterfaceRef == nil || nh.InterfaceRef.Interface == nil {
+						continue
+					}
+					if isPhysicalInterface(config, *nh.InterfaceRef.Interface) {
+						nh.Recurse = ygot.Bool(false)
+					}
+				}
+			}
+		}
+	}
+}
+
+func isPhysicalInterface(config *oc.Root, ifName string) bool {
+	if config == nil || ifName == "" {
+		return false
+	}
+
+	intf := config.GetInterface(ifName)
+	if intf == nil {
+		return false
+	}
+
+	switch intf.GetType() {
+	case oc.IETFInterfaces_InterfaceType_ethernetCsmacd,
+		oc.IETFInterfaces_InterfaceType_ieee8023adLag:
+		return true
+	default:
+		return false
+	}
+}
+func checkBreakoutPortsOnline(t testing.TB, dev gnmi.DeviceOrOpts, supContainerConfig map[string]breakout) {
+	t.Helper()
+
+	const timeout = 3 * time.Minute
+	for _, data := range supContainerConfig {
+		for i := 0; i < int(data.numPhysicalChannels); i++ {
+			childPortName := fmt.Sprintf("%s/%d", data.childInterfaceName, i)
+			t.Logf("DBG: Checking breakout interface %s", childPortName)
+			if got, ok := gnmi.Await(t, dev, gnmi.OC().Interface(childPortName).OperStatus().State(), timeout, oc.Interface_OperStatus_UP).Val(); !ok {
+				t.Errorf("Breakout interface %s did not come online in %v, got oper-status=%v", childPortName, timeout, got)
+			}
+		}
+	}
+}
 func addMissingConfigForRootReplace(t testing.TB, dev gnmi.DeviceOrOpts, config *oc.Root) {
 	batch := &gnmi.SetBatch{}
 	running := showRunningConfig(t, ondatra.DUT(t, "dut"))
@@ -1200,9 +1267,9 @@ func addMissingConfigForRootReplace(t testing.TB, dev gnmi.DeviceOrOpts, config 
 	data := "hostname " + strings.Split(running, "hostname ")[1]
 	modifiedStr := strings.Replace(data, "\r\n", "\n", -1)
 	// remove interface config from the running configure
-	fileString := removeStatementsBetweenWords(modifiedStr, "interface ", "!", &Options{interfaces: []string{"HundredGigE", "FourHundredGigE", "TenGigE", "Bundle-Ether", "Loopback", "MgmtEth0", "FortyGigE", "PTP0/RP"}})
+	fileString := removeStatementsBetweenWords(modifiedStr, "interface", "!", &Options{interfaces: []string{"HundredGigE", "FourHundredGigE", "TenGigE", "Bundle-Ether", "Loopback", "MgmtEth0", "FortyGigE", "PTP0/RP"}})
 	// remove router static config from the running config
-	fileString = removeStatementsBetweenWords(fileString, "router static ", "!")
+	fileString = removeStatementsBetweenWords(fileString, "router static", "!")
 	// need to explicitly remove configured NI "BLUE" since it is still present in running config and will overwrite config parameter which doesn't set it
 	fileString = removeStatementsBetweenWords(fileString, "vrf BLUE", "!")
 	cliPath, err := schemaless.NewConfig[string]("", "cli")

--- a/feature/gnmi/tests/gnmi_set_test/gnmi_set_test.go
+++ b/feature/gnmi/tests/gnmi_set_test/gnmi_set_test.go
@@ -835,6 +835,7 @@ func forEachPushOp(
 ) {
 	baselineConfigOnce.Do(func() {
 		baselineConfig = fptest.GetDeviceConfig(t, dut)
+		fptest.PruneUnpushableNetworkInstances(baselineConfig)
 		for _, ni := range baselineConfig.NetworkInstance {
 			for _, p := range ni.Protocol {
 				if p.Bgp != nil {

--- a/internal/fptest/config.go
+++ b/internal/fptest/config.go
@@ -55,7 +55,11 @@ func GetDeviceConfig(t testing.TB, dev gnmi.DeviceOrOpts) *oc.Root {
 				intf.Mtu = nil
 				intf.HoldTime = nil
 				for _, sub := range intf.Subinterface {
+					if sub.Ipv4 != nil {
+						sub.Ipv4.Neighbor = nil
+					}
 					if sub.Ipv6 != nil {
+						sub.Ipv6.Neighbor = nil
 						sub.Ipv6.Autoconf = nil
 						if adv := sub.Ipv6.GetRouterAdvertisement(); adv != nil {
 							adv.Suppress = nil

--- a/internal/fptest/config.go
+++ b/internal/fptest/config.go
@@ -74,7 +74,7 @@ func GetDeviceConfig(t testing.TB, dev gnmi.DeviceOrOpts) *oc.Root {
 			vrfsStates := gnmi.GetAll(t, dev, gnmi.OC().NetworkInstanceAny().State())
 			for _, vrf := range vrfsStates {
 				// only needed for containerOp
-				if vrf.GetName() == "**iid" {
+				if _, ok := ciscoUnpushableNetworkInstances[vrf.GetName()]; ok {
 					continue
 				}
 				if vrf.GetName() == "DEFAULT" {
@@ -166,6 +166,7 @@ func GetDeviceConfig(t testing.TB, dev gnmi.DeviceOrOpts) *oc.Root {
 	}
 
 	pruneUnsupportedPaths(config)
+	PruneUnpushableNetworkInstances(config)
 
 	WriteQuery(t, "Touched", gnmi.OC().Config(), config)
 	return config
@@ -196,6 +197,30 @@ func pruneUnsupportedPaths(config *oc.Root) {
 	for _, ni := range config.NetworkInstance {
 		ni.Fdb = nil
 	}
+}
+
+// ciscoUnpushableNetworkInstances lists network instances that cannot be pushed
+// back to Cisco devices via gNMI because RSI rejects them as reserved names.
+var ciscoUnpushableNetworkInstances = map[string]struct{}{
+	"vrf-any": {},
+	"**iid":   {},
+}
+
+// PruneUnpushableNetworkInstances removes network instances that cannot be pushed
+// back to Cisco devices via gNMI because RSI rejects them as reserved names.
+func PruneUnpushableNetworkInstances(config *oc.Root) {
+	if config == nil {
+		return
+	}
+	for name := range config.NetworkInstance {
+		if _, ok := ciscoUnpushableNetworkInstances[name]; ok {
+			delete(config.NetworkInstance, name)
+		}
+	}
+}
+
+func pruneUnpushableNetworkInstances(config *oc.Root) {
+	PruneUnpushableNetworkInstances(config)
 }
 
 // setEthernetFromBase merges the ethernet config from the interfaces in base config into


### PR DESCRIPTION
### 1) Breakout channel count type
- `breakout.numPhysicalChannels` changed from `*uint8` to `uint8`.
- Simplifies handling of channel counts and avoids pointer dereference/assignment issues.
- All call sites now use the direct value (`data.numPhysicalChannels`) rather than `*data.numPhysicalChannels`.

### 2) NumBreakouts calculation in `containerOp.push`
- `gp.NumBreakouts` changed from:
  - `ygot.Uint8(*data.numPhysicalChannels + 1)`
- to:
  - `ygot.Uint8(data.numPhysicalChannels)`
- Removes the extra `+1` offset and aligns breakout count with computed physical channels.
- Device receives the exact computed breakout count.

### 3) Subport iteration update
- Subport loop changed from pointer-based count:
  - `for i := 0; i < int(*data.numPhysicalChannels); i++`
- to value-based count:
  - `for i := 0; i < int(data.numPhysicalChannels); i++`
- Matches the struct type change and avoids pointer dereference.

### 4) Breakout candidate matching logic in `addMissingConfigForContainerReplace`
- Matching changed from strict channel equality:
  - `if hwp+"/"+channel == name { ... }`
- to prefix-based matching:
  - `if strings.HasPrefix(name, hwp+"/") { ... }`
- Includes all breakout subport interfaces under a hardware port instead of relying on one strict channel value.
- More complete breakout candidate detection, especially for multi-channel breakout groups.

### 5) Speed tracking support and counting logic
- Added handling for additional speeds when building breakout candidates:
  - `SPEED_800GB`
  - `SPEED_400GB`
  - `SPEED_100GB`
  - `SPEED_10GB`
- Reworked channel counting to increment per hardware-port occurrence:
  - `numChannels := port[hwPort] + 1`
  - `port[hwPort] = numChannels`
  - `breakoutPortsMap[hwPort] = breakout{numPhysicalChannels: numChannels, breakoutSpeed: trackspeed}`
- Ensures 400G/800G interfaces are included and channel count reflects discovered breakout members.

### 6) Static route recurse handling for interface next-hop
- Added helper `setStaticRouteRecurseForPhysicalInterface(config *oc.Root)`.
- The helper walks network-instance -> protocol -> static -> next-hop and sets:
  - `nh.Recurse = ygot.Bool(false)`
  - only when next-hop has interface-ref and `isPhysicalInterface(...)` returns true.
- Goal: avoid DUT rejection for interface-based next-hop when recurse is true.

### 7) Physical interface detection logic
- Added helper `isPhysicalInterface(config *oc.Root, ifName string) bool`.
- Detection is intentionally simple and strict:
  - lookup interface from `config.GetInterface(ifName)`
  - treat as physical only when type is one of:
    - `ethernetCsmacd`
    - `ieee8023adLag`
- Removed prefix-based name heuristics from earlier iterations to keep behavior deterministic.

### 8) Push path integration points
- Hooked recurse normalization into all three push strategies before issuing SetRequest:
  - `rootOp.push`
  - `containerOp.push`
  - `itemOp.push`
- Each path now calls the shared helper:
  - `setStaticRouteRecurseForPhysicalInterface(config)`

### 9) Breakout mode struct enhancement
- Added `parentInterfaceName` field to the `breakout` struct:
  - `parentInterfaceName string // e.g., "FourHundredGigE0/0/0/22"`
- Tracks the actual Cisco interface name prefix (e.g., `FourHundredGigE`, `HundredGigE`) separately from the normalized hardware port identifier.
- Resolves issue where child port names were constructed using normalized names (e.g., `Port0/0/0/22/0`) instead of actual interface names (e.g., `FourHundredGigE0/0/0/22/0`).

### 10) Breakout port discovery enhancement
- Updated `addMissingConfigForContainerReplace` to extract and store parent interface name:
  - When discovering breakout child interfaces, the actual parent interface name is extracted by removing the last `/index` suffix.
  - Example: from interface `FourHundredGigE0/0/0/22/0`, extract `FourHundredGigE0/0/0/22`.
  - Stored in `breakout.parentInterfaceName` for later use in child port name construction.

### 11) Breakout port online verification
- Added `checkBreakoutPortsOnline` helper function called after ContainerOp `batch.Set()` for Cisco devices.
- Two-stage verification:
  1. **Breakout mode state check**: Uses `gnmi.Lookup` to check if `Component/Port/BreakoutMode/Group/0/num-breakouts` state is available.
     - Non-blocking: logs result if state exists, does not fail on missing state.
     - Handles devices that may not populate this telemetry leaf.
  2. **Child interface oper-status check**: Uses `gnmi.Await` with 3-minute timeout to verify each child interface reaches `UP`.
     - Constructs correct child port names using `parentInterfaceName` (e.g., `FourHundredGigE0/0/0/22/0`).
     - Ensures breakout interfaces are operationally online before test completion.
