### PR TITLE
Fix Deviation Issue

### DIFF
--- a/feature/interface/lacp/tests/lacp_interval_test/metadata.textproto
+++ b/feature/interface/lacp/tests/lacp_interval_test/metadata.textproto
@@ -10,7 +10,7 @@ platform_exceptions: {
     vendor: CISCO
   }
   deviations: {
-    ipv4_missing_enabled: true
+    ipv4_missing_enabled: false
   }
 }
 platform_exceptions: {

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -944,7 +944,7 @@ func NewAggregateInterface(t *testing.T, dut *ondatra.DUTDevice, b *gnmi.SetBatc
 	}
 
 	agg.GetOrCreateAggregation().LagType = l.AggType
-
+	gnmi.BatchReplace(b, gnmi.OC().Interface(aggID).Config(), agg)
 	// Set LACP mode to ACTIVE for the LAG interface
 	if l.LacpParams != nil {
 		if l.LacpParams.Activity == nil || l.LacpParams.Period == nil {
@@ -956,7 +956,7 @@ func NewAggregateInterface(t *testing.T, dut *ondatra.DUTDevice, b *gnmi.SetBatc
 		lacpPath := gnmi.OC().Lacp().Interface(aggID)
 		gnmi.BatchReplace(b, lacpPath.Config(), lacp)
 	}
-	gnmi.BatchReplace(b, gnmi.OC().Interface(aggID).Config(), agg)
+
 	gnmi.BatchDelete(b, gnmi.OC().Interface(aggID).Aggregation().MinLinks().Config())
 
 	l.PopulateOndatraPorts(t, dut)


### PR DESCRIPTION
# Changes

## internal/cfgplugins/interface.go

**Fix: apply aggregate interface config before LACP parameters in `NewAggregateInterface`**

Previously, `gnmi.BatchReplace` for the aggregate interface (`agg`) was called
*after* the LACP interface parameters were added to the batch. This caused the
aggregate to be configured out-of-order — LACP settings were pushed before the
LAG interface itself existed on the device.

The `gnmi.BatchReplace(b, gnmi.OC().Interface(aggID).Config(), agg)` call has
been moved to immediately after `agg.GetOrCreateAggregation().LagType` is set,
so the aggregate interface config is always present in the batch before any LACP
parameters are appended.

## feature/interface/lacp/tests/lacp_interval_test/metadata.textproto

**Fix: set `ipv4_missing_enabled` deviation to `false` for Cisco**

The `ipv4_missing_enabled` deviation for the Cisco platform exception was
incorrectly set to `true`. Corrected to `false`.