### PR TITLE
Extended coverage for Interface hold-time test

### DIFF
--- a/feature/interface/holdtime/otg_tests/holdtime_test/README.md
+++ b/feature/interface/holdtime/otg_tests/holdtime_test/README.md
@@ -2,13 +2,14 @@
 
 ## Summary
 
-Verify configurability of interface hold-time down of 300ms  and hold-time up of 5 sec.\
-Verify oper-state behaviour
+Verify configurability of interface hold-time down of 300ms and hold-time up of 180 sec (3 min).
+Verify oper-state behavior and hardware-level traffic loss duration.
 
 ## Procedure
 *   Configure DUT port-1 to OTG port-1
 *   Configure static LAG on DUT and OTG with port-1 as member
-*   Configure hold-time down 300ms and hold-time up 5000ms
+*   Configure hold-time down 300ms and hold-time up 180000ms (3 minutes)
+*   Configure traffic flow from ATE port-1 to ATE port-2 over the LAG interface.
 ### TC1 - configuration verification:
 *   Get hold-time state from device and check if it matches what was send in configuration. (some implementation may round-up/round-down values)
 ### TC2 - long down:
@@ -34,12 +35,12 @@ Verify oper-state behaviour
 *   Start sending Ethernet Remote Fault (RF) from OTG port-1 (or other mean which disable laser on OTG)
 *   Read timestamp of last oper-status change   
 *   Stop sending Ethernet Remote Fault (RF) from OTG port-1 (or other mean which disable laser on OTG). Read and store timestamp form OTG of last operation (OTG_STATE_CHANGE_TS).
-*   wait 6 seconds
+*   wait 185 seconds
 *   Read timestamp of last oper-status change  form DUT port-1 (DUT_LAST_CHANGE_TS)
 *   Verify that DUT LAG:
   * oper-status is UP
   * oper-status last change time has changed
-  * DUT_LAST_CHANGE_TS = OTG_STATE_CHANGE_TS + 5000ms +/- tolerance; Use tolerance of 200ms.
+  * DUT_LAST_CHANGE_TS = OTG_STATE_CHANGE_TS + 180000ms +/- tolerance; Use tolerance of 200ms.
 
 ### TC5 - short down:
 *   Read timestamp of last oper-status change   
@@ -48,6 +49,37 @@ Verify oper-state behaviour
   * oper-status is UP
   * oper-status last change time has NOT changed
 *   Stop sending Ethernet Remote Fault (RF) from OTG port-1 
+
+### TC6 - traffic loss duration:
+*   Start continuous traffic flow from ATE port-1 to ATE port-2 over the LAG interface.
+*   Shutdown/disable the member link DUT port-1 (e.g., by sending Ethernet Remote Fault (RF) from OTG port-1).
+*   Measure the duration of traffic loss (packet loss) on the traffic flow at the receiver.
+*   Verify that the traffic loss duration \(t_{\text{loss}}\) satisfies the relation:
+  * \(t_{\text{loss}} \le \text{hold-time down} + \text{failover tolerance}\)
+  * Specifically, \(t_{\text{loss}} \le 300\text{ ms} + 100\text{ ms} = 400\text{ ms}\).
+
+## Canonical OC
+
+```json
+{
+  "interfaces": {
+    "interface": [
+      {
+        "name": "Ethernet1",
+        "config": {
+          "name": "Ethernet1"
+        },
+        "hold-time": {
+          "config": {
+            "up": 180000,
+            "down": 300
+          }
+        }
+      }
+    ]
+  }
+}
+```
 
 ## OpenConfig Path and RPC Coverage
 
@@ -70,3 +102,4 @@ rpcs:
 ## Minimum DUT Platform Requirement
 
 FFF
+


### PR DESCRIPTION
Enhancing the coverage for Interface hold-time test
-Updated the summaries and procedures to test the current design specifications: hold-time down of 300 ms and hold-time up of 180,000 ms (3 minutes).
-Modified TC4 - long up to wait for 185 seconds and assert state recovery matching the 180s timer.
-Added a new testcase TC6 - traffic loss duration to inject continuous data-plane traffic and assert that the total packet loss duration
