### PR TITLE
Ignore specific branch in pull request workflow

### DIFF
--- a/.github/workflows/test_gap_analysis.yaml
+++ b/.github/workflows/test_gap_analysis.yaml
@@ -2,6 +2,8 @@ name: FNT Gap Analysis
 
 on:
   pull_request:
+    branches-ignore:
+      - feature/gnsi/certz
     # No paths filter for testing triggers.
 
 permissions: {}


### PR DESCRIPTION
This test seems to constantly timeout or fail for 'not enough tokens' or whatever, stop the madness.

When this is more reliable someone else can rollback this change.