### PR TITLE
Update bgp_multipath_ecmp_test.go

### DIFF
--- a/feature/bgp/multipath/otg_tests/bgp_multipath_ecmp_test/bgp_multipath_ecmp_test.go
+++ b/feature/bgp/multipath/otg_tests/bgp_multipath_ecmp_test/bgp_multipath_ecmp_test.go
@@ -78,11 +78,11 @@ func randRange(t *testing.T, start, end uint32, count int) []uint32 {
 	if count > int(end-start) {
 		t.Fatal("randRange: count greater than end-start.")
 	}
-	rand.New(rand.NewSource(time.Now().UnixNano()))
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	var result []uint32
 	for len(result) < count {
 		diff := end - start
-		randomValue := rand.Int31n(int32(diff)) + int32(start)
+		randomValue := r.Int31n(int32(diff)) + int32(start)
 		result = append(result, uint32(randomValue))
 	}
 	return result
@@ -112,8 +112,6 @@ func configureFlow(t *testing.T, bs *cfgplugins.BGPSession) {
 	udp := flow.Packet().Add().Udp()
 	udp.SrcPort().SetValues(randRange(t, 34525, 65535, 500))
 	udp.DstPort().SetValues(randRange(t, 49152, 65535, 500))
-	v4.Src().SetValue(bs.ATEPorts[0].IPv4)
-	v4.Dst().SetValue(prefixesStart)
 }
 
 func verifyECMPLoadBalance(t *testing.T, ate *ondatra.ATEDevice, pc int, expectedLinks int) {


### PR DESCRIPTION
Code fixes: 
1. In configureFlow, the test configures the IPv4 Source and Destination to increment but then immediately overwrites the field choices with static values. 
2. Updated the broken rand range function. 