### PR TITLE
gRIBI scale: juniper set vrf selection policy on *sub*interface

### DIFF
--- a/feature/gribi/otg_tests/gribi_full_scale_down/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_full_scale_down/metadata.textproto
@@ -33,6 +33,7 @@ platform_exceptions: {
   }
   deviations: {
     no_mix_of_tagged_and_untagged_subinterfaces: true
+    interface_ref_interface_id_format: true
   }
 }
 

--- a/feature/gribi/otg_tests/gribi_full_scale_t0/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_full_scale_t0/metadata.textproto
@@ -33,6 +33,7 @@ platform_exceptions: {
   }
   deviations: {
     no_mix_of_tagged_and_untagged_subinterfaces: true
+    interface_ref_interface_id_format: true
   }
 }
 

--- a/feature/gribi/otg_tests/gribi_full_scale_t1/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_full_scale_t1/metadata.textproto
@@ -33,5 +33,6 @@ platform_exceptions: {
   }
   deviations: {
     no_mix_of_tagged_and_untagged_subinterfaces: true
+    interface_ref_interface_id_format: true
   }
 }

--- a/feature/gribi/otg_tests/gribi_full_scale_t2/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_full_scale_t2/metadata.textproto
@@ -44,5 +44,6 @@ platform_exceptions: {
   }
   deviations: {
     no_mix_of_tagged_and_untagged_subinterfaces: true
+    interface_ref_interface_id_format: true
   }
 }


### PR DESCRIPTION
Juniper requires the vrf selection policy to be set on the sub-interface