### PR TITLE
RT-2.10: Use deviation for LSP Remaining Lifetime

### DIFF
--- a/feature/isis/otg_tests/isis_change_lsp_lifetime_test/isis_change_lsp_lifetime_test.go
+++ b/feature/isis/otg_tests/isis_change_lsp_lifetime_test/isis_change_lsp_lifetime_test.go
@@ -166,8 +166,10 @@ func TestISISChangeLSPLifetime(t *testing.T) {
 			if got, want := isis.GetGlobal().GetTimers().GetLspLifetimeInterval(), uint16(lspLifetime); got != want {
 				t.Errorf("FAIL- Expected lsp lifetime interval not found, got %d, want %d", got, want)
 			}
-			if got, want := isis.GetLevel(2).GetLsp(dutLspID).GetRemainingLifetime(), uint16(lspLifetime); got >= want {
-				t.Errorf("FAIL- Expected remaining lifetime not found, got %d,want less then %d", got, want)
+			if !deviations.ISISLspMetadataLeafsUnsupported(ts.DUT) {
+				if got, want := isis.GetLevel(2).GetLsp(dutLspID).GetRemainingLifetime(), uint16(lspLifetime); got >= want {
+					t.Errorf("FAIL- Expected remaining lifetime not found, got %d,want less then %d", got, want)
+				}
 			}
 			if got, want := isis.GetLevel(2).GetLsp(dutLspID).GetLspId(), dutLspID; got != want {
 				t.Errorf("FAIL- Expected DUT lsp id not found, got %s, want %s", got, want)

--- a/feature/isis/otg_tests/isis_change_lsp_lifetime_test/isis_change_lsp_lifetime_test.go
+++ b/feature/isis/otg_tests/isis_change_lsp_lifetime_test/isis_change_lsp_lifetime_test.go
@@ -168,7 +168,7 @@ func TestISISChangeLSPLifetime(t *testing.T) {
 			}
 			if !deviations.ISISLspMetadataLeafsUnsupported(ts.DUT) {
 				if got, want := isis.GetLevel(2).GetLsp(dutLspID).GetRemainingLifetime(), uint16(lspLifetime); got >= want {
-					t.Errorf("FAIL- Expected remaining lifetime not found, got %d,want less then %d", got, want)
+					t.Errorf("FAIL- Expected remaining lifetime to be less than %d, got %d", want, got)
 				}
 			}
 			if got, want := isis.GetLevel(2).GetLsp(dutLspID).GetLspId(), dutLspID; got != want {


### PR DESCRIPTION
The deviation `ISISLspMetadataLeafsUnsupported` returns true for devices that don't support ISIS-LSP metadata paths. 
It is already used in one subtest of RT-2.10. 
Use the same deviation in the subtest `Lsp checks` for Remaining Lifetime.