### PR TITLE
Fix plan ID in trust_bundle/metadata.textproto

### DIFF
--- a/feature/security/gnsi/certz/tests/trust_bundle/metadata.textproto
+++ b/feature/security/gnsi/certz/tests/trust_bundle/metadata.textproto
@@ -2,6 +2,6 @@
 # proto-message: Metadata
 
 uuid:  "2d5f9729-f436-4750-9140-1f0beadf6206"
-plan_id:  "# CERTZ-4"
+plan_id:  "CERTZ-4"
 description:  "gNSI Trust Bundle"
 testbed:  TESTBED_DUT_ATE_2LINKS


### PR DESCRIPTION
While fixing the test registry, I found out the inconsistent plan ID in the trust_bundle test's metadata file. This PR fixes the name by removing the leading '# '. 