### PR TITLE
Relax gRIBI validation to RIB ACK for local dial test

### DIFF
--- a/feature/container/networking/tests/container_connectivity/cntr_test.go
+++ b/feature/container/networking/tests/container_connectivity/cntr_test.go
@@ -194,7 +194,7 @@ func TestDialLocal(t *testing.T) {
 
 	gribiClient := gribi.Client{
 		DUT:         dut,
-		FIBACK:      true,
+		FIBACK:      false,
 		Persistence: true,
 	}
 	if err := gribiClient.Start(t); err != nil {
@@ -207,8 +207,8 @@ func TestDialLocal(t *testing.T) {
 	defer gribiClient.FlushAll(t)
 
 	//Program a sample gRIBI Entry on DUT for gRIBI Get query response.
-	gribiClient.AddNH(t, 2001, "Decap", deviations.DefaultNetworkInstance(dut), fluent.InstalledInFIB)
-	gribiClient.AddNHG(t, 201, map[uint64]uint64{2001: 1}, deviations.DefaultNetworkInstance(dut), fluent.InstalledInFIB)
+	gribiClient.AddNH(t, 2001, "Decap", deviations.DefaultNetworkInstance(dut), fluent.InstalledInRIB)
+	gribiClient.AddNHG(t, 201, map[uint64]uint64{2001: 1}, deviations.DefaultNetworkInstance(dut), fluent.InstalledInRIB)
 
 	// Dynamically fetch the actual gNMI and gRIBI ports the DUT is configured with.
 	gnmiPort := introspect.DUTDialer(t, dut, introspect.GNMI).DevicePort


### PR DESCRIPTION
Relax the next-hop programming check in TestDialLocal from InstalledInFIB to
InstalledInRIB, and set FIBACK to false on the test gRIBI client.

The objective of TestDialLocal is to verify that a client running inside the
host-networked container can successfully dial and query the local gRIBI
daemon on the switch. It programs a dummy gRIBI next-hop solely to verify that
the container client's subsequent gRIBI Get RPC can receive a populated AFT stream.

Since the test does not validate actual hardware-plane traffic forwarding or
ASIC next-hop resolution, waiting for FIB-level ACKs (FIB_ACK) is an
unnecessary constraint. It causes false failures on platforms that do not
support FIB ACKs for decap next-hops.

Relying on RIB-level ACKs (RIB_ACK) is sufficient to ensure the gRIBI server has
committed the entry to the RIB, allowing the container client's Get RPC to read
it back successfully, while making the test portable across all hardware vendors.
