### PR TITLE
Modifications to RT2.12,static_route_isis_redistribution_test.go

### DIFF
--- a/feature/isis/otg_tests/static_route_isis_redistribution/static_route_isis_redistribution_test.go
+++ b/feature/isis/otg_tests/static_route_isis_redistribution/static_route_isis_redistribution_test.go
@@ -334,10 +334,6 @@ func configureOTGFlows(t *testing.T, top gosnappi.Config, ts *isissession.TestSe
 	v4FIp.Src().SetValue(srcV4.Address())
 	v4FIp.Dst().Increment().SetStart(v4TrafficStart).SetCount(254)
 
-	eth := v4F.EgressPacket().Add().Ethernet()
-	ethTag := eth.Dst().MetricTags().Add()
-	ethTag.SetName("MACTrackingv4").SetOffset(36).SetLength(12)
-
 	v6F := top.Flows().Add()
 	v6F.SetName(v6Flow).Metrics().SetEnable(true)
 	v6F.TxRx().Device().SetTxNames([]string{srcV6.Name()}).SetRxNames([]string{dst1V6.Name()})
@@ -349,9 +345,6 @@ func configureOTGFlows(t *testing.T, top gosnappi.Config, ts *isissession.TestSe
 	v6FIP.Src().SetValue(srcV6.Address())
 	v6FIP.Dst().Increment().SetStart(v6TrafficStart).SetCount(1)
 
-	eth = v6F.EgressPacket().Add().Ethernet()
-	ethTag = eth.Dst().MetricTags().Add()
-	ethTag.SetName("MACTrackingv6").SetOffset(36).SetLength(12)
 }
 
 func advertiseRoutesWithISIS(t *testing.T, ts *isissession.TestSession) {


### PR DESCRIPTION
As confirmed by the Keysight team, Ixia does not support 12-bit egress tracking in a virtual environment. 
Additionally, although egress tracking is configured, the test does not perform any packet validation based on egress tracking. 
The README also does not specify egress tracking as a requirement; therefore, it has been removed. 
This change has no impact on existing route/traffic test validation or test results.