### PR TITLE
authz finalize error handling

### DIFF
--- a/internal/security/authz/authz.go
+++ b/internal/security/authz/authz.go
@@ -19,9 +19,10 @@ package authz
 
 import (
 	"context"
-
 	"crypto/tls"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -145,7 +146,7 @@ func (p *AuthorizationPolicy) Rotate(t *testing.T, dut *ondatra.DUTDevice, creat
 		t.Fatalf("Error while finalizing rotate request  %v", err)
 	}
 	_, err = rotateStream.Recv()
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("Error while receiving finalize response %v", err)
 	}
 	_, finalPolicy := Get(t, dut)


### PR DESCRIPTION
Check for EOF after Authz finalize since it signals end of stream

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."