### PR TITLE
system_base_test: add domain-name telemetry and config paths to README

### DIFF
--- a/feature/system/system_base_test/tests/hostname_test/README.md
+++ b/feature/system/system_base_test/tests/hostname_test/README.md
@@ -14,11 +14,14 @@ any security setup for connecting to the services.
 
 1. Configure DUT with service configurations for all required services
 2. The test will verify if the hostname configuration paths can be read, updated and deleted.
+3. The test will verify if the domain-name configuration paths can be read, updated and deleted.
 
 ## OpenConfig Path and RPC Coverage
 
 ```yaml
 paths:
+   /system/config/domain-name:
+   /system/state/domain-name:
    /system/config/hostname:
    /system/state/hostname:
 

--- a/feature/system/system_base_test/tests/hostname_test/README.md
+++ b/feature/system/system_base_test/tests/hostname_test/README.md
@@ -16,6 +16,18 @@ any security setup for connecting to the services.
 2. The test will verify if the hostname configuration paths can be read, updated and deleted.
 3. The test will verify if the domain-name configuration paths can be read, updated and deleted.
 
+#### Canonical OC
+```json
+{
+  "system": {
+    "config": {
+      "domain-name": "test.name.example",
+      "hostname": "abcdefghijkmnop"
+    }
+  }
+}
+```
+
 ## OpenConfig Path and RPC Coverage
 
 ```yaml


### PR DESCRIPTION
Fixes #5725

* (M) feature/system/system_base_test/tests/hostname_test/README.md
  - Add `/system/config/domain-name` and `/system/state/domain-name` to OpenConfig Path Coverage.
  - Document domain-name test procedure step in README.md.
  - Add Canonical OC JSON section for system hostname & domain-name configuration.

### Rationale
`hostname_test.go` contains test coverage for `TestDomainName` (verifying gNMI set, get, await, and delete for domain-name paths), but these paths were previously omitted from the `README.md` specification table. This PR brings the `README.md` specification into complete alignment with the implemented test code and adds the required Canonical OC block.
