### PR TITLE
gNMI-1.28: fix Arista telemetry interfaces test failures

### DIFF
--- a/feature/gnmi/tests/telemetry_interfaces_test/metadata.textproto
+++ b/feature/gnmi/tests/telemetry_interfaces_test/metadata.textproto
@@ -6,6 +6,16 @@ description: "Telemetry: Interface openconfig validation."
 testbed: TESTBED_DUT_2LINKS
 platform_exceptions: {
   platform: {
+    vendor: ARISTA
+  }
+  deviations: {
+    missing_value_for_defaults: true
+    state_path_unsupported: true
+  }
+}
+
+platform_exceptions: {
+  platform: {
     vendor: PALOALTO
   }
 }

--- a/feature/gnmi/tests/telemetry_interfaces_test/telemetry_interfaces_test.go
+++ b/feature/gnmi/tests/telemetry_interfaces_test/telemetry_interfaces_test.go
@@ -207,9 +207,8 @@ func testTelemetryInterfacesAggregation(t *testing.T, dut *ondatra.DUTDevice, po
 	t.Helper()
 	p := gnmi.OC()
 
-	// FIX: Nokia (SR Linux) rejects LAG configuration on physical ports.
 	if deviations.StatePathsUnsupported(dut) {
-		t.Skip("Aggregation configuration on physical ports is not supported on Nokia.")
+		t.Skip("Aggregation configuration on physical ports is not supported on this platform.")
 	}
 
 	intfAggregationPassed := make(map[string][]any)
@@ -276,7 +275,6 @@ func testTelemetryInterfacesStateRate(t *testing.T, dut *ondatra.DUTDevice, port
 	t.Helper()
 	p := gnmi.OC()
 
-	// FIX: Skip if the platform does not support the /interfaces/interface/state/in-rate leaf.
 	if deviations.StatePathsUnsupported(dut) {
 		t.Skip("State/Rate telemetry paths are not supported on this platform.")
 	}
@@ -337,6 +335,9 @@ func testTelemetryInterfacesStateSubinterface(t *testing.T, dut *ondatra.DUTDevi
 		t.Logf("\n\n Iteration on port %s on DUT %s: \n\n", port, dut.Name())
 
 		i := &oc.Interface_Subinterface{Index: ygot.Uint32(subIntfIndex)}
+		if deviations.RequireRoutedSubinterface0(dut) {
+			i.Ipv4 = &oc.Interface_Subinterface_Ipv4{Enabled: ygot.Bool(true)}
+		}
 		gnmi.Update(t, dut, p.Interface(port).Subinterface(subIntfIndex).Config(), i)
 		time.Sleep(2 * time.Minute)
 
@@ -459,7 +460,7 @@ func testTelemetryInterfacesConfig(t *testing.T, dut *ondatra.DUTDevice, ports [
 // TestTelemetryInterfaces tests interfaces oc paths.
 func TestTelemetryInterfaces(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
-	port1 := strings.ToLower(dut.Port(t, "port1").Name())
+	port1 := dut.Port(t, "port1").Name()
 
 	// Ensure the test interface is explicitly enabled and configured with its mandatory base schema type upfront.
 	p := gnmi.OC()


### PR DESCRIPTION
The gNMI-1.28 telemetry_interfaces_test fails on Arista EOS for several independent reasons: the test lowercases the Ondatra port name before using it in OpenConfig interface configuration, default description state is not present unless explicitly configured, the state/rate paths are handled through the test's existing state_path_unsupported deviation, routed subinterface 0 requires IPv4 to be explicitly enabled, and aggregation cannot be configured directly on the physical test port.

gNMI-1.28, port names: use the port name exactly as returned by Ondatra instead of lowercasing it. EOS treats the lowercased name as a different interface, which causes the interface type Set to apply to the wrong interface object and fail validation.

gNMI-1.28, default description state: add Arista to the existing missing_value_for_defaults deviation. This lets the state validation skip the default description leaf when the platform does not report a default value for it.

gNMI-1.28, state/rate and aggregation paths: add Arista to the existing state_path_unsupported deviation. This uses the same test mechanism already used for platforms that do not support the tested state/rate paths or physical-port aggregation configuration. The expected handling of /interfaces/interface/state/in-rate and out-rate is still being clarified; the test README lists those paths, but they are not present in the current openconfig-interfaces model or in the test's canonical OC example.

gNMI-1.28, aggregation skip text: make the aggregation skip message platform-generic instead of Nokia-specific because the skip is now driven by the platform deviation rather than a single vendor.

gNMI-1.28, routed subinterface 0: when the existing RequireRoutedSubinterface0 deviation is set, include IPv4 enabled state in the subinterface config pushed by the test. EOS requires that explicit configuration before the subinterface state validation can succeed.

With these changes, gNMI-1.28 passes on Arista EOS.