### PR TITLE
gNMI-1.13: add laser-temperature instant telemetry path and Canonical OC to README

### DIFF
--- a/feature/platform/tests/optics_power_and_bias_current_test/README.md
+++ b/feature/platform/tests/optics_power_and_bias_current_test/README.md
@@ -80,7 +80,18 @@ to Automatic Test Equipment (ATE).
 ## Canonical OC
 
 ```json
-{}
+{
+  "openconfig-platform:components": {
+    "component": [
+      {
+        "config": {
+          "name": "transceiver1"
+        },
+        "name": "transceiver1"
+      }
+    ]
+  }
+}
 ```
 
 ## OpenConfig Path and RPC Coverage
@@ -108,6 +119,8 @@ paths:
   /components/component/transceiver/physical-channels/channel/state/input-power/instant:
     platform_type: ["TRANSCEIVER"]
   /components/component/transceiver/physical-channels/channel/state/laser-bias-current/instant:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/physical-channels/channel/state/laser-temperature/instant:
     platform_type: ["TRANSCEIVER"]
   /components/component/transceiver/physical-channels/channel/state/output-power/instant:
     platform_type: ["TRANSCEIVER"]


### PR DESCRIPTION
Fixes #5732

* (M) feature/platform/tests/optics_power_and_bias_current_test/README.md
  - Add /components/component/transceiver/physical-channels/channel/state/laser-temperature/instant with platform_type ["TRANSCEIVER"].
  - Add RFC 7951 compliant Canonical OC JSON section qualified with openconfig-platform:components.