### PR TITLE
[gNMI-1.6]: Fix usage of RequireTransportSecurity deviation

### DIFF
--- a/feature/gnmi/tests/gnmi_ni_test/gnmi_ni_test.go
+++ b/feature/gnmi/tests/gnmi_ni_test/gnmi_ni_test.go
@@ -95,7 +95,7 @@ func ConfigureAdditionalNetworkInstance(batch *gnmi.SetBatch, t *testing.T, dut 
 	// Configure non-default network instance.
 	cfgplugins.NewNetworkInstance(t, dut, batch, &dutPort2NetworkInstanceIParams)
 	transportSec := transportSecurity
-	if deviations.RequireTransportSecurity(dut) {
+	if !deviations.RequireTransportSecurity(dut) {
 		transportSec = false
 	}
 	// Configure non-default gNMI server.

--- a/feature/gnmi/tests/gnmi_ni_test/metadata.textproto
+++ b/feature/gnmi/tests/gnmi_ni_test/metadata.textproto
@@ -38,7 +38,7 @@ platform_exceptions: {
   }
   deviations: {
     interface_enabled: true
-    require_transport_security: true
+    require_transport_security: false
     default_ni_gnmi_server_name: "gnmi_gnoi_gnsi"
   }
 }


### PR DESCRIPTION
Issue:

Changes introduced in openconfig/featureprofiles#5496, enabled transport security by default recently.

The test fails when a gNMI Set RPC attempts to configure a gRPC server with transport-security: true but without providing a corresponding certificate-id value. The EOS device rejects the request because TLS secured transport cannot be started without an SSL certificate reference.

The deviation added for Juniper (RequireTransportSecurity) is incorrectly used in the test code, where the transport-security is set as false when the deviation is true or else the value remains as true.

Fix:

Corrected the usage of the deviation: RequireTransportSecurity. When the deviation is false or unset, transport-security is set to false and a gNMI server is configured to start in a new network instance.