### PR TITLE
RT-5.1: Add missing interface MTU and subinterface neighbor origin telemetry paths

### DIFF
--- a/feature/interface/singleton/otg_tests/singleton_test/README.md
+++ b/feature/interface/singleton/otg_tests/singleton_test/README.md
@@ -173,6 +173,9 @@ Verify that interface packet counters are properly incremented in every streamin
 * /interfaces/interface/state/counters/out-unicast-pkts
 * /interfaces/interface/subinterfaces/subinterface/ipv4/state/mtu
 * /interfaces/interface/subinterfaces/subinterface/ipv6/state/mtu
+* /interfaces/interface/state/mtu
+* /interfaces/interface/subinterfaces/subinterface/ipv4/neighbors/neighbor/state/origin
+* /interfaces/interface/subinterfaces/subinterface/ipv6/neighbors/neighbor/state/origin
 * /interfaces/interface/state/oper-status
 * /interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/ip
 * /interfaces/interface/subinterfaces/subinterface/ipv4/state/counters/in-pkts
@@ -204,6 +207,65 @@ Verify that interface packet counters are properly incremented in every streamin
 
 vRX
 
+## Canonical OC
+
+```json
+{
+  "openconfig-interfaces:interfaces": {
+    "interface": [
+      {
+        "config": {
+          "description": "DUT to ATE source",
+          "enabled": true,
+          "mtu": 1514,
+          "name": "port1"
+        },
+        "name": "port1",
+        "subinterfaces": {
+          "subinterface": [
+            {
+              "index": 0,
+              "openconfig-if-ip:ipv4": {
+                "addresses": {
+                  "address": [
+                    {
+                      "config": {
+                        "ip": "192.0.2.1",
+                        "prefix-length": 30
+                      },
+                      "ip": "192.0.2.1"
+                    }
+                  ]
+                },
+                "config": {
+                  "mtu": 1500
+                }
+              },
+              "openconfig-if-ip:ipv6": {
+                "addresses": {
+                  "address": [
+                    {
+                      "config": {
+                        "ip": "2001:db8::1",
+                        "prefix-length": 126
+                      },
+                      "ip": "2001:db8::1"
+                    }
+                  ]
+                },
+                "config": {
+                  "mtu": 1500
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
 ## OpenConfig Path and RPC Coverage
 
 The below yaml defines the OC paths and RPC intended to be covered by this test.
@@ -229,6 +291,9 @@ paths:
   /interfaces/interface/state/counters/out-unicast-pkts:
   /interfaces/interface/subinterfaces/subinterface/ipv4/state/mtu:
   /interfaces/interface/subinterfaces/subinterface/ipv6/state/mtu:
+  /interfaces/interface/state/mtu:
+  /interfaces/interface/subinterfaces/subinterface/ipv4/neighbors/neighbor/state/origin:
+  /interfaces/interface/subinterfaces/subinterface/ipv6/neighbors/neighbor/state/origin:
   /interfaces/interface/state/oper-status:
   /interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/ip:
   /interfaces/interface/subinterfaces/subinterface/ipv4/state/counters/in-pkts:


### PR DESCRIPTION
Fixes #5745

* (M) feature/interface/singleton/otg_tests/singleton_test/README.md
  - Add /interfaces/interface/state/mtu.
  - Add /interfaces/interface/subinterfaces/subinterface/ipv4/neighbors/neighbor/state/origin.
  - Add /interfaces/interface/subinterfaces/subinterface/ipv6/neighbors/neighbor/state/origin.
  - Add RFC 7951 Canonical OC JSON configuration block.