### PR TITLE
Update record_payload_truncation_test.go

### DIFF
--- a/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
+++ b/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
@@ -64,7 +64,11 @@ func sendOversizedPayload(t *testing.T, dut *ondatra.DUTDevice) {
 			nh1.NextHop = oc.UnionString(nhAddress)
 		}
 	}
-	gnmi.Update(t, dut, gnmi.OC().Config(), ocRoot)
+	gnmiClient, err := dut.RawAPIs().BindingDUT().DialGNMI(context.Background(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(45000000), grpc.MaxCallSendMsgSize(45000000)))
+	if err != nil {
+		t.Fatalf("Failed to dial gNMI with custom message size: %v", err)
+	}
+	gnmi.Update(t, dut.GNMIOpts().WithClient(gnmiClient), gnmi.OC().Config(), ocRoot)
 }
 
 func TestAccountzRecordPayloadTruncation(t *testing.T) {

--- a/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
+++ b/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
@@ -64,10 +64,17 @@ func sendOversizedPayload(t *testing.T, dut *ondatra.DUTDevice) {
 			nh1.NextHop = oc.UnionString(nhAddress)
 		}
 	}
-	gnmiClient, err := dut.RawAPIs().BindingDUT().DialGNMI(context.Background(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(45000000), grpc.MaxCallSendMsgSize(45000000)))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	gnmiClient, err := dut.RawAPIs().BindingDUT().DialGNMI(ctx, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(45000000), grpc.MaxCallSendMsgSize(45000000)))
 	if err != nil {
 		t.Fatalf("Failed to dial gNMI with custom message size: %v", err)
 	}
+	t.Cleanup(func() {
+		for i := 0; i < 150; i++ {
+			gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(fmt.Sprintf("acctz-test-ni-%d", i)).Config())
+		}
+	})
 	gnmi.Update(t, dut.GNMIOpts().WithClient(gnmiClient), gnmi.OC().Config(), ocRoot)
 }
 


### PR DESCRIPTION
- Increasing the gNMI max message size limits in the gNSI record payload truncation test to prevent size-limit errors.