### PR TITLE
RT-7.5: add transitivity check for link-bw extended communities

### DIFF
--- a/feature/bgp/policybase/otg_tests/link_bandwidth_test/link_bandwidth_test.go
+++ b/feature/bgp/policybase/otg_tests/link_bandwidth_test/link_bandwidth_test.go
@@ -435,11 +435,19 @@ func validateRouteCommunityV4(t *testing.T, td testData, ec extCommunity) {
 }
 
 func isLinkBandwidthV4(ec *otgtelemetry.BgpPeer_UnicastIpv4Prefix_ExtendedCommunity) bool {
-	return ec.Structured != nil && ec.Structured.NonTransitive_2OctetAsType != nil && ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype != nil
+	return ec.Structured != nil &&
+		((ec.Structured.Transitive_2OctetAsType != nil &&
+			ec.Structured.Transitive_2OctetAsType.LinkBandwidthSubtype != nil) ||
+			(ec.Structured.NonTransitive_2OctetAsType != nil &&
+				ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype != nil))
 }
 
 func isLinkBandwidthV6(ec *otgtelemetry.BgpPeer_UnicastIpv6Prefix_ExtendedCommunity) bool {
-	return ec.Structured != nil && ec.Structured.NonTransitive_2OctetAsType != nil && ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype != nil
+	return ec.Structured != nil &&
+		((ec.Structured.Transitive_2OctetAsType != nil &&
+			ec.Structured.Transitive_2OctetAsType.LinkBandwidthSubtype != nil) ||
+			(ec.Structured.NonTransitive_2OctetAsType != nil &&
+				ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype != nil))
 }
 
 func matchesExpectedBandwidth(community string, gotBW float32) bool {
@@ -538,8 +546,15 @@ func validateRouteCommunityV4Prefix(t *testing.T, td testData, community, v4Pref
 			default:
 				for _, ec := range prefix.ExtendedCommunity {
 					if isLinkBandwidthV4(ec) {
-						if matchesExpectedBandwidth(community, ygot.BinaryToFloat32(ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype.GetBandwidth())) {
-							return true
+						if ec.Structured.Transitive_2OctetAsType != nil && ec.Structured.Transitive_2OctetAsType.LinkBandwidthSubtype != nil {
+							if matchesExpectedBandwidth(community, ygot.BinaryToFloat32(ec.Structured.Transitive_2OctetAsType.LinkBandwidthSubtype.GetBandwidth())) {
+								return true
+							}
+						}
+						if ec.Structured.NonTransitive_2OctetAsType != nil && ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype != nil {
+							if matchesExpectedBandwidth(community, ygot.BinaryToFloat32(ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype.GetBandwidth())) {
+								return true
+							}
 						}
 					}
 				}
@@ -581,11 +596,20 @@ func validateRouteCommunityV4Prefix(t *testing.T, td testData, community, v4Pref
 					if !isLinkBandwidthV4(ec) {
 						continue
 					}
-					lbSubType := ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype
-					gotBW := ygot.BinaryToFloat32(lbSubType.GetBandwidth())
-					t.Logf("V4 Bandwidth from OTG: %v (AS=%d)", gotBW, lbSubType.GetGlobal_2ByteAs())
-					if lbSubType.GetGlobal_2ByteAs() != 23456 && lbSubType.GetGlobal_2ByteAs() != 32002 && lbSubType.GetGlobal_2ByteAs() != 32001 {
-						t.Errorf("AS number should be 23456 or %d got %d", ateAS, lbSubType.GetGlobal_2ByteAs())
+					var gotBW float32
+					var globalAS uint16
+					if ec.Structured.Transitive_2OctetAsType != nil && ec.Structured.Transitive_2OctetAsType.LinkBandwidthSubtype != nil {
+						lbSubType := ec.Structured.Transitive_2OctetAsType.LinkBandwidthSubtype
+						gotBW = ygot.BinaryToFloat32(lbSubType.GetBandwidth())
+						globalAS = lbSubType.GetGlobal_2ByteAs()
+					} else {
+						lbSubType := ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype
+						gotBW = ygot.BinaryToFloat32(lbSubType.GetBandwidth())
+						globalAS = lbSubType.GetGlobal_2ByteAs()
+					}
+					t.Logf("V4 Bandwidth from OTG: %v (AS=%d)", gotBW, globalAS)
+					if globalAS != 23456 && globalAS != 32002 && globalAS != 32001 {
+						t.Errorf("AS number should be 23456 or %d got %d", ateAS, globalAS)
 						return
 					}
 					if !matchesExpectedBandwidth(community, gotBW) {
@@ -642,8 +666,15 @@ func validateRouteCommunityV6Prefix(t *testing.T, td testData, community, v6Pref
 			default:
 				for _, ec := range prefix.ExtendedCommunity {
 					if isLinkBandwidthV6(ec) {
-						if matchesExpectedBandwidth(community, ygot.BinaryToFloat32(ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype.GetBandwidth())) {
-							return true
+						if ec.Structured.Transitive_2OctetAsType != nil && ec.Structured.Transitive_2OctetAsType.LinkBandwidthSubtype != nil {
+							if matchesExpectedBandwidth(community, ygot.BinaryToFloat32(ec.Structured.Transitive_2OctetAsType.LinkBandwidthSubtype.GetBandwidth())) {
+								return true
+							}
+						}
+						if ec.Structured.NonTransitive_2OctetAsType != nil && ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype != nil {
+							if matchesExpectedBandwidth(community, ygot.BinaryToFloat32(ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype.GetBandwidth())) {
+								return true
+							}
 						}
 					}
 				}
@@ -685,11 +716,20 @@ func validateRouteCommunityV6Prefix(t *testing.T, td testData, community, v6Pref
 					if !isLinkBandwidthV6(ec) {
 						continue
 					}
-					lbSubType := ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype
-					gotBW := ygot.BinaryToFloat32(lbSubType.GetBandwidth())
-					t.Logf("V6 Bandwidth from OTG: %v (AS=%d)", gotBW, lbSubType.GetGlobal_2ByteAs())
-					if lbSubType.GetGlobal_2ByteAs() != 23456 && lbSubType.GetGlobal_2ByteAs() != 32002 && lbSubType.GetGlobal_2ByteAs() != 32001 {
-						t.Errorf("AS number should be 23456 or %d got %d", ateAS, lbSubType.GetGlobal_2ByteAs())
+					var gotBW float32
+					var globalAS uint16
+					if ec.Structured.Transitive_2OctetAsType != nil && ec.Structured.Transitive_2OctetAsType.LinkBandwidthSubtype != nil {
+						lbSubType := ec.Structured.Transitive_2OctetAsType.LinkBandwidthSubtype
+						gotBW = ygot.BinaryToFloat32(lbSubType.GetBandwidth())
+						globalAS = lbSubType.GetGlobal_2ByteAs()
+					} else {
+						lbSubType := ec.Structured.NonTransitive_2OctetAsType.LinkBandwidthSubtype
+						gotBW = ygot.BinaryToFloat32(lbSubType.GetBandwidth())
+						globalAS = lbSubType.GetGlobal_2ByteAs()
+					}
+					t.Logf("V6 Bandwidth from OTG: %v (AS=%d)", gotBW, globalAS)
+					if globalAS != 23456 && globalAS != 32002 && globalAS != 32001 {
+						t.Errorf("AS number should be 23456 or %d got %d", ateAS, globalAS)
 						return
 					}
 					if !matchesExpectedBandwidth(community, gotBW) {
@@ -1192,12 +1232,12 @@ func (td *testData) advertiseRoutesWithEBGP(t *testing.T) {
 	// Configure routes with Link bandwidth community.
 	netv43 := bgp4Peer1.V4Routes().Add().SetName("v4-bgpNet-dev3")
 	netv43.Addresses().Add().SetAddress(advertisedIPv43.address).SetPrefix(advertisedIPv43.prefix)
-	extcommv4 := netv43.ExtendedCommunities().Add().NonTransitive2OctetAsType().LinkBandwidthSubtype()
+	extcommv4 := netv43.ExtendedCommunities().Add().Transitive2OctetAsType().LinkBandwidthSubtype()
 	extcommv4.SetGlobal2ByteAs(23456)
 	extcommv4.SetBandwidth(1000)
 	netv63 := bgp6Peer1.V6Routes().Add().SetName("v6-bgpNet-dev3")
 	netv63.Addresses().Add().SetAddress(advertisedIPv63.address).SetPrefix(advertisedIPv63.prefix)
-	extcommv6 := netv63.ExtendedCommunities().Add().NonTransitive2OctetAsType().LinkBandwidthSubtype()
+	extcommv6 := netv63.ExtendedCommunities().Add().Transitive2OctetAsType().LinkBandwidthSubtype()
 	extcommv6.SetGlobal2ByteAs(23456)
 	extcommv6.SetBandwidth(1000)
 


### PR DESCRIPTION
- update validation on OTG Port2 to accept both transitive and non-transitive extended communities since vendor implementations can use either encoding while adding link-bandwidth EC through routing policy
- use transitive encoding for link-bandwidth EC across eBGP on OTG Port1 to align with RFC 4360

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."