### PR TITLE
Remove static sleep from the google_discovery_protocol_packetout_lag_test

### DIFF
--- a/feature/p4rt/otg_tests/google_discovery_protocol_packetout_lag_test/google_discovery_protocol_packetout_lag_test.go
+++ b/feature/p4rt/otg_tests/google_discovery_protocol_packetout_lag_test/google_discovery_protocol_packetout_lag_test.go
@@ -176,9 +176,10 @@ func testPacketOut(ctx context.Context, t *testing.T, args *testArgs) {
 			// Wait for ate stats to be populated
 			timeout := 4 * time.Minute
 			if test.expectPass {
+				expectedCount := uint64(float64(packetCount) * 0.95)
 				gnmi.Watch(t, args.ate.OTG(), gnmi.OTG().Port(port1).Counters().InFrames().State(), timeout, func(val *ygnmi.Value[uint64]) bool {
 					count, present := val.Val()
-					return present && (count-counter0 >= uint64(float64(packetCount)*0.95))
+					return present && count >= counter0 && (count-counter0 >= expectedCount)
 				}).Await(t)
 			} else {
 				time.Sleep(10 * time.Second)

--- a/feature/p4rt/otg_tests/google_discovery_protocol_packetout_lag_test/google_discovery_protocol_packetout_lag_test.go
+++ b/feature/p4rt/otg_tests/google_discovery_protocol_packetout_lag_test/google_discovery_protocol_packetout_lag_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
 	"github.com/openconfig/ondatra/netutil"
+	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 	p4v1pb "github.com/p4lang/p4runtime/go/p4/v1"
 )
@@ -173,7 +174,15 @@ func testPacketOut(ctx context.Context, t *testing.T, args *testArgs) {
 			sendPackets(t, test.client, packets, packetCount)
 
 			// Wait for ate stats to be populated
-			time.Sleep(4 * time.Minute)
+			timeout := 4 * time.Minute
+			if test.expectPass {
+				gnmi.Watch(t, args.ate.OTG(), gnmi.OTG().Port(port1).Counters().InFrames().State(), timeout, func(val *ygnmi.Value[uint64]) bool {
+					count, present := val.Val()
+					return present && (count-counter0 >= uint64(float64(packetCount)*0.95))
+				}).Await(t)
+			} else {
+				time.Sleep(10 * time.Second)
+			}
 			otgutils.LogFlowMetrics(t, args.ate.OTG(), args.top)
 			otgutils.LogPortMetrics(t, args.ate.OTG(), args.top)
 			// Check packet counters after packet out


### PR DESCRIPTION
The test used a hardcoded sleep of 4 minutes. The changes here replaces it with a dynamic `gnmi.Watch` to ensure we continue as-soon-as the counter is available. 