### PR TITLE
Stabilizing code: Add watch loop before querying counter values

### DIFF
--- a/feature/acl/otg_tests/acl_dscp_match/acl_dscp_match_test.go
+++ b/feature/acl/otg_tests/acl_dscp_match/acl_dscp_match_test.go
@@ -173,10 +173,12 @@ func runTest(t *testing.T, tc testCase, dut *ondatra.DUTDevice, ate *ondatra.ATE
 		otg.StartTraffic(t)
 		waitForTraffic(t, otg, tc.flowName, trafficTimeout)
 
-		gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(tc.flowName).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
+		if _, ok := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(tc.flowName).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
 			f, present := val.Val()
 			return present && f.GetCounters() != nil && f.GetCounters().GetOutPkts() >= uint64(noOfPackets)
-		}).Await(t)
+		}).Await(t); !ok {
+			t.Errorf("Timeout waiting for flow %s to transmit %d packets", tc.flowName, noOfPackets)
+		}
 		
 		otgutils.LogFlowMetrics(t, otg, *config)
 		otgutils.LogPortMetrics(t, otg, *config)

--- a/feature/acl/otg_tests/acl_dscp_match/acl_dscp_match_test.go
+++ b/feature/acl/otg_tests/acl_dscp_match/acl_dscp_match_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openconfig/ondatra/otg"
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
+	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
 )
 
 const (
@@ -172,6 +173,11 @@ func runTest(t *testing.T, tc testCase, dut *ondatra.DUTDevice, ate *ondatra.ATE
 		otg.StartTraffic(t)
 		waitForTraffic(t, otg, tc.flowName, trafficTimeout)
 
+		gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(tc.flowName).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
+			f, present := val.Val()
+			return present && f.GetCounters() != nil && f.GetCounters().GetOutPkts() >= uint64(noOfPackets)
+		}).Await(t)
+		
 		otgutils.LogFlowMetrics(t, otg, *config)
 		otgutils.LogPortMetrics(t, otg, *config)
 

--- a/feature/acl/otg_tests/acl_dscp_match/acl_dscp_match_test.go
+++ b/feature/acl/otg_tests/acl_dscp_match/acl_dscp_match_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
 	"github.com/openconfig/ondatra/otg"
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
-	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
 )
 
 const (
@@ -179,7 +179,7 @@ func runTest(t *testing.T, tc testCase, dut *ondatra.DUTDevice, ate *ondatra.ATE
 		}).Await(t); !ok {
 			t.Errorf("Timeout waiting for flow %s to transmit %d packets", tc.flowName, noOfPackets)
 		}
-		
+
 		otgutils.LogFlowMetrics(t, otg, *config)
 		otgutils.LogPortMetrics(t, otg, *config)
 

--- a/feature/bgp/policybase/otg_tests/bgp_3level_nested_policy_test/bgp_3level_nested_policy_test.go
+++ b/feature/bgp/policybase/otg_tests/bgp_3level_nested_policy_test/bgp_3level_nested_policy_test.go
@@ -918,6 +918,12 @@ func checkTraffic(t *testing.T, td testData, flowName string) {
 	otgutils.LogPortMetrics(t, td.ate.OTG(), td.top)
 
 	t.Log("Checking flow telemetry...")
+	if _, ok := gnmi.Watch(t, td.ate.OTG(), gnmi.OTG().Flow(flowName).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
+		f, present := val.Val()
+		return present && f.GetCounters() != nil && f.GetCounters().GetOutPkts() >= uint64(totalPackets)
+	}).Await(t); !ok {
+		t.Errorf("Timeout waiting for flow %s to transmit %d packets", flowName, totalPackets)
+	}
 	recvMetric := gnmi.Get(t, td.ate.OTG(), gnmi.OTG().Flow(flowName).State())
 	txPackets := recvMetric.GetCounters().GetOutPkts()
 	rxPackets := recvMetric.GetCounters().GetInPkts()

--- a/feature/bgp/policybase/otg_tests/comm_match_action_test/bgp_comm_match_action_test.go
+++ b/feature/bgp/policybase/otg_tests/comm_match_action_test/bgp_comm_match_action_test.go
@@ -53,6 +53,7 @@ const (
 	acceptPolicy         = "PERMIT-ALL"
 	matchStdCommunitySet = "match_std_comms"
 	addStdCommunitySet   = "add_std_comms"
+	totalPackets         = 1000
 )
 
 var (
@@ -471,7 +472,7 @@ func configureOTG(t *testing.T, otg *otg.OTG) gosnappi.Config {
 		SetTxNames([]string{iDut2Ipv4.Name()}).
 		SetRxNames(dstBgp4PeerRoutes)
 	flowipv4.Size().SetFixed(512)
-	flowipv4.Duration().FixedPackets().SetPackets(1000)
+	flowipv4.Duration().FixedPackets().SetPackets(totalPackets)
 	e1 := flowipv4.Packet().Add().Ethernet()
 	e1.Src().SetValue(iDut2Eth.Mac())
 	v4 := flowipv4.Packet().Add().Ipv4()
@@ -491,7 +492,7 @@ func configureOTG(t *testing.T, otg *otg.OTG) gosnappi.Config {
 		SetTxNames([]string{iDut2Ipv6.Name()}).
 		SetRxNames(dstBgp6PeerRoutes)
 	flowipv6.Size().SetFixed(512)
-	flowipv6.Duration().FixedPackets().SetPackets(1000)
+	flowipv6.Duration().FixedPackets().SetPackets(totalPackets)
 	e2 := flowipv6.Packet().Add().Ethernet()
 	e2.Src().SetValue(iDut2Eth.Mac())
 	v6 := flowipv6.Packet().Add().Ipv6()
@@ -515,6 +516,12 @@ func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, conf gosnappi.Config) {
 	otg := ate.OTG()
 	otgutils.LogFlowMetrics(t, otg, conf)
 	for _, flow := range conf.Flows().Items() {
+		if _, ok := gnmi.Watch(t, otg, gnmi.OTG().Flow(flow.Name()).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
+			f, present := val.Val()
+			return present && f.GetCounters() != nil && f.GetCounters().GetOutPkts() >= totalPackets
+		}).Await(t); !ok {
+			t.Errorf("Timeout waiting for flow to transmit %d packets", totalPackets)
+		}
 		recvMetric := gnmi.Get(t, otg, gnmi.OTG().Flow(flow.Name()).State())
 		txPackets := float32(recvMetric.GetCounters().GetOutPkts())
 		rxPackets := float32(recvMetric.GetCounters().GetInPkts())

--- a/feature/bgp/route_selection/otg_tests/route_leakage_between_nondefault_vrfs/route_leakage_between_nondefault_vrfs_test.go
+++ b/feature/bgp/route_selection/otg_tests/route_leakage_between_nondefault_vrfs/route_leakage_between_nondefault_vrfs_test.go
@@ -399,7 +399,7 @@ func verifyTrafficFlow(t *testing.T, ate *ondatra.ATEDevice, config gosnappi.Con
 	for _, flow := range config.Flows().Items() {
 		if _, ok := gnmi.Watch(t, otg, gnmi.OTG().Flow(flow.Name()).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
 			f, present := val.Val()
-			return present && f.GetCounters() != nil && f.GetCounters().GetOutPkts() >= uint64(uint32(totalPackets))
+			return present && f.GetCounters() != nil && f.GetCounters().GetOutPkts() >= totalPackets
 		}).Await(t); !ok {
 			t.Errorf("Flow %s did not send any packets", flow.Name())
 		}

--- a/feature/bgp/route_selection/otg_tests/route_leakage_between_nondefault_vrfs/route_leakage_between_nondefault_vrfs_test.go
+++ b/feature/bgp/route_selection/otg_tests/route_leakage_between_nondefault_vrfs/route_leakage_between_nondefault_vrfs_test.go
@@ -402,7 +402,7 @@ func verifyTrafficFlow(t *testing.T, ate *ondatra.ATEDevice, config gosnappi.Con
 			return present && f.GetCounters() != nil && f.GetCounters().GetOutPkts() >= uint64(uint32(totalPackets))
 		}).Await(t); !ok {
 			t.Errorf("Flow %s did not send any packets", flow.Name())
-		}		
+		}
 		flowMetrics := gnmi.Get(t, otg, gnmi.OTG().Flow(flow.Name()).State())
 		txPackets := flowMetrics.GetCounters().GetOutPkts()
 		rxPackets := flowMetrics.GetCounters().GetInPkts()

--- a/feature/bgp/route_selection/otg_tests/route_leakage_between_nondefault_vrfs/route_leakage_between_nondefault_vrfs_test.go
+++ b/feature/bgp/route_selection/otg_tests/route_leakage_between_nondefault_vrfs/route_leakage_between_nondefault_vrfs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
 	"github.com/openconfig/ondatra/otg"
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
@@ -396,6 +397,12 @@ func verifyTrafficFlow(t *testing.T, ate *ondatra.ATEDevice, config gosnappi.Con
 	otg := ate.OTG()
 
 	for _, flow := range config.Flows().Items() {
+		if _, ok := gnmi.Watch(t, otg, gnmi.OTG().Flow(flow.Name()).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
+			f, present := val.Val()
+			return present && f.GetCounters() != nil && f.GetCounters().GetOutPkts() >= uint64(uint32(totalPackets))
+		}).Await(t); !ok {
+			t.Errorf("Flow %s did not send any packets", flow.Name())
+		}		
 		flowMetrics := gnmi.Get(t, otg, gnmi.OTG().Flow(flow.Name()).State())
 		txPackets := flowMetrics.GetCounters().GetOutPkts()
 		rxPackets := flowMetrics.GetCounters().GetInPkts()

--- a/feature/gribi/otg_tests/encap_decap_scale/encap_decap_scale_test.go
+++ b/feature/gribi/otg_tests/encap_decap_scale/encap_decap_scale_test.go
@@ -38,6 +38,8 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
+	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )
 
@@ -527,6 +529,12 @@ func verifyTraffic(t *testing.T, args *testArgs, flowList []string) {
 	t.Helper()
 	for _, flowName := range flowList {
 		t.Logf("Verifying flow metrics for the flow %s\n", flowName)
+		if _, ok := gnmi.Watch(t, args.ate.OTG(), gnmi.OTG().Flow(flowName).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
+			f, present := val.Val()
+			return present && f.GetCounters() != nil && f.GetCounters().GetOutPkts() >= uint64(1000)
+		}).Await(t); !ok {
+			t.Errorf("Flow %s did not send any packets", flowName)
+		}
 		recvMetric := gnmi.Get(t, args.ate.OTG(), gnmi.OTG().Flow(flowName).State())
 		txPackets := recvMetric.GetCounters().GetOutPkts()
 		rxPackets := recvMetric.GetCounters().GetInPkts()

--- a/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -30,8 +30,8 @@ import (
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
 	"github.com/openconfig/testt"
-	"github.com/openconfig/ygot/ygot"
 	"github.com/openconfig/ygnmi/ygnmi"
+	"github.com/openconfig/ygot/ygot"
 )
 
 const (
@@ -520,14 +520,14 @@ func testTrafficFlows(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config,
 	for _, flow := range flows {
 		t.Run(flow.Name(), func(t *testing.T) {
 			t.Logf("*** Verifying %v traffic on OTG ... ", flow.Name())
-			
+
 			if _, ok := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Transmit().State(), 15*time.Second, func(val *ygnmi.Value[bool]) bool {
 				transmitState, present := val.Val()
 				return present && !transmitState
 			}).Await(t); !ok {
 				t.Fatalf("Timeout waiting for flow %s to stop transmitting", flow.Name())
 			}
-			
+
 			outPktsRaw := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State())
 			if outPktsRaw == 0 {
 				t.Fatalf("OutPkts == 0, want >0.")

--- a/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -520,14 +520,18 @@ func testTrafficFlows(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config,
 	for _, flow := range flows {
 		t.Run(flow.Name(), func(t *testing.T) {
 			t.Logf("*** Verifying %v traffic on OTG ... ", flow.Name())
-			outPktsVal, ok := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State(), 15*time.Second, func(val *ygnmi.Value[uint64]) bool {
-				v, present := val.Val()
-				return present && v > 0
-			}).Await(t)
-			if !ok {
+			
+			if _, ok := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Transmit().State(), 15*time.Second, func(val *ygnmi.Value[bool]) bool {
+				transmitState, present := val.Val()
+				return present && !transmitState
+			}).Await(t); !ok {
+				t.Fatalf("Timeout waiting for flow %s to stop transmitting", flow.Name())
+			}
+			
+			outPktsRaw := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State())
+			if outPktsRaw == 0 {
 				t.Fatalf("OutPkts == 0, want >0.")
 			}
-			outPktsRaw, _ := outPktsVal.Val()
 			outPkts := float32(outPktsRaw)
 
 			var inPkts float32

--- a/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -532,11 +532,11 @@ func testTrafficFlows(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config,
 
 			var inPkts float32
 			if expectPass {
-				inPktsVal, _ := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().InPkts().State(), 15*time.Second, func(val *ygnmi.Value[uint64]) bool {
+				inPktsVal, ok := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().InPkts().State(), 15*time.Second, func(val *ygnmi.Value[uint64]) bool {
 					v, present := val.Val()
 					return present && v == outPktsRaw
 				}).Await(t)
-				if inPktsVal != nil {
+				if ok {
 					inPktsRaw, _ := inPktsVal.Val()
 					inPkts = float32(inPktsRaw)
 				} else {

--- a/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -31,10 +31,11 @@ import (
 	"github.com/openconfig/ondatra/gnmi/oc"
 	"github.com/openconfig/testt"
 	"github.com/openconfig/ygot/ygot"
+	"github.com/openconfig/ygnmi/ygnmi"
 )
 
 const (
-	trafficDuration = 1 * time.Minute
+	trafficDuration = 30 * time.Second
 	ipv4PrefixLen   = 30
 	ipv6PrefixLen   = 126
 )
@@ -486,6 +487,7 @@ func getIPinIPFlow(args *testArgs, src attrs.Attributes, dst attrs.Attributes, f
 	flow.Size().SetFixed(1024)
 	flow.Rate().SetPps(100)
 	flow.Duration().FixedPackets().SetPackets(100)
+	flow.Duration().Continuous()
 
 	return flow
 }
@@ -518,11 +520,30 @@ func testTrafficFlows(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config,
 	for _, flow := range flows {
 		t.Run(flow.Name(), func(t *testing.T) {
 			t.Logf("*** Verifying %v traffic on OTG ... ", flow.Name())
-			outPkts := float32(gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State()))
-			inPkts := float32(gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().InPkts().State()))
-
-			if outPkts == 0 {
+			outPktsVal, ok := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State(), 15*time.Second, func(val *ygnmi.Value[uint64]) bool {
+				v, present := val.Val()
+				return present && v > 0
+			}).Await(t)
+			if !ok {
 				t.Fatalf("OutPkts == 0, want >0.")
+			}
+			outPktsRaw, _ := outPktsVal.Val()
+			outPkts := float32(outPktsRaw)
+
+			var inPkts float32
+			if expectPass {
+				inPktsVal, _ := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().InPkts().State(), 15*time.Second, func(val *ygnmi.Value[uint64]) bool {
+					v, present := val.Val()
+					return present && v == outPktsRaw
+				}).Await(t)
+				if inPktsVal != nil {
+					inPktsRaw, _ := inPktsVal.Val()
+					inPkts = float32(inPktsRaw)
+				} else {
+					inPkts = float32(gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().InPkts().State()))
+				}
+			} else {
+				inPkts = float32(gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().InPkts().State()))
 			}
 
 			lossPct := (outPkts - inPkts) * 100 / outPkts

--- a/feature/system/control_plane_traffic/otg_tests/default_copp_test/default_copp_test.go
+++ b/feature/system/control_plane_traffic/otg_tests/default_copp_test/default_copp_test.go
@@ -385,7 +385,7 @@ func (ce *commonEntities) testCoppSystemHelper(t *testing.T, tc *coppSystemTestc
 	finalCounters := gnmi.Get(t, ce.dut, gnmi.OC().Interface(ce.dut.Port(t, dutIncomingPort).Name()).Counters().State())
 	finalInPkts := finalCounters.GetInPkts()
 	t.Logf("Final incoming packets: %v", finalInPkts)
-
+	// TODO: b/540356827 gnmi.Watch doesn't work with arista-platform-control-plane-traffic-counters:l3-lpm-overflow
 	var finalPktCounts []float64
 	timeout := 45 * time.Second
 	pollInterval := 5 * time.Second

--- a/feature/system/control_plane_traffic/otg_tests/default_copp_test/default_copp_test.go
+++ b/feature/system/control_plane_traffic/otg_tests/default_copp_test/default_copp_test.go
@@ -385,7 +385,42 @@ func (ce *commonEntities) testCoppSystemHelper(t *testing.T, tc *coppSystemTestc
 	finalCounters := gnmi.Get(t, ce.dut, gnmi.OC().Interface(ce.dut.Port(t, dutIncomingPort).Name()).Counters().State())
 	finalInPkts := finalCounters.GetInPkts()
 	t.Logf("Final incoming packets: %v", finalInPkts)
-	finalPktCounts := ce.getDroppedPktCounts(t, tc.counters)
+
+	var finalPktCounts []float64
+	timeout := 45 * time.Second
+	pollInterval := 5 * time.Second
+
+	for start := time.Now(); ; {
+		finalPktCounts = ce.getDroppedPktCounts(t, tc.counters)
+
+		allMatched := true
+		for idx := range tc.counters {
+			if tc.increasedDropCount && finalPktCounts[idx] <= initialPktCounts[idx] {
+				allMatched = false
+				t.Logf("Waiting for counter %s to increase. Current: %v, Initial: %v", tc.counters[idx], finalPktCounts[idx], initialPktCounts[idx])
+				break
+			}
+			if !tc.increasedDropCount && finalPktCounts[idx] != initialPktCounts[idx] {
+				allMatched = false
+				break
+			}
+		}
+
+		if allMatched {
+			break // The counters reached the expected state
+		}
+
+		if !tc.increasedDropCount {
+			break // If we expect NO drops and they increased, break
+		}
+
+		if time.Since(start) > timeout {
+			t.Logf("Timeout reached waiting for telemetry updates.")
+			break
+		}
+
+		time.Sleep(pollInterval)
+	}
 	for idx, counter := range tc.counters {
 		if tc.increasedDropCount && finalPktCounts[idx] <= initialPktCounts[idx] {
 			t.Errorf("testCoppSystemHelper: Drop count validation failed for testcase: %s, counter: %s. Final dropped pkt count: %v, Initial dropped pkt count: %v", tc.name, counter, finalPktCounts[idx], initialPktCounts[idx])


### PR DESCRIPTION
 Added stabilizations - Add watch loop with gnmi Await before querying counter values, updated traffic duration. All the tests were passing in the first attempt (except encap_decap_scale - more underlying issues)
