### PR TITLE
Update large_set_consistency_test.go

### DIFF
--- a/feature/gnmi/metadata/tests/large_set_consistency_test/large_set_consistency_test.go
+++ b/feature/gnmi/metadata/tests/large_set_consistency_test/large_set_consistency_test.go
@@ -267,6 +267,8 @@ func checkshortStringMetadata1(t *testing.T, gnmiClient gnmigrpc.GNMIClient, dut
 	}
 }
 
+// During the Set push, an external reader should see EITHER the complete old config
+// OR the complete new config. Any partial string or missing data is a failure.
 func checkshortStringMetadata2(t *testing.T, gnmiClient gpb.GNMIClient, dut *ondatra.DUTDevice) {
 	t.Helper()
 	got, getRespTimeStamp := extractMetadataAnnotation(t, gnmiClient, dut)

--- a/feature/gnmi/metadata/tests/large_set_consistency_test/large_set_consistency_test.go
+++ b/feature/gnmi/metadata/tests/large_set_consistency_test/large_set_consistency_test.go
@@ -259,7 +259,9 @@ func getNotificationsUsingGNMIGet(t *testing.T, gnmiClient gpb.GNMIClient, dut *
 	return getResponse.GetNotification()
 }
 
-func checkshortStringMetadata1(t *testing.T, gnmiClient gnmigrpc.GNMIClient, dut *ondatra.DUTDevice, done *atomic.Int64) {
+// During the Set push, an external reader should see EITHER the complete old config
+// OR the complete new config. Any partial string or missing data is a failure.
+func checkshortStringMetadata1(t *testing.T, gnmiClient gpb.GNMIClient, dut *ondatra.DUTDevice, done *atomic.Int64) {
 	t.Helper()
 	got, _ := extractMetadataAnnotation(t, gnmiClient, dut)
 	if got != shortStringMetadata1 && got != shortStringMetadata2 {
@@ -267,8 +269,6 @@ func checkshortStringMetadata1(t *testing.T, gnmiClient gnmigrpc.GNMIClient, dut
 	}
 }
 
-// During the Set push, an external reader should see EITHER the complete old config
-// OR the complete new config. Any partial string or missing data is a failure.
 func checkshortStringMetadata2(t *testing.T, gnmiClient gpb.GNMIClient, dut *ondatra.DUTDevice) {
 	t.Helper()
 	got, getRespTimeStamp := extractMetadataAnnotation(t, gnmiClient, dut)

--- a/feature/gnmi/metadata/tests/large_set_consistency_test/large_set_consistency_test.go
+++ b/feature/gnmi/metadata/tests/large_set_consistency_test/large_set_consistency_test.go
@@ -259,12 +259,11 @@ func getNotificationsUsingGNMIGet(t *testing.T, gnmiClient gpb.GNMIClient, dut *
 	return getResponse.GetNotification()
 }
 
-func checkshortStringMetadata1(t *testing.T, gnmiClient gpb.GNMIClient, dut *ondatra.DUTDevice, done *atomic.Int64) {
+func checkshortStringMetadata1(t *testing.T, gnmiClient gnmigrpc.GNMIClient, dut *ondatra.DUTDevice, done *atomic.Int64) {
 	t.Helper()
-	got, getRespTimeStamp := extractMetadataAnnotation(t, gnmiClient, dut)
-	want := shortStringMetadata1
-	if got != want && getRespTimeStamp < done.Load() {
-		t.Errorf("extractMetadataAnnotation: got %v, want %v", got, want)
+	got, _ := extractMetadataAnnotation(t, gnmiClient, dut)
+	if got != shortStringMetadata1 && got != shortStringMetadata2 {
+		t.Errorf("extractMetadataAnnotation: got %v, want either %v or %v", got, shortStringMetadata1, shortStringMetadata2)
 	}
 }
 


### PR DESCRIPTION
- Resolved a race condition in concurrent metadata polling that caused false test failures due to strict RPC timestamp comparisons during large Set operations.

- Updated the transition validation logic to accept either the complete old or new configuration string, strictly verifying datastore consistency without relying on brittle timing assumptions.