### PR TITLE
ci: Fix proto-file header in lacp_member_reboot_test/metadata.textproto

### DIFF
--- a/feature/interface/lacp/otg_tests/lacp_member_reboot_test/metadata.textproto
+++ b/feature/interface/lacp/otg_tests/lacp_member_reboot_test/metadata.textproto
@@ -1,5 +1,5 @@
-# proto-file: third_party/openconfig/featureprofiles/proto/metadata.proto
-# proto-message: openconfig.testing.Metadata
+# proto-file: github.com/openconfig/featureprofiles/proto/metadata.proto
+# proto-message: Metadata
 
 uuid: "e1ad8b60-cb7c-4510-a13e-3113d7b4968b"
 plan_id: "RT-5.16"

--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -1197,6 +1197,11 @@ test: {
   exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/interface/lacp/otg_tests/lacp_fallback_test/lacp_fallback_test.go"
 }
 test: {
+  id: "RT-5.16"
+  description: "LACP Member Linecard Reboot"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/interface/lacp/otg_tests/lacp_member_reboot_test/README.md"
+}
+test: {
   id: "RT-5.2"
   description: "Aggregate Interfaces"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/interface/aggregate/otg_tests/aggregate_test/README.md"
@@ -1243,12 +1248,6 @@ test: {
   description: "Disable IPv6 ND Router Arvetisment"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/interface/ip/otg_tests/disable_ipv6_nd_ra_test/README.md"
   exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/interface/ip/otg_tests/disable_ipv6_nd_ra_test/disable_ipv6_nd_ra_test.go"
-}
-test: {
-  id: "RT-5.16"
-  description: "LACP Member Linecard Reboot"
-  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/interface/lacp/otg_tests/lacp_member_reboot_test/README.md"
-  exec: " "
 }
 test: {
   id: "RT-6.1"


### PR DESCRIPTION
Fixes #5780

* (M) feature/interface/lacp/otg_tests/lacp_member_reboot_test/metadata.textproto
  - Fix proto-file header to use github.com/openconfig/featureprofiles/proto/metadata.proto instead of internal google3 path.
  - Fix proto-message to Metadata.