### PR TITLE
P4RT-6.1 : fixed 5% packet-in loss tolerance in performance test

### DIFF
--- a/feature/p4rt/otg_tests/performance_test/performance_test.go
+++ b/feature/p4rt/otg_tests/performance_test/performance_test.go
@@ -329,7 +329,8 @@ func testPktInPktOut(t *testing.T, args *testArgs) {
 		if (counter1 - counter0) < uint64(float32(3*packetCount)*0.95) {
 			t.Errorf("Number of Packetout packets, got: %d, want: %d", counter1-counter0, (3 * packetCount))
 		}
-		_, packetinPackets, err := args.leader.StreamChannelGetPackets(&streamName, uint64(pktIn), 30*time.Second)
+		// Collect packetin and fail if fewer than 95% of the packets are received.
+		_, packetinPackets, err := args.leader.StreamChannelGetPackets(&streamName, uint64(float32(pktIn)*0.95), 30*time.Second)
 		if err != nil {
 			t.Errorf("Unexpected error on StreamChannelGetPackets: %v", err)
 		}

--- a/feature/p4rt/otg_tests/performance_test/performance_test.go
+++ b/feature/p4rt/otg_tests/performance_test/performance_test.go
@@ -330,7 +330,7 @@ func testPktInPktOut(t *testing.T, args *testArgs) {
 			t.Errorf("Number of Packetout packets, got: %d, want: %d", counter1-counter0, (3 * packetCount))
 		}
 		// Collect packetin and fail if fewer than 95% of the packets are received.
-		_, packetinPackets, err := args.leader.StreamChannelGetPackets(&streamName, uint64(float32(pktIn)*0.95), 30*time.Second)
+		_, packetinPackets, err := args.leader.StreamChannelGetPackets(&streamName, uint64(pktIn*95/100), 30*time.Second)
 		if err != nil {
 			t.Errorf("Unexpected error on StreamChannelGetPackets: %v", err)
 		}


### PR DESCRIPTION
Packet loss tolerance logic was not incorporated correctly for packet-in.
With the fix, packet-in collection gate to 95% of expected packets so a benign single-packet punt drop no longer triggers an i/o timeout failure, while still failing fatally below 95%.