### PR TITLE
RT-1.5: Add standard neighbor prefix-limit state paths to README

### DIFF
--- a/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/README.md
+++ b/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/README.md
@@ -26,6 +26,10 @@ BGP Prefix Limit
 paths:
   ## Config Paths ##
   /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/ipv4-unicast/prefix-limit/config/max-prefixes:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/ipv4-unicast/prefix-limit/config/max-prefixes:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/ipv4-unicast/prefix-limit/config/warning-threshold-pct:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/ipv6-unicast/prefix-limit/config/max-prefixes:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/ipv6-unicast/prefix-limit/config/warning-threshold-pct:
 
   ## State Paths ##
   /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/state/peer-group-name:

--- a/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/README.md
+++ b/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/README.md
@@ -24,13 +24,20 @@ BGP Prefix Limit
 
 ```yaml
 paths:
+  ## Config Paths ##
+  /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/ipv4-unicast/prefix-limit/config/max-prefixes:
+
+  ## State Paths ##
   /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/state/peer-group-name:
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/state/neighbor-address:
-  /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/ipv4-unicast/prefix-limit/config/max-prefixes:
   /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/ipv4-unicast/prefix-limit/state/warning-threshold-pct:
   /network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/ipv4-unicast/prefix-limit/state/prefix-limit-exceeded:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/ipv4-unicast/prefix-limit/state/prefix-limit-exceeded:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/ipv4-unicast/prefix-limit/state/warning-threshold-pct:
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/ipv4-unicast/prefix-limit-received/state/prefix-limit-exceeded:
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/ipv4-unicast/prefix-limit-received/state/warning-threshold-pct:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/ipv6-unicast/prefix-limit/state/prefix-limit-exceeded:
+  /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/ipv6-unicast/prefix-limit/state/warning-threshold-pct:
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/ipv6-unicast/prefix-limit-received/state/prefix-limit-exceeded:
   /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/ipv6-unicast/prefix-limit-received/state/warning-threshold-pct:
 


### PR DESCRIPTION
* (M) feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/README.md
  - Add standard non-deviation /bgp/neighbors/neighbor/.../ipv4-unicast/prefix-limit/state/prefix-limit-exceeded.
  - Add standard non-deviation /bgp/neighbors/neighbor/.../ipv4-unicast/prefix-limit/state/warning-threshold-pct.
  - Add standard non-deviation /bgp/neighbors/neighbor/.../ipv6-unicast/prefix-limit/state/prefix-limit-exceeded.
  - Add standard non-deviation /bgp/neighbors/neighbor/.../ipv6-unicast/prefix-limit/state/warning-threshold-pct.
  - Add Config Paths and State Paths YAML headers.