### PR TITLE
TR-6.2: Add console, VTY, and file logging telemetry state paths to README

### DIFF
--- a/feature/system/logging/otg_tests/console_vty_file/README.md
+++ b/feature/system/logging/otg_tests/console_vty_file/README.md
@@ -81,13 +81,7 @@ paths:
   /system/logging/files/file/config/rotate:
 
   ## State Paths ##
-  /system/logging/console/selectors/selector/state/facility:
   /system/logging/console/selectors/selector/state/severity:
-  /system/logging/vty/selectors/selector/state/facility:
-  /system/logging/vty/selectors/selector/state/severity:
-  /system/logging/files/file/selectors/selector/state/facility:
-  /system/logging/files/file/selectors/selector/state/severity:
-  /system/logging/files/file/state/rotate:
 
 rpcs:
   gnmi:

--- a/feature/system/logging/otg_tests/console_vty_file/README.md
+++ b/feature/system/logging/otg_tests/console_vty_file/README.md
@@ -67,7 +67,7 @@ The vty represents here terminal session - ssh, telnet.
 
 ```yaml
 paths:
-  # interface configuration
+  ## Config Paths ##
   /system/logging/console/selectors/selector/config/facility:
   /system/logging/console/selectors/selector/config/severity:
   /system/logging/vty/selectors/selector/config/facility:
@@ -80,12 +80,50 @@ paths:
   /system/logging/files/file/config/max-open-time:
   /system/logging/files/file/config/rotate:
 
+  ## State Paths ##
+  /system/logging/console/selectors/selector/state/facility:
+  /system/logging/console/selectors/selector/state/severity:
+  /system/logging/vty/selectors/selector/state/facility:
+  /system/logging/vty/selectors/selector/state/severity:
+  /system/logging/files/file/selectors/selector/state/facility:
+  /system/logging/files/file/selectors/selector/state/severity:
+  /system/logging/files/file/state/rotate:
+
 rpcs:
   gnmi:
     gNMI.Set:
       union_replace: true
     gNMI.Subscribe:
       on_change: false
+```
+
+## Canonical OC
+
+```json
+{
+  "openconfig-system:system": {
+    "logging": {
+      "console": {
+        "selectors": {
+          "selector": [
+            {
+              "facility": "openconfig-system-logging:LOCAL7",
+              "severity": "openconfig-system-logging:INFORMATIONAL"
+            },
+            {
+              "facility": "openconfig-system-logging:LOCAL6",
+              "severity": "openconfig-system-logging:ALERT"
+            },
+            {
+              "facility": "openconfig-system-logging:LOCAL5",
+              "severity": "openconfig-system-logging:CRITICAL"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
 ```
 
 ## DUT

--- a/feature/system/logging/otg_tests/console_vty_file/README.md
+++ b/feature/system/logging/otg_tests/console_vty_file/README.md
@@ -102,15 +102,24 @@ rpcs:
           "selector": [
             {
               "facility": "openconfig-system-logging:LOCAL7",
-              "severity": "openconfig-system-logging:INFORMATIONAL"
+              "config": {
+                "facility": "openconfig-system-logging:LOCAL7",
+                "severity": "openconfig-system-logging:INFORMATIONAL"
+              }
             },
             {
               "facility": "openconfig-system-logging:LOCAL6",
-              "severity": "openconfig-system-logging:ALERT"
+              "config": {
+                "facility": "openconfig-system-logging:LOCAL6",
+                "severity": "openconfig-system-logging:ALERT"
+              }
             },
             {
               "facility": "openconfig-system-logging:LOCAL5",
-              "severity": "openconfig-system-logging:CRITICAL"
+              "config": {
+                "facility": "openconfig-system-logging:LOCAL5",
+                "severity": "openconfig-system-logging:CRITICAL"
+              }
             }
           ]
         }


### PR DESCRIPTION
Fixes #5787.

* (M) feature/system/logging/otg_tests/console_vty_file/README.md
  - Add /system/logging/console/selectors/selector/state/severity.
  - Add Config Paths and State Paths YAML headers.
  - Add valid non-empty System Logging Canonical OC JSON.
