### PR TITLE
RT-6.1: Register missing LLDP system-description and port-id-type telemetry paths

### DIFF
--- a/feature/lldp/otg_tests/core_lldp_tlv_population_test/README.md
+++ b/feature/lldp/otg_tests/core_lldp_tlv_population_test/README.md
@@ -17,6 +17,41 @@ Determine LLDP advertisement and reception operates correctly.
         configuration of lldp/interfaces/interface/config/enabled (TRUE or
         FALSE) on any interface.
 
+## Canonical OC
+
+```json
+{
+  "openconfig-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "port1",
+        "config": {
+          "name": "port1",
+          "enabled": true
+        }
+      }
+    ]
+  },
+  "openconfig-lldp:lldp": {
+    "config": {
+      "enabled": true,
+      "system-description": "DUT"
+    },
+    "interfaces": {
+      "interface": [
+        {
+          "name": "port1",
+          "config": {
+            "name": "port1",
+            "enabled": true
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
 ## OpenConfig Path and RPC Coverage
 
 The below yaml defines the OC paths intended to be covered by this test.  OC paths used for test setup are not listed here.
@@ -33,11 +68,13 @@ paths:
   /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id:
   /lldp/interfaces/interface/neighbors/neighbor/state/chassis-id-type:
   /lldp/interfaces/interface/neighbors/neighbor/state/port-id:
+  /lldp/interfaces/interface/neighbors/neighbor/state/port-id-type:
   /lldp/interfaces/interface/neighbors/neighbor/state/system-name:
   /lldp/interfaces/interface/neighbors/neighbor/state/system-description:
   /lldp/interfaces/interface/state/name:
   /lldp/state/chassis-id:
   /lldp/state/chassis-id-type:
+  /lldp/state/system-description:
   /lldp/state/system-name:
 
 rpcs:


### PR DESCRIPTION
Fixes #5789.

* (M) feature/lldp/otg_tests/core_lldp_tlv_population_test/README.md
  - Add /lldp/interfaces/interface/neighbors/neighbor/state/port-id-type.
  - Add /lldp/state/system-description.
  - Add valid non-empty LLDP Canonical OC JSON.