### PR TITLE
Fix ACCTZ-1.1 and ACCTZ-2.1 fail gRPC auth regression

### DIFF
--- a/internal/security/acctz/acctz.go
+++ b/internal/security/acctz/acctz.go
@@ -1662,7 +1662,7 @@ func logExpectedFailGRPCError(t *testing.T, dut *ondatra.DUTDevice, err error, r
 		t.Logf("Got expected error %s with bad creds, error: %s", rpcDesc, err)
 		return
 	}
-	t.Logf("Did not get expected error %s with bad creds. %v", rpcDesc, err)
+	t.Errorf("Did not get expected error %s with bad creds. %v", rpcDesc, err)
 }
 
 func expectedAuthzStatus(dut *ondatra.DUTDevice, status acctzpb.AuthzDetail_AuthzStatus, rpcName string) acctzpb.AuthzDetail_AuthzStatus {

--- a/internal/security/acctz/acctz.go
+++ b/internal/security/acctz/acctz.go
@@ -741,7 +741,7 @@ func SendGnmiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 		failpass = failAuthorizePassword
 	} else {
 		failuser = FailAuthenticateUsername
-		failpass = failPassword
+		failpass = failAuthenticatePassword
 	}
 	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, failuser, passKey, failpass))
 	var gnmiClient gnmipb.GNMIClient
@@ -767,11 +767,7 @@ func SendGnmiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 	}
 	// Send an unsuccessful gNMI capabilities request (bad creds in context).
 	_, err1 := gnmiClient.Capabilities(ctx, &gnmipb.CapabilityRequest{})
-	if err1 != nil && status.Code(err1) == codes.PermissionDenied {
-		t.Logf("Got expected error fetching capabilities with no permissions, error: %s", err1)
-	} else {
-		t.Errorf("Did not get expected error fetching capabilities with no permissions. %v", err1)
-	}
+	logExpectedFailGRPCError(t, dut, err1, "fetching capabilities")
 
 	if !deviations.AcctzRecordFailGrpcUnsupported(dut) {
 		records = append(records, &acctzpb.RecordResponse{
@@ -874,7 +870,7 @@ func SendGnoiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 		failpass = failAuthorizePassword
 	} else {
 		failuser = FailAuthenticateUsername
-		failpass = failPassword
+		failpass = failAuthenticatePassword
 	}
 	var gnoiSystemClient systempb.SystemClient
 	ctx := context.Background()
@@ -902,11 +898,7 @@ func SendGnoiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 	if dut.Vendor() == ondatra.NOKIA {
 		rpcName = gnoiTimePath
 		_, err = gnoiSystemClient.Time(ctx, &systempb.TimeRequest{})
-		if err != nil && status.Code(err) == codes.PermissionDenied {
-			t.Logf("Got expected error getting gnoi system time with no permissions, error: %s", err)
-		} else {
-			t.Errorf("Did not get expected error getting gnoi system time with no permissions. error: %s", err)
-		}
+		logExpectedFailGRPCError(t, dut, err, "getting gnoi system time")
 	} else {
 		rpcName = gnoiPingPath
 		gnoiSystemPingClient, err1 := gnoiSystemClient.Ping(ctx, &systempb.PingRequest{
@@ -917,11 +909,7 @@ func SendGnoiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 			t.Errorf("Got unexpected error getting gnoi system ping client, error: %s", err1)
 		}
 		_, err = gnoiSystemPingClient.Recv()
-		if err != nil && status.Code(err) == codes.PermissionDenied {
-			t.Logf("Got expected error getting gnoi system ping with no permissions, error: %s", err)
-		} else {
-			t.Errorf("Did not get expected error getting gnoi system ping with no permissions. error: %s", err)
-		}
+		logExpectedFailGRPCError(t, dut, err, "getting gnoi system ping")
 	}
 
 	if !deviations.AcctzRecordFailGrpcUnsupported(dut) {
@@ -1037,7 +1025,7 @@ func SendGnsiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 		failpass = failAuthorizePassword
 	} else {
 		failuser = FailAuthenticateUsername
-		failpass = failPassword
+		failpass = failAuthenticatePassword
 	}
 	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, failuser, passKey, failpass))
 	var authzClient authzpb.AuthzClient
@@ -1060,11 +1048,7 @@ func SendGnsiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 	// Send an unsuccessful gNSI authz get request (bad creds in context), we don't
 	// care about receiving on it, just want to make the request.
 	_, err := authzClient.Get(ctx, &authzpb.GetRequest{})
-	if err != nil && status.Code(err) == codes.PermissionDenied {
-		t.Logf("Got expected error fetching authz policy with no permissions, error: %s", err)
-	} else {
-		t.Errorf("Did not get expected error fetching authz policy with no permissions. error: %s", err)
-	}
+	logExpectedFailGRPCError(t, dut, err, "fetching authz policy")
 	if !deviations.AcctzRecordFailGrpcUnsupported(dut) {
 		records = append(records, &acctzpb.RecordResponse{
 			ServiceRequest: &acctzpb.RecordResponse_GrpcService{
@@ -1159,7 +1143,7 @@ func SendGribiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespon
 		failpass = failAuthorizePassword
 	} else {
 		failuser = FailAuthenticateUsername
-		failpass = failPassword
+		failpass = failAuthenticatePassword
 	}
 	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, failuser, passKey, failpass))
 
@@ -1181,11 +1165,7 @@ func SendGribiRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespon
 		t.Fatalf("Got unexpected error during gribi get request, error: %s", err)
 	}
 	_, err = gribiGetClient.Recv()
-	if err != nil && status.Code(err) == codes.PermissionDenied {
-		t.Logf("Got expected error during gribi recv request with no permissions, error: %s", err)
-	} else {
-		t.Errorf("Did not get expected error during gribi recv request with no permissions. error: %s", err)
-	}
+	logExpectedFailGRPCError(t, dut, err, "during gribi recv request")
 
 	records = append(records, &acctzpb.RecordResponse{
 		ServiceRequest: &acctzpb.RecordResponse_GrpcService{
@@ -1321,7 +1301,7 @@ func SendP4rtRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 		failpass = failAuthorizePassword
 	} else {
 		failuser = FailAuthenticateUsername
-		failpass = failPassword
+		failpass = failAuthenticatePassword
 	}
 	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(userKey, failuser, passKey, failpass))
 
@@ -1330,11 +1310,7 @@ func SendP4rtRPCs(t *testing.T, dut *ondatra.DUTDevice) []*acctzpb.RecordRespons
 		t.Fatalf("Got unexpected error during p4rt get request, error: %s", err)
 	}
 	_, err = p4rtclient.Capabilities(ctx, &p4pb.CapabilitiesRequest{})
-	if err != nil && status.Code(err) == codes.PermissionDenied {
-		t.Logf("Got expected error getting p4rt capabilities with no permissions, error: %s", err)
-	} else {
-		t.Errorf("Did not get expected error fetching pr4t capabilities with no permissions, error: %s", err)
-	}
+	logExpectedFailGRPCError(t, dut, err, "getting p4rt capabilities")
 	if !deviations.AcctzRecordFailGrpcUnsupported(dut) {
 		records = append(records, &acctzpb.RecordResponse{
 			ServiceRequest: &acctzpb.RecordResponse_GrpcService{
@@ -1670,6 +1646,23 @@ func SendShellCommand(t *testing.T, dut *ondatra.DUTDevice, staticBinding bool) 
 	})
 
 	return records
+}
+
+func logExpectedFailGRPCError(t *testing.T, dut *ondatra.DUTDevice, err error, rpcDesc string) {
+	t.Helper()
+	if dut.Vendor() == ondatra.ARISTA {
+		if err != nil && status.Code(err) == codes.PermissionDenied {
+			t.Logf("Got expected error %s with no permissions, error: %s", rpcDesc, err)
+			return
+		}
+		t.Errorf("Did not get expected error %s with no permissions. %v", rpcDesc, err)
+		return
+	}
+	if err != nil {
+		t.Logf("Got expected error %s with bad creds, error: %s", rpcDesc, err)
+		return
+	}
+	t.Logf("Did not get expected error %s with bad creds. %v", rpcDesc, err)
 }
 
 func expectedAuthzStatus(dut *ondatra.DUTDevice, status acctzpb.AuthzDetail_AuthzStatus, rpcName string) acctzpb.AuthzDetail_AuthzStatus {


### PR DESCRIPTION
## Summary

Fixes ACCTZ-1.1 (`record_subscribe_full`) and ACCTZ-2.1 (`record_subscribe_partial`) failures on Cisco IOS-XR caused by a regression in fail gRPC RPC handling.

PR #5309 changed fail gRPC calls to use `failPassword` (`"baggins"`), which is the same password Credentialz configures on the DUT for user `bilbo`. As a result, fail RPCs authenticated successfully and acctz recorded `AUTHZ_STATUS_PERMIT` instead of the expected `AUTHZ_STATUS_DENY`.

This change restores the prior behavior:

- Use `failAuthenticatePassword` (`"bagginsTest123!"`) for fail gRPC RPCs on non-Arista platforms so authentication fails as intended.
- Add `logExpectedFailGRPCError()` for vendor-specific error validation:
  - **Arista:** expect `codes.PermissionDenied` (authorization deny via `failauthuser`)
  - **Cisco and others:** accept any RPC error from bad credentials (e.g. `Unauthenticated`)

## Root cause

| | Before #5309 (pass) | After #5309 (fail) |
|---|---|---|
| Fail gRPC password | `"bagginsTest123!"` | `"baggins"` (matches DUT) |
| RPC result | `Unauthenticated` | RPC succeeds |
| Acctz authz status | `DENY` | `PERMIT` |
