### PR TITLE
Stabilizing Traffic Validation functions

### DIFF
--- a/feature/gnmi/otg_tests/aggregate_interface_counters_test/aggregate_interface_counters_test.go
+++ b/feature/gnmi/otg_tests/aggregate_interface_counters_test/aggregate_interface_counters_test.go
@@ -386,6 +386,10 @@ func (tc *testCase) verifyATE(t *testing.T) {
 	t.Logf("Checking if LAG is up on OTG")
 	gnmi.Await(t, tc.ate.OTG(), gnmi.OTG().Lag(ateDst.Name).OperStatus().State(), time.Minute, otgtelemetry.Lag_OperStatus_UP)
 
+	// Ensure ARP and NDP resolve so that initial packet counters (in/out pkts) are non-zero and exported by the NOS.
+	otgutils.WaitForARP(t, tc.ate.OTG(), tc.top, "IPv4")
+	otgutils.WaitForARP(t, tc.ate.OTG(), tc.top, "IPv6")
+
 	otgutils.LogLAGMetrics(t, tc.ate.OTG(), tc.top)
 	if tc.lagType == oc.IfAggregate_AggregationType_LACP {
 		otgutils.LogLACPMetrics(t, tc.ate.OTG(), tc.top)

--- a/feature/gribi/otg_tests/gribi_route_test/gribi_route_test.go
+++ b/feature/gribi/otg_tests/gribi_route_test/gribi_route_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"strconv"
 	"testing"
@@ -173,6 +174,18 @@ func TestGRIBIFailover(t *testing.T) {
 	top := configureOTG(t, ate)
 	t.Log("Configure VRF_Policy")
 	configureVrfSelectionPolicyC(t, dut)
+
+	otgutils.WaitForARP(t, ate.OTG(), top, "IPv4")
+	verifyBgpTelemetry(t, dut)
+
+	llAddress, found := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Interface("port1.Eth").Ipv4Neighbor(dutPort1.IPv4).LinkLayerAddress().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
+		return val.IsPresent()
+	}).Await(t)
+	if !found {
+		t.Fatalf("Could not get the LinkLayerAddress %s", llAddress)
+	}
+	dstMac, _ := llAddress.Val()
+
 	t.Log("Configure GRIBI")
 
 	ctx := context.Background()
@@ -194,16 +207,6 @@ func TestGRIBIFailover(t *testing.T) {
 	}
 
 	configureGribiRoute(t, dut, tcArgs)
-
-	llAddress, found := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Interface("port1.Eth").Ipv4Neighbor(dutPort1.IPv4).LinkLayerAddress().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
-		return val.IsPresent()
-	}).Await(t)
-	if !found {
-		t.Fatalf("Could not get the LinkLayerAddress %s", llAddress)
-	}
-	dstMac, _ := llAddress.Val()
-
-	verifyBgpTelemetry(t, dut)
 
 	args := &testArgs{
 		dut:       dut,
@@ -379,7 +382,6 @@ func configNonDefaultNetworkInstance(t *testing.T, dut *ondatra.DUTDevice) {
 func configureVrfSelectionPolicyC(t *testing.T, dut *ondatra.DUTDevice) {
 	t.Helper()
 	d := &oc.Root{}
-	time.Sleep(100 * time.Second)
 	dutPolFwdPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding()
 
 	pfRule1 := &policyFwRule{SeqID: 1, family: "ipv4", protocol: 4, sourceAddr: ipv4OuterSrc111WithMask,
@@ -605,12 +607,47 @@ func sendTraffic(t *testing.T, args *testArgs, top gosnappi.Config, ate *ondatra
 	otgutils.LogPortMetrics(t, ate.OTG(), top)
 }
 
-// verifyTrafficFlow verify the each flow on ATE
+// verifyTrafficFlow verifies each flow on ATE using gnmi.Watch.
 func verifyTrafficFlow(t *testing.T, ate *ondatra.ATEDevice, flow gosnappi.Flow) bool {
-	rxPkts := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().InPkts().State())
-	txPkts := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State())
-	lostPkt := txPkts - rxPkts
-	if got := (lostPkt * 100 / txPkts); got >= tolerancePct {
+	t.Helper()
+	otg := ate.OTG()
+	flowName := flow.Name()
+
+	outPktsQuery := gnmi.OTG().Flow(flowName).Counters().OutPkts().State()
+	inPktsQuery := gnmi.OTG().Flow(flowName).Counters().InPkts().State()
+
+	// Watch InPkts and live OutPkts for up to 45 seconds until counters settle within +/- tolerance.
+	_, ok := gnmi.Watch(t, otg, inPktsQuery, 45*time.Second, func(v *ygnmi.Value[uint64]) bool {
+		rx, present := v.Val()
+		if !present {
+			return false
+		}
+
+		txVal, txPresent := gnmi.Lookup(t, otg, outPktsQuery).Val()
+		if !txPresent || txVal == 0 {
+			return false // Keep waiting if tx hasn't populated or is 0
+		}
+
+		// Calculate percentage difference.
+		// Using float64 protects against uint64 underflow and handles rx > tx.
+		diffPct := (float64(txVal) - float64(rx)) * 100 / float64(txVal)
+
+		// math.Abs ensures we check +/- tolerance limits equally
+		return math.Abs(diffPct) <= float64(tolerancePct)
+	}).Await(t)
+
+	if !ok {
+		// Fetch absolute final values after the 45s timeout
+		lastTx, _ := gnmi.Lookup(t, otg, outPktsQuery).Val()
+		lastRx, _ := gnmi.Lookup(t, otg, inPktsQuery).Val()
+
+		if lastTx == 0 {
+			t.Errorf("IXIA traffic generation failed: flow %s transmitted 0 packets after 45s", flowName)
+			return false
+		}
+
+		diffPct := (float64(lastTx) - float64(lastRx)) * 100 / float64(lastTx)
+		t.Errorf("Generic Test Assertion Failure: Flow %s counters outside of ±%d%% tolerance. Difference: %.2f%% (tx: %d, rx: %d)", flowName, tolerancePct, diffPct, lastTx, lastRx)
 		return false
 	}
 	return true
@@ -668,7 +705,6 @@ func captureAndValidatePackets(t *testing.T, args *testArgs, packetVal *packetVa
 	}
 	args.otgConfig.Captures().Clear()
 	args.otg.PushConfig(t, args.otgConfig)
-	time.Sleep(30 * time.Second)
 }
 
 func validateTrafficDecap(t *testing.T, packetSource *gopacket.PacketSource) {

--- a/feature/gribi/otg_tests/gribi_route_test/gribi_route_test.go
+++ b/feature/gribi/otg_tests/gribi_route_test/gribi_route_test.go
@@ -175,7 +175,6 @@ func TestGRIBIFailover(t *testing.T) {
 	t.Log("Configure VRF_Policy")
 	configureVrfSelectionPolicyC(t, dut)
 
-	otgutils.WaitForARP(t, ate.OTG(), top, "IPv4")
 	verifyBgpTelemetry(t, dut)
 
 	llAddress, found := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Interface("port1.Eth").Ipv4Neighbor(dutPort1.IPv4).LinkLayerAddress().State(), time.Minute, func(val *ygnmi.Value[string]) bool {

--- a/feature/isis/otg_tests/static_route_isis_redistribution/static_route_isis_redistribution_test.go
+++ b/feature/isis/otg_tests/static_route_isis_redistribution/static_route_isis_redistribution_test.go
@@ -421,7 +421,7 @@ func verifyPrefix(t *testing.T, ts *isissession.TestSession, shouldBePresent boo
 func verifyV6Prefix(t *testing.T, ts *isissession.TestSession, shouldBePresent bool) {
 
 	t.Run("Verify Route on OTG", func(t *testing.T) {
-		_, ok := gnmi.WatchAll(t, ts.ATE.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(v6Route).State(), 30*time.Second, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_Ipv6Reachability_Prefix]) bool {
+		_, ok := gnmi.WatchAll(t, ts.ATE.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(v6Route).State(), time.Minute, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_Ipv6Reachability_Prefix]) bool {
 			prefix, present := v.Val()
 			return present && prefix.GetPrefix() == v6Route
 		}).Await(t)
@@ -440,7 +440,7 @@ func verifyV6Prefix(t *testing.T, ts *isissession.TestSession, shouldBePresent b
 func verifyPrefixMetric(t *testing.T, ts *isissession.TestSession, expectedMetric uint32) {
 
 	t.Run("Verify Route Metric on OTG", func(t *testing.T) {
-		_, ok := gnmi.WatchAll(t, ts.ATE.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().ExtendedIpv4Reachability().Prefix(v4Route).Metric().State(), 30*time.Second, func(v *ygnmi.Value[uint32]) bool {
+		_, ok := gnmi.WatchAll(t, ts.ATE.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().ExtendedIpv4Reachability().Prefix(v4Route).Metric().State(), time.Minute, func(v *ygnmi.Value[uint32]) bool {
 			if !v.IsPresent() {
 				return false
 			}
@@ -459,7 +459,7 @@ func verifyPrefixMetric(t *testing.T, ts *isissession.TestSession, expectedMetri
 func verifyV6PrefixMetric(t *testing.T, ts *isissession.TestSession, expectedMetric uint32) {
 
 	t.Run("Verify Route Metric on OTG", func(t *testing.T) {
-		_, ok := gnmi.WatchAll(t, ts.ATE.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(v6Route).Metric().State(), 30*time.Second, func(v *ygnmi.Value[uint32]) bool {
+		_, ok := gnmi.WatchAll(t, ts.ATE.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(v6Route).Metric().State(), time.Minute, func(v *ygnmi.Value[uint32]) bool {
 			if !v.IsPresent() {
 				return false
 			}
@@ -737,7 +737,7 @@ func TestStaticToISISRedistribution(t *testing.T) {
 					ts.ATE.OTG().StopTraffic(t)
 
 					for _, flow := range tc.trafficFlows {
-						loss := otgutils.GetFlowLossPct(t, ts.ATE.OTG(), flow, 20*time.Second)
+						loss := otgutils.GetFlowLossPct(t, ts.ATE.OTG(), flow, 45*time.Second)
 						if loss > lossTolerance {
 							t.Errorf("Traffic loss too high for flow %s", flow)
 						} else {

--- a/feature/mpls/sr/otg_tests/isis_node_sid_forward/isis_node_sid_forward_test.go
+++ b/feature/mpls/sr/otg_tests/isis_node_sid_forward/isis_node_sid_forward_test.go
@@ -234,8 +234,8 @@ func awaitTrafficCounters(t *testing.T, ate *ondatra.ATEDevice, flowName string,
 func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice) {
 
 	// Await until counter values are stabilized
-	awaitTrafficCounters(t, ate, v4FlowName, fixedPackets, time.Second*15)
-	awaitTrafficCounters(t, ate, v6FlowName, fixedPackets, time.Second*15)
+	awaitTrafficCounters(t, ate, v4FlowName, fixedPackets, time.Second*45)
+	awaitTrafficCounters(t, ate, v6FlowName, fixedPackets, time.Second*45)
 
 	recvMetricV4 := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(v4FlowName).State())
 	recvMetricV6 := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(v6FlowName).State())

--- a/feature/staticroute/tests/static_route_test/static_route_test.go
+++ b/feature/staticroute/tests/static_route_test/static_route_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
 	"github.com/openconfig/ondatra/otg"
+	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )
 

--- a/feature/staticroute/tests/static_route_test/static_route_test.go
+++ b/feature/staticroute/tests/static_route_test/static_route_test.go
@@ -214,53 +214,49 @@ func createTrafficFlows(t *testing.T,
 }
 
 // Send traffic and validate traffic.
-func verifyTrafficStreams(t *testing.T,
-	ate *ondatra.ATEDevice,
-	top gosnappi.Config,
-	otg *otg.OTG,
-	trafficFlows ...gosnappi.Flow) {
+func verifyTrafficStreams(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config, otg *otg.OTG, trafficFlows ...gosnappi.Flow) {
 	t.Helper()
 
 	t.Log("Starting traffic for 30 seconds")
 	ate.OTG().StartTraffic(t)
-	time.Sleep(30 * time.Second) // Traffic transmission period
+	time.Sleep(30 * time.Second)
 
 	t.Log("Stopping traffic and waiting for traffic stats to settle")
 	ate.OTG().StopTraffic(t)
 
-	// Loop through each flow to validate packets using Watch instead of static sleep
+	// Loop through each flow to validate packets
 	for _, flow := range trafficFlows {
 		flowName := flow.Name()
 		inPktsQuery := gnmi.OTG().Flow(flowName).Counters().InPkts().State()
 		outPktsQuery := gnmi.OTG().Flow(flowName).Counters().OutPkts().State()
 
-		// Watch for up to 15 seconds for the counters to sync and fall within tolerance
-		_, watchOk := gnmi.Watch(t, otg, inPktsQuery, 15*time.Second, func(v *ygnmi.Value[uint64]) bool {
+		// Fetch TX packets once since traffic is stopped and this value is static
+		txPkts := float32(gnmi.Get(t, otg, outPktsQuery))
+
+		// Fail fast if no traffic was sent, saving a 15-second timeout wait
+		if txPkts == 0 {
+			t.Errorf("Flow %s reported 0 transmitted packets. Traffic generation failed.", flowName)
+			continue 
+		}
+
+		// Calculate bounds once before entering the watch loop
+		lowerBound := txPkts * (1 - tolerance)
+		upperBound := txPkts * (1 + tolerance)
+
+		// Watch for up to 45 seconds for the counters to sync and fall within tolerance
+		_, watchOk := gnmi.Watch(t, otg, inPktsQuery, 45*time.Second, func(v *ygnmi.Value[uint64]) bool {
 			rx, present := v.Val()
 			if !present {
 				return false
 			}
 
-			tx := gnmi.Get(t, otg, outPktsQuery)
-			if tx == 0 {
-				return false
-			}
-
 			rxPkts := float32(rx)
-			txPkts := float32(tx)
-
-			lowerBound := txPkts * (1 - tolerance)
-			upperBound := txPkts * (1 + tolerance)
-
 			// Return true to exit Watch loop as soon as it's within tolerance
 			return rxPkts >= lowerBound && rxPkts <= upperBound
 		}).Await(t)
 
-		// Fetch final values for logging/error reporting
-		txPkts := float32(gnmi.Get(t, otg, outPktsQuery))
+		// Fetch final RX value for logging/error reporting
 		rxPkts := float32(gnmi.Get(t, otg, inPktsQuery))
-		lowerBound := txPkts * (1 - tolerance)
-		upperBound := txPkts * (1 + tolerance)
 
 		if !watchOk || rxPkts < lowerBound || rxPkts > upperBound {
 			t.Errorf("Received packets for flow %s are outside of the acceptable range: %v (1%% tolerance from %v)", flowName, rxPkts, txPkts)
@@ -268,6 +264,7 @@ func verifyTrafficStreams(t *testing.T,
 			t.Logf("Received packets for flow %s are within the acceptable range: %v (1%% tolerance from %v)", flowName, rxPkts, txPkts)
 		}
 	}
+
 	otgutils.LogFlowMetrics(t, ate.OTG(), top)
 }
 

--- a/feature/staticroute/tests/static_route_test/static_route_test.go
+++ b/feature/staticroute/tests/static_route_test/static_route_test.go
@@ -223,29 +223,52 @@ func verifyTrafficStreams(t *testing.T,
 
 	t.Log("Starting traffic for 30 seconds")
 	ate.OTG().StartTraffic(t)
-	time.Sleep(30 * time.Second)
-	t.Log("Stopping traffic and waiting 10 seconds for traffic stats to complete")
+	time.Sleep(30 * time.Second) // Traffic transmission period
+
+	t.Log("Stopping traffic and waiting for traffic stats to settle")
 	ate.OTG().StopTraffic(t)
-	time.Sleep(10 * time.Second)
 
-	otgutils.LogFlowMetrics(t, ate.OTG(), top)
-
-	// Loop through each flow to validate packets
+	// Loop through each flow to validate packets using Watch instead of static sleep
 	for _, flow := range trafficFlows {
 		flowName := flow.Name()
-		txPkts := float32(gnmi.Get(t, otg, gnmi.OTG().Flow(flowName).Counters().OutPkts().State()))
-		rxPkts := float32(gnmi.Get(t, otg, gnmi.OTG().Flow(flowName).Counters().InPkts().State()))
+		inPktsQuery := gnmi.OTG().Flow(flowName).Counters().InPkts().State()
+		outPktsQuery := gnmi.OTG().Flow(flowName).Counters().OutPkts().State()
 
-		// Calculate the acceptable lower and upper bounds for rxPkts
+		// Watch for up to 15 seconds for the counters to sync and fall within tolerance
+		_, watchOk := gnmi.Watch(t, otg, inPktsQuery, 15*time.Second, func(v *ygnmi.Value[uint64]) bool {
+			rx, present := v.Val()
+			if !present {
+				return false
+			}
+
+			tx := gnmi.Get(t, otg, outPktsQuery)
+			if tx == 0 {
+				return false
+			}
+
+			rxPkts := float32(rx)
+			txPkts := float32(tx)
+
+			lowerBound := txPkts * (1 - tolerance)
+			upperBound := txPkts * (1 + tolerance)
+
+			// Return true to exit Watch loop as soon as it's within tolerance
+			return rxPkts >= lowerBound && rxPkts <= upperBound
+		}).Await(t)
+
+		// Fetch final values for logging/error reporting
+		txPkts := float32(gnmi.Get(t, otg, outPktsQuery))
+		rxPkts := float32(gnmi.Get(t, otg, inPktsQuery))
 		lowerBound := txPkts * (1 - tolerance)
 		upperBound := txPkts * (1 + tolerance)
 
-		if rxPkts < lowerBound || rxPkts > upperBound {
+		if !watchOk || rxPkts < lowerBound || rxPkts > upperBound {
 			t.Errorf("Received packets for flow %s are outside of the acceptable range: %v (1%% tolerance from %v)", flowName, rxPkts, txPkts)
 		} else {
 			t.Logf("Received packets for flow %s are within the acceptable range: %v (1%% tolerance from %v)", flowName, rxPkts, txPkts)
 		}
 	}
+	otgutils.LogFlowMetrics(t, ate.OTG(), top)
 }
 
 func configureStaticRoute(t *testing.T, dut *ondatra.DUTDevice) {

--- a/feature/staticroute/tests/static_route_test/static_route_test.go
+++ b/feature/staticroute/tests/static_route_test/static_route_test.go
@@ -233,12 +233,6 @@ func verifyTrafficStreams(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Con
 		// Fetch TX packets once since traffic is stopped and this value is static
 		txPkts := float32(gnmi.Get(t, otg, outPktsQuery))
 
-		// Fail fast if no traffic was sent, saving a 15-second timeout wait
-		if txPkts == 0 {
-			t.Errorf("Flow %s reported 0 transmitted packets. Traffic generation failed.", flowName)
-			continue 
-		}
-
 		// Calculate bounds once before entering the watch loop
 		lowerBound := txPkts * (1 - tolerance)
 		upperBound := txPkts * (1 + tolerance)
@@ -250,8 +244,13 @@ func verifyTrafficStreams(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Con
 				return false
 			}
 
+			// Prevent the test from passing if both TX and RX are 0
+			if txPkts == 0 {
+				return false
+			}
+
 			rxPkts := float32(rx)
-			// Return true to exit Watch loop as soon as it's within tolerance
+			// Return true to exit Watch loop as soon as it's within +/- tolerance limits
 			return rxPkts >= lowerBound && rxPkts <= upperBound
 		}).Await(t)
 
@@ -259,9 +258,13 @@ func verifyTrafficStreams(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Con
 		rxPkts := float32(gnmi.Get(t, otg, inPktsQuery))
 
 		if !watchOk || rxPkts < lowerBound || rxPkts > upperBound {
-			t.Errorf("Received packets for flow %s are outside of the acceptable range: %v (1%% tolerance from %v)", flowName, rxPkts, txPkts)
+			if txPkts == 0 {
+				t.Errorf("IXIA traffic generation failed: flow %s transmitted 0 packets after 45s", flowName)
+			} else {
+				t.Errorf("Generic Test Assertion Failure: Received packets for flow %s are outside of the acceptable range: %v (± tolerance from %v)", flowName, rxPkts, txPkts)
+			}
 		} else {
-			t.Logf("Received packets for flow %s are within the acceptable range: %v (1%% tolerance from %v)", flowName, rxPkts, txPkts)
+			t.Logf("Received packets for flow %s are within the acceptable range: %v (± tolerance from %v)", flowName, rxPkts, txPkts)
 		}
 	}
 


### PR DESCRIPTION
1. RT-1.25 - Removed unnecessary sleep and added gnmi.Watch with Await for querying counter values. 
2. SR-1.1 - Increase await time from 15s to 45s.
3. RT-2.12 - Increase await times. 
4. RT-14.2 - Removed unnecessary sleep and added gnmi.Watch with Await for querying counter values. 
5. gNMI-1.23 - Ensure ARP and NDP resolve so that initial packet counters (in/out pkts) are non-zero.