### PR TITLE
containerztest: remove container during cleanup after stop

### DIFF
--- a/internal/containerztest/containerztest.go
+++ b/internal/containerztest/containerztest.go
@@ -242,8 +242,7 @@ func Stop(ctx context.Context, t *testing.T, cli *client.Client, instNameToStop 
 	t.Helper()
 	t.Logf("Attempting to stop container %s", instNameToStop)
 	if err := cli.StopContainer(ctx, instNameToStop, true); err != nil {
-		s, _ := status.FromError(err)
-		if s.Code() == codes.NotFound {
+		if status.Code(err) == codes.NotFound {
 			t.Logf("StopContainer: Container %s not found (may have already been stopped and removed): %v", instNameToStop, err)
 		} else {
 			t.Logf("StopContainer for %s encountered an issue: %v", instNameToStop, err)
@@ -254,8 +253,7 @@ func Stop(ctx context.Context, t *testing.T, cli *client.Client, instNameToStop 
 
 	t.Logf("Attempting to remove container %s", instNameToStop)
 	if err := cli.RemoveContainer(ctx, instNameToStop, true); err != nil {
-		s, _ := status.FromError(err)
-		if s.Code() == codes.NotFound {
+		if status.Code(err) == codes.NotFound {
 			t.Logf("RemoveContainer: Container %s not found (may have already been removed): %v", instNameToStop, err)
 		} else {
 			t.Logf("RemoveContainer for %s encountered an issue: %v", instNameToStop, err)

--- a/internal/containerztest/containerztest.go
+++ b/internal/containerztest/containerztest.go
@@ -251,6 +251,18 @@ func Stop(ctx context.Context, t *testing.T, cli *client.Client, instNameToStop 
 	} else {
 		t.Logf("Container %s stopped successfully.", instNameToStop)
 	}
+
+	t.Logf("Attempting to remove container %s", instNameToStop)
+	if err := cli.RemoveContainer(ctx, instNameToStop, true); err != nil {
+		s, _ := status.FromError(err)
+		if s.Code() == codes.NotFound {
+			t.Logf("RemoveContainer: Container %s not found (may have already been removed): %v", instNameToStop, err)
+		} else {
+			t.Logf("RemoveContainer for %s encountered an issue: %v", instNameToStop, err)
+		}
+	} else {
+		t.Logf("Container %s removed successfully.", instNameToStop)
+	}
 }
 
 // WaitForRunning polls until a container instance is in the RUNNING state.


### PR DESCRIPTION
**Summary**

- Fixes cleanup behavior in container helper teardown.
- internal/containerztest/containerztest.go Stop() previously stopped containers but did not remove them.
**Problem**

- Residual container instances (for example cntr-test-conn created in cntr_test.go) could remain after tests.
- This can cause cross-test interference such as container name/port conflicts in subsequent runs.
**Change**

- In internal/containerztest/containerztest.go, update Stop() to call RemoveContainer(ctx, instNameToStop, true) after StopContainer(...).
- Handle NotFound gracefully to keep cleanup idempotent.

**Impact**

- Applies to tests using containerztest.Setup() cleanup path (including container connectivity and lifecycle tests).
- Improves teardown correctness and reduces stale-resource failures.