### PR TITLE
gNMI-1.18: Fix Arista IC pattern to exclude FAP core sub-components

### DIFF
--- a/feature/platform/fabric/otg_tests/sampled_backplane_capacity_counters_test/sampled_backplane_capacity_counters_test.go
+++ b/feature/platform/fabric/otg_tests/sampled_backplane_capacity_counters_test/sampled_backplane_capacity_counters_test.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	icPattern = map[ondatra.Vendor]string{
-		ondatra.ARISTA:  "^SwitchChip",
+		ondatra.ARISTA:  `^SwitchChip\d+/\d+$`,
 		ondatra.CISCO:   "^[0-9]/[0-9]/CPU[0-9]-NPU[0-9]",
 		ondatra.JUNIPER: "NPU[0-9]$",
 		ondatra.NOKIA:   "^SwitchChip",


### PR DESCRIPTION
The Arista icPattern regex ^SwitchChip matches both parent FAP components (SwitchChip3/0) and core sub-components (SwitchChip3/0.0). Core sub-components do not support backplane-facing-capacity telemetry because fabric bandwidth is a per-FAP property, not per-core. Tighten the regex to ^SwitchChip\d+/\d+$ to match only parent FAPs.

This is taking over #5673