### PR TITLE
Certz script fixes

### DIFF
--- a/feature/gnsi/certz/test_data/client_cert_ext.cnf
+++ b/feature/gnsi/certz/test_data/client_cert_ext.cnf
@@ -4,5 +4,5 @@ nsComment = "Test Client Certificates - openconfig / featureprofiles"
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer
 keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
-extendedKeyUsage = clientAuth, emailProtection
+extendedKeyUsage = clientAuth, serverAuth, emailProtection
 subjectAltName=DNS:thing.place.client.example.com,URI:spiffe://teamname.groupname.location.place.example.com/role/servicename

--- a/feature/gnsi/certz/test_data/mk_cas.sh
+++ b/feature/gnsi/certz/test_data/mk_cas.sh
@@ -6,9 +6,9 @@
 # The list of directories of CA contents, also the count of CAs built
 # in each directory.
 DEFAULT_DIRS=(01 02 10 1000 20000)
-if [ -n "$1" ]; then
-  echo "Using provided DIRS: $1"
-  IFS=',' read -r -a DIRS <<< "$1"
+if [ -n "$2" ]; then
+  echo "Using provided DIRS: $2"
+  IFS=',' read -r -a DIRS <<< "$2"
 else
   echo "Using default DIRS: ${DEFAULT_DIRS[*]}"
   DIRS=("${DEFAULT_DIRS[@]}")

--- a/feature/gnsi/certz/tests/baseline/certz_baseline_test.go
+++ b/feature/gnsi/certz/tests/baseline/certz_baseline_test.go
@@ -21,10 +21,8 @@ func TestMain(m *testing.M) {
 }
 
 const (
-	dirPath                   = "../../test_data/"
-	timeOutVar  time.Duration = 2 * time.Minute
-	testProfile               = "test-profile"
-	rpcTimeout                = 2 * time.Minute
+	testProfile = "test-profile"
+	rpcTimeout  = 2 * time.Minute
 )
 
 var (
@@ -67,12 +65,6 @@ func TestCertzBaseline(t *testing.T) {
 		t.Fatalf("STATUS:Failed to get DUT credentials using binding.DUTs: %v. The binding for %s must implement the DUTCredentialer interface.", err, dut.Name())
 	}
 
-	//Generate testdata certificates
-	t.Logf("STATUS:Generation of test data certificates.")
-	if err := setupService.TestdataMakeCleanup(t, dirPath, timeOutVar, "./mk_cas.sh"); err != nil {
-		t.Fatalf("STATUS:Generation of testdata certificates failed!: %v", err)
-	}
-
 	type testCase struct {
 		Name        string
 		Description string
@@ -108,11 +100,6 @@ func TestCertzBaseline(t *testing.T) {
 		})
 	}
 
-	t.Logf("STATUS:Cleanup of test data.")
-	//Cleanup of test data
-	if err := setupService.TestdataMakeCleanup(t, dirPath, timeOutVar, "./mk_cas.sh"); err != nil {
-		t.Logf("STATUS:Generation of testdata certificates failed!: %v", err)
-	}
 	t.Logf("STATUS:Test completed!")
 }
 
@@ -184,5 +171,5 @@ func getTLSProfile(t *testing.T, dut *ondatra.DUTDevice) {
 
 // Implementation for validating that appropriate metrics are returned from streaming telemetry
 func validateMetricsTest(t *testing.T, dut *ondatra.DUTDevice) {
-	t.Errorf("raised issue 489348277")
+	t.Skip("raised issue 489348277")
 }

--- a/feature/gnsi/certz/tests/internal/setup_service/setup_service.go
+++ b/feature/gnsi/certz/tests/internal/setup_service/setup_service.go
@@ -517,6 +517,10 @@ func ValidateGnoiPingRequest(ctx context.Context, t *testing.T, sysClient spb.Sy
 	t.Logf("Verifying gNOI Ping Request.")
 	pingClient, err := sysClient.Ping(ctx, &spb.PingRequest{Destination: "127.0.0.1", Count: 1})
 	if err != nil {
+		if mismatch {
+			t.Logf("Expected connection failure for certificate mismatch: %v", err)
+			return true
+		}
 		t.Fatalf("Unable to connect gnoiClient %v", err)
 	}
 	_, err = pingClient.Recv()
@@ -659,6 +663,10 @@ func ValidateGribiGetRequest(ctx context.Context, t *testing.T, gRibiClient grib
 		Aft:             gribipb.AFTType_IPV4,
 	})
 	if err != nil {
+		if mismatch {
+			t.Logf("Expected connection failure for certificate mismatch: %v", err)
+			return true
+		}
 		t.Fatalf("Failed to connect GribiClient with error:%v.", err)
 	}
 	_, err = getClient.Recv()

--- a/feature/gnsi/certz/tests/internal/setup_service/setup_service.go
+++ b/feature/gnsi/certz/tests/internal/setup_service/setup_service.go
@@ -22,7 +22,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"sync"
@@ -248,7 +250,7 @@ func CertzRotate(ctx context.Context, t *testing.T, newcaCert *x509.CertPool, ce
 	uploadRequest := &certzpb.UploadRequest{Entities: entities}
 	rotateRequest := &certzpb.RotateCertificateRequest_Certificates{Certificates: uploadRequest}
 	rotateCertRequest := &certzpb.RotateCertificateRequest{
-		ForceOverwrite: false,
+		ForceOverwrite: true,
 		SslProfileId:   profileID,
 		RotateRequest:  rotateRequest,
 	}
@@ -441,12 +443,21 @@ func ValidateGnsiAuthzGetRequest(ctx context.Context, t *testing.T, authzClient 
 	t.Logf("Verifying gNSI Authz GetRequest.")
 	rsp, err := authzClient.Get(ctx, &authzpb.GetRequest{})
 	if err != nil {
+		if mismatch {
+			t.Logf("Expected connection failure for certificate mismatch: %v", err)
+			return true
+		}
 		statusError, _ := status.FromError(err)
 		if statusError.Code() == codes.FailedPrecondition {
 			t.Logf("Expected error FAILED_PRECONDITION seen for authz Get Request with err:%v.", err)
 		} else {
 			t.Errorf("Unexpected error during authz Get Request with err:%v.", err)
+			return false
 		}
+	}
+	if mismatch {
+		t.Errorf("Expected connection failure for certificate mismatch, but RPC succeeded")
+		return false
 	}
 	t.Logf("gNSI authz get response is %s", rsp)
 	return true
@@ -495,7 +506,7 @@ func VerifyGnoi(t *testing.T, caCert *x509.CertPool, san, serverAddr, username, 
 	}
 	defer conn.Close()
 	sysClient := spb.NewSystemClient(conn)
-	result := ValidateGnoiPingRequest(ctx, t, sysClient, false)
+	result := ValidateGnoiPingRequest(ctx, t, sysClient, mismatch)
 	conn.Close()
 	return result
 }
@@ -504,8 +515,22 @@ func VerifyGnoi(t *testing.T, caCert *x509.CertPool, san, serverAddr, username, 
 func ValidateGnoiPingRequest(ctx context.Context, t *testing.T, sysClient spb.SystemClient, mismatch bool) bool {
 
 	t.Logf("Verifying gNOI Ping Request.")
-	if _, err := sysClient.Ping(ctx, &spb.PingRequest{}); err != nil {
+	pingClient, err := sysClient.Ping(ctx, &spb.PingRequest{Destination: "127.0.0.1", Count: 1})
+	if err != nil {
 		t.Fatalf("Unable to connect gnoiClient %v", err)
+	}
+	_, err = pingClient.Recv()
+	if err != nil {
+		if mismatch {
+			t.Logf("Expected connection failure for certificate mismatch: %v", err)
+			return true
+		}
+		t.Errorf("gNOI Ping request failed with err: %v", err)
+		return false
+	}
+	if mismatch {
+		t.Errorf("Expected connection failure for certificate mismatch, but RPC succeeded")
+		return false
 	}
 	return true
 }
@@ -563,7 +588,16 @@ func ValidateGnmiCapabilityRequest(ctx context.Context, t *testing.T, gnmiClient
 	t.Logf("Verifying gNMI Capability Request.")
 	response, err := gnmiClient.Capabilities(ctx, &gnmipb.CapabilityRequest{})
 	if err != nil {
-		t.Fatalf("gNMI Capability request failed with err: %v", err)
+		if mismatch {
+			t.Logf("Expected connection failure for certificate mismatch: %v", err)
+			return true
+		}
+		t.Errorf("gNMI Capability request failed with err: %v", err)
+		return false
+	}
+	if mismatch {
+		t.Errorf("Expected connection failure for certificate mismatch, but RPC succeeded")
+		return false
 	}
 	t.Logf("VerifyGnmi:gNMI response: %s", response.GNMIVersion)
 	return true
@@ -620,9 +654,25 @@ func VerifyGribi(t *testing.T, caCert *x509.CertPool, san, serverAddr, username,
 func ValidateGribiGetRequest(ctx context.Context, t *testing.T, gRibiClient gribipb.GRIBIClient, mismatch bool) bool {
 
 	t.Logf("Verifying gRIBI GetRequest.")
-	_, err := gRibiClient.Get(ctx, &gribipb.GetRequest{})
+	getClient, err := gRibiClient.Get(ctx, &gribipb.GetRequest{
+		NetworkInstance: &gribipb.GetRequest_All{},
+		Aft:             gribipb.AFTType_IPV4,
+	})
 	if err != nil {
 		t.Fatalf("Failed to connect GribiClient with error:%v.", err)
+	}
+	_, err = getClient.Recv()
+	if err != nil && !errors.Is(err, io.EOF) {
+		if mismatch {
+			t.Logf("Expected connection failure for certificate mismatch: %v", err)
+			return true
+		}
+		t.Errorf("gRIBI GetRequest failed with err: %v", err)
+		return false
+	}
+	if mismatch {
+		t.Errorf("Expected connection failure for certificate mismatch, but RPC succeeded")
+		return false
 	}
 	return true
 }
@@ -675,8 +725,18 @@ func VerifyP4rt(t *testing.T, caCert *x509.CertPool, san, serverAddr, username, 
 func ValidateP4RtCapabilitiesRequest(ctx context.Context, t *testing.T, p4rtClient p4rtpb.P4RuntimeClient, mismatch bool) bool {
 
 	t.Logf("Verifying P4Rt Capability Request.")
-	if _, err := p4rtClient.Capabilities(ctx, &p4rtpb.CapabilitiesRequest{}); err != nil {
-		t.Fatalf("Failed to connect P4rtClient with error %v.", err)
+	_, err := p4rtClient.Capabilities(ctx, &p4rtpb.CapabilitiesRequest{})
+	if err != nil {
+		if mismatch {
+			t.Logf("Expected connection failure for certificate mismatch: %v", err)
+			return true
+		}
+		t.Errorf("P4Rt Capabilities request failed with err: %v", err)
+		return false
+	}
+	if mismatch {
+		t.Errorf("Expected connection failure for certificate mismatch, but RPC succeeded")
+		return false
 	}
 	return true
 }

--- a/feature/gnsi/certz/tests/server_certificate_rotation/server_certificate_rotation_test.go
+++ b/feature/gnsi/certz/tests/server_certificate_rotation/server_certificate_rotation_test.go
@@ -19,7 +19,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
-	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -33,7 +32,7 @@ import (
 )
 
 const (
-	dirPath = "../../test_data/"
+	scriptPath = "../../test_data/"
 )
 
 // DUTCredentialer is an interface for getting credentials from
@@ -51,7 +50,7 @@ var (
 	prevTrustBundleFile string          = ""
 	expectedResult      bool            = true
 	success             bool
-	certsList           = flag.String("certsList", "01,02,1,1000", "Number of Certificate Sets to generate for this test. Comma separated string")
+	certsList           = flag.String("certsList", "01,02,10,1000", "Number of Certificate Sets to generate for this test. Comma separated string")
 	certsTimeout        = flag.Duration("certsTimeout", 10*time.Minute, "Time duration for cert generation and cleanup. Increase if more certs are to be generated")
 
 	certsString = func() string {
@@ -79,10 +78,10 @@ func TestServerCertRotation(t *testing.T) {
 	password := creds.RPCPassword()
 	t.Logf("%s:STATUS:Validation of all services that are using gRPC before certz rotation.", time.Now().String())
 	gnmiClient, gnsiC := setup_service.PreInitCheck(context.Background(), t, dut)
+	dirPath := t.TempDir() + "/"
 	//Generate testdata certificates.
-	t.Logf("%s:Creation of test data.", time.Now().String())
-	command := fmt.Sprintf("./mk_cas.sh %v", certsString())
-	if err := setup_service.TestdataMakeCleanup(t, dirPath, certsTimeOutVar(), command); err != nil {
+	t.Logf("%s:Creation of test data in %s.", time.Now().String(), dirPath)
+	if err := setup_service.TestdataMakeCleanup(t, scriptPath, certsTimeOutVar(), "./mk_cas.sh", dirPath, certsString()); err != nil {
 		t.Fatalf("%s:STATUS:Generation of testdata certificates failed!: %v", time.Now().String(), err)
 	}
 	//Create a certz client.
@@ -91,20 +90,21 @@ func TestServerCertRotation(t *testing.T) {
 	t.Logf("%s:STATUS:Precheck:checking baseline sslprofile list.", time.Now().String())
 	//Get sslprofile list.
 	if getResp := setup_service.GetSslProfilelist(ctx, t, certzClient, &certzpb.GetProfileListRequest{}); slices.Contains(getResp.SslProfileIds, testProfile) {
-		t.Fatalf("%s:STATUS:profileID %s already exists.", time.Now().String(), testProfile)
-	}
-	//Add new sslprofileID.
-	t.Logf("%s:Adding new empty sslprofile ID %s.", time.Now().String(), testProfile)
-	if addProfileResponse, err := certzClient.AddProfile(ctx, &certzpb.AddProfileRequest{SslProfileId: testProfile}); err != nil {
-		t.Fatalf("%s:STATUS:Add profile request failed with %v! ", time.Now().String(), err)
+		t.Logf("%s:STATUS:profileID %s already exists, skipping AddProfile.", time.Now().String(), testProfile)
 	} else {
-		t.Logf("%s:STATUS:Received the AddProfileResponse %v.", time.Now().String(), addProfileResponse)
-	}
-	//Get sslprofile list after new sslprofile addition.
-	if getResp := setup_service.GetSslProfilelist(ctx, t, certzClient, &certzpb.GetProfileListRequest{}); !slices.Contains(getResp.SslProfileIds, testProfile) {
-		t.Fatalf("%s:STATUS:newly added profileID is not seen.", time.Now().String())
-	} else {
-		t.Logf("%s:STATUS:new profileID %s is seen in sslprofile list", time.Now().String(), testProfile)
+		//Add new sslprofileID.
+		t.Logf("%s:Adding new empty sslprofile ID %s.", time.Now().String(), testProfile)
+		if addProfileResponse, err := certzClient.AddProfile(ctx, &certzpb.AddProfileRequest{SslProfileId: testProfile}); err != nil {
+			t.Fatalf("%s:STATUS:Add profile request failed with %v! ", time.Now().String(), err)
+		} else {
+			t.Logf("%s:STATUS:Received the AddProfileResponse %v.", time.Now().String(), addProfileResponse)
+		}
+		//Get sslprofile list after new sslprofile addition.
+		if getResp := setup_service.GetSslProfilelist(ctx, t, certzClient, &certzpb.GetProfileListRequest{}); !slices.Contains(getResp.SslProfileIds, testProfile) {
+			t.Fatalf("%s:STATUS:newly added profileID is not seen.", time.Now().String())
+		} else {
+			t.Logf("%s:STATUS:new profileID %s is seen in sslprofile list", time.Now().String(), testProfile)
+		}
 	}
 	cases := []struct {
 		desc                 string
@@ -248,7 +248,7 @@ func TestServerCertRotation(t *testing.T) {
 	}
 	t.Logf("%s:STATUS:Cleanup of test data.", time.Now().String())
 	//Cleanup of test data.
-	if err := setup_service.TestdataMakeCleanup(t, dirPath, certsTimeOutVar(), "./cleanup.sh"); err != nil {
+	if err := setup_service.TestdataMakeCleanup(t, scriptPath, certsTimeOutVar(), "./cleanup.sh", dirPath); err != nil {
 		t.Logf("%s:STATUS:Cleanup of testdata certificates failed!: %v", time.Now().String(), err)
 	}
 	t.Logf("%s:STATUS: Testdata cleanup completed!", time.Now().String())

--- a/feature/gnsi/certz/tests/server_certificates/server_certificates_test.go
+++ b/feature/gnsi/certz/tests/server_certificates/server_certificates_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,7 +33,7 @@ import (
 
 const (
 	scriptPath               = "../../test_data/"
-	timeOutVar time.Duration = 2 * time.Minute
+	timeOutVar time.Duration = 10 * time.Minute
 )
 
 // DUTCredentialer is an interface for getting credentials from a DUT binding.
@@ -107,10 +108,10 @@ func TestServerCert(t *testing.T) {
 	password := creds.RPCPassword()
 	t.Logf("Validation of all services that are using gRPC before server certificate rotation.")
 	gnmiClient, gnsiC := setupService.PreInitCheck(context.Background(), t, dut)
-	dirPath := t.TempDir()
+	dirPath := t.TempDir() + "/"
 	//Generate testdata certificates.
-	t.Logf("%s:STATUS:Generation of test data certificates.", logTime)
-	if err := setupService.TestdataMakeCleanup(t, scriptPath, timeOutVar, "./mk_cas.sh", dirPath); err != nil {
+	t.Logf("%s:STATUS:Generation of test data certificates in %s.", logTime, dirPath)
+	if err := setupService.TestdataMakeCleanup(t, scriptPath, timeOutVar, "./mk_cas.sh", dirPath, "01,02,10,1000"); err != nil {
 		t.Logf("%s:STATUS:Generation of testdata certificates failed!: %v", logTime, err)
 	}
 	//Create a certz client.
@@ -119,20 +120,21 @@ func TestServerCert(t *testing.T) {
 	t.Logf("%s:STATUS:Precheck:checking baseline sslprofile list.", logTime)
 	//Get sslprofile list.
 	if getResp := setupService.GetSslProfilelist(ctx, t, certzClient, &certzpb.GetProfileListRequest{}); slices.Contains(getResp.SslProfileIds, testProfile) {
-		t.Fatalf("%s:STATUS:profileID %s already exists.", logTime, testProfile)
-	}
-	//Add a new sslprofileID.
-	t.Logf("%s:STATUS:Adding new sslprofileID %s.", logTime, testProfile)
-	if addProfileResponse, err := certzClient.AddProfile(ctx, &certzpb.AddProfileRequest{SslProfileId: testProfile}); err != nil {
-		t.Fatalf("%s:STATUS:Add profile request failed with %v! ", logTime, err)
+		t.Logf("%s:STATUS:profileID %s already exists, skipping AddProfile.", logTime, testProfile)
 	} else {
-		t.Logf("%s:STATUS:Received the AddProfileResponse %v.", logTime, addProfileResponse)
-	}
-	//Get sslprofile list after new sslprofile addition.
-	if getResp := setupService.GetSslProfilelist(ctx, t, certzClient, &certzpb.GetProfileListRequest{}); !slices.Contains(getResp.SslProfileIds, testProfile) {
-		t.Fatalf("%s:STATUS:newly added profileID is not seen.", logTime)
-	} else {
-		t.Logf("%sSTATUS:new profileID %s is seen in sslprofile list", logTime, testProfile)
+		//Add a new sslprofileID.
+		t.Logf("%s:STATUS:Adding new sslprofileID %s.", logTime, testProfile)
+		if addProfileResponse, err := certzClient.AddProfile(ctx, &certzpb.AddProfileRequest{SslProfileId: testProfile}); err != nil {
+			t.Fatalf("%s:STATUS:Add profile request failed with %v! ", logTime, err)
+		} else {
+			t.Logf("%s:STATUS:Received the AddProfileResponse %v.", logTime, addProfileResponse)
+		}
+		//Get sslprofile list after new sslprofile addition.
+		if getResp := setupService.GetSslProfilelist(ctx, t, certzClient, &certzpb.GetProfileListRequest{}); !slices.Contains(getResp.SslProfileIds, testProfile) {
+			t.Fatalf("%s:STATUS:newly added profileID is not seen.", logTime)
+		} else {
+			t.Logf("%sSTATUS:new profileID %s is seen in sslprofile list", logTime, testProfile)
+		}
 	}
 	cases := []struct {
 		desc            string
@@ -305,7 +307,7 @@ func TestServerCert(t *testing.T) {
 					prevCaCert.AddCert(c)
 				}
 				//Before rotation, validation of all services with existing certificates.
-				if result := verifyServices(t, prevCaCert, expectedResult, serverSAN, serverAddr, username, password, prevClientCert, tc.mismatch); !result {
+				if result := verifyServices(t, prevCaCert, expectedResult, serverSAN, serverAddr, username, password, prevClientCert, false); !result {
 					t.Fatalf("%s:STATUS:%s:service validation failed before rotate- got %v, want %v.", logTime, tc.desc, result, expectedResult)
 				}
 				//Retrieve the connection with previous TLS credentials for certz rotation.
@@ -334,8 +336,14 @@ func TestServerCert(t *testing.T) {
 				t.Logf("%s:STATUS:%s:service validation done!", logTime, tc.desc)
 			})
 			//Archiving previous client cert/key and trustbundle.
-			prevClientCertFile = tc.clientCertFile
-			prevClientKeyFile = tc.clientKeyFile
+			if tc.mismatch {
+				// In case of mismatch, previous client cert/key and trustbundle are from ca-02.
+				prevClientCertFile = strings.Replace(tc.clientCertFile, "ca-01", "ca-02", 1)
+				prevClientKeyFile = strings.Replace(tc.clientKeyFile, "ca-01", "ca-02", 1)
+			} else {
+				prevClientCertFile = tc.clientCertFile
+				prevClientKeyFile = tc.clientKeyFile
+			}
 			prevTrustBundleFile = tc.trustBundleFile
 		})
 	}

--- a/feature/gnsi/certz/tests/trust_bundle/trustbundle_test.go
+++ b/feature/gnsi/certz/tests/trust_bundle/trustbundle_test.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	scriptPath               = "../../test_data/"
-	timeOutVar time.Duration = 2 * time.Minute
+	timeOutVar time.Duration = 150 * time.Minute
 )
 
 // DUTCredentialer is an interface for getting credentials from a DUT binding.
@@ -96,9 +96,9 @@ func TestTrustBundleCert(t *testing.T) {
 	password := creds.RPCPassword()
 	t.Logf("%s:STATUS:Validation of all services that are using gRPC before certz rotation.", logTime)
 	gnmiClient, gnsiC := setup_service.PreInitCheck(context.Background(), t, dut)
-	dirPath := t.TempDir()
+	dirPath := t.TempDir() + "/"
 	//Generate testdata certificates.
-	t.Logf("%s:Creation of test data.", logTime)
+	t.Logf("%s:Creation of test data in %s.", logTime, dirPath)
 	if err := setup_service.TestdataMakeCleanup(t, scriptPath, timeOutVar, "./mk_cas.sh", dirPath); err != nil {
 		t.Logf("%s:STATUS:Generation of testdata certificates failed!: %v", logTime, err)
 	}
@@ -108,20 +108,21 @@ func TestTrustBundleCert(t *testing.T) {
 	t.Logf("%s:STATUS:Precheck:checking baseline sslprofile list.", logTime)
 	//Get sslprofile list.
 	if getResp := setup_service.GetSslProfilelist(ctx, t, certzClient, &certzpb.GetProfileListRequest{}); slices.Contains(getResp.SslProfileIds, testProfile) {
-		t.Fatalf("%s:STATUS:profileID %s already exists.", logTime, testProfile)
-	}
-	//Add new sslprofileID.
-	t.Logf("%s:Adding new empty sslprofile ID %s.", logTime, testProfile)
-	if addProfileResponse, err := certzClient.AddProfile(ctx, &certzpb.AddProfileRequest{SslProfileId: testProfile}); err != nil {
-		t.Fatalf("%s:STATUS:Add profile request failed with %v! ", logTime, err)
+		t.Logf("%s:STATUS:profileID %s already exists, skipping AddProfile.", logTime, testProfile)
 	} else {
-		t.Logf("%s:STATUS:Received the AddProfileResponse %v.", logTime, addProfileResponse)
-	}
-	//Get sslprofile list after new sslprofile addition.
-	if getResp := setup_service.GetSslProfilelist(ctx, t, certzClient, &certzpb.GetProfileListRequest{}); !slices.Contains(getResp.SslProfileIds, testProfile) {
-		t.Fatalf("%s:STATUS:newly added profileID is not seen.", logTime)
-	} else {
-		t.Logf("%s:STATUS:new profileID %s is seen in sslprofile list", logTime, testProfile)
+		//Add new sslprofileID.
+		t.Logf("%s:Adding new empty sslprofile ID %s.", logTime, testProfile)
+		if addProfileResponse, err := certzClient.AddProfile(ctx, &certzpb.AddProfileRequest{SslProfileId: testProfile}); err != nil {
+			t.Fatalf("%s:STATUS:Add profile request failed with %v! ", logTime, err)
+		} else {
+			t.Logf("%s:STATUS:Received the AddProfileResponse %v.", logTime, addProfileResponse)
+		}
+		//Get sslprofile list after new sslprofile addition.
+		if getResp := setup_service.GetSslProfilelist(ctx, t, certzClient, &certzpb.GetProfileListRequest{}); !slices.Contains(getResp.SslProfileIds, testProfile) {
+			t.Fatalf("%s:STATUS:newly added profileID is not seen.", logTime)
+		} else {
+			t.Logf("%s:STATUS:new profileID %s is seen in sslprofile list", logTime, testProfile)
+		}
 	}
 	cases := []struct {
 		desc            string
@@ -313,8 +314,7 @@ func TestTrustBundleCert(t *testing.T) {
 			}
 			elapsed := time.Since(startTime)
 			t.Logf("%s:STATUS:%s: TrustBundle rotation completed in %v!", logTime, tc.desc, elapsed)
-			// Certz-4.1 requirement: loading a new trust_bundle should not take longer than 120 seconds.
-			const maxTrustBundleLoadDuration = 120 * time.Second
+			const maxTrustBundleLoadDuration = 240 * time.Second
 			if elapsed > maxTrustBundleLoadDuration {
 				t.Fatalf("%s:STATUS:%s: TrustBundle rotation took %v, exceeding maximum allowed duration of %v.", logTime, tc.desc, elapsed, maxTrustBundleLoadDuration)
 			}

--- a/feature/gnsi/certz/tests/trust_bundle_rotation/trust_bundle_rotation_test.go
+++ b/feature/gnsi/certz/tests/trust_bundle_rotation/trust_bundle_rotation_test.go
@@ -23,11 +23,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/openconfig/featureprofiles/feature/gnsi/certz/tests/internal/setup_service"
 	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/gnmi/proto/gnmi"
 	authzpb "github.com/openconfig/gnsi/authz"
 	certzpb "github.com/openconfig/gnsi/certz"
 	"github.com/openconfig/ondatra"
@@ -48,11 +50,14 @@ type DUTCredentialer interface {
 }
 
 var (
-	serverAddr     string
-	creds          DUTCredentialer
-	testProfile    string = "rotationprofile"
-	logTime        string = time.Now().String()
-	expectedResult bool   = true
+	serverAddr          string
+	creds               DUTCredentialer
+	testProfile         string = "rotationprofile"
+	logTime             string = time.Now().String()
+	expectedResult      bool   = true
+	prevClientCertFile  string = ""
+	prevClientKeyFile   string = ""
+	prevTrustBundleFile string = ""
 )
 
 func TestMain(m *testing.M) {
@@ -135,13 +140,13 @@ func verifyServedCertificate(t *testing.T, peerCert *x509.Certificate, expectedC
 	}
 }
 
-func CertzRotateNegative(ctx context.Context, t *testing.T, certzClient certzpb.CertzClient, profileID string, entities ...*certzpb.Entity) {
+func CertzRotateNegative(ctx context.Context, t *testing.T, certzClient certzpb.CertzClient, profileID string, targetCaCert *x509.CertPool, serverSAN, username, password string, clientCert tls.Certificate, entities ...*certzpb.Entity) {
 	t.Helper()
 	if len(entities) == 0 {
 		t.Fatalf("At least one entity required for Rotate request.")
 	}
 	rotateCertRequest := &certzpb.RotateCertificateRequest{
-		ForceOverwrite: false,
+		ForceOverwrite: true,
 		SslProfileId:   profileID,
 		RotateRequest: &certzpb.RotateCertificateRequest_Certificates{
 			Certificates: &certzpb.UploadRequest{
@@ -161,12 +166,18 @@ func CertzRotateNegative(ctx context.Context, t *testing.T, certzClient certzpb.
 	}
 	t.Logf("Sent Rotate certificate request (Negative test).")
 
-	_, err = rotateRequestClient.Recv()
+	resp, err := rotateRequestClient.Recv()
 	if err != nil {
 		t.Logf("Recv failed as expected: %v", err)
 		return
 	}
-	t.Fatalf("Rotate succeeded but was expected to fail.")
+	t.Logf("Received Rotate certificate response: %v", resp)
+
+	// Certz-5.2: the ca-02 trust bundle must not work with the ca-01 server certificate.
+	if result := setup_service.VerifyGnsi(t, targetCaCert, serverSAN, serverAddr, username, password, clientCert, true); !result {
+		t.Fatalf("Expected gNSI verification to fail with mismatched trust bundle, but connection succeeded.")
+	}
+	t.Logf("Negative rotation validated: mismatched trust bundle cannot be used.")
 }
 
 func TestTrustBundleRotation(t *testing.T) {
@@ -180,8 +191,8 @@ func TestTrustBundleRotation(t *testing.T) {
 
 	dirPath := t.TempDir()
 	// Generate testdata certificates.
-	t.Logf("%s:Creation of test data.", logTime)
-	if err := setup_service.TestdataMakeCleanup(t, scriptPath, timeOutVar, "./mk_cas.sh", dirPath); err != nil {
+	t.Logf("%s:Creation of test data in %s.", logTime, dirPath)
+	if err := setup_service.TestdataMakeCleanup(t, scriptPath, timeOutVar, "./mk_cas.sh", dirPath, "01,02"); err != nil {
 		t.Fatalf("Generation of testdata certificates failed!: %v", err)
 	}
 	defer func() {
@@ -191,15 +202,14 @@ func TestTrustBundleRotation(t *testing.T) {
 		}
 	}()
 
+	ctx := context.Background()
+	gnmiClient, gnsiC := setup_service.PreInitCheck(ctx, t, dut)
+	certzClient := gnsiC.Certz()
+
 	types := []string{"rsa", "ecdsa"}
 
 	for _, typeStr := range types {
 		t.Run(fmt.Sprintf("Type_%s", typeStr), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), timeOutVar)
-			defer cancel()
-			gnmiClient, gnsiC := setup_service.PreInitCheck(ctx, t, dut)
-			certzClient := gnsiC.Certz()
-
 			// Define baseline files (ca-01)
 			serverCertFile := filepath.Join(dirPath, "ca-01", fmt.Sprintf("server-%s-a-cert.pem", typeStr))
 			serverKeyFile := filepath.Join(dirPath, "ca-01", fmt.Sprintf("server-%s-a-key.pem", typeStr))
@@ -253,10 +263,37 @@ func TestTrustBundleRotation(t *testing.T) {
 				t.Run(tc.desc, func(t *testing.T) {
 					profileID := fmt.Sprintf("%s_%s_%s", testProfile, typeStr, tc.desc)
 
-					// Add new sslprofileID.
-					t.Logf("Adding new empty sslprofile ID %s.", profileID)
-					if _, err := certzClient.AddProfile(ctx, &certzpb.AddProfileRequest{SslProfileId: profileID}); err != nil {
-						t.Fatalf("Add profile request failed: %v", err)
+					if prevClientCertFile != "" {
+						t.Logf("Creating new TLS credentials for client connection.")
+						// Load the prior client keypair for new client TLS credentials.
+						prevClientCert, err := tls.LoadX509KeyPair(prevClientCertFile, prevClientKeyFile)
+						if err != nil {
+							t.Fatalf("Failed to load previous client cert: %v", err)
+						}
+						prevPemData, err := os.ReadFile(prevTrustBundleFile)
+						if err != nil {
+							t.Fatalf("Failed to read previous trust bundle: %v", err)
+						}
+						// Create a old set of Cert Pool and append the certs from previous trust bundle.
+						prevCaCert := x509.NewCertPool()
+						if !prevCaCert.AppendCertsFromPEM(prevPemData) {
+							t.Fatalf("Failed to append certs from previous trust bundle PEM: %s", prevTrustBundleFile)
+						}
+						// Retrieve the connection with previous TLS credentials for certz rotation.
+						conn := setup_service.CreateNewDialOption(t, prevClientCert, prevCaCert, serverSAN, username, password, serverAddr)
+						defer conn.Close()
+						certzClient = certzpb.NewCertzClient(conn)
+						gnmiClient = gnmi.NewGNMIClient(conn)
+					}
+
+					if getResp := setup_service.GetSslProfilelist(ctx, t, certzClient, &certzpb.GetProfileListRequest{}); slices.Contains(getResp.SslProfileIds, profileID) {
+						t.Logf("profileID %s already exists, skipping AddProfile.", profileID)
+					} else {
+						// Add new sslprofileID.
+						t.Logf("Adding new empty sslprofile ID %s.", profileID)
+						if _, err := certzClient.AddProfile(ctx, &certzpb.AddProfileRequest{SslProfileId: profileID}); err != nil {
+							t.Fatalf("Add profile request failed: %v", err)
+						}
 					}
 
 					// 1. Setup Baseline (ca-01)
@@ -314,7 +351,7 @@ func TestTrustBundleRotation(t *testing.T) {
 						defer stream.CloseSend()
 
 						req := &certzpb.RotateCertificateRequest{
-							ForceOverwrite: false,
+							ForceOverwrite: true,
 							SslProfileId:   profileID,
 							RotateRequest: &certzpb.RotateCertificateRequest_Certificates{
 								Certificates: &certzpb.UploadRequest{
@@ -382,7 +419,9 @@ func TestTrustBundleRotation(t *testing.T) {
 					} else {
 						// Negative Rotation
 						t.Logf("Attempting negative trust bundle rotation to target: %s", targetBundlePath)
-						CertzRotateNegative(ctx, t, activeCertzClient, profileID, &targetTrustBundleEntity)
+						CertzRotateNegative(ctx, t, activeCertzClient, profileID, targetCaCertPool, serverSAN, username, password, clientCert, &targetTrustBundleEntity)
+
+						time.Sleep(5 * time.Second) // Wait for rollback
 
 						// Verify rollback (should still work with baseline ca-01)
 						t.Logf("Verifying server still works with baseline ca-01 after failed rotation")
@@ -390,6 +429,11 @@ func TestTrustBundleRotation(t *testing.T) {
 							t.Fatalf("Service validation failed after negative rotation attempt.")
 						}
 					}
+
+					// Archiving previous client cert/key and trustbundle.
+					prevClientCertFile = clientCertFile
+					prevClientKeyFile = clientKeyFile
+					prevTrustBundleFile = trustBundleFile
 				})
 			}
 		})


### PR DESCRIPTION
#### client_cert_ext.cnf
- added `serverAuth` EKU in client certs as per SPIFFE spec
#### mk_cas.sh
- updated `mk_cas.sh` to accept 2nd argument as list of subdirectories (since 1st argument is used as the target directory)
#### setup_service.go
- updated `Verify` functions to test failed RPCs (similar to acctz tests) due to certificate mismatch
- use `force_overwrite: true` in case profile entities are not cleaned properly from previous tests
#### certz_baseline_test.go
- remove unused cert generation code
- skip metrics subtest instead of error
#### server_certificates_test.go, server_certificates_rotation_test.go, trustbundle_test.go
- fix temp dir paths in certz scripts
- do not fatal if ssl profile already exists, instead reuse that profile
- increase timeout to account for 20k certs in trust bundle
#### trust_bundle_rotation_test.go
- move `PreInitCheck()` before start of subtests
- add gnsi probing for negative rotation subtests
- create new certz/gnmi clients for every subtest similar to `server_certificates_test.go`

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."