### PR TITLE
Update telemetry_basic_check_test.go

### DIFF
--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -79,7 +79,13 @@ func getMacAddress(t *testing.T, dut *ondatra.DUTDevice, intfName string) (strin
 		opts = append(opts, ygnmi.WithFT(ft))
 		t.Logf("Using functional translator %q for MAC address on %s", ciscoMACFT, intfName)
 	}
-	return gnmi.Lookup(t, dut.GNMIOpts().WithYGNMIOpts(opts...), gnmi.OC().Interface(intfName).Ethernet().MacAddress().State()).Val()
+	val, ok := gnmi.Watch(t, dut.GNMIOpts().WithYGNMIOpts(opts...), gnmi.OC().Interface(intfName).Ethernet().MacAddress().State(), time.Minute, func(v *ygnmi.Value[string]) bool {
+		return v.IsPresent()
+	}).Await(t)
+	if ok {
+		return val.Val()
+	}
+	return "", false
 }
 
 const (
@@ -1003,7 +1009,6 @@ func TestIntfCounterUpdate(t *testing.T) {
 	v4 := flowipv4.Packet().Add().Ipv4()
 	v4.Src().SetValue(ip4_1.Address())
 	v4.Dst().SetValue(ip4_2.Address())
-	v4.Priority().Dscp().Phb().SetValue(56)
 	otg.PushConfig(t, config)
 	otg.StartProtocols(t)
 	otgutils.WaitForARP(t, ate.OTG(), config, "IPv4")

--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -80,7 +80,8 @@ func getMacAddress(t *testing.T, dut *ondatra.DUTDevice, intfName string) (strin
 		t.Logf("Using functional translator %q for MAC address on %s", ciscoMACFT, intfName)
 	}
 	val, ok := gnmi.Watch(t, dut.GNMIOpts().WithYGNMIOpts(opts...), gnmi.OC().Interface(intfName).Ethernet().MacAddress().State(), time.Minute, func(v *ygnmi.Value[string]) bool {
-		return v.IsPresent()
+		val, present := v.Val()
+		return present && val != ""
 	}).Await(t)
 	if ok {
 		return val.Val()


### PR DESCRIPTION
- Use gnmi.Watch instead of gnmi.Lookup to avoid errors seen by duplicate entries. 
- Remove DSCP56 as it is reserved for Network control traffic and control plane is dropping the traffic due to rate limit. README doesn't mention about type of traffic. The requirement is only to check interface counters. 