### PR TITLE
feature/sflow: fix KNE sFlow source-address to match capture filter

### DIFF
--- a/feature/sflow/otg_tests/sflow_base_test/sflow_base_test.go
+++ b/feature/sflow/otg_tests/sflow_base_test/sflow_base_test.go
@@ -79,14 +79,14 @@ var (
 	sflowCfgv4KNE = &cfgplugins.SFlowGlobalParams{
 		Ni:              mgmtVRF,
 		IntfName:        "port1",
-		SrcAddrV4:       "192.0.2.1",
+		SrcAddrV4:       "203.0.113.1",
 		IP:              "IPv4",
 		MinSamplingRate: 10,
 	}
 	sflowCfgv6KNE = &cfgplugins.SFlowGlobalParams{
 		Ni:              mgmtVRF,
 		IntfName:        "port1",
-		SrcAddrV6:       "2001:db8::1",
+		SrcAddrV6:       "2001:db8::203:0:113:1",
 		IP:              "IPv6",
 		MinSamplingRate: 10,
 	}


### PR DESCRIPTION
Align sflowCfgv{4,6}KNE.SrcAddr* with dutlo0Attrs (loopback), matching
the physical config path. Only the KNE code path changes; hardware
behavior is unchanged.