### PR TITLE
Update route_leakage_between_nondefault_vrfs_test.go

### DIFF
--- a/feature/bgp/route_selection/otg_tests/route_leakage_between_nondefault_vrfs/route_leakage_between_nondefault_vrfs_test.go
+++ b/feature/bgp/route_selection/otg_tests/route_leakage_between_nondefault_vrfs/route_leakage_between_nondefault_vrfs_test.go
@@ -416,6 +416,7 @@ func verifyTrafficFlow(t *testing.T, ate *ondatra.ATEDevice, config gosnappi.Con
 		}
 
 		var expectedPackets uint64
+		tolerancePackets := uint64(2)
 		if expectTrafficPass {
 			expectedPackets = totalPackets
 		} else {
@@ -424,10 +425,18 @@ func verifyTrafficFlow(t *testing.T, ate *ondatra.ATEDevice, config gosnappi.Con
 
 		t.Logf("Expecting %d packets for flow %s", expectedPackets, flow.Name())
 		msg := fmt.Sprintf("Sent %d packets, expected %d packets, received %d packets.", txPackets, expectedPackets, rxPackets)
-		if rxPackets == expectedPackets {
-			t.Log(msg)
+		if expectTrafficPass {
+			if rxPackets >= expectedPackets-tolerancePackets && rxPackets <= expectedPackets+tolerancePackets {
+				t.Log(msg)
+			} else {
+				t.Error(msg)
+			}
 		} else {
-			t.Error(msg)
+			if rxPackets == expectedPackets {
+				t.Log(msg)
+			} else {
+				t.Error(msg)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Add two packet tolerance to stabilize the code. 