### PR TITLE
[PF-1.9] Test fixes for egress_handle_ttl_test.go Arista configuration

### DIFF
--- a/feature/policy_forwarding/decapsulation/otg_tests/ip_guev1_static_decap_subnet_range/metadata.textproto
+++ b/feature/policy_forwarding/decapsulation/otg_tests/ip_guev1_static_decap_subnet_range/metadata.textproto
@@ -14,6 +14,6 @@ platform_exceptions: {
     interface_enabled: true
     default_network_instance: "default"
     policy_rule_counters_oc_unsupported: true
-    gue_gre_decap_unsupported: true
+    gue_gre_decap_oc_unsupported: true
   }
 }

--- a/feature/policy_forwarding/decapsulation/otg_tests/ipv4_guev1_decap_and_hashing_test/metadata.textproto
+++ b/feature/policy_forwarding/decapsulation/otg_tests/ipv4_guev1_decap_and_hashing_test/metadata.textproto
@@ -15,7 +15,7 @@ platform_exceptions: {
     isis_instance_enabled_required: true
     multipath_unsupported_neighbor_or_afisafi: true
     static_mpls_lsp_oc_unsupported: true
-    gue_gre_decap_unsupported: true
+    gue_gre_decap_oc_unsupported: true
     load_interval_not_supported: true
     load_balance_policy_oc_unsupported: true
   }

--- a/feature/policy_forwarding/otg_tests/mpls_gre_ipv4_decap_scale_test/metadata.textproto
+++ b/feature/policy_forwarding/otg_tests/mpls_gre_ipv4_decap_scale_test/metadata.textproto
@@ -17,7 +17,7 @@ platform_exceptions: {
   mpls_label_classification_unsupported: true
   aggregate_atomic_update: true
   interface_enabled: true
-  gue_gre_decap_unsupported: true
+  gue_gre_decap_oc_unsupported: true
   static_mpls_unsupported: true
   default_network_instance: "default"
   }

--- a/feature/policy_forwarding/otg_tests/mpls_gre_ipv4_decap_test/metadata.textproto
+++ b/feature/policy_forwarding/otg_tests/mpls_gre_ipv4_decap_test/metadata.textproto
@@ -17,7 +17,7 @@ platform_exceptions: {
   mpls_label_classification_unsupported: true
   aggregate_atomic_update: true
   interface_enabled: true
-  gue_gre_decap_unsupported: true
+  gue_gre_decap_oc_unsupported: true
   static_mpls_unsupported: true
   default_network_instance: "default"
   }

--- a/feature/policy_forwarding/otg_tests/mpls_gre_udp_decap_test/metadata.textproto
+++ b/feature/policy_forwarding/otg_tests/mpls_gre_udp_decap_test/metadata.textproto
@@ -13,7 +13,7 @@ platform_exceptions: {
   deviations: {
     interface_enabled: true
     default_network_instance: "default"
-    gue_gre_decap_unsupported: true
+    gue_gre_decap_oc_unsupported: true
     policy_forwarding_unsupported: true
     interface_policy_forwarding_unsupported: true
   }

--- a/feature/policy_forwarding/otg_tests/mpls_gre_udp_qos/metadata.textproto
+++ b/feature/policy_forwarding/otg_tests/mpls_gre_udp_qos/metadata.textproto
@@ -15,7 +15,7 @@ platform_exceptions: {
     default_network_instance: "default"
     next_hop_group_config_unsupported: true
     mpls_unsupported: true
-    gue_gre_decap_unsupported: true
+    gue_gre_decap_oc_unsupported: true
     mpls_label_classification_unsupported: true
     local_proxy_unsupported: true
     static_mpls_unsupported: true

--- a/feature/policy_forwarding/otg_tests/mpls_gue_ipv4_decap_scale_test/metadata.textproto
+++ b/feature/policy_forwarding/otg_tests/mpls_gue_ipv4_decap_scale_test/metadata.textproto
@@ -17,7 +17,7 @@ platform_exceptions: {
   mpls_label_classification_unsupported: true
   aggregate_atomic_update: true
   interface_enabled: true
-  gue_gre_decap_unsupported: true
+  gue_gre_decap_oc_unsupported: true
   static_mpls_unsupported: true
   default_network_instance: "default"
   }

--- a/feature/policy_forwarding/otg_tests/mpls_gue_ipv4_decap_test/metadata.textproto
+++ b/feature/policy_forwarding/otg_tests/mpls_gue_ipv4_decap_test/metadata.textproto
@@ -17,7 +17,7 @@ platform_exceptions: {
   mpls_label_classification_unsupported: true
   aggregate_atomic_update: true
   interface_enabled: true
-  gue_gre_decap_unsupported: true
+  gue_gre_decap_oc_unsupported: true
   static_mpls_unsupported: true
   default_network_instance: "default"
   }

--- a/feature/policy_forwarding/vrf_selection/otg_tests/multiple_vrfs_and_gue_decap/metadata.textproto
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/multiple_vrfs_and_gue_decap/metadata.textproto
@@ -13,7 +13,7 @@ platform_exceptions: {
   deviations: {
     interface_enabled: true
     default_network_instance: "default"
-    gue_gre_decap_unsupported: true
+    gue_gre_decap_oc_unsupported: true
     network_instance_import_export_policy_oc_unsupported: true
   }
 }

--- a/feature/qos/otg_tests/egress_traffic_classification_and_rewrite_test/metadata.textproto
+++ b/feature/qos/otg_tests/egress_traffic_classification_and_rewrite_test/metadata.textproto
@@ -15,6 +15,6 @@ platform_exceptions: {
     default_network_instance: "default"
     qos_remark_oc_unsupported: true
     static_mpls_lsp_oc_unsupported: true
-    gue_gre_decap_unsupported: true
+    gue_gre_decap_oc_unsupported: true
   }
 }

--- a/feature/ttl/otg_tests/egress/egress_handle_ttl_test.go
+++ b/feature/ttl/otg_tests/egress/egress_handle_ttl_test.go
@@ -44,13 +44,12 @@ const (
 	pps             = 100   // Packets per second
 	mplsLabelV4     = 99910 // Static Mpls currently supported range 16 - 99999 (99910 instead of 100010)
 	mplsLabelV6     = 99920 // Static Mpls currently supported range 16 - 99999 (99920 instead of 100020)
-	sleepTime       = 20
+	sleepTime       = 3
 	flowname        = "trafficItem"
 	tolerance       = 2
 	udpDecapPort    = 6080 // UDP destination port for GUE-like decapsulation
 	defaultNI       = "DEFAULT"
 	policyName      = "decap-policy"
-	policyId        = 1
 	lspName1        = "lsp1"
 	lspName2        = "lsp2"
 )
@@ -786,10 +785,24 @@ func createIPv6oMPLSoGREFlow(t *testing.T, dut *ondatra.DUTDevice, otgConfig *ot
 	}
 }
 
+func getDefaultGueDecapParams(t *testing.T, dut *ondatra.DUTDevice, ipType string) (cfgplugins.OcPolicyForwardingParams, *oc.NetworkInstance_PolicyForwarding) {
+	t.Helper()
+	_, _, pf := cfgplugins.SetupPolicyForwardingInfraOC(deviations.DefaultNetworkInstance(dut))
+	return cfgplugins.OcPolicyForwardingParams{
+		NetworkInstanceName: deviations.DefaultNetworkInstance(dut),
+		InterfaceID:         dut.Port(t, "port1").Name(),
+		AppliedPolicyName:   policyName,
+		GUEPort:             udpDecapPort,
+		IPType:              ipType,
+		TunnelIP:            ipv4Decap,
+		Dynamic:             true,
+	}, pf
+}
+
 func createIPv4oUDPFlow(t *testing.T, dut *ondatra.DUTDevice, otgConfig *otg.OTG, config gosnappi.Config, innerTTL, outerTTL, mplsTTL int) {
 	t.Helper()
-	dp1 := dut.Port(t, "port1")
-	cfgplugins.ConfigureDutWithGueDecap(t, dut, udpDecapPort, "ipv4", ipv4Decap, dp1.Name(), policyName, policyId)
+	ocPFParams, pf := getDefaultGueDecapParams(t, dut, "ipv4")
+	cfgplugins.DecapGroupConfigGue(t, dut, pf, ocPFParams)
 	config.Flows().Clear()
 	flow := addFlow(t, config, &flowArgs{flowName: flowname + "-ipv4",
 		outerSrcIP: atePort1.IPv4, outerDstIP: ipv4Decap, outerIpv4Ttl: outerTTL, ipv4Flow: true})
@@ -812,8 +825,8 @@ func createIPv4oUDPFlow(t *testing.T, dut *ondatra.DUTDevice, otgConfig *otg.OTG
 
 func createIPv6oUDPFlow(t *testing.T, dut *ondatra.DUTDevice, otgConfig *otg.OTG, config gosnappi.Config, innerTTL, outerTTL, mplsTTL int) {
 	t.Helper()
-	dp1 := dut.Port(t, "port1")
-	cfgplugins.ConfigureDutWithGueDecap(t, dut, udpDecapPort, "ipv6", ipv4Decap, dp1.Name(), policyName, policyId)
+	ocPFParams, pf := getDefaultGueDecapParams(t, dut, "ipv6")
+	cfgplugins.DecapGroupConfigGue(t, dut, pf, ocPFParams)
 	config.Flows().Clear()
 	flow := addFlow(t, config, &flowArgs{flowName: flowname + "-ipv6",
 		outerSrcIP: atePort1.IPv4, outerDstIP: ipv4Decap, outerIpv4Ttl: outerTTL, ipv4Flow: true})
@@ -835,8 +848,8 @@ func createIPv6oUDPFlow(t *testing.T, dut *ondatra.DUTDevice, otgConfig *otg.OTG
 
 func createIPv4oMPLSoUDPFlow(t *testing.T, dut *ondatra.DUTDevice, otgConfig *otg.OTG, config gosnappi.Config, innerTTL, outerTTL, mplsTTL int) {
 	t.Helper()
-	dp1 := dut.Port(t, "port1")
-	cfgplugins.ConfigureDutWithGueDecap(t, dut, udpDecapPort, "mpls", ipv4Decap, dp1.Name(), policyName, policyId)
+	ocPFParams, pf := getDefaultGueDecapParams(t, dut, "mpls")
+	cfgplugins.DecapGroupConfigGue(t, dut, pf, ocPFParams)
 	config.Flows().Clear()
 	flow := addFlow(t, config, &flowArgs{flowName: flowname + "-ipv4",
 		outerSrcIP: atePort1.IPv4, outerDstIP: ipv4Decap, outerIpv4Ttl: outerTTL, ipv4Flow: true})

--- a/feature/ttl/otg_tests/egress/metadata.textproto
+++ b/feature/ttl/otg_tests/egress/metadata.textproto
@@ -14,6 +14,6 @@ platform_exceptions: {
     default_network_instance: "default"
     static_mpls_lsp_oc_unsupported: true
     gre_decapsulation_oc_unsupported: true
-    decapsulate_gue_oc_unsupported: true
+    gue_gre_decap_oc_unsupported: true
   }
 }

--- a/internal/cfgplugins/policyforwarding.go
+++ b/internal/cfgplugins/policyforwarding.go
@@ -849,7 +849,7 @@ func PushPolicyForwardingConfig(t *testing.T, dut *ondatra.DUTDevice, ni *oc.Net
 
 // DecapGroupConfigGre configures the interface decap-group.
 func DecapGroupConfigGre(t *testing.T, dut *ondatra.DUTDevice, pf *oc.NetworkInstance_PolicyForwarding, ocPFParams OcPolicyForwardingParams) {
-	if deviations.GueGreDecapUnsupported(dut) {
+	if deviations.GueGreDecapOCUnsupported(dut) {
 		switch dut.Vendor() {
 		case ondatra.ARISTA:
 			if ocPFParams.Dynamic {
@@ -868,7 +868,7 @@ func DecapGroupConfigGre(t *testing.T, dut *ondatra.DUTDevice, pf *oc.NetworkIns
 
 // DecapGroupConfigGue configures the interface decap-group for GUE.
 func DecapGroupConfigGue(t *testing.T, dut *ondatra.DUTDevice, pf *oc.NetworkInstance_PolicyForwarding, ocPFParams OcPolicyForwardingParams) {
-	if deviations.GueGreDecapUnsupported(dut) {
+	if deviations.GueGreDecapOCUnsupported(dut) {
 		switch dut.Vendor() {
 		case ondatra.ARISTA:
 			if ocPFParams.Dynamic {
@@ -885,23 +885,22 @@ func DecapGroupConfigGue(t *testing.T, dut *ondatra.DUTDevice, pf *oc.NetworkIns
 	}
 }
 
-// aristaGueDecapCLIConfig configures GUEDEcapConfig for Arista
+// aristaGueDecapCLIConfig configures GUE decap for Arista. It clears any existing
+// UDP port mapping for the given port before applying the new configuration.
 func aristaGueDecapCLIConfig(t *testing.T, dut *ondatra.DUTDevice, params OcPolicyForwardingParams) {
-
 	decapProto := params.DecapProtocol
 	if decapProto == "" {
 		decapProto = params.IPType
 	}
-
-	cliConfig := fmt.Sprintf(`
-		                    ip decap-group type udp destination port %v payload %s
-							tunnel type %s-over-udp udp destination port %v
-							ip decap-group %s
-							tunnel type UDP
-							tunnel decap-ip %s
-							tunnel decap-interface %s
-							`, params.GUEPort, decapProto, params.IPType, params.GUEPort, params.AppliedPolicyName, params.TunnelIP, params.InterfaceID)
-	helpers.GnmiCLIConfig(t, dut, cliConfig)
+	helpers.GnmiCLIConfig(t, dut, fmt.Sprintf(`no ip decap-group type udp destination port %d`, params.GUEPort))
+	helpers.GnmiCLIConfig(t, dut, fmt.Sprintf(`
+		ip decap-group type udp destination port %[1]d payload %[2]s
+		tunnel type %[3]s-over-udp udp destination port %[1]d
+		ip decap-group %[4]s
+		tunnel type UDP
+		tunnel decap-ip %[5]s
+		tunnel decap-interface %[6]s
+		`, params.GUEPort, decapProto, params.IPType, params.AppliedPolicyName, params.TunnelIP, params.InterfaceID))
 }
 
 // aristaGreDecapCLIConfig configures GREDEcapConfig for Arista
@@ -1208,40 +1207,6 @@ func NewConfigureGRETunnel(t *testing.T, dut *ondatra.DUTDevice, decapIp string,
 	}
 }
 
-// ConfigureDutWithGueDecap configures the DUT to decapsulate GUE (Generic UDP Encapsulation) traffic. It supports both native CLI configuration (for vendors like Arista) and OpenConfig (GNMI) configuration.
-func ConfigureDutWithGueDecap(t *testing.T, dut *ondatra.DUTDevice, guePort int, ipType, tunIP, decapInt, policyName string, policyId int) {
-	t.Logf("Configure DUT with decapsulation UDP port %v", guePort)
-	if deviations.DecapsulateGueOCUnsupported(dut) {
-		switch dut.Vendor() {
-		case ondatra.ARISTA:
-			cliConfig := fmt.Sprintf(`
-                            ip decap-group type udp destination port %[1]d payload %[2]s 
-                            tunnel type %[2]s-over-udp udp destination port %[1]d
-                            ip decap-group test
-                            tunnel type UDP
-                            tunnel decap-ip %[3]s
-                            tunnel decap-interface %[4]s
-                            `, guePort, ipType, tunIP, decapInt)
-			helpers.GnmiCLIConfig(t, dut, cliConfig)
-
-		default:
-			t.Errorf("deviation decapsulateGueOCUnsupported is not handled for the dut: %v", dut.Vendor())
-		}
-	} else {
-		// TODO: As per the latest OpenConfig GNMI OC schema — the Encapsulation/Decapsulation sub-tree is not fully implemented, need to add OC commands once implemented.
-		d := &oc.Root{}
-		ni1 := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
-		npf := ni1.GetOrCreatePolicyForwarding()
-		np := npf.GetOrCreatePolicy(policyName)
-		np.PolicyId = ygot.String(policyName)
-		npRule := np.GetOrCreateRule(uint32(policyId))
-		ip := npRule.GetOrCreateIpv4()
-		ip.DestinationAddressPrefixSet = ygot.String(tunIP)
-		ip.Protocol = oc.PacketMatchTypes_IP_PROTOCOL_IP_UDP
-		// transport := npRule.GetOrCreateTransport()
-		// transport.SetDestinationPort()
-	}
-}
 
 // PbrRule defines a policy-based routing rule configuration
 type PbrRule struct {

--- a/internal/deviations/deviations.go
+++ b/internal/deviations/deviations.go
@@ -1377,7 +1377,7 @@ func MacsecOCUnsupported(dut *ondatra.DUTDevice) bool {
 
 // GueGreDecapOCUnsupported returns true if gue gre decap is unsupported
 func GueGreDecapOCUnsupported(dut *ondatra.DUTDevice) bool {
-	return lookupDUTDeviations(dut).GetGueGreDecapUnsupported()
+	return lookupDUTDeviations(dut).GetGueGreDecapOcUnsupported()
 }
 
 // MplsLabelClassificationOCUnsupported returns true if mpls label classification is unsupported
@@ -1410,10 +1410,6 @@ func InterfacePolicyForwardingOCUnsupported(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetInterfacePolicyForwardingUnsupported()
 }
 
-// GueGreDecapUnsupported returns true if gue or gre decap is unsupported
-func GueGreDecapUnsupported(dut *ondatra.DUTDevice) bool {
-	return lookupDUTDeviations(dut).GetGueGreDecapUnsupported()
-}
 
 // StaticMplsUnsupported returns true if static mpls is unsupported
 func StaticMplsUnsupported(dut *ondatra.DUTDevice) bool {
@@ -1632,10 +1628,6 @@ func PredefinedMaxEcmpPaths(dut *ondatra.DUTDevice) bool {
 	return lookupDUTDeviations(dut).GetPredefinedMaxEcmpPaths()
 }
 
-// DecapsulateGueOCUnsupported returns true if decapsulation group is not supported
-func DecapsulateGueOCUnsupported(dut *ondatra.DUTDevice) bool {
-	return lookupDUTDeviations(dut).GetDecapsulateGueOcUnsupported()
-}
 
 // LinePortUnsupported returns whether the DUT does not support line-port configuration on optical channel components.
 func LinePortUnsupported(dut *ondatra.DUTDevice) bool {

--- a/proto/metadata.proto
+++ b/proto/metadata.proto
@@ -783,7 +783,7 @@ message Metadata {
     bool macsec_unsupported = 279;
 
     // Arista b/390506900
-    bool gue_gre_decap_unsupported = 280;
+    bool gue_gre_decap_oc_unsupported = 280;
 
     // Arista b/390506584
     bool mpls_label_classification_unsupported = 281;


### PR DESCRIPTION
Problem with egress_handle_ttl_test:
Currently, egress_handle_ttl_test.go passes IPv4oUDPTest then fails IPv6oUDPTest immediately afterwards. This is because the egress_handle_ttl_test.go test does not clean up the cli between test cases. In order to switch the same udp port (6080) to another payload type, it first must be deconfigured (no ip decap-group type udp destination port) before reassigned to a different payload type.

Solution:
Modify the ConfigureDutWithGueDecap, which configures udp dest port, to clean up the config between test runs. ConfigureDutWithGueDecap can call the existing aristaGueDecapCLIConfig function to avoid code duplication, and aristaGueDecapCLIConfig can clean up the udp port to payload mapping before reassigning the payload.

Additional test improvement:
since only 5 packets are being sent, the time.sleep can be 3 seconds instead of 20 seconds (this will decrease the time spent sleeping in the test from 10 minutes to 1 minute).

Code refactoring:
Duplicate functions DecapGroupConfigGue and ConfigureDutWithGueDecap: These 2 functions have identical functionality (configuring a GUE decap group), so they can be consolidated. They also use the deviations GueGreDecapUnsupported and DecapsulateGueOCUnsupported that are only used in these 2 functions. Instead, there can be a single deviation GueGreDecapOCUnsupported to distinguish if we should use the CLI for configuring GUE and GRE decap groups.

Failing test run w
[pf-1.9_failing_run.txt](https://github.com/user-attachments/files/30836309/pf-1.9_failing_run.txt)
ithout these changes: 

Passing test run with these changes:
[pf-1.9_passing.txt](https://github.com/user-attachments/files/30836311/pf-1.9_passing.txt)
