### PR TITLE
ci-trigger: Make physical device types vendor-only in gateway

### DIFF
--- a/tools/ci-trigger/config.go
+++ b/tools/ci-trigger/config.go
@@ -128,10 +128,10 @@ var virtualDeviceMachineType = map[deviceType]string{
 
 // physicalDeviceTypes is a list of device types that can execute tests on real hardware.
 var physicalDeviceTypes = []deviceType{
-	{Vendor: opb.Device_ARISTA, HardwareModel: "7808"},
-	{Vendor: opb.Device_CISCO, HardwareModel: "8808"},
-	{Vendor: opb.Device_JUNIPER, HardwareModel: "PTX10008"},
-	{Vendor: opb.Device_NOKIA, HardwareModel: "7250 IXR-10e"},
+	{Vendor: opb.Device_ARISTA},
+	{Vendor: opb.Device_CISCO},
+	{Vendor: opb.Device_JUNIPER},
+	{Vendor: opb.Device_NOKIA},
 }
 
 func titleCase(input string) string {


### PR DESCRIPTION
ci-trigger: Make physical device types vendor-only in gateway
Removes the hardcoded hardware models (7808, 8808, etc.) from the
physicalDeviceTypes list. 
This ensures that the trigger gateway publishes physical test requests
with an empty HardwareModel. The execution backend  can
then run the tests without forcing a specific hardware model override, 
allowing tests to be matched dynamically by vendor and pool label while
still respecting any test-specific hardware requirements.