### PR TITLE
bgp/isis: modified redistribution test and gnoi helper

### DIFF
--- a/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
+++ b/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
@@ -21,8 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/github.com/openconfig/ondatra"
-	"github.com/open-traffic-generator/gosnappi"
+	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/openconfig/featureprofiles/internal/cfgplugins"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
@@ -30,6 +29,7 @@ import (
 	"github.com/openconfig/featureprofiles/internal/helpers"
 	"github.com/openconfig/featureprofiles/internal/isissession"
 	"github.com/openconfig/featureprofiles/internal/otgutils"
+	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
 	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"

--- a/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
+++ b/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
@@ -21,14 +21,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-traffic-generator/snappi/gosnappi"
+	"github.com/github.com/openconfig/ondatra"
+	"github.com/open-traffic-generator/gosnappi"
 	"github.com/openconfig/featureprofiles/internal/cfgplugins"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/featureprofiles/internal/gnoi"
 	"github.com/openconfig/featureprofiles/internal/helpers"
 	"github.com/openconfig/featureprofiles/internal/isissession"
 	"github.com/openconfig/featureprofiles/internal/otgutils"
-	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
 	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
@@ -98,7 +99,7 @@ type testCase struct {
 	name                string
 	desc                string
 	applyPolicyFunc     func(t *testing.T, dut *ondatra.DUTDevice)
-	verifyTelemetryFunc func(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice)
+	verifyTelemetryFunc func(t *testing.T, ts *isissession.TestSession)
 	testTraffic         bool
 	ipv4                bool
 }
@@ -124,7 +125,7 @@ func TestBGPToISISRedistribution(t *testing.T) {
 			name:                "NonMatchingPrefix",
 			desc:                "Non matching IPv4 BGP prefixes in a prefix-set should not be redistributed to IS-IS",
 			applyPolicyFunc:     nonMatchingPrefixRoutePolicy,
-			verifyTelemetryFunc: verifyNonMatchingPrefixTelemetry,
+			verifyTelemetryFunc: func(t *testing.T, ts *isissession.TestSession) { verifyNonMatchingPrefixTelemetry(t, ts.DUT, ts.ATE) },
 			testTraffic:         false,
 			ipv4:                true,
 		},
@@ -132,23 +133,41 @@ func TestBGPToISISRedistribution(t *testing.T) {
 			name:                "MatchingPrefix",
 			desc:                "Matching IPv4 BGP prefixes in a prefix-set should be redistributed to IS-IS",
 			applyPolicyFunc:     matchingPrefixRoutePolicy,
-			verifyTelemetryFunc: verifyMatchingPrefixTelemetry,
+			verifyTelemetryFunc: func(t *testing.T, ts *isissession.TestSession) { verifyMatchingPrefixTelemetry(t, ts.DUT, ts.ATE) },
 			testTraffic:         true,
 			ipv4:                true,
 		},
 		{
-			name:                "NonMatchingCommunity",
-			desc:                "IPv4: Non matching BGP community in a community-set should not be redistributed to IS-IS",
-			applyPolicyFunc:     nonMatchingCommunityRoutePolicy,
-			verifyTelemetryFunc: verifyNonMatchingCommunityTelemetry,
-			testTraffic:         false,
+			name:                "MatchingPrefixWithRestart",
+			desc:                "Verify BGP-to-ISIS redistributed routes persist after routing daemon restart",
+			applyPolicyFunc:     matchingPrefixRoutePolicy,
+			verifyTelemetryFunc: verifyMatchingPrefixWithRestartTelemetry,
+			testTraffic:         true,
 			ipv4:                true,
+		},
+		{
+			name:                "MatchingPrefixWithSharedNexthop",
+			desc:                "Verify BGP-to-ISIS redistributed routes persist after routing daemon restart with Shared Nexthop",
+			applyPolicyFunc:     applySharedNexthopRoutePolicy,
+			verifyTelemetryFunc: verifyMatchingPrefixWithRestartTelemetry,
+			testTraffic:         true,
+			ipv4:                true,
+		},
+		{
+			name:            "NonMatchingCommunity",
+			desc:            "IPv4: Non matching BGP community in a community-set should not be redistributed to IS-IS",
+			applyPolicyFunc: nonMatchingCommunityRoutePolicy,
+			verifyTelemetryFunc: func(t *testing.T, ts *isissession.TestSession) {
+				verifyNonMatchingCommunityTelemetry(t, ts.DUT, ts.ATE)
+			},
+			testTraffic: false,
+			ipv4:        true,
 		},
 		{
 			name:                "MatchingCommunity",
 			desc:                "IPv4: Matching BGP community in a community-set should be redistributed to IS-IS",
 			applyPolicyFunc:     matchingCommunityRoutePolicy,
-			verifyTelemetryFunc: verifyMatchingCommunityTelemetry,
+			verifyTelemetryFunc: func(t *testing.T, ts *isissession.TestSession) { verifyMatchingCommunityTelemetry(t, ts.DUT, ts.ATE) },
 			testTraffic:         true,
 			ipv4:                true,
 		},
@@ -156,7 +175,7 @@ func TestBGPToISISRedistribution(t *testing.T) {
 			name:                "NonMatchingPrefixV6",
 			desc:                "Non matching IPv6 BGP prefixes in a prefix-set should not be redistributed to IS-IS",
 			applyPolicyFunc:     nonMatchingPrefixRoutePolicyV6,
-			verifyTelemetryFunc: verifyNonMatchingPrefixTelemetryV6,
+			verifyTelemetryFunc: func(t *testing.T, ts *isissession.TestSession) { verifyNonMatchingPrefixTelemetryV6(t, ts.DUT, ts.ATE) },
 			testTraffic:         false,
 			ipv4:                false,
 		},
@@ -164,23 +183,41 @@ func TestBGPToISISRedistribution(t *testing.T) {
 			name:                "MatchingPrefixV6",
 			desc:                "Matching IPv6 BGP prefixes in a prefix-set should be redistributed to IS-IS",
 			applyPolicyFunc:     matchingPrefixRoutePolicyV6,
-			verifyTelemetryFunc: verifyMatchingPrefixTelemetryV6,
+			verifyTelemetryFunc: func(t *testing.T, ts *isissession.TestSession) { verifyMatchingPrefixTelemetryV6(t, ts.DUT, ts.ATE) },
 			testTraffic:         true,
 			ipv4:                false,
 		},
 		{
-			name:                "NonMatchingCommunityV6",
-			desc:                "IPv6: Non matching BGP community in a community-set should not be redistributed to IS-IS",
-			applyPolicyFunc:     nonMatchingCommunityRoutePolicyV6,
-			verifyTelemetryFunc: verifyNonMatchingCommunityTelemetryV6,
-			testTraffic:         false,
+			name:                "MatchingPrefixWithRestartV6",
+			desc:                "Verify IPv6 BGP-to-ISIS redistributed routes persist after routing daemon restart",
+			applyPolicyFunc:     matchingPrefixRoutePolicyV6,
+			verifyTelemetryFunc: verifyMatchingPrefixWithRestartTelemetryV6,
+			testTraffic:         true,
 			ipv4:                false,
+		},
+		{
+			name:                "MatchingPrefixWithSharedNexthopV6",
+			desc:                "Verify IPv6 BGP-to-ISIS redistributed routes persist after routing daemon restart with Shared Nexthop",
+			applyPolicyFunc:     applySharedNexthopRoutePolicyV6,
+			verifyTelemetryFunc: verifyMatchingPrefixWithRestartTelemetryV6,
+			testTraffic:         true,
+			ipv4:                false,
+		},
+		{
+			name:            "NonMatchingCommunityV6",
+			desc:            "IPv6: Non matching BGP community in a community-set should not be redistributed to IS-IS",
+			applyPolicyFunc: nonMatchingCommunityRoutePolicyV6,
+			verifyTelemetryFunc: func(t *testing.T, ts *isissession.TestSession) {
+				verifyNonMatchingCommunityTelemetryV6(t, ts.DUT, ts.ATE)
+			},
+			testTraffic: false,
+			ipv4:        false,
 		},
 		{
 			name:                "MatchingCommunityV6",
 			desc:                "IPv6: Matching BGP community in a community-set should be redistributed to IS-IS",
 			applyPolicyFunc:     matchingCommunityRoutePolicyV6,
-			verifyTelemetryFunc: verifyMatchingCommunityTelemetryV6,
+			verifyTelemetryFunc: func(t *testing.T, ts *isissession.TestSession) { verifyMatchingCommunityTelemetryV6(t, ts.DUT, ts.ATE) },
 			testTraffic:         true,
 			ipv4:                false,
 		},
@@ -197,7 +234,7 @@ func TestBGPToISISRedistribution(t *testing.T) {
 				bgpISISRedistributionV6(t, ts.DUT, "set")
 				defer bgpISISRedistributionV6(t, ts.DUT, "delete")
 			}
-			tc.verifyTelemetryFunc(t, ts.DUT, ts.ATE)
+			tc.verifyTelemetryFunc(t, ts)
 			if tc.testTraffic {
 				if tc.ipv4 {
 					createFlow(t, ts)
@@ -892,11 +929,12 @@ func createFlowV6(t *testing.T, ts *isissession.TestSession) {
 }
 
 func checkTraffic(t *testing.T, ts *isissession.TestSession, flowName string) {
-	defer otgutils.LogFlowMetrics(t, ts.ATE.OTG(), ts.ATETop)
-	defer otgutils.LogPortMetrics(t, ts.ATE.OTG(), ts.ATETop)
 	ts.ATE.OTG().StartTraffic(t)
 	time.Sleep(time.Second * 30)
 	ts.ATE.OTG().StopTraffic(t)
+
+	otgutils.LogFlowMetrics(t, ts.ATE.OTG(), ts.ATETop)
+	otgutils.LogPortMetrics(t, ts.ATE.OTG(), ts.ATETop)
 
 	t.Log("Checking flow telemetry...")
 	otgutils.ExpectedTrafficLoss(t, ts.ATE.OTG(), flowName, 0, 1)
@@ -911,4 +949,142 @@ func containsValue[T comparable](slice []T, val T) bool {
 		}
 	}
 	return found
+}
+
+func verifyMatchingPrefixWithRestartTelemetry(t *testing.T, ts *isissession.TestSession) {
+	verifyMatchingPrefixTelemetry(t, ts.DUT, ts.ATE)
+	t.Log("Restarting routing process via gNOI...")
+	gnoi.RestartRoutingProcess(t, ts.DUT)
+
+	t.Log("Wait for BGP and ISIS sessions to re-establish...")
+	cfgplugins.VerifyDUTBGPEstablished(t, ts.DUT)
+	cfgplugins.VerifyOTGBGPEstablished(t, ts.ATE)
+	ts.MustAdjacency(t)
+
+	verifyMatchingPrefixTelemetry(t, ts.DUT, ts.ATE)
+}
+
+func verifyMatchingPrefixWithRestartTelemetryV6(t *testing.T, ts *isissession.TestSession) {
+	verifyMatchingPrefixTelemetryV6(t, ts.DUT, ts.ATE)
+	t.Log("Restarting routing process via gNOI...")
+	gnoi.RestartRoutingProcess(t, ts.DUT)
+
+	t.Log("Wait for BGP and ISIS sessions to re-establish...")
+	cfgplugins.VerifyDUTBGPEstablished(t, ts.DUT)
+	cfgplugins.VerifyOTGBGPEstablished(t, ts.ATE)
+	ts.MustAdjacency(t)
+
+	verifyMatchingPrefixTelemetryV6(t, ts.DUT, ts.ATE)
+}
+
+func configureSharedNexthopStaticRoute(t *testing.T, dut *ondatra.DUTDevice) {
+	sV4 := &cfgplugins.StaticRouteCfg{
+		NetworkInstance: deviations.DefaultNetworkInstance(dut),
+		Prefix:          advertisedIPv4.cidr(t),
+		NextHops: map[string]oc.NetworkInstance_Protocol_Static_NextHop_NextHop_Union{
+			"0": oc.UnionString(isissession.ATETrafficAttrs.IPv4),
+		},
+	}
+	b := &gnmi.SetBatch{}
+	if _, err := cfgplugins.NewStaticRouteCfg(b, sV4, dut); err != nil {
+		t.Fatalf("Failed to configure static route: %v", err)
+	}
+	b.Set(t, dut)
+}
+
+func deleteSharedNexthopStaticRoute(t *testing.T, dut *ondatra.DUTDevice) {
+	gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(
+		oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC,
+		deviations.StaticProtocolName(dut)).Static(advertisedIPv4.cidr(t)).Config())
+}
+
+func configureSharedNexthopStaticRouteV6(t *testing.T, dut *ondatra.DUTDevice) {
+	sV6 := &cfgplugins.StaticRouteCfg{
+		NetworkInstance: deviations.DefaultNetworkInstance(dut),
+		Prefix:          advertisedIPv6.cidr(t),
+		NextHops: map[string]oc.NetworkInstance_Protocol_Static_NextHop_NextHop_Union{
+			"0": oc.UnionString(isissession.ATETrafficAttrs.IPv6),
+		},
+	}
+	b := &gnmi.SetBatch{}
+	if _, err := cfgplugins.NewStaticRouteCfg(b, sV6, dut); err != nil {
+		t.Fatalf("Failed to configure static route V6: %v", err)
+	}
+	b.Set(t, dut)
+}
+
+func deleteSharedNexthopStaticRouteV6(t *testing.T, dut *ondatra.DUTDevice) {
+	gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(
+		oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC,
+		deviations.StaticProtocolName(dut)).Static(advertisedIPv6.cidr(t)).Config())
+}
+
+func staticISISRedistribution(t *testing.T, dut *ondatra.DUTDevice, operation string) {
+	dni := deviations.DefaultNetworkInstance(dut)
+	root := &oc.Root{}
+	if deviations.EnableTableConnections(dut) {
+		fptest.ConfigEnableTbNative(t, dut)
+	}
+	tableConn := root.GetOrCreateNetworkInstance(dni).GetOrCreateTableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV4)
+	if operation == "set" {
+		if !deviations.SkipSettingDisableMetricPropagation(dut) {
+			tableConn.SetDisableMetricPropagation(false)
+		}
+		if !deviations.DefaultRoutePolicyUnsupported(dut) {
+			tableConn.SetDefaultImportPolicy(oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE)
+		}
+		tableConn.SetImportPolicy([]string{v4RoutePolicy})
+		gnmi.Update(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV4).Config(), tableConn)
+	} else if operation == "delete" {
+		gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV4).Config())
+	}
+}
+
+func staticISISRedistributionV6(t *testing.T, dut *ondatra.DUTDevice, operation string) {
+	dni := deviations.DefaultNetworkInstance(dut)
+	root := &oc.Root{}
+	if deviations.EnableTableConnections(dut) {
+		fptest.ConfigEnableTbNative(t, dut)
+	}
+	tableConn := root.GetOrCreateNetworkInstance(dni).GetOrCreateTableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV6)
+	if operation == "set" {
+		if !deviations.SkipSettingDisableMetricPropagation(dut) {
+			tableConn.SetDisableMetricPropagation(false)
+		}
+		if !deviations.DefaultRoutePolicyUnsupported(dut) {
+			tableConn.SetDefaultImportPolicy(oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE)
+		}
+		tableConn.SetImportPolicy([]string{v6RoutePolicy})
+		gnmi.Update(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV6).Config(), tableConn)
+	} else if operation == "delete" {
+		gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV6).Config())
+	}
+}
+
+func applySharedNexthopRoutePolicy(t *testing.T, dut *ondatra.DUTDevice) {
+	matchingPrefixRoutePolicy(t, dut)
+
+	configureSharedNexthopStaticRoute(t, dut)
+	t.Cleanup(func() {
+		deleteSharedNexthopStaticRoute(t, dut)
+	})
+
+	staticISISRedistribution(t, dut, "set")
+	t.Cleanup(func() {
+		staticISISRedistribution(t, dut, "delete")
+	})
+}
+
+func applySharedNexthopRoutePolicyV6(t *testing.T, dut *ondatra.DUTDevice) {
+	matchingPrefixRoutePolicyV6(t, dut)
+
+	configureSharedNexthopStaticRouteV6(t, dut)
+	t.Cleanup(func() {
+		deleteSharedNexthopStaticRouteV6(t, dut)
+	})
+
+	staticISISRedistributionV6(t, dut, "set")
+	t.Cleanup(func() {
+		staticISISRedistributionV6(t, dut, "delete")
+	})
 }

--- a/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
+++ b/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
@@ -929,6 +929,7 @@ func createFlowV6(t *testing.T, ts *isissession.TestSession) {
 }
 
 func checkTraffic(t *testing.T, ts *isissession.TestSession, flowName string) {
+	t.Helper()
 	ts.ATE.OTG().StartTraffic(t)
 	time.Sleep(time.Second * 30)
 	ts.ATE.OTG().StopTraffic(t)

--- a/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
+++ b/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
@@ -759,47 +759,47 @@ func verifyMatchingCommunityTelemetryV6(t *testing.T, dut *ondatra.DUTDevice, at
 		t.Errorf("Prefix not found, want: %s", advertisedIPv6.address)
 	}
 }
-
 func bgpISISRedistribution(t *testing.T, dut *ondatra.DUTDevice, operation string) {
-	dni := deviations.DefaultNetworkInstance(dut)
-	root := &oc.Root{}
+	// 1. Handle direct device configuration first
 	if deviations.EnableTableConnections(dut) {
 		fptest.ConfigEnableTbNative(t, dut)
 	}
-	tableConn := root.GetOrCreateNetworkInstance(dni).GetOrCreateTableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV4)
-	if operation == "set" {
-		if !deviations.SkipSettingDisableMetricPropagation(dut) {
-			tableConn.SetDisableMetricPropagation(false)
-		}
-		if !deviations.DefaultRoutePolicyUnsupported(dut) {
-			tableConn.SetDefaultImportPolicy(oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE)
-		}
-		tableConn.SetImportPolicy([]string{v4RoutePolicy})
-		gnmi.Update(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV4).Config(), tableConn)
-	} else if operation == "delete" {
-		gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV4).Config())
-	}
-}
 
+	// 2. Build the configuration batch using the standard plugin
+	b := &gnmi.SetBatch{}
+	cfgplugins.ConfigureTableConnection(t, dut, b, &cfgplugins.TableConnectionCfg{
+		SrcProto:                 oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP,
+		DstProto:                 oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+		Afi:                      oc.Types_ADDRESS_FAMILY_IPV4,
+		ImportPolicies:           []string{v4RoutePolicy},
+		DisableMetricPropagation: false,
+		DefaultImportPolicy:      oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE,
+		Delete:                   operation == "delete",
+	})
+
+	// 3. Execute the batch
+	b.Set(t, dut)
+}
 func bgpISISRedistributionV6(t *testing.T, dut *ondatra.DUTDevice, operation string) {
-	dni := deviations.DefaultNetworkInstance(dut)
-	root := &oc.Root{}
+	// 1. Handle direct device configuration first
 	if deviations.EnableTableConnections(dut) {
 		fptest.ConfigEnableTbNative(t, dut)
 	}
-	tableConn := root.GetOrCreateNetworkInstance(dni).GetOrCreateTableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV6)
-	if operation == "set" {
-		if !deviations.SkipSettingDisableMetricPropagation(dut) {
-			tableConn.SetDisableMetricPropagation(false)
-		}
-		if !deviations.DefaultRoutePolicyUnsupported(dut) {
-			tableConn.SetDefaultImportPolicy(oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE)
-		}
-		tableConn.SetImportPolicy([]string{v6RoutePolicy})
-		gnmi.Update(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV6).Config(), tableConn)
-	} else if operation == "delete" {
-		gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV6).Config())
-	}
+
+	// 2. Build the configuration batch using the standard plugin
+	b := &gnmi.SetBatch{}
+	cfgplugins.ConfigureTableConnection(t, dut, b, &cfgplugins.TableConnectionCfg{
+		SrcProto:                 oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP,
+		DstProto:                 oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+		Afi:                      oc.Types_ADDRESS_FAMILY_IPV6,
+		ImportPolicies:           []string{v6RoutePolicy},
+		DisableMetricPropagation: false,
+		DefaultImportPolicy:      oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE,
+		Delete:                   operation == "delete",
+	})
+
+	// 3. Execute the batch
+	b.Set(t, dut)
 }
 func bgpISISRedistributionWithRouteTagPolicy(t *testing.T, dut *ondatra.DUTDevice, afi oc.E_Types_ADDRESS_FAMILY) {
 	dni := deviations.DefaultNetworkInstance(dut)
@@ -1019,49 +1019,6 @@ func deleteSharedNexthopStaticRouteV6(t *testing.T, dut *ondatra.DUTDevice) {
 		oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC,
 		deviations.StaticProtocolName(dut)).Static(advertisedIPv6.cidr(t)).Config())
 }
-
-func staticISISRedistribution(t *testing.T, dut *ondatra.DUTDevice, operation string) {
-	dni := deviations.DefaultNetworkInstance(dut)
-	root := &oc.Root{}
-	if deviations.EnableTableConnections(dut) {
-		fptest.ConfigEnableTbNative(t, dut)
-	}
-	tableConn := root.GetOrCreateNetworkInstance(dni).GetOrCreateTableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV4)
-	if operation == "set" {
-		if !deviations.SkipSettingDisableMetricPropagation(dut) {
-			tableConn.SetDisableMetricPropagation(false)
-		}
-		if !deviations.DefaultRoutePolicyUnsupported(dut) {
-			tableConn.SetDefaultImportPolicy(oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE)
-		}
-		tableConn.SetImportPolicy([]string{v4RoutePolicy})
-		gnmi.Update(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV4).Config(), tableConn)
-	} else if operation == "delete" {
-		gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV4).Config())
-	}
-}
-
-func staticISISRedistributionV6(t *testing.T, dut *ondatra.DUTDevice, operation string) {
-	dni := deviations.DefaultNetworkInstance(dut)
-	root := &oc.Root{}
-	if deviations.EnableTableConnections(dut) {
-		fptest.ConfigEnableTbNative(t, dut)
-	}
-	tableConn := root.GetOrCreateNetworkInstance(dni).GetOrCreateTableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV6)
-	if operation == "set" {
-		if !deviations.SkipSettingDisableMetricPropagation(dut) {
-			tableConn.SetDisableMetricPropagation(false)
-		}
-		if !deviations.DefaultRoutePolicyUnsupported(dut) {
-			tableConn.SetDefaultImportPolicy(oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE)
-		}
-		tableConn.SetImportPolicy([]string{v6RoutePolicy})
-		gnmi.Update(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV6).Config(), tableConn)
-	} else if operation == "delete" {
-		gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS, oc.Types_ADDRESS_FAMILY_IPV6).Config())
-	}
-}
-
 func applySharedNexthopRoutePolicy(t *testing.T, dut *ondatra.DUTDevice) {
 	matchingPrefixRoutePolicy(t, dut)
 
@@ -1070,9 +1027,31 @@ func applySharedNexthopRoutePolicy(t *testing.T, dut *ondatra.DUTDevice) {
 		deleteSharedNexthopStaticRoute(t, dut)
 	})
 
-	staticISISRedistribution(t, dut, "set")
+	// Enable Table Connections if the deviation requires it
+	if deviations.EnableTableConnections(dut) {
+		fptest.ConfigEnableTbNative(t, dut)
+	}
+
+	b := &gnmi.SetBatch{}
+	cfgplugins.ConfigureTableConnection(t, dut, b, &cfgplugins.TableConnectionCfg{
+		SrcProto:                 oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC,
+		DstProto:                 oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+		Afi:                      oc.Types_ADDRESS_FAMILY_IPV4,
+		ImportPolicies:           []string{v4RoutePolicy},
+		DisableMetricPropagation: false,
+		DefaultImportPolicy:      oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE,
+	})
+	b.Set(t, dut)
+
 	t.Cleanup(func() {
-		staticISISRedistribution(t, dut, "delete")
+		bCleanup := &gnmi.SetBatch{}
+		cfgplugins.ConfigureTableConnection(t, dut, bCleanup, &cfgplugins.TableConnectionCfg{
+			SrcProto: oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC,
+			DstProto: oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+			Afi:      oc.Types_ADDRESS_FAMILY_IPV4,
+			Delete:   true,
+		})
+		bCleanup.Set(t, dut)
 	})
 }
 
@@ -1084,8 +1063,30 @@ func applySharedNexthopRoutePolicyV6(t *testing.T, dut *ondatra.DUTDevice) {
 		deleteSharedNexthopStaticRouteV6(t, dut)
 	})
 
-	staticISISRedistributionV6(t, dut, "set")
+	// Enable Table Connections if the deviation requires it
+	if deviations.EnableTableConnections(dut) {
+		fptest.ConfigEnableTbNative(t, dut)
+	}
+
+	b := &gnmi.SetBatch{}
+	cfgplugins.ConfigureTableConnection(t, dut, b, &cfgplugins.TableConnectionCfg{
+		SrcProto:                 oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC,
+		DstProto:                 oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+		Afi:                      oc.Types_ADDRESS_FAMILY_IPV6,
+		ImportPolicies:           []string{v6RoutePolicy},
+		DisableMetricPropagation: false,
+		DefaultImportPolicy:      oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE,
+	})
+	b.Set(t, dut)
+
 	t.Cleanup(func() {
-		staticISISRedistributionV6(t, dut, "delete")
+		bCleanup := &gnmi.SetBatch{}
+		cfgplugins.ConfigureTableConnection(t, dut, bCleanup, &cfgplugins.TableConnectionCfg{
+			SrcProto: oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC,
+			DstProto: oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_ISIS,
+			Afi:      oc.Types_ADDRESS_FAMILY_IPV6,
+			Delete:   true,
+		})
+		bCleanup.Set(t, dut)
 	})
 }

--- a/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
+++ b/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
@@ -509,7 +509,7 @@ func verifyMatchingPrefixTelemetry(t *testing.T, dut *ondatra.DUTDevice, ate *on
 }
 
 func verifyNonMatchingCommunityTelemetry(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
-	commSet := gnmi.Get[*oc.RoutingPolicy_DefinedSets_BgpDefinedSets_CommunitySet](t, dut, gnmi.OC().RoutingPolicy().DefinedSets().BgpDefinedSets().CommunitySet(v4CommunitySet).State())
+	commSet := gnmi.Get[*oc.RoutingPolicy_DefinedSets_BgpDefinedSets_CommunitySet](t, dut, gnmi.OC().RoutingPolicy().DefinedSets().BgpDefinedSets().CommunitySet(v6CommunitySet).State())
 	if commSet == nil {
 		t.Errorf("Community set is nil, want non-nil")
 	}
@@ -530,7 +530,7 @@ func verifyNonMatchingCommunityTelemetry(t *testing.T, dut *ondatra.DUTDevice, a
 }
 
 func verifyMatchingCommunityTelemetry(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
-	commSet := gnmi.Get[*oc.RoutingPolicy_DefinedSets_BgpDefinedSets_CommunitySet](t, dut, gnmi.OC().RoutingPolicy().DefinedSets().BgpDefinedSets().CommunitySet(v4CommunitySet).State())
+	commSet := gnmi.Get[*oc.RoutingPolicy_DefinedSets_BgpDefinedSets_CommunitySet](t, dut, gnmi.OC().RoutingPolicy().DefinedSets().BgpDefinedSets().CommunitySet(v6CommunitySet).State())
 	if commSet == nil {
 		t.Errorf("Community set is nil, want non-nil")
 	}
@@ -712,12 +712,16 @@ func verifyMatchingPrefixTelemetryV6(t *testing.T, dut *ondatra.DUTDevice, ate *
 		t.Errorf("Prefix is nil, want: %s", advertisedIPv6.cidr(t))
 	}
 
-	_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(advertisedIPv6.address).State(), 60*time.Second, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_Ipv6Reachability_Prefix]) bool {
+	// Normalize the IPv6 address to its standard compressed format (e.g. 2001:db8:128:128::)
+	compressedAddr := net.ParseIP(advertisedIPv6.address).String()
+
+	_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(compressedAddr).State(), 60*time.Second, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_Ipv6Reachability_Prefix]) bool {
 		prefix, present := v.Val()
-		return present && prefix.GetPrefix() == advertisedIPv6.address
+		return present && prefix.GetPrefix() == compressedAddr
 	}).Await(t)
+
 	if !ok {
-		t.Errorf("Prefix not found, want: %s", advertisedIPv6.address)
+		t.Errorf("Prefix not found, want: %s", compressedAddr)
 	}
 }
 
@@ -967,6 +971,7 @@ func verifyMatchingPrefixWithRestartTelemetry(t *testing.T, ts *isissession.Test
 
 func verifyMatchingPrefixWithRestartTelemetryV6(t *testing.T, ts *isissession.TestSession) {
 	verifyMatchingPrefixTelemetryV6(t, ts.DUT, ts.ATE)
+	time.Sleep(2 * time.Minute)
 	t.Log("Restarting routing process via gNOI...")
 	gnoi.RestartRoutingProcess(t, ts.DUT)
 

--- a/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
+++ b/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
@@ -509,7 +509,7 @@ func verifyMatchingPrefixTelemetry(t *testing.T, dut *ondatra.DUTDevice, ate *on
 }
 
 func verifyNonMatchingCommunityTelemetry(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
-	commSet := gnmi.Get[*oc.RoutingPolicy_DefinedSets_BgpDefinedSets_CommunitySet](t, dut, gnmi.OC().RoutingPolicy().DefinedSets().BgpDefinedSets().CommunitySet(v6CommunitySet).State())
+	commSet := gnmi.Get[*oc.RoutingPolicy_DefinedSets_BgpDefinedSets_CommunitySet](t, dut, gnmi.OC().RoutingPolicy().DefinedSets().BgpDefinedSets().CommunitySet(v4CommunitySet).State())
 	if commSet == nil {
 		t.Errorf("Community set is nil, want non-nil")
 	}
@@ -530,7 +530,7 @@ func verifyNonMatchingCommunityTelemetry(t *testing.T, dut *ondatra.DUTDevice, a
 }
 
 func verifyMatchingCommunityTelemetry(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
-	commSet := gnmi.Get[*oc.RoutingPolicy_DefinedSets_BgpDefinedSets_CommunitySet](t, dut, gnmi.OC().RoutingPolicy().DefinedSets().BgpDefinedSets().CommunitySet(v6CommunitySet).State())
+	commSet := gnmi.Get[*oc.RoutingPolicy_DefinedSets_BgpDefinedSets_CommunitySet](t, dut, gnmi.OC().RoutingPolicy().DefinedSets().BgpDefinedSets().CommunitySet(v4CommunitySet).State())
 	if commSet == nil {
 		t.Errorf("Community set is nil, want non-nil")
 	}

--- a/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
+++ b/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
@@ -16,11 +16,6 @@ package bgp_isis_redistribution_test
 
 import (
 	"fmt"
-	"net"
-	"strconv"
-	"testing"
-	"time"
-
 	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/openconfig/featureprofiles/internal/cfgplugins"
 	"github.com/openconfig/featureprofiles/internal/deviations"
@@ -35,6 +30,10 @@ import (
 	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
+	"net"
+	"strconv"
+	"testing"
+	"time"
 )
 
 const (
@@ -100,8 +99,16 @@ type testCase struct {
 	desc                string
 	applyPolicyFunc     func(t *testing.T, dut *ondatra.DUTDevice)
 	verifyTelemetryFunc func(t *testing.T, ts *isissession.TestSession)
+	skipFunc            func(t *testing.T, dut *ondatra.DUTDevice)
 	testTraffic         bool
 	ipv4                bool
+}
+
+func skipRoutingRestart(t *testing.T, dut *ondatra.DUTDevice) {
+	t.Helper()
+	if deviations.RoutingRestartViaGnoiUnsupported(dut) {
+		t.Skip("Skipping routing restart via gNOI due to deviation")
+	}
 }
 
 func TestBGPToISISRedistribution(t *testing.T) {
@@ -142,6 +149,7 @@ func TestBGPToISISRedistribution(t *testing.T) {
 			desc:                "Verify BGP-to-ISIS redistributed routes persist after routing daemon restart",
 			applyPolicyFunc:     matchingPrefixRoutePolicy,
 			verifyTelemetryFunc: verifyMatchingPrefixWithRestartTelemetry,
+			skipFunc:            skipRoutingRestart,
 			testTraffic:         true,
 			ipv4:                true,
 		},
@@ -150,6 +158,7 @@ func TestBGPToISISRedistribution(t *testing.T) {
 			desc:                "Verify BGP-to-ISIS redistributed routes persist after routing daemon restart with Shared Nexthop",
 			applyPolicyFunc:     applySharedNexthopRoutePolicy,
 			verifyTelemetryFunc: verifyMatchingPrefixWithRestartTelemetry,
+			skipFunc:            skipRoutingRestart,
 			testTraffic:         true,
 			ipv4:                true,
 		},
@@ -192,6 +201,7 @@ func TestBGPToISISRedistribution(t *testing.T) {
 			desc:                "Verify IPv6 BGP-to-ISIS redistributed routes persist after routing daemon restart",
 			applyPolicyFunc:     matchingPrefixRoutePolicyV6,
 			verifyTelemetryFunc: verifyMatchingPrefixWithRestartTelemetryV6,
+			skipFunc:            skipRoutingRestart,
 			testTraffic:         true,
 			ipv4:                false,
 		},
@@ -200,6 +210,7 @@ func TestBGPToISISRedistribution(t *testing.T) {
 			desc:                "Verify IPv6 BGP-to-ISIS redistributed routes persist after routing daemon restart with Shared Nexthop",
 			applyPolicyFunc:     applySharedNexthopRoutePolicyV6,
 			verifyTelemetryFunc: verifyMatchingPrefixWithRestartTelemetryV6,
+			skipFunc:            skipRoutingRestart,
 			testTraffic:         true,
 			ipv4:                false,
 		},
@@ -226,6 +237,9 @@ func TestBGPToISISRedistribution(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Description: %s", tc.desc)
+			if tc.skipFunc != nil {
+				tc.skipFunc(t, ts.DUT)
+			}
 			tc.applyPolicyFunc(t, ts.DUT)
 			if tc.ipv4 {
 				bgpISISRedistribution(t, ts.DUT, "set")
@@ -234,13 +248,18 @@ func TestBGPToISISRedistribution(t *testing.T) {
 				bgpISISRedistributionV6(t, ts.DUT, "set")
 				defer bgpISISRedistributionV6(t, ts.DUT, "delete")
 			}
-			tc.verifyTelemetryFunc(t, ts)
 			if tc.testTraffic {
 				if tc.ipv4 {
 					createFlow(t, ts)
-					checkTraffic(t, ts, v4FlowName)
 				} else {
 					createFlowV6(t, ts)
+				}
+			}
+			tc.verifyTelemetryFunc(t, ts)
+			if tc.testTraffic {
+				if tc.ipv4 {
+					checkTraffic(t, ts, v4FlowName)
+				} else {
 					checkTraffic(t, ts, v6FlowName)
 				}
 			}
@@ -426,6 +445,72 @@ func matchingCommunityRoutePolicy(t *testing.T, dut *ondatra.DUTDevice) {
 	}
 }
 
+func waitForIPv4PrefixAbsent(t *testing.T, ate *ondatra.ATEDevice, prefix string, timeout time.Duration) {
+	t.Helper()
+	// Check if prefix is currently present in OTG LSDB (e.g. from a previous subtest).
+	// If present, wait for DUT route withdrawal to propagate to OTG.
+	prefixes := gnmi.LookupAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().ExtendedIpv4Reachability().Prefix(prefix).State())
+	hasPrefix := false
+	for _, p := range prefixes {
+		if val, ok := p.Val(); ok && val.GetPrefix() == prefix {
+			hasPrefix = true
+			break
+		}
+	}
+	if hasPrefix {
+		t.Logf("Prefix %s is currently present in LSDB; waiting for withdrawal...", prefix)
+		_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().ExtendedIpv4Reachability().Prefix(prefix).State(), timeout, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_ExtendedIpv4Reachability_Prefix]) bool {
+			_, present := v.Val()
+			return !present
+		}).Await(t)
+		if !ok {
+			t.Errorf("Timed out waiting for prefix %s to be withdrawn from LSDB", prefix)
+		}
+		return
+	}
+
+	_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().ExtendedIpv4Reachability().Prefix(prefix).State(), timeout, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_ExtendedIpv4Reachability_Prefix]) bool {
+		pfx, present := v.Val()
+		return present && pfx.GetPrefix() == prefix
+	}).Await(t)
+	if ok {
+		t.Errorf("Prefix found, not want: %s", prefix)
+	}
+}
+
+func waitForIPv6PrefixAbsent(t *testing.T, ate *ondatra.ATEDevice, prefix string, timeout time.Duration) {
+	t.Helper()
+	// Check if prefix is currently present in OTG LSDB (e.g. from a previous subtest).
+	// If present, wait for DUT route withdrawal to propagate to OTG.
+	prefixes := gnmi.LookupAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(prefix).State())
+	hasPrefix := false
+	for _, p := range prefixes {
+		if val, ok := p.Val(); ok && val.GetPrefix() == prefix {
+			hasPrefix = true
+			break
+		}
+	}
+	if hasPrefix {
+		t.Logf("Prefix %s is currently present in LSDB; waiting for withdrawal...", prefix)
+		_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(prefix).State(), timeout, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_Ipv6Reachability_Prefix]) bool {
+			_, present := v.Val()
+			return !present
+		}).Await(t)
+		if !ok {
+			t.Errorf("Timed out waiting for prefix %s to be withdrawn from LSDB", prefix)
+		}
+		return
+	}
+
+	_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(prefix).State(), timeout, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_Ipv6Reachability_Prefix]) bool {
+		pfx, present := v.Val()
+		return present && pfx.GetPrefix() == prefix
+	}).Await(t)
+	if ok {
+		t.Errorf("Prefix found, not want: %s", prefix)
+	}
+}
+
 func verifyNonMatchingPrefixTelemetry(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
 	rPolicy := gnmi.Get[*oc.RoutingPolicy](t, dut, gnmi.OC().RoutingPolicy().State())
 
@@ -480,13 +565,7 @@ func verifyNonMatchingPrefixTelemetry(t *testing.T, dut *ondatra.DUTDevice, ate 
 		t.Errorf("Import policy: %v, want: %s", importPolicy, []string{v4RoutePolicy})
 	}
 
-	_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().ExtendedIpv4Reachability().Prefix(advertisedIPv4.address).State(), 30*time.Second, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_ExtendedIpv4Reachability_Prefix]) bool {
-		prefix, present := v.Val()
-		return present && prefix.GetPrefix() == advertisedIPv4.address
-	}).Await(t)
-	if ok {
-		t.Errorf("Prefix found, not want: %s", advertisedIPv4.address)
-	}
+	waitForIPv4PrefixAbsent(t, ate, advertisedIPv4.address, 30*time.Second)
 }
 
 func verifyMatchingPrefixTelemetry(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
@@ -520,13 +599,7 @@ func verifyNonMatchingCommunityTelemetry(t *testing.T, dut *ondatra.DUTDevice, a
 		t.Errorf("Community set member: %v, want: %s or %d", commSetMember, nonMatchingCommunityVal, cm)
 	}
 
-	_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().ExtendedIpv4Reachability().Prefix(advertisedIPv4.address).State(), 30*time.Second, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_ExtendedIpv4Reachability_Prefix]) bool {
-		_, present := v.Val()
-		return !present
-	}).Await(t)
-	if ok {
-		t.Errorf("Prefix found, not want: %s", advertisedIPv4.address)
-	}
+	waitForIPv4PrefixAbsent(t, ate, advertisedIPv4.address, 30*time.Second)
 }
 
 func verifyMatchingCommunityTelemetry(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
@@ -693,13 +766,7 @@ func verifyNonMatchingPrefixTelemetryV6(t *testing.T, dut *ondatra.DUTDevice, at
 		t.Errorf("Import policy: %v, want: %s", importPolicy, []string{v6RoutePolicy})
 	}
 
-	_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(advertisedIPv6.address).State(), 60*time.Second, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_Ipv6Reachability_Prefix]) bool {
-		prefix, present := v.Val()
-		return present && prefix.GetPrefix() == advertisedIPv6.address
-	}).Await(t)
-	if ok {
-		t.Errorf("Prefix found, not want: %s", advertisedIPv6.address)
-	}
+	waitForIPv6PrefixAbsent(t, ate, advertisedIPv6.address, 60*time.Second)
 }
 
 func verifyMatchingPrefixTelemetryV6(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
@@ -712,16 +779,13 @@ func verifyMatchingPrefixTelemetryV6(t *testing.T, dut *ondatra.DUTDevice, ate *
 		t.Errorf("Prefix is nil, want: %s", advertisedIPv6.cidr(t))
 	}
 
-	// Normalize the IPv6 address to its standard compressed format (e.g. 2001:db8:128:128::)
-	compressedAddr := net.ParseIP(advertisedIPv6.address).String()
-
-	_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(compressedAddr).State(), 60*time.Second, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_Ipv6Reachability_Prefix]) bool {
+	_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(advertisedIPv6.address).State(), 60*time.Second, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_Ipv6Reachability_Prefix]) bool {
 		prefix, present := v.Val()
-		return present && prefix.GetPrefix() == compressedAddr
+		return present && prefix.GetPrefix() == advertisedIPv6.address
 	}).Await(t)
 
 	if !ok {
-		t.Errorf("Prefix not found, want: %s", compressedAddr)
+		t.Errorf("Prefix not found, want: %s", advertisedIPv6.address)
 	}
 }
 
@@ -735,13 +799,7 @@ func verifyNonMatchingCommunityTelemetryV6(t *testing.T, dut *ondatra.DUTDevice,
 		t.Errorf("Community set member: %v, want: %s or %d", commSetMember, nonMatchingCommunityVal, cm)
 	}
 
-	_, ok := gnmi.WatchAll(t, ate.OTG(), gnmi.OTG().IsisRouter("devIsis").LinkStateDatabase().LspsAny().Tlvs().Ipv6Reachability().Prefix(advertisedIPv6.address).State(), 60*time.Second, func(v *ygnmi.Value[*otgtelemetry.IsisRouter_LinkStateDatabase_Lsps_Tlvs_Ipv6Reachability_Prefix]) bool {
-		_, present := v.Val()
-		return !present
-	}).Await(t)
-	if ok {
-		t.Errorf("Prefix found, not want: %s", advertisedIPv6.address)
-	}
+	waitForIPv6PrefixAbsent(t, ate, advertisedIPv6.address, 60*time.Second)
 }
 
 func verifyMatchingCommunityTelemetryV6(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
@@ -957,6 +1015,9 @@ func containsValue[T comparable](slice []T, val T) bool {
 }
 
 func verifyMatchingPrefixWithRestartTelemetry(t *testing.T, ts *isissession.TestSession) {
+	if deviations.RoutingRestartViaGnoiUnsupported(ts.DUT) {
+		t.Skip("Skipping routing restart via gNOI due to deviation")
+	}
 	verifyMatchingPrefixTelemetry(t, ts.DUT, ts.ATE)
 	t.Log("Restarting routing process via gNOI...")
 	gnoi.RestartRoutingProcess(t, ts.DUT)
@@ -970,8 +1031,10 @@ func verifyMatchingPrefixWithRestartTelemetry(t *testing.T, ts *isissession.Test
 }
 
 func verifyMatchingPrefixWithRestartTelemetryV6(t *testing.T, ts *isissession.TestSession) {
+	if deviations.RoutingRestartViaGnoiUnsupported(ts.DUT) {
+		t.Skip("Skipping routing restart via gNOI due to deviation")
+	}
 	verifyMatchingPrefixTelemetryV6(t, ts.DUT, ts.ATE)
-	time.Sleep(2 * time.Minute)
 	t.Log("Restarting routing process via gNOI...")
 	gnoi.RestartRoutingProcess(t, ts.DUT)
 

--- a/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
+++ b/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/bgp_isis_redistribution_test.go
@@ -16,6 +16,11 @@ package bgp_isis_redistribution_test
 
 import (
 	"fmt"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
 	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/openconfig/featureprofiles/internal/cfgplugins"
 	"github.com/openconfig/featureprofiles/internal/deviations"
@@ -30,10 +35,6 @@ import (
 	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
-	"net"
-	"strconv"
-	"testing"
-	"time"
 )
 
 const (

--- a/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/metadata.textproto
+++ b/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/metadata.textproto
@@ -49,5 +49,6 @@ platform_exceptions: {
   interface_enabled: true
   skip_prefix_set_mode: true
   enable_table_connections: true
+  static_protocol_name: "static"
   }
 }

--- a/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/metadata.textproto
+++ b/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/metadata.textproto
@@ -16,6 +16,7 @@ platform_exceptions:  {
     interface_enabled:  true
     default_network_instance:  "default"
     isis_interface_afi_unsupported:  true
+    routing_restart_via_gnoi_unsupported: true
   }
 }
 platform_exceptions: {

--- a/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/metadata.textproto
+++ b/feature/bgp/bgp_isis_redistribution/otg_tests/bgp_isis_redistribution_test/metadata.textproto
@@ -33,6 +33,7 @@ platform_exceptions: {
     vendor: CISCO
   }
   deviations: {
+    routing_restart_via_gnoi_unsupported: true
     skip_isis_set_level:  true
     skip_isis_set_metric_style_type:  true
     bgp_conditions_match_community_set_unsupported: true

--- a/internal/cfgplugins/tableconnections.go
+++ b/internal/cfgplugins/tableconnections.go
@@ -18,8 +18,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/featureprofiles/internal/helpers"
 	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/ondatra/gnmi/oc"
 )
 
 // DeviationCiscoTableConnectionsStatictoBGPMetricPropagation is used as an alternative to
@@ -45,4 +49,26 @@ func DeviationCiscoTableConnectionsStatictoBGPMetricPropagation(t *testing.T, du
 		cliConfig = fmt.Sprintf("router bgp 64512\n address-family %v unicast\n redistribute static metric %d route-policy %s\n !\n!\n", aftype, metric, routePolicyName)
 	}
 	helpers.GnmiCLIConfig(t, dut, cliConfig)
+}
+
+// ConfigureTableConnection sets or deletes a table connection redistribution policy on the DUT.
+func ConfigureTableConnection(t *testing.T, dut *ondatra.DUTDevice, srcProto, dstProto oc.E_PolicyTypes_INSTALL_PROTOCOL_TYPE, afi oc.E_Types_ADDRESS_FAMILY, importPolicies []string, disableMetricPropagation bool, defaultImportPolicy oc.E_RoutingPolicy_DefaultPolicyType, operation string) {
+	dni := deviations.DefaultNetworkInstance(dut)
+	if deviations.EnableTableConnections(dut) {
+		fptest.ConfigEnableTbNative(t, dut)
+	}
+	if operation == "delete" {
+		gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(srcProto, dstProto, afi).Config())
+		return
+	}
+	root := &oc.Root{}
+	tableConn := root.GetOrCreateNetworkInstance(dni).GetOrCreateTableConnection(srcProto, dstProto, afi)
+	if !deviations.SkipSettingDisableMetricPropagation(dut) {
+		tableConn.SetDisableMetricPropagation(disableMetricPropagation)
+	}
+	if !deviations.DefaultRoutePolicyUnsupported(dut) {
+		tableConn.SetDefaultImportPolicy(defaultImportPolicy)
+	}
+	tableConn.SetImportPolicy(importPolicies)
+	gnmi.Update(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(srcProto, dstProto, afi).Config(), tableConn)
 }

--- a/internal/cfgplugins/tableconnections.go
+++ b/internal/cfgplugins/tableconnections.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/openconfig/featureprofiles/internal/deviations"
-	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/featureprofiles/internal/helpers"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
@@ -51,24 +50,37 @@ func DeviationCiscoTableConnectionsStatictoBGPMetricPropagation(t *testing.T, du
 	helpers.GnmiCLIConfig(t, dut, cliConfig)
 }
 
-// ConfigureTableConnection sets or deletes a table connection redistribution policy on the DUT.
-func ConfigureTableConnection(t *testing.T, dut *ondatra.DUTDevice, srcProto, dstProto oc.E_PolicyTypes_INSTALL_PROTOCOL_TYPE, afi oc.E_Types_ADDRESS_FAMILY, importPolicies []string, disableMetricPropagation bool, defaultImportPolicy oc.E_RoutingPolicy_DefaultPolicyType, operation string) {
+// TableConnectionCfg holds the configuration parameters for a table connection.
+type TableConnectionCfg struct {
+	SrcProto                 oc.E_PolicyTypes_INSTALL_PROTOCOL_TYPE
+	DstProto                 oc.E_PolicyTypes_INSTALL_PROTOCOL_TYPE
+	Afi                      oc.E_Types_ADDRESS_FAMILY
+	ImportPolicies           []string
+	DisableMetricPropagation bool
+	DefaultImportPolicy      oc.E_RoutingPolicy_DefaultPolicyType
+	Delete                   bool
+}
+
+// ConfigureTableConnection appends a table connection redistribution policy configuration to the batch.
+func ConfigureTableConnection(t *testing.T, dut *ondatra.DUTDevice, sb *gnmi.SetBatch, cfg *TableConnectionCfg) *gnmi.SetBatch {
 	dni := deviations.DefaultNetworkInstance(dut)
-	if deviations.EnableTableConnections(dut) {
-		fptest.ConfigEnableTbNative(t, dut)
+
+	if cfg.Delete {
+		gnmi.BatchDelete(sb, gnmi.OC().NetworkInstance(dni).TableConnection(cfg.SrcProto, cfg.DstProto, cfg.Afi).Config())
+		return sb
 	}
-	if operation == "delete" {
-		gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(srcProto, dstProto, afi).Config())
-		return
-	}
+
 	root := &oc.Root{}
-	tableConn := root.GetOrCreateNetworkInstance(dni).GetOrCreateTableConnection(srcProto, dstProto, afi)
+	tableConn := root.GetOrCreateNetworkInstance(dni).GetOrCreateTableConnection(cfg.SrcProto, cfg.DstProto, cfg.Afi)
+
 	if !deviations.SkipSettingDisableMetricPropagation(dut) {
-		tableConn.SetDisableMetricPropagation(disableMetricPropagation)
+		tableConn.SetDisableMetricPropagation(cfg.DisableMetricPropagation)
 	}
 	if !deviations.DefaultRoutePolicyUnsupported(dut) {
-		tableConn.SetDefaultImportPolicy(defaultImportPolicy)
+		tableConn.SetDefaultImportPolicy(cfg.DefaultImportPolicy)
 	}
-	tableConn.SetImportPolicy(importPolicies)
-	gnmi.Update(t, dut, gnmi.OC().NetworkInstance(dni).TableConnection(srcProto, dstProto, afi).Config(), tableConn)
+	tableConn.SetImportPolicy(cfg.ImportPolicies)
+
+	gnmi.BatchUpdate(sb, gnmi.OC().NetworkInstance(dni).TableConnection(cfg.SrcProto, cfg.DstProto, cfg.Afi).Config(), tableConn)
+	return sb
 }

--- a/internal/cfgplugins/tableconnections.go
+++ b/internal/cfgplugins/tableconnections.go
@@ -16,12 +16,13 @@ package cfgplugins
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/helpers"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	"testing"
 )
 
 // DeviationCiscoTableConnectionsStatictoBGPMetricPropagation is used as an alternative to

--- a/internal/cfgplugins/tableconnections.go
+++ b/internal/cfgplugins/tableconnections.go
@@ -16,13 +16,12 @@ package cfgplugins
 
 import (
 	"fmt"
-	"testing"
-
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/helpers"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	"testing"
 )
 
 // DeviationCiscoTableConnectionsStatictoBGPMetricPropagation is used as an alternative to

--- a/internal/gnoi/gnoi.go
+++ b/internal/gnoi/gnoi.go
@@ -117,7 +117,7 @@ func KillProcess(t *testing.T, dut *ondatra.DUTDevice, daemon Daemon, signal spb
 	time.Sleep(120 * time.Second)
 
 	if waitForRestart {
-		gnmi.WatchAll(
+		_, ok := gnmi.WatchAll(
 			t,
 			dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_ON_CHANGE)),
 			gnmi.OC().System().ProcessAny().State(),
@@ -129,7 +129,10 @@ func KillProcess(t *testing.T, dut *ondatra.DUTDevice, daemon Daemon, signal spb
 				}
 				return val.GetName() == daemonName && val.GetPid() != pid
 			},
-		)
+		).Await(t)
+		if !ok {
+			t.Fatalf("Timed out waiting for process %s to restart with a new PID", daemonName)
+		}
 	}
 }
 

--- a/internal/gnoi/gnoi.go
+++ b/internal/gnoi/gnoi.go
@@ -21,13 +21,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/system"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	spb "github.com/openconfig/gnoi/system"
-	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ygnmi/ygnmi"
+
 )
 
 var (
@@ -143,4 +145,14 @@ func FetchProcessName(dut *ondatra.DUTDevice, daemon Daemon) (string, error) {
 		return "", fmt.Errorf("daemon %s not defined for vendor %s", daemon, dut.Vendor().String())
 	}
 	return d, nil
+}
+
+// RestartRoutingProcess restarts the routing daemon on the DUT via gNOI and waits for it to restart.
+// If the device does not support restarting the routing process via gNOI, the test is skipped.
+func RestartRoutingProcess(t *testing.T, dut *ondatra.DUTDevice) {
+	t.Helper()
+	if deviations.RoutingRestartViaGnoiUnsupported(dut) {
+		t.Skip("Skipping routing restart via gNOI due to deviation")
+	}
+	KillProcess(t, dut, ROUTING, SigTerm, true, true)
 }

--- a/internal/gnoi/gnoi.go
+++ b/internal/gnoi/gnoi.go
@@ -25,11 +25,10 @@ import (
 	"github.com/openconfig/featureprofiles/internal/system"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	spb "github.com/openconfig/gnoi/system"
+	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ygnmi/ygnmi"
-
 )
 
 var (

--- a/internal/gnoi/gnoi.go
+++ b/internal/gnoi/gnoi.go
@@ -112,6 +112,18 @@ func KillProcess(t *testing.T, dut *ondatra.DUTDevice, daemon Daemon, signal spb
 	_, err = gnoiClient.System().KillProcess(context.Background(), killProcessRequest)
 	if err != nil {
 		t.Logf("Error: %v in executing the kill process %v", err.Error(), daemonName)
+		if signal == SigTerm {
+			t.Logf("Retrying with SIGNAL_KILL (cold restart)...")
+			currentPid := system.FindProcessIDByName(t, dut, daemonName)
+			if currentPid != 0 {
+				killProcessRequest.Pid = uint32(currentPid)
+			}
+			killProcessRequest.Signal = SigKill
+			_, err = gnoiClient.System().KillProcess(context.Background(), killProcessRequest)
+		}
+		if err != nil {
+			t.Fatalf("Failed to kill process %v: %v", daemonName, err)
+		}
 	}
 
 	time.Sleep(120 * time.Second)
@@ -119,7 +131,7 @@ func KillProcess(t *testing.T, dut *ondatra.DUTDevice, daemon Daemon, signal spb
 	if waitForRestart {
 		_, ok := gnmi.WatchAll(
 			t,
-			dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_ON_CHANGE)),
+			dut.GNMIOpts().WithYGNMIOpts(ygnmi.WithSubscriptionMode(gpb.SubscriptionMode_SAMPLE)),
 			gnmi.OC().System().ProcessAny().State(),
 			time.Minute,
 			func(p *ygnmi.Value[*oc.System_Process]) bool {


### PR DESCRIPTION
RT-1.28: BGP to IS-IS redistribution

This test verifies that BGP routes (IPv4/IPv6, standard and shared next-hop) redistributed into IS-IS persist and forward traffic correctly after a routing daemon restart.
Setup: Establish BGP and IS-IS sessions with an ATE, configure route redistribution on the DUT, and send continuous traffic.
Execution: Restart the DUT's routing daemon via a gNOI KillProcess command and monitor recovery.
Success Criteria: The BGP and IS-IS sessions must successfully re-establish, all redistributed prefixes must remain correctly programmed in the routing/forwarding tables, and data-plane traffic must recover to 0% loss with no stuck routes
https://critique.corp.google.com/cl/960238530