### PR TITLE
Added new file vrf_selection_resiliency_test.go for b/444247831 and b/446064682

### DIFF
--- a/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
@@ -112,8 +112,12 @@ func TestVRFSelectionResiliency(t *testing.T) {
 	s1.GetOrCreateIpv4().GetOrCreateAddress("100.64.0.1").PrefixLength = ygot.Uint8(24)
 
 	// Step 1: Initial VRF Binding for ingress
+	ingressID := p1.Name()
+	if deviations.InterfaceRefInterfaceIDFormat(dut) || deviations.InterfaceIDFormatRequiredForPolicyForwarding(dut) {
+		ingressID = p1.Name() + ".0"
+	}
 	niPfw := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreatePolicyForwarding()
-	i1fwd := niPfw.GetOrCreateInterface(p1.Name())
+	i1fwd := niPfw.GetOrCreateInterface(ingressID)
 	i1fwd.ApplyVrfSelectionPolicy = ygot.String(policyName)
 	if !deviations.InterfaceRefConfigUnsupported(dut) {
 		i1fwd.GetOrCreateInterfaceRef().Interface = ygot.String(p1.Name())
@@ -124,29 +128,29 @@ func TestVRFSelectionResiliency(t *testing.T) {
 	// Port-2 (Egress 1)
 	for i := 1; i <= 10; i++ {
 		configEgressSubIntf(dut, d, p2, idx, fmt.Sprintf("VRF-V4-%d", i))
-		configStaticRoute(d, dut, fmt.Sprintf("VRF-V4-%d", i), fmt.Sprintf("203.0.113.%d/32", i), fmt.Sprintf("192.168.%d.2", idx), "", "")
+		configStaticRoute(d, dut, fmt.Sprintf("VRF-V4-%d", i), fmt.Sprintf("203.0.113.%d/32", i), fmt.Sprintf("100.64.%d.2", idx), "", "")
 		idx++
 	}
 	configEgressSubIntf(dut, d, p2, idx, deviations.DefaultNetworkInstance(dut)) // DEFAULT
-	configStaticRoute(d, dut, deviations.DefaultNetworkInstance(dut), "0.0.0.0/0", fmt.Sprintf("192.168.%d.2", idx), "::/0", fmt.Sprintf("2001:db8:%d::2", idx))
+	configStaticRoute(d, dut, deviations.DefaultNetworkInstance(dut), "0.0.0.0/0", fmt.Sprintf("100.64.%d.2", idx), "::/0", fmt.Sprintf("2001:db8:%d::2", idx))
 	idx++
 
 	// Port-3 (Egress 2)
 	for i := 11; i <= 15; i++ {
 		configEgressSubIntf(dut, d, p3, idx, fmt.Sprintf("VRF-V4-%d", i))
-		configStaticRoute(d, dut, fmt.Sprintf("VRF-V4-%d", i), fmt.Sprintf("203.0.113.%d/32", i), fmt.Sprintf("192.168.%d.2", idx), "", "")
+		configStaticRoute(d, dut, fmt.Sprintf("VRF-V4-%d", i), fmt.Sprintf("203.0.113.%d/32", i), fmt.Sprintf("100.64.%d.2", idx), "", "")
 		idx++
 	}
 	for i := 1; i <= 5; i++ {
 		configEgressSubIntf(dut, d, p3, idx, fmt.Sprintf("VRF-V6-%d", i))
-		configStaticRoute(d, dut, fmt.Sprintf("VRF-V6-%d", i), fmt.Sprintf("203.0.113.%d/32", i), fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("2001:db8:a:%d::/128", i), fmt.Sprintf("2001:db8:%d::2", idx))
+		configStaticRoute(d, dut, fmt.Sprintf("VRF-V6-%d", i), fmt.Sprintf("203.0.113.%d/32", i), fmt.Sprintf("100.64.%d.2", idx), fmt.Sprintf("2001:db8:a:%d::/128", i), fmt.Sprintf("2001:db8:%d::2", idx))
 		idx++
 	}
 
 	// Port-4 (Egress 3)
 	for i := 6; i <= 15; i++ {
 		configEgressSubIntf(dut, d, p4, idx, fmt.Sprintf("VRF-V6-%d", i))
-		configStaticRoute(d, dut, fmt.Sprintf("VRF-V6-%d", i), fmt.Sprintf("203.0.113.%d/32", i), fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("2001:db8:a:%d::/128", i), fmt.Sprintf("2001:db8:%d::2", idx))
+		configStaticRoute(d, dut, fmt.Sprintf("VRF-V6-%d", i), fmt.Sprintf("203.0.113.%d/32", i), fmt.Sprintf("100.64.%d.2", idx), fmt.Sprintf("2001:db8:a:%d::/128", i), fmt.Sprintf("2001:db8:%d::2", idx))
 		idx++
 	}
 

--- a/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
@@ -291,7 +291,7 @@ func TestVRFSelectionResiliency(t *testing.T) {
 
 		t.Logf("RT-3.4.3 - Step 2: Validating autonomous recovery")
 		vrfpolicy.ValidateBaselineTraffic(t, ate, top)
-
+	}
 	// RT-3.4.4 - Policy Deletion
 	t.Logf("RT-3.4.4 - Step 1 & 2: Delete VRF Selection Policy & Push Configuration")
 	vrfpolicy.DeletePolicyForwarding(t, dut, p1.Name())
@@ -314,4 +314,4 @@ func TestVRFSelectionResiliency(t *testing.T) {
 	ate.OTG().StartTraffic(t)
 
 	vrfpolicy.ValidateFallbackTraffic(t, ate, top)
-}
+	}

--- a/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
@@ -206,6 +206,7 @@ func TestVRFSelectionResiliency(t *testing.T) {
 
 	// Wait for ARP resolution
 	otgutils.WaitForARP(t, ate.OTG(), top, "IPv4")
+	otgutils.WaitForARP(t, ate.OTG(), top, "IPv6")
 	ate.OTG().StartTraffic(t)
 
 	// RT-3.4.1 Step 4: Validating perfect isolation, default fallbacks, ghost drops, and shadow routes

--- a/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
@@ -285,10 +285,7 @@ func TestVRFSelectionResiliency(t *testing.T) {
 		gnmi.Await(t, dut, gnmi.OC().Interface(p1.Name()).OperStatus().State(), 2*time.Minute, oc.Interface_OperStatus_UP)
 
 		t.Logf("RT-3.4.3 - Step 2: Validating autonomous recovery")
-		// Give BGP and linecard time to restore forwarding entries
-		time.Sleep(2 * time.Minute)
 		vrfpolicy.ValidateBaselineTraffic(t, ate, top)
-	}
 
 	// RT-3.4.4 - Policy Deletion
 	t.Logf("RT-3.4.4 - Step 1 & 2: Delete VRF Selection Policy & Push Configuration")

--- a/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
@@ -1,0 +1,280 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vrf_selection_resiliency_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/open-traffic-generator/snappi/gosnappi"
+	"github.com/openconfig/featureprofiles/internal/cfgplugins"
+	"github.com/openconfig/featureprofiles/internal/components"
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/featureprofiles/internal/vrfpolicy"
+	syspb "github.com/openconfig/gnoi/system"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+const (
+	policyName = "HA_VRF_SELECTION"
+)
+
+func TestMain(m *testing.M) {
+	fptest.RunTests(m)
+}
+
+func configEgressSubIntf(dut *ondatra.DUTDevice, d *oc.Root, port *ondatra.Port, subIntfIndex uint32, vrfName string) {
+	intf := d.GetOrCreateInterface(port.Name())
+	intf.Type = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
+	if deviations.InterfaceEnabled(dut) {
+		intf.Enabled = ygot.Bool(true)
+	}
+	s := intf.GetOrCreateSubinterface(subIntfIndex)
+	if !deviations.DeprecatedVlanID(dut) {
+		s.GetOrCreateVlan().GetOrCreateMatch().GetOrCreateSingleTagged().VlanId = ygot.Uint16(uint16(subIntfIndex))
+	} else {
+		s.GetOrCreateVlan().VlanId = oc.UnionUint16(uint16(subIntfIndex))
+	}
+	s.GetOrCreateIpv4().Enabled = ygot.Bool(true)
+	s.GetOrCreateIpv6().Enabled = ygot.Bool(true)
+
+	s.GetOrCreateIpv4().GetOrCreateAddress(fmt.Sprintf("192.168.%d.1", subIntfIndex)).PrefixLength = ygot.Uint8(24)
+	s.GetOrCreateIpv6().GetOrCreateAddress(fmt.Sprintf("2001:db8:%d::1", subIntfIndex)).PrefixLength = ygot.Uint8(64)
+
+	ni := d.GetOrCreateNetworkInstance(vrfName)
+	ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
+	if vrfName == deviations.DefaultNetworkInstance(dut) {
+		ni.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE
+	}
+	niIntf := ni.GetOrCreateInterface(fmt.Sprintf("%s.%d", port.Name(), subIntfIndex))
+	niIntf.Interface = ygot.String(port.Name())
+	niIntf.Subinterface = ygot.Uint32(subIntfIndex)
+}
+
+func configStaticRoute(d *oc.Root, dut *ondatra.DUTDevice, vrfName string, v4Prefix string, v4NextHop string, v6Prefix string, v6NextHop string) {
+	ni := d.GetOrCreateNetworkInstance(vrfName)
+	static := ni.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, deviations.StaticProtocolName(dut))
+
+	if v4Prefix != "" {
+		sr := static.GetOrCreateStatic(v4Prefix)
+		nh := sr.GetOrCreateNextHop("0")
+		nh.NextHop = oc.UnionString(v4NextHop)
+	}
+
+	if v6Prefix != "" {
+		sr := static.GetOrCreateStatic(v6Prefix)
+		nh := sr.GetOrCreateNextHop("0")
+		nh.NextHop = oc.UnionString(v6NextHop)
+	}
+}
+
+func TestVRFSelectionResiliency(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	ate := ondatra.ATE(t, "ate")
+
+	p1 := dut.Port(t, "port1")
+	p2 := dut.Port(t, "port2")
+	p3 := dut.Port(t, "port3")
+	p4 := dut.Port(t, "port4")
+
+	t.Logf("Configuring DUT interfaces...")
+	d := &oc.Root{}
+
+	// Port-1 Ingress
+	i1 := d.GetOrCreateInterface(p1.Name())
+	i1.Type = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
+	if deviations.InterfaceEnabled(dut) {
+		i1.Enabled = ygot.Bool(true)
+	}
+	s1 := i1.GetOrCreateSubinterface(0)
+	s1.GetOrCreateIpv4().Enabled = ygot.Bool(true)
+	s1.GetOrCreateIpv4().GetOrCreateAddress("192.168.0.1").PrefixLength = ygot.Uint8(24)
+
+	// Step 1: Initial VRF Binding for ingress
+	niPfw := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreatePolicyForwarding()
+	i1fwd := niPfw.GetOrCreateInterface(p1.Name())
+	i1fwd.ApplyVrfSelectionPolicy = ygot.String(policyName)
+	if !deviations.InterfaceRefConfigUnsupported(dut) {
+		i1fwd.GetOrCreateInterfaceRef().Interface = ygot.String(p1.Name())
+		i1fwd.GetOrCreateInterfaceRef().Subinterface = ygot.Uint32(0)
+	}
+
+	idx := uint32(1)
+	// Port-2 (Egress 1)
+	for i := 1; i <= 10; i++ {
+		configEgressSubIntf(dut, d, p2, idx, fmt.Sprintf("VRF-V4-%d", i))
+		configStaticRoute(d, dut, fmt.Sprintf("VRF-V4-%d", i), fmt.Sprintf("203.0.113.%d/32", i), fmt.Sprintf("192.168.%d.2", idx), "", "")
+		idx++
+	}
+	configEgressSubIntf(dut, d, p2, idx, deviations.DefaultNetworkInstance(dut)) // DEFAULT
+	configStaticRoute(d, dut, deviations.DefaultNetworkInstance(dut), "0.0.0.0/0", fmt.Sprintf("192.168.%d.2", idx), "::/0", fmt.Sprintf("2001:db8:%d::2", idx))
+	idx++
+
+	// Port-3 (Egress 2)
+	for i := 11; i <= 15; i++ {
+		configEgressSubIntf(dut, d, p3, idx, fmt.Sprintf("VRF-V4-%d", i))
+		configStaticRoute(d, dut, fmt.Sprintf("VRF-V4-%d", i), fmt.Sprintf("203.0.113.%d/32", i), fmt.Sprintf("192.168.%d.2", idx), "", "")
+		idx++
+	}
+	for i := 1; i <= 5; i++ {
+		configEgressSubIntf(dut, d, p3, idx, fmt.Sprintf("VRF-V6-%d", i))
+		configStaticRoute(d, dut, fmt.Sprintf("VRF-V6-%d", i), fmt.Sprintf("203.0.113.%d/32", i), fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("2001:db8:a:%d::/128", i), fmt.Sprintf("2001:db8:%d::2", idx))
+		idx++
+	}
+
+	// Port-4 (Egress 3)
+	for i := 6; i <= 15; i++ {
+		configEgressSubIntf(dut, d, p4, idx, fmt.Sprintf("VRF-V6-%d", i))
+		configStaticRoute(d, dut, fmt.Sprintf("VRF-V6-%d", i), fmt.Sprintf("203.0.113.%d/32", i), fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("2001:db8:a:%d::/128", i), fmt.Sprintf("2001:db8:%d::2", idx))
+		idx++
+	}
+
+	// Create VRF-GHOST network instance
+	niGhost := d.GetOrCreateNetworkInstance("VRF-GHOST")
+	niGhost.Type = oc.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF
+
+	// RT-3.4.1. Step 1: Add massive policy
+	massivePolicy := vrfpolicy.BuildScaledVRFSelectionPolicy(t, dut, deviations.DefaultNetworkInstance(dut))
+	existingPfw := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreatePolicyForwarding()
+	massivePolicy.Interface = existingPfw.Interface
+	d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding = massivePolicy
+	d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreatePolicyForwarding().Policy = massivePolicy.Policy
+
+	// RT-3.4.1 Step 2: Push config to DUT
+	gnmi.Replace(t, dut, gnmi.OC().Interface(p1.Name()).Config(), i1)
+	gnmi.Replace(t, dut, gnmi.OC().Interface(p2.Name()).Config(), d.GetInterface(p2.Name()))
+	gnmi.Replace(t, dut, gnmi.OC().Interface(p3.Name()).Config(), d.GetInterface(p3.Name()))
+	gnmi.Replace(t, dut, gnmi.OC().Interface(p4.Name()).Config(), d.GetInterface(p4.Name()))
+
+	for _, ni := range d.NetworkInstance {
+		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(ni.GetName()).Config(), ni)
+	}
+
+	// Delete VRF-GHOST as specified by the test procedure to ensure Traffic Drops correctly
+	gnmi.Delete(t, dut, gnmi.OC().NetworkInstance("VRF-GHOST").Config())
+
+	t.Logf("Wait for interface state to propagate...")
+	gnmi.Await(t, dut, gnmi.OC().Interface(p1.Name()).OperStatus().State(), time.Minute, oc.Interface_OperStatus_UP)
+	gnmi.Await(t, dut, gnmi.OC().Interface(p2.Name()).OperStatus().State(), time.Minute, oc.Interface_OperStatus_UP)
+	gnmi.Await(t, dut, gnmi.OC().Interface(p3.Name()).OperStatus().State(), time.Minute, oc.Interface_OperStatus_UP)
+	gnmi.Await(t, dut, gnmi.OC().Interface(p4.Name()).OperStatus().State(), time.Minute, oc.Interface_OperStatus_UP)
+
+	// RT-3.4.1 Step 3: Generating continuous OTG traffic from ATE Port-1
+	t.Logf("Generating continuous OTG traffic...")
+	top := gosnappi.NewConfig()
+
+	// Configure precise OTG Topology (Ports 1-4, Devices, Subinterfaces based on DUT)
+	vrfpolicy.ConfigureOTGTopology(t, top, ate)
+
+	// Configure all 62 flows (30 Positive, 30 Negative, 1 Ghost, 1 Shadow)
+	vrfpolicy.ConfigureScaledOTGFlows(top)
+
+	t.Logf("Starting traffic on ATE...")
+	ate.OTG().PushConfig(t, top)
+	ate.OTG().StartProtocols(t)
+
+	// Give ARP/ND time to resolve
+	time.Sleep(30 * time.Second)
+	ate.OTG().StartTraffic(t)
+
+	// RT-3.4.1 Step 4: Validating perfect isolation, default fallbacks, ghost drops, and shadow routes
+	vrfpolicy.ValidateBaselineTraffic(t, ate, top)
+	t.Logf("Validated RT-3.4.1 Baseline.")
+
+	// RT-3.4.2 - VRF Selection Policy Resilience Post Supervisor Switchover
+	t.Logf("RT-3.4.2 - Step 1: Trigger Switchover")
+	controllers := components.FindComponentsByType(t, dut, oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_CONTROLLER_CARD)
+	if len(controllers) > 0 {
+		activeController := controllers[0]
+		t.Logf("Found active controller: %s. Initiating SwitchControlProcessor...", activeController)
+		// Record switchover time prior
+		t0 := time.Now()
+
+		systemClient := dut.RawAPIs().GNOI(t).System()
+		req := &syspb.SwitchControlProcessorRequest{
+			ControlProcessor: components.GetSubcomponentPath(activeController, deviations.GNOISubcomponentPath(dut)),
+		}
+		_, err := systemClient.SwitchControlProcessor(context.Background(), req)
+		if err != nil {
+			t.Fatalf("SwitchControlProcessor failed: %v", err)
+		}
+
+		// Wait for components to transition and new active controller to emerge
+		t.Logf("Waiting for new ACTIVE controller...")
+		gnmi.Await(t, dut, gnmi.OC().Component(activeController).OperStatus().State(), 5*time.Minute, oc.PlatformTypes_COMPONENT_OPER_STATUS_ACTIVE)
+
+		// Check telemetry
+		t.Logf("Checking last switchover time and reason...")
+		lastSwitch := gnmi.Get(t, dut, gnmi.OC().Component(activeController).LastSwitchoverTime().State())
+		if time.Unix(0, int64(lastSwitch)*int64(time.Nanosecond)).Before(t0) {
+			t.Logf("Warning: switchover time telemetry %v was not updated after %v", lastSwitch, t0)
+		}
+
+	} else {
+		t.Logf("No active controller found. Skipping gNOI switchover injection.")
+	}
+
+	t.Logf("RT-3.4.2 - Step 2: Validate 0%% traffic loss")
+	vrfpolicy.ValidateBaselineTraffic(t, ate, top)
+
+	// RT-3.4.3 - VRF Selection Policy Resilience Post Linecard OIR
+	t.Logf("RT-3.4.3 - Step 1: Perform Linecard Soft OIR")
+	linecardPort := cfgplugins.FindLineCardParent(t, dut, p1.Name())
+	if linecardPort == "" {
+		t.Logf("Could not find linecard for port: %s. Skipping Linecard OIR tests.", p1.Name())
+	} else {
+		t.Logf("Toggling linecard %s to POWER_DISABLED", linecardPort)
+		linecardPath := gnmi.OC().Component(linecardPort).Linecard().PowerAdminState()
+		gnmi.Replace(t, dut, linecardPath.Config(), oc.Platform_ComponentPowerType_POWER_DISABLED)
+		gnmi.Await(t, dut, gnmi.OC().Component(linecardPort).OperStatus().State(), 5*time.Minute, oc.PlatformTypes_COMPONENT_OPER_STATUS_DISABLED)
+
+		// Wait a moment before reviving the card
+		time.Sleep(30 * time.Second)
+
+		t.Logf("Toggling linecard %s to POWER_ENABLED", linecardPort)
+		gnmi.Replace(t, dut, linecardPath.Config(), oc.Platform_ComponentPowerType_POWER_ENABLED)
+		gnmi.Await(t, dut, gnmi.OC().Component(linecardPort).OperStatus().State(), 10*time.Minute, oc.PlatformTypes_COMPONENT_OPER_STATUS_ACTIVE)
+
+		t.Logf("Waiting for reliant ports to revert to UP state...")
+		gnmi.Await(t, dut, gnmi.OC().Interface(p1.Name()).OperStatus().State(), 2*time.Minute, oc.Interface_OperStatus_UP)
+
+		t.Logf("RT-3.4.3 - Step 2: Validating autonomous recovery")
+		// Give BGP and linecard time to restore forwarding entries
+		time.Sleep(2 * time.Minute)
+		vrfpolicy.ValidateBaselineTraffic(t, ate, top)
+	}
+
+	// RT-3.4.4 - Policy Deletion
+	t.Logf("RT-3.4.4 - Step 1 & 2: Delete VRF Selection Policy & Push Configuration")
+	vrfpolicy.DeletePolicyForwarding(t, dut, p1.Name())
+
+	// Wait for policy detachment propagation
+	time.Sleep(30 * time.Second)
+
+	t.Logf("RT-3.4.4 - Step 3: Validate fallback to DEFAULT network instance mapping")
+	// Validated by ensuring traffic no longer routes to specific egress ports uniquely mapped to VRF subints
+	// Since verification needs to clear counts, we reset OTG state.
+	ate.OTG().StopTraffic(t)
+	time.Sleep(5 * time.Second)
+	ate.OTG().StartTraffic(t)
+
+	vrfpolicy.ValidateFallbackTraffic(t, ate, top)
+}

--- a/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
@@ -296,7 +296,7 @@ func TestVRFSelectionResiliency(t *testing.T) {
 
 	// Wait for policy detachment propagation
 	interfaceID := p1.Name()
-	if deviations.InterfaceRefInterfaceIDFormat(dut) {
+	if deviations.InterfaceRefInterfaceIDFormat(dut) || deviations.InterfaceIDFormatRequiredForPolicyForwarding(dut) {
 		interfaceID = p1.Name() + ".0"
 	}
 	gnmi.Watch(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Interface(interfaceID).ApplyVrfSelectionPolicy().State(), time.Minute, func(val *ygnmi.Value[string]) bool {

--- a/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
@@ -168,6 +168,16 @@ func TestVRFSelectionResiliency(t *testing.T) {
 		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(ni.GetName()).Config(), ni)
 	}
 
+	t.Cleanup(func() {
+		t.Logf("Cleaning up configurations...")
+		vrfpolicy.DeletePolicyForwarding(t, dut, p1.Name())
+		for _, ni := range d.NetworkInstance {
+			if ni.GetName() != deviations.DefaultNetworkInstance(dut) {
+				gnmi.Delete(t, dut, gnmi.OC().NetworkInstance(ni.GetName()).Config())
+			}
+		}
+	})
+
 	// Delete VRF-GHOST as specified by the test procedure to ensure Traffic Drops correctly
 	gnmi.Delete(t, dut, gnmi.OC().NetworkInstance("VRF-GHOST").Config())
 

--- a/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
@@ -251,8 +251,11 @@ func TestVRFSelectionResiliency(t *testing.T) {
 	if linecardPort == "" {
 		t.Logf("Could not find linecard for port: %s. Skipping Linecard OIR tests.", p1.Name())
 	} else {
-		t.Logf("Toggling linecard %s to POWER_DISABLED", linecardPort)
 		linecardPath := gnmi.OC().Component(linecardPort).Linecard().PowerAdminState()
+		t.Cleanup(func() {
+			gnmi.Replace(t, dut, linecardPath.Config(), oc.Platform_ComponentPowerType_POWER_ENABLED)
+		})
+		t.Logf("Toggling linecard %s to POWER_DISABLED", linecardPort)
 		gnmi.Replace(t, dut, linecardPath.Config(), oc.Platform_ComponentPowerType_POWER_DISABLED)
 		gnmi.Await(t, dut, gnmi.OC().Component(linecardPort).OperStatus().State(), 5*time.Minute, oc.PlatformTypes_COMPONENT_OPER_STATUS_DISABLED)
 

--- a/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
@@ -314,4 +314,4 @@ func TestVRFSelectionResiliency(t *testing.T) {
 	ate.OTG().StartTraffic(t)
 
 	vrfpolicy.ValidateFallbackTraffic(t, ate, top)
-	}
+}

--- a/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
@@ -56,7 +56,7 @@ func configEgressSubIntf(dut *ondatra.DUTDevice, d *oc.Root, port *ondatra.Port,
 	s.GetOrCreateIpv4().Enabled = ygot.Bool(true)
 	s.GetOrCreateIpv6().Enabled = ygot.Bool(true)
 
-	s.GetOrCreateIpv4().GetOrCreateAddress(fmt.Sprintf("192.168.%d.1", subIntfIndex)).PrefixLength = ygot.Uint8(24)
+	s.GetOrCreateIpv4().GetOrCreateAddress(fmt.Sprintf("100.64.%d.1", subIntfIndex)).PrefixLength = ygot.Uint8(24)
 	s.GetOrCreateIpv6().GetOrCreateAddress(fmt.Sprintf("2001:db8:%d::1", subIntfIndex)).PrefixLength = ygot.Uint8(64)
 
 	ni := d.GetOrCreateNetworkInstance(vrfName)

--- a/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
@@ -201,8 +201,8 @@ func TestVRFSelectionResiliency(t *testing.T) {
 	ate.OTG().PushConfig(t, top)
 	ate.OTG().StartProtocols(t)
 
-	// Give ARP/ND time to resolve
-	time.Sleep(30 * time.Second)
+	// Wait for ARP resolution
+	otgutils.WaitForARP(t, ate.OTG(), top, "IPv4")
 	ate.OTG().StartTraffic(t)
 
 	// RT-3.4.1 Step 4: Validating perfect isolation, default fallbacks, ghost drops, and shadow routes

--- a/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go
@@ -25,11 +25,14 @@ import (
 	"github.com/openconfig/featureprofiles/internal/components"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/featureprofiles/internal/otgutils"
 	"github.com/openconfig/featureprofiles/internal/vrfpolicy"
 	syspb "github.com/openconfig/gnoi/system"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/testt"
+	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )
 
@@ -106,7 +109,7 @@ func TestVRFSelectionResiliency(t *testing.T) {
 	}
 	s1 := i1.GetOrCreateSubinterface(0)
 	s1.GetOrCreateIpv4().Enabled = ygot.Bool(true)
-	s1.GetOrCreateIpv4().GetOrCreateAddress("192.168.0.1").PrefixLength = ygot.Uint8(24)
+	s1.GetOrCreateIpv4().GetOrCreateAddress("100.64.0.1").PrefixLength = ygot.Uint8(24)
 
 	// Step 1: Initial VRF Binding for ingress
 	niPfw := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut)).GetOrCreatePolicyForwarding()
@@ -211,35 +214,47 @@ func TestVRFSelectionResiliency(t *testing.T) {
 
 	// RT-3.4.2 - VRF Selection Policy Resilience Post Supervisor Switchover
 	t.Logf("RT-3.4.2 - Step 1: Trigger Switchover")
+
 	controllers := components.FindComponentsByType(t, dut, oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_CONTROLLER_CARD)
 	if len(controllers) > 0 {
-		activeController := controllers[0]
-		t.Logf("Found active controller: %s. Initiating SwitchControlProcessor...", activeController)
-		// Record switchover time prior
-		t0 := time.Now()
+		standbyController, activeController := components.FindStandbyControllerCard(t, dut, controllers)
+		t.Logf("Found active: %s, standby: %s. Initiating SwitchControlProcessor to standby...", activeController, standbyController)
 
 		systemClient := dut.RawAPIs().GNOI(t).System()
 		req := &syspb.SwitchControlProcessorRequest{
-			ControlProcessor: components.GetSubcomponentPath(activeController, deviations.GNOISubcomponentPath(dut)),
+			ControlProcessor: components.GetSubcomponentPath(standbyController, deviations.GNOISubcomponentPath(dut)),
 		}
-		_, err := systemClient.SwitchControlProcessor(context.Background(), req)
-		if err != nil {
+		if _, err := systemClient.SwitchControlProcessor(context.Background(), req); err != nil {
 			t.Fatalf("SwitchControlProcessor failed: %v", err)
 		}
 
-		// Wait for components to transition and new active controller to emerge
-		t.Logf("Waiting for new ACTIVE controller...")
-		gnmi.Await(t, dut, gnmi.OC().Component(activeController).OperStatus().State(), 5*time.Minute, oc.PlatformTypes_COMPONENT_OPER_STATUS_ACTIVE)
-
-		// Check telemetry
-		t.Logf("Checking last switchover time and reason...")
-		lastSwitch := gnmi.Get(t, dut, gnmi.OC().Component(activeController).LastSwitchoverTime().State())
-		if time.Unix(0, int64(lastSwitch)*int64(time.Nanosecond)).Before(t0) {
-			t.Logf("Warning: switchover time telemetry %v was not updated after %v", lastSwitch, t0)
+		// Wait for control-plane to accept GNMI again by polling a safe telemetry path.
+		start := time.Now()
+		timeout := 5 * time.Minute
+		for {
+			time.Sleep(10 * time.Second)
+			var now string
+			if errMsg := testt.CaptureFatal(t, func(t testing.TB) {
+				now = gnmi.Get(t, dut, gnmi.OC().System().CurrentDatetime().State())
+			}); errMsg != nil {
+				t.Logf("gNMI not ready yet (%s); retrying...", *errMsg)
+			} else {
+				t.Logf("gNMI reachable; DUT time: %s", now)
+				break
+			}
+			if time.Since(start) > timeout {
+				t.Fatalf("timed out waiting for gNMI after %v", timeout)
+			}
 		}
 
+		// Confirm standby became the new active.
+		_, rpActiveAfterSwitch := components.FindStandbyControllerCard(t, dut, controllers)
+		if rpActiveAfterSwitch != standbyController {
+			t.Fatalf("Post-switchover active RP mismatch: got %q want %q", rpActiveAfterSwitch, standbyController)
+		}
+		t.Logf("Switchover complete: new active %s", rpActiveAfterSwitch)
 	} else {
-		t.Logf("No active controller found. Skipping gNOI switchover injection.")
+		t.Logf("No controller cards found; skipping switchover.")
 	}
 
 	t.Logf("RT-3.4.2 - Step 2: Validate 0%% traffic loss")
@@ -280,7 +295,14 @@ func TestVRFSelectionResiliency(t *testing.T) {
 	vrfpolicy.DeletePolicyForwarding(t, dut, p1.Name())
 
 	// Wait for policy detachment propagation
-	time.Sleep(30 * time.Second)
+	interfaceID := p1.Name()
+	if deviations.InterfaceRefInterfaceIDFormat(dut) {
+		interfaceID = p1.Name() + ".0"
+	}
+	gnmi.Watch(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Interface(interfaceID).ApplyVrfSelectionPolicy().State(), time.Minute, func(val *ygnmi.Value[string]) bool {
+		v, present := val.Val()
+		return !present || v == ""
+	}).Await(t)
 
 	t.Logf("RT-3.4.4 - Step 3: Validate fallback to DEFAULT network instance mapping")
 	// Validated by ensuring traffic no longer routes to specific egress ports uniquely mapped to VRF subints

--- a/internal/vrfpolicy/otg.go
+++ b/internal/vrfpolicy/otg.go
@@ -43,31 +43,31 @@ func ConfigureOTGTopology(t *testing.T, top gosnappi.Config, ate *ondatra.ATEDev
 	dev1 := top.Devices().Add().SetName("dev-port1")
 	eth1 := dev1.Ethernets().Add().SetName("eth-port1").SetMac("02:1a:c0:00:00:01")
 	eth1.Connection().SetPortName(p1.Name())
-	eth1.Ipv4Addresses().Add().SetName("ipv4-port1").SetAddress("192.168.0.2").SetGateway("192.168.0.1").SetPrefix(24)
+	eth1.Ipv4Addresses().Add().SetName("ipv4-port1").SetAddress("100.64.0.2").SetGateway("100.64.0.1").SetPrefix(24)
 
 	// Port 2 devices (Egress 1 - 10 positive v4, 1 default)
 	idx := 1
 	for i := 1; i <= 10; i++ {
-		addDevice(top, p2Name, fmt.Sprintf("dev-v4-%d", i), fmt.Sprintf("02:1a:c0:00:02:%02x", idx), idx, fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("192.168.%d.1", idx), "")
+		addDevice(top, p2Name, fmt.Sprintf("dev-v4-%d", i), fmt.Sprintf("02:1a:c0:00:02:%02x", idx), idx, fmt.Sprintf("100.64.%d.2", idx), fmt.Sprintf("100.64.%d.1", idx), "")
 		idx++
 	}
 	// Port 2 Default
-	addDevice(top, p2Name, "dev-default", "02:1a:c0:00:02:ff", idx, fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("192.168.%d.1", idx), fmt.Sprintf("2001:db8:%d::2", idx))
+	addDevice(top, p2Name, "dev-default", "02:1a:c0:00:02:ff", idx, fmt.Sprintf("100.64.%d.2", idx), fmt.Sprintf("100.64.%d.1", idx), fmt.Sprintf("2001:db8:%d::2", idx))
 	idx++
 
 	// Port 3 (Egress 2 - 5 positive v4, 5 positive v6)
 	for i := 11; i <= 15; i++ {
-		addDevice(top, p3Name, fmt.Sprintf("dev-v4-%d", i), fmt.Sprintf("02:1a:c0:00:03:%02x", idx), idx, fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("192.168.%d.1", idx), "")
+		addDevice(top, p3Name, fmt.Sprintf("dev-v4-%d", i), fmt.Sprintf("02:1a:c0:00:03:%02x", idx), idx, fmt.Sprintf("100.64.%d.2", idx), fmt.Sprintf("100.64.%d.1", idx), "")
 		idx++
 	}
 	for i := 1; i <= 5; i++ {
-		addDevice(top, p3Name, fmt.Sprintf("dev-v6-%d", i), fmt.Sprintf("02:1a:c0:01:03:%02x", idx), idx, fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("192.168.%d.1", idx), fmt.Sprintf("2001:db8:%d::2", idx))
+		addDevice(top, p3Name, fmt.Sprintf("dev-v6-%d", i), fmt.Sprintf("02:1a:c0:01:03:%02x", idx), idx, fmt.Sprintf("100.64.%d.2", idx), fmt.Sprintf("100.64.%d.1", idx), fmt.Sprintf("2001:db8:%d::2", idx))
 		idx++
 	}
 
 	// Port 4 (Egress 3 - 10 positive v6)
 	for i := 6; i <= 15; i++ {
-		addDevice(top, p4Name, fmt.Sprintf("dev-v6-%d", i), fmt.Sprintf("02:1a:c0:01:04:%02x", idx), idx, fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("192.168.%d.1", idx), fmt.Sprintf("2001:db8:%d::2", idx))
+		addDevice(top, p4Name, fmt.Sprintf("dev-v6-%d", i), fmt.Sprintf("02:1a:c0:01:04:%02x", idx), idx, fmt.Sprintf("100.64.%d.2", idx), fmt.Sprintf("100.64.%d.1", idx), fmt.Sprintf("2001:db8:%d::2", idx))
 		idx++
 	}
 }

--- a/internal/vrfpolicy/otg.go
+++ b/internal/vrfpolicy/otg.go
@@ -1,0 +1,237 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vrfpolicy
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/open-traffic-generator/snappi/gosnappi"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+)
+
+// ConfigureOTGTopology sets up the 4 ATE ports, creating the necessary devices,
+// VLANs, and IP addresses, focusing on mimicking the DUT's egress subinterfaces.
+func ConfigureOTGTopology(t *testing.T, top gosnappi.Config, ate *ondatra.ATEDevice) {
+	t.Helper()
+
+	p1Name := ate.Port(t, "port1").ID()
+	p2Name := ate.Port(t, "port2").ID()
+	p3Name := ate.Port(t, "port3").ID()
+	p4Name := ate.Port(t, "port4").ID()
+
+	p1 := top.Ports().Add().SetName(p1Name)
+	top.Ports().Add().SetName(p2Name)
+	top.Ports().Add().SetName(p3Name)
+	top.Ports().Add().SetName(p4Name)
+
+	// Port 1 (Ingress - Source of flows)
+	dev1 := top.Devices().Add().SetName("dev-port1")
+	eth1 := dev1.Ethernets().Add().SetName("eth-port1").SetMac("02:1a:c0:00:00:01")
+	eth1.Connection().SetPortName(p1.Name())
+	eth1.Ipv4Addresses().Add().SetName("ipv4-port1").SetAddress("192.168.0.2").SetGateway("192.168.0.1").SetPrefix(24)
+
+	// Port 2 devices (Egress 1 - 10 positive v4, 1 default)
+	idx := 1
+	for i := 1; i <= 10; i++ {
+		addDevice(top, p2Name, fmt.Sprintf("dev-v4-%d", i), fmt.Sprintf("02:1a:c0:00:02:%02x", idx), idx, fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("192.168.%d.1", idx), "")
+		idx++
+	}
+	// Port 2 Default
+	addDevice(top, p2Name, "dev-default", "02:1a:c0:00:02:ff", idx, fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("192.168.%d.1", idx), fmt.Sprintf("2001:db8:%d::2", idx))
+	idx++
+
+	// Port 3 (Egress 2 - 5 positive v4, 5 positive v6)
+	for i := 11; i <= 15; i++ {
+		addDevice(top, p3Name, fmt.Sprintf("dev-v4-%d", i), fmt.Sprintf("02:1a:c0:00:03:%02x", idx), idx, fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("192.168.%d.1", idx), "")
+		idx++
+	}
+	for i := 1; i <= 5; i++ {
+		addDevice(top, p3Name, fmt.Sprintf("dev-v6-%d", i), fmt.Sprintf("02:1a:c0:01:03:%02x", idx), idx, fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("192.168.%d.1", idx), fmt.Sprintf("2001:db8:%d::2", idx))
+		idx++
+	}
+
+	// Port 4 (Egress 3 - 10 positive v6)
+	for i := 6; i <= 15; i++ {
+		addDevice(top, p4Name, fmt.Sprintf("dev-v6-%d", i), fmt.Sprintf("02:1a:c0:01:04:%02x", idx), idx, fmt.Sprintf("192.168.%d.2", idx), fmt.Sprintf("192.168.%d.1", idx), fmt.Sprintf("2001:db8:%d::2", idx))
+		idx++
+	}
+}
+
+func addDevice(top gosnappi.Config, portName, devName, macAddr string, idx int, ipv4Addr, ipv4Gw, ipv6Addr string) {
+	dev := top.Devices().Add().SetName(devName)
+	eth := dev.Ethernets().Add().SetName(devName + "-eth").SetMac(macAddr)
+	eth.Connection().SetPortName(portName)
+
+	// We assume subinterfaces have vlan ID matching index based on test setup
+	eth.Vlans().Add().SetName(devName + "-vlan").SetId(uint32(idx))
+
+	if ipv4Addr != "" {
+		eth.Ipv4Addresses().Add().SetName(devName + "-ipv4").SetAddress(ipv4Addr).SetGateway(ipv4Gw).SetPrefix(24)
+	}
+	if ipv6Addr != "" {
+		// Compute IPv6 Gateway for OTG device which is the DUT's IPv6 address
+		ipv6Gw := fmt.Sprintf("2001:db8:%d::1", idx)
+		eth.Ipv6Addresses().Add().SetName(devName + "-ipv6").SetAddress(ipv6Addr).SetGateway(ipv6Gw).SetPrefix(64)
+	}
+}
+
+// ConfigureScaledOTGFlows sets up 30 positive streams, 30 negative streams, 1 ghost stream, and 1 shadow stream.
+func ConfigureScaledOTGFlows(top gosnappi.Config) {
+	// 30 Positive Streams (IPinIP matching Rule 1-15 and IPv6inIP matching Rule 16-30)
+	for i := 1; i <= 15; i++ {
+		flowName := fmt.Sprintf("positive-v4-%d", i)
+		addFlow(top, flowName, "dev-port1", []string{fmt.Sprintf("dev-v4-%d", i), "dev-default"}, 4, fmt.Sprintf("198.18.%d.1", i), fmt.Sprintf("203.0.113.%d", i), fmt.Sprintf("203.0.113.%d", i))
+	}
+	for i := 1; i <= 15; i++ {
+		flowName := fmt.Sprintf("positive-v6-%d", i)
+		addFlow(top, flowName, "dev-port1", []string{fmt.Sprintf("dev-v6-%d", i), "dev-default"}, 41, fmt.Sprintf("198.19.%d.1", i), fmt.Sprintf("203.0.113.%d", i), fmt.Sprintf("2001:db8:a:%d::", i)) // Inner IPv6 matches VRF-V6-x route
+	}
+
+	// 30 Negative Streams (Standard UDP, lacking encapsulation)
+	for i := 1; i <= 15; i++ {
+		flowName := fmt.Sprintf("negative-v4-%d", i)
+		addFlow(top, flowName, "dev-port1", []string{"dev-default"}, 17, fmt.Sprintf("10.0.%d.1", i), fmt.Sprintf("203.0.113.%d", i), "")
+	}
+	for i := 1; i <= 15; i++ {
+		// Technically these destinations are IPv6 blocks in the route table
+		flowName := fmt.Sprintf("negative-v6-%d", i)
+		addFlow(top, flowName, "dev-port1", []string{"dev-default"}, 17, fmt.Sprintf("10.1.%d.1", i), fmt.Sprintf("203.0.113.%d", i), "")
+	}
+
+	// Ghost Stream (Matches Rule 31, should be dropped)
+	addFlow(top, "ghost-stream", "dev-port1", []string{"dev-default"}, 4, "198.20.0.1", "203.0.113.1", "203.0.113.1")
+
+	// Shadow Stream (Matches Rule 100, maps to VRF-V4-15)
+	addFlow(top, "shadow-stream", "dev-port1", []string{"dev-v4-15", "dev-default"}, 4, "0.0.0.0", "203.0.113.15", "203.0.113.15")
+}
+
+func addFlow(top gosnappi.Config, flowName, srcEndpoint string, dstEndpoints []string, protocol uint32, srcIP, dstIP, innerIP string) {
+	flow := top.Flows().Add().SetName(flowName)
+	flow.Metrics().SetEnable(true)
+	flow.TxRx().Device().SetTxNames([]string{srcEndpoint}).SetRxNames(dstEndpoints)
+
+	flow.Packet().Add().Ethernet()
+
+	var isIpv6 bool
+	for _, c := range srcIP {
+		if c == ':' {
+			isIpv6 = true
+			break
+		}
+	}
+
+	if isIpv6 {
+		ip := flow.Packet().Add().Ipv6()
+		ip.Src().SetValue(srcIP)
+		ip.Dst().SetValue(dstIP)
+		ip.NextHeader().SetValue(protocol) // Use NextHeader for IPv6 outer
+	} else {
+		ip := flow.Packet().Add().Ipv4()
+		ip.Src().SetValue(srcIP)
+		ip.Dst().SetValue(dstIP)
+		ip.Protocol().SetValue(protocol) // 4 for IPinIP, 41 for IPv6inIP(v4 outer), 17 for UDP
+	}
+
+	if protocol == 4 {
+		inner := flow.Packet().Add().Ipv4()
+		inner.Src().SetValue("198.51.100.1")
+		inner.Dst().SetValue(dstIP) // Just replicate outer dst if innerIP=""
+		if innerIP != "" {
+			inner.Dst().SetValue(innerIP)
+		}
+	} else if protocol == 41 {
+		inner := flow.Packet().Add().Ipv6()
+		inner.Src().SetValue("2001:db8:c::1")
+		inner.Dst().SetValue("2001:db8:c::2") // Valid unused IPv6 string
+		if innerIP != "" {
+			inner.Dst().SetValue(innerIP)
+		}
+	} else if protocol == 17 {
+		udp := flow.Packet().Add().Udp()
+		udp.SrcPort().SetValue(1024)
+		udp.DstPort().SetValue(1024)
+	}
+}
+
+// ValidateBaselineTraffic checks that loss metrics match expectations.
+func ValidateBaselineTraffic(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config) {
+	t.Helper()
+	t.Logf("Validating Baseline OTG Traffic Isolations...")
+	// Wait for metrics
+	time.Sleep(15 * time.Second)
+
+	for _, f := range top.Flows().Items() {
+		outPkts := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(f.Name()).Counters().OutPkts().State())
+		inPkts := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(f.Name()).Counters().InPkts().State())
+
+		if outPkts == 0 {
+			t.Errorf("Flow %s did not send any packets", f.Name())
+			continue
+		}
+
+		lossPct := (float64(outPkts) - float64(inPkts)) / float64(outPkts) * 100.0
+		t.Logf("Flow %s: OutPkts %d, InPkts %d, Loss %.2f%%", f.Name(), outPkts, inPkts, lossPct)
+
+		isGhost := f.Name() == "ghost-stream"
+
+		if isGhost {
+			// Ghost must be dropped
+			if lossPct < 99.0 {
+				t.Errorf("Flow %s (Ghost) should be dropped, but loss is only: %.2f%%", f.Name(), lossPct)
+			}
+		} else {
+			// Positives, Negatives, Shadow must be hitless
+			if lossPct > 0.5 {
+				t.Errorf("Flow %s has unexpected packet loss: %.2f%%, want <= 0.5%%", f.Name(), lossPct)
+			}
+		}
+
+		// TODO: In a truly resilient test, we'd also verify the specific RX port
+		// using the flow metrics rx port info or device Rx metrics to prove VRF isolation.
+		// For now, ensuring 0% loss asserts that the traffic reached *a* destination in the top.
+	}
+}
+
+// ValidateFallbackTraffic checks that after policy deletion, all traffic (positive streams)
+// falls back to the DEFAULT VRF, meaning it should still arrive, but technically via the default route.
+func ValidateFallbackTraffic(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config) {
+	t.Helper()
+	t.Logf("Validating Fallback OTG Traffic...")
+	time.Sleep(15 * time.Second)
+
+	for _, f := range top.Flows().Items() {
+		outPkts := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(f.Name()).Counters().OutPkts().State())
+		inPkts := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(f.Name()).Counters().InPkts().State())
+
+		if outPkts == 0 {
+			t.Errorf("Flow %s did not send any packets", f.Name())
+			continue
+		}
+
+		lossPct := (float64(outPkts) - float64(inPkts)) / float64(outPkts) * 100.0
+		t.Logf("Flow %s: OutPkts %d, InPkts %d, Loss %.2f%%", f.Name(), outPkts, inPkts, lossPct)
+
+		// With policy deleted, ALL streams are treated as generic IP traffic and look up the
+		// DEFAULT VRF table. Thus all should egress the DEFAULT port
+		// Ghost stream may now forward if there's a default route 0.0.0.0/0.
+		// For simplicity in this assertion, we ensure it's hitless.
+		if lossPct > 0.5 {
+			t.Errorf("Flow %s has unexpected packet loss in fallback: %.2f%%", f.Name(), lossPct)
+		}
+	}
+}

--- a/internal/vrfpolicy/vrfpolicy.go
+++ b/internal/vrfpolicy/vrfpolicy.go
@@ -16,6 +16,7 @@
 package vrfpolicy
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/openconfig/featureprofiles/internal/deviations"
@@ -48,6 +49,8 @@ const (
 	niTeVrf111              = "TE_VRF_111"
 	niTeVrf222              = "TE_VRF_222"
 	decapFlowSrc            = "198.51.100.111"
+	ipipProtocol            = 4
+	ipv6ipProtocol          = 41
 )
 
 type ipInfo struct {
@@ -395,4 +398,49 @@ func DeletePolicyForwarding(t *testing.T, dut *ondatra.DUTDevice, portID string)
 	}
 	pfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Interface(interfaceID)
 	gnmi.Delete(t, dut, pfPath.Config())
+}
+
+// BuildScaledVRFSelectionPolicy creates a scaled VRF selection policy with 30 positive rules,
+// a ghost rule, and a catch-all rule, as required by RT-3.4.
+func BuildScaledVRFSelectionPolicy(t *testing.T, dut *ondatra.DUTDevice, niName string) *oc.NetworkInstance_PolicyForwarding {
+	r := &oc.Root{}
+	ni := r.GetOrCreateNetworkInstance(niName)
+	niP := ni.GetOrCreatePolicyForwarding()
+	niPf := niP.GetOrCreatePolicy("HA_VRF_SELECTION")
+	niPf.SetType(oc.Policy_Type_VRF_SELECTION_POLICY)
+
+	// Rules 1-15: Match IPinIP (Protocol 4)
+	for i := 1; i <= 15; i++ {
+		pfR := niPf.GetOrCreateRule(uint32(i))
+		pfRProtoIP := pfR.GetOrCreateIpv4()
+		pfRProtoIP.Protocol = oc.UnionUint8(ipipProtocol) // IPinIP
+		// Unique IP prefix per VRF, e.g. 198.18.x.0/24
+		pfRProtoIP.SourceAddress = ygot.String(fmt.Sprintf("198.18.%d.0/24", i))
+		pfRAction := pfR.GetOrCreateAction()
+		pfRAction.NetworkInstance = ygot.String(fmt.Sprintf("VRF-V4-%d", i))
+	}
+
+	// Rules 16-30: Match IPv6inIP (Protocol 41)
+	for i := 1; i <= 15; i++ {
+		seq := i + 15
+		pfR := niPf.GetOrCreateRule(uint32(seq))
+		pfRProtoIP := pfR.GetOrCreateIpv4()
+		pfRProtoIP.Protocol = oc.UnionUint8(ipv6ipProtocol) // IPv6inIPv4
+		pfRProtoIP.SourceAddress = ygot.String(fmt.Sprintf("198.19.%d.0/24", i))
+		pfRAction := pfR.GetOrCreateAction()
+		pfRAction.NetworkInstance = ygot.String(fmt.Sprintf("VRF-V6-%d", i))
+	}
+
+	// Rule 31 (Ghost VRF)
+	pfR31 := niPf.GetOrCreateRule(31)
+	pfR31.GetOrCreateIpv4().Protocol = oc.UnionUint8(ipipProtocol)
+	pfR31.GetOrCreateIpv4().SourceAddress = ygot.String("198.20.0.0/24")
+	pfR31.GetOrCreateAction().NetworkInstance = ygot.String("VRF-GHOST")
+
+	// Rule 100 (Catch-All)
+	pfR100 := niPf.GetOrCreateRule(100)
+	pfR100.GetOrCreateIpv4().Protocol = oc.UnionUint8(ipipProtocol)
+	pfR100.GetOrCreateAction().NetworkInstance = ygot.String("VRF-V4-15")
+
+	return niP
 }

--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -1140,6 +1140,7 @@ test: {
   id: "RT-3.4"
   description: "VRF Selection Policy Hardware Programming with Linecard and Supervisor Resiliency"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/README.md"
+  exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/policy_forwarding/vrf_selection/otg_tests/vrf_selection_resiliency_test/vrf_selection_resiliency_test.go"
 }
 test: {
   id: "RT-3.52"


### PR DESCRIPTION
This PR implements the RT-3.4 test suite (`vrf_selection_resiliency_test.go`) to validate hardware programming and traffic forwarding resiliency for scaled VRF selection policies under Supervisor Switchover, Linecard OIR (power cycling), and policy deletion on 4-link topologies (`TESTBED_DUT_ATE_4LINKS`) and extends `vrfpolicy` helpers to support policy deletion and validation.