### PR TITLE
Revert "Hardening gNSI credentialz helpers and SSH auth tests for spec-compliant rotations, deterministic versioning, and vendor-safe cleanup/validation"

### DIFF
--- a/feature/gnsi/credentialz/tests/hiba_authentication/hiba_authentication_test.go
+++ b/feature/gnsi/credentialz/tests/hiba_authentication/hiba_authentication_test.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	username        = "testuser"
-	maxSSHRetryTime = 30 // Unit is seconds.
+	username               = "testuser"
+	maxSSHRetryTime        = 30 // Unit is seconds.
+	hostCertificateVersion = "v1.0"
 )
 
 var (
@@ -44,8 +45,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestCredentialz(t *testing.T) {
-	hostCertificateVersion := fmt.Sprintf("v1.0-%d", time.Now().Unix())
-
 	dut := ondatra.DUT(t, "dut")
 	dir := t.TempDir()
 	credz.CreateHibaKeys(t, dut, dir)
@@ -56,15 +55,13 @@ func TestCredentialz(t *testing.T) {
 		cpb.AuthenticationType_AUTHENTICATION_TYPE_PUBKEY,
 	})
 
-	credz.RotateAuthorizedPrincipalCheck(t, dut, cpb.AuthorizedPrincipalCheckRequest_TOOL_HIBA_DEFAULT)
-
 	t.Run("auth should fail hiba host certificate not present", func(t *testing.T) {
 		var startingRejectCounter uint64
 		if !deviations.SSHServerCountersUnsupported(dut) {
 			startingRejectCounter, _ = credz.GetRejectTelemetry(t, dut)
 		}
 
-		// Verify ssh with hiba fails as expected (no host cert pushed yet).
+		// Verify ssh with hiba fails as expected.
 		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 		defer cancel()
 		startTime := time.Now()
@@ -99,7 +96,11 @@ func TestCredentialz(t *testing.T) {
 			uint64(hostCertificateCreatedOn),
 		)
 
-		credz.RotateTrustedUserCA(t, dut, dir, hostCertificateVersion, uint64(hostCertificateCreatedOn))
+		// Setup trusted user ca on the dut.
+		credz.RotateTrustedUserCA(t, dut, dir)
+
+		// Setup hiba for authorized principals command.
+		credz.RotateAuthorizedPrincipalCheck(t, dut, cpb.AuthorizedPrincipalCheckRequest_TOOL_HIBA_DEFAULT)
 
 		var startingAcceptCounter, startingLastAcceptTime uint64
 		if !deviations.SSHServerCountersUnsupported(dut) {
@@ -147,24 +148,26 @@ func TestCredentialz(t *testing.T) {
 		case ondatra.NOKIA:
 			wantHostCertificateCreatedOn *= 1e9
 		}
+		// if !cmp.Equal(time.Unix(0, int64(gotHostCertificateCreatedOn)), time.Unix(hostCertificateCreatedOn, 0)) {
 		if got, want := int64(gotHostCertificateCreatedOn), wantHostCertificateCreatedOn; got != want {
 			t.Fatalf(
 				"Telemetry reports host certificate created on is not correct\n\tgot: %d\n\twant: %d",
-				got, want,
+				gotHostCertificateCreatedOn, hostCertificateCreatedOn,
 			)
 		}
 	})
 
 	t.Cleanup(func() {
-		// Cleanup to remove previous policy which only allowed key auth to make sure
-		// we don't leave dut in a state where we can't reset config for further tests.
+		// Cleanup to remove previous policy which only allowed key auth to make sure we don't leave dut in a
+		// state where we can't reset config for further tests.
 		credz.RotateAuthenticationTypes(t, dut, []cpb.AuthenticationType{
 			cpb.AuthenticationType_AUTHENTICATION_TYPE_PASSWORD,
 			cpb.AuthenticationType_AUTHENTICATION_TYPE_PUBKEY,
 			cpb.AuthenticationType_AUTHENTICATION_TYPE_KBDINTERACTIVE,
 		})
 
-		credz.RotateTrustedUserCA(t, dut, "", "", 0)
+		// Remove user ca so subsequent fail cases work.
+		// credz.RotateTrustedUserCA(t, dut, "")
 
 		// Clear hiba for authorized principals command.
 		credz.RotateAuthorizedPrincipalCheck(t, dut, cpb.AuthorizedPrincipalCheckRequest_TOOL_UNSPECIFIED)

--- a/feature/gnsi/credentialz/tests/host_certificates/host_certificates_test.go
+++ b/feature/gnsi/credentialz/tests/host_certificates/host_certificates_test.go
@@ -15,13 +15,14 @@
 package hostcertificates_test
 
 import (
-	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/featureprofiles/internal/args"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/featureprofiles/internal/security/credz"
 	"github.com/openconfig/ondatra"
@@ -30,12 +31,12 @@ import (
 )
 
 const (
-	hostCertificateVersion = "v1.0"
-	passwordVersion        = "v1.0"
+	username = "testuser"
 )
 
 var (
-	username                 = "testuser"
+	passwordVersion          = credz.GenerateVersion()
+	hostCertificateVersion   = credz.GenerateVersion()
 	hostCertificateCreatedOn = uint64(time.Now().Unix())
 	passwordCreatedOn        = uint64(time.Now().Unix())
 )
@@ -47,14 +48,6 @@ func TestMain(m *testing.M) {
 func TestCredentialz(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
-	// Derive unique version strings from a single timestamp using distinct suffixes.
-	// This avoids time.Sleep (per repo style guide) while keeping the two host
-	// certificate versions deterministically unique.
-	now := time.Now().Unix()
-	passwordVer := fmt.Sprintf("%s-%d", passwordVersion, now)
-	hostCertificateVersion1 := fmt.Sprintf("%s-%d-1", hostCertificateVersion, now)
-	hostCertificateVersion2 := fmt.Sprintf("%s-%d-2", hostCertificateVersion, now)
-
 	// Create temporary directory for storing ssh keys/certificates.
 	dir := t.TempDir()
 
@@ -63,50 +56,47 @@ func TestCredentialz(t *testing.T) {
 	password := credz.GeneratePassword()
 
 	t.Logf("Rotating user password on DUT")
-	credz.RotateUserPassword(t, dut, username, password, passwordVer, uint64(passwordCreatedOn))
+	credz.RotateUserPassword(t, dut, username, password, passwordVersion, uint64(passwordCreatedOn))
 
 	// Create ssh keys/certificates for CA & host.
 	credz.CreateSSHKeyPair(t, dir, "ca")
 	credz.CreateSSHKeyPair(t, dir, dut.ID())
-	credz.RotateAuthenticationArtifacts(t, dut, dir, "", hostCertificateVersion1, hostCertificateCreatedOn)
-	dutKey := credz.GetDutPublicKey(t, dut, "")
+	credz.RotateAuthenticationArtifacts(t, dut, dir, "", hostCertificateVersion, hostCertificateCreatedOn)
+	dutKey := credz.GetDutPublicKey(t, dut, "ssh-ed25519")
 	credz.CreateHostCertificate(t, dut, dir, dutKey)
-	credz.RotateAuthenticationArtifacts(t, dut, "", dir, hostCertificateVersion2, hostCertificateCreatedOn)
+	hostCertificateVersion = credz.GenerateVersion()
+	hostCertificateCreatedOn = uint64(time.Now().Unix())
+	credz.RotateAuthenticationArtifacts(t, dut, "", dir, hostCertificateVersion, hostCertificateCreatedOn)
 
 	t.Run("dut should return signed host certificate", func(t *testing.T) {
 		certificateContents, err := os.ReadFile(fmt.Sprintf("%s/%s-cert.pub", dir, dut.ID()))
 		if err != nil {
 			t.Fatalf("Failed reading host signed certificate, error: %s", err)
 		}
-		wantHostKey, _, _, _, err := ssh.ParseAuthorizedKey(certificateContents)
+		publicKey, _, _, _, err := ssh.ParseAuthorizedKey(certificateContents)
 		if err != nil {
 			t.Fatalf("Failed parsing host certificate authorized (cert)key: %s", err)
 		}
 
-		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-		defer cancel()
-		client, err := credz.SSHWithPassword(ctx, dut, username, password)
-		if err != nil {
-			t.Fatalf("Failed dialing ssh with password: %s", err)
+		cert, ok := publicKey.(*ssh.Certificate)
+		if !ok {
+			t.Fatalf("Failed to get SSH certificate")
 		}
-		defer client.Close()
+		wantHostKey := strings.Trim(string(ssh.MarshalAuthorizedKey(cert.Key)), "\n")
+		gotHostKey := credz.GetConfiguredHostKey(t, dut, "ssh-ed25519", *args.Fqdn)
 
-		gotHostKey, _, _, _, err := ssh.ParseAuthorizedKey(client.HostKey())
-		if err != nil {
-			t.Fatalf("Failed parsing host certificate from device: %s", err)
-		}
-
-		if !cmp.Equal(gotHostKey.Marshal(), wantHostKey.Marshal()) {
-			t.Fatalf("Host presented key (cert) does not match expected. got: %x, want: %x", gotHostKey.Marshal(), wantHostKey.Marshal())
+		// Verify correct host certificate is returned by the dut.
+		if diff := cmp.Diff(gotHostKey, wantHostKey); diff != "" {
+			t.Errorf("Host presented key (cert) that does not match expected host certificate. +got, -want: %s", diff)
 		}
 
 		// Verify host certificate telemetry values.
 		sshServer := gnmi.Get(t, dut, gnmi.OC().System().SshServer().State())
 		gotHostCertificateVersion := sshServer.GetActiveHostCertificateVersion()
-		if !cmp.Equal(gotHostCertificateVersion, hostCertificateVersion2) {
+		if !cmp.Equal(gotHostCertificateVersion, hostCertificateVersion) {
 			t.Errorf(
 				"Telemetry reports host certificate version is not correct\n\tgot: %s\n\twant: %s",
-				gotHostCertificateVersion, hostCertificateVersion2,
+				gotHostCertificateVersion, hostCertificateVersion,
 			)
 		}
 		gotHostCertificateCreatedOn := sshServer.GetActiveHostCertificateCreatedOn()
@@ -121,12 +111,5 @@ func TestCredentialz(t *testing.T) {
 				want, got,
 			)
 		}
-	})
-
-	t.Cleanup(func() {
-		// Remove host artifacts from the dut.
-		credz.RotateAuthenticationArtifacts(t, dut, "", "", "", 0)
-		// Cleanup user password after test.
-		credz.RotateUserPassword(t, dut, username, "", "", 0)
 	})
 }

--- a/feature/gnsi/credentialz/tests/password_console_login/password_console_login_test.go
+++ b/feature/gnsi/credentialz/tests/password_console_login/password_console_login_test.go
@@ -16,7 +16,6 @@ package passwordconsolelogin_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -28,12 +27,12 @@ import (
 )
 
 const (
-	username        = "testuser"
-	passwordVersion = "v1.0"
+	username = "testuser"
 )
 
 var (
 	passwordCreatedOn = time.Now().Unix()
+	passwordVersion   = credz.GenerateVersion()
 )
 
 func TestMain(m *testing.M) {
@@ -41,9 +40,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestCredentialz(t *testing.T) {
-	passwordVersion := fmt.Sprintf("%s-%d", passwordVersion, time.Now().Unix())
-
 	dut := ondatra.DUT(t, "dut")
+	// target := credz.GetDutTarget(t, dut)
 
 	// Add any vendor specific cli to enable the ssh login using password
 	switch dut.Vendor() {
@@ -145,10 +143,4 @@ func TestCredentialz(t *testing.T) {
 			}
 		})
 	}
-
-	t.Cleanup(func() {
-		// Cleanup user password after test.
-		credz.RotateUserPassword(t, dut, username, "", "", 0)
-		credz.SSHCleanup(t, dut)
-	})
 }

--- a/feature/gnsi/credentialz/tests/ssh_password_login_disallowed/ssh_password_login_disallowed_test.go
+++ b/feature/gnsi/credentialz/tests/ssh_password_login_disallowed/ssh_password_login_disallowed_test.go
@@ -16,7 +16,6 @@ package sshpasswordlogindisallowed_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"google.golang.org/grpc/codes"
@@ -41,7 +40,6 @@ const (
 	userPrincipal   = "my_principal"
 	command         = "show version"
 	maxSSHRetryTime = 120 // Unit is seconds.
-	passwordVersion = "v1.0"
 )
 
 func TestMain(m *testing.M) {
@@ -49,16 +47,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestCredentialz(t *testing.T) {
-	version := fmt.Sprintf("%s-%d", passwordVersion, time.Now().Unix())
-
 	dut := ondatra.DUT(t, "dut")
+	// target := credz.GetDutTarget(t, dut)
 	recordStartTime := timestamppb.New(time.Now())
-
-	credz.RotateAuthenticationTypes(t, dut, []cpb.AuthenticationType{
-		cpb.AuthenticationType_AUTHENTICATION_TYPE_PASSWORD,
-		cpb.AuthenticationType_AUTHENTICATION_TYPE_PUBKEY,
-		cpb.AuthenticationType_AUTHENTICATION_TYPE_KBDINTERACTIVE,
-	})
 
 	// Create temporary directory for storing ssh keys/certificates.
 	dir, err := os.MkdirTemp("", "")
@@ -82,19 +73,16 @@ func TestCredentialz(t *testing.T) {
 	credz.CreateSSHKeyPairAlgo(t, dir, username, algo)
 	credz.CreateUserCertificate(t, dir, userPrincipal)
 
-	// Setup user and password on DUT.
+	// Setup user and password.
 	credz.SetupUser(t, dut, username)
 	password := credz.GeneratePassword()
-	credz.RotateUserPassword(t, dut, username, password, version, uint64(time.Now().Unix()))
+	credz.RotateUserPassword(t, dut, username, password, credz.GenerateVersion(), uint64(time.Now().Unix()))
 
-	credz.RotateTrustedUserCA(t, dut, dir, version, uint64(time.Now().Unix()))
-
-	// Restrict authentication to public key only (disallow password).
+	credz.RotateTrustedUserCA(t, dut, dir)
 	credz.RotateAuthenticationTypes(t, dut, []cpb.AuthenticationType{
 		cpb.AuthenticationType_AUTHENTICATION_TYPE_PUBKEY,
 	})
-
-	credz.RotateAuthorizedPrincipal(t, dut, username, userPrincipal, version, uint64(time.Now().Unix()))
+	credz.RotateAuthorizedPrincipal(t, dut, username, userPrincipal)
 
 	t.Run("auth should fail ssh password authentication disallowed", func(t *testing.T) {
 		var startingRejectCounter, startingLastRejectTime uint64
@@ -119,7 +107,7 @@ func TestCredentialz(t *testing.T) {
 			time.Sleep(5 * time.Second)
 		}
 
-		// Verify ssh reject counters incremented appropriately.
+		// Verify ssh counters.
 		if !deviations.SSHServerCountersUnsupported(dut) {
 			endingRejectCounter, endingLastRejectTime := credz.GetRejectTelemetry(t, dut)
 			if endingRejectCounter <= startingRejectCounter {
@@ -141,6 +129,7 @@ func TestCredentialz(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
 		defer cancel()
 		startTime := time.Now()
+		// var conn *ssh.Client
 		var conn binding.SSHClient
 		for {
 			conn, err = credz.SSHWithCertificate(ctx, t, dut, username, dir)
@@ -156,17 +145,15 @@ func TestCredentialz(t *testing.T) {
 			time.Sleep(5 * time.Second)
 		}
 
-		// Send command for accounting verification. RunCommand runs to completion and
-		// returns a binding.CommandResult, which exposes only Output()/Error() and holds
-		// no session/stream resources, so there is nothing to close here. Connection
-		// cleanup is handled by conn.Close() above.
-		res, err := conn.RunCommand(ctx, command)
+		// Send command for accounting.
+		sess, err := conn.RunCommand(ctx, "show version")
 		if err != nil {
-			t.Fatalf("Failed running command %q, error: %s", command, err)
+			t.Fatalf("Failed creating ssh session, error: %s", err)
 		}
-		t.Logf("Command %q output: %s", command, res.Output())
+		defer sess.Output()
+		sess.Output()
 
-		// Verify ssh accept counters incremented appropriately.
+		// Verify ssh counters.
 		if !deviations.SSHServerCountersUnsupported(dut) {
 			endingAcceptCounter, endingLastAcceptTime := credz.GetAcceptTelemetry(t, dut)
 			if endingAcceptCounter <= startingAcceptCounter {
@@ -177,7 +164,7 @@ func TestCredentialz(t *testing.T) {
 			}
 		}
 
-		// Verify accounting record for the authenticated user.
+		// Verify accounting record.
 		acctzClient := dut.RawAPIs().GNSI(t).AcctzStream()
 		ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
@@ -228,8 +215,5 @@ func TestCredentialz(t *testing.T) {
 			cpb.AuthenticationType_AUTHENTICATION_TYPE_PUBKEY,
 			cpb.AuthenticationType_AUTHENTICATION_TYPE_KBDINTERACTIVE,
 		})
-		credz.RotateUserPassword(t, dut, username, "", "", 0)
-		credz.RotateAuthorizedPrincipal(t, dut, username, "", "", 0)
-		credz.RotateTrustedUserCA(t, dut, "", "", 0)
 	})
 }

--- a/feature/gnsi/credentialz/tests/ssh_public_key_authentication/ssh_public_key_authentication_test.go
+++ b/feature/gnsi/credentialz/tests/ssh_public_key_authentication/ssh_public_key_authentication_test.go
@@ -95,13 +95,12 @@ func TestCredentialz(t *testing.T) {
 
 		res, err := sshClient.RunCommand(ctx, "show version")
 		if err != nil {
-			t.Fatalf("RunCommand failed, err: %v", err)
+			t.Fatalf("CombinedOutput failed, err: %v", err)
 		}
-		t.Logf("SSH session output: %s", res.Output())
+		t.Logf("SSH session output: %s", res)
 
 		sshClient.Close()
 		time.Sleep(2 * time.Second)
-
 		// Verify ssh counters.
 		if !deviations.SSHServerCountersUnsupported(dut) {
 			endingAcceptCounter, endingLastAcceptTime := credz.GetAcceptTelemetry(t, dut)

--- a/internal/security/credz/credz.go
+++ b/internal/security/credz/credz.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -39,24 +38,21 @@ import (
 )
 
 const (
-	lowercase         = "abcdefghijklmnopqrstuvwxyz"
-	uppercase         = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	digits            = "0123456789"
-	symbols           = "!@#$%^&*(){}[]\\|:;\"'"
-	space             = " "
+	lowercase = "abcdefghijklmnopqrstuvwxyz"
+	uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	digits    = "0123456789"
+	symbols   = "!@#$%^&*(){}[]\\:;\"'"
+	// space             = " "
 	dutKey            = "dut"
 	userKey           = "testuser"
 	caKey             = "ca"
 	minPasswordLength = 24
 	maxPasswordLength = 32
 	defaultSSHPort    = 22
+)
 
-	// rotateStreamTimeout bounds a single end-to-end credentialz Rotate stream
-	// (open -> Send -> Recv -> Send(Finalize) -> drain to io.EOF). It must be
-	// generous enough for slow control-plane commits yet short enough that a
-	// stuck stream fails fast instead of hanging until the outer `go test`
-	// -timeout fires.
-	rotateStreamTimeout = 60 * time.Second
+var (
+	charClasses = []string{lowercase, uppercase, digits, symbols}
 )
 
 // PrettyPrint prints rpc requests/responses in a pretty format.
@@ -77,12 +73,6 @@ func SetupUser(t *testing.T, dut *ondatra.DUTDevice, username string) {
 // - Must be 24-32 characters long.
 // - Must use 4 of the 5 character classes ([a-z], [A-Z], [0-9], [!@#$%^&*(){}[]\|:;'"], [ ]).
 func GeneratePassword() string {
-	// charClasses is a function-local slice (not a package-level var) so that
-	// concurrent callers of GeneratePassword do not race on a shared slice:
-	// rand.Shuffle below reorders it in place, which would otherwise mutate
-	// global state and introduce a data race.
-	charClasses := []string{lowercase, uppercase, digits, symbols, space}
-
 	// Create random length between 24-32 characters long.
 	delta := maxPasswordLength - minPasswordLength + 1
 	length := minPasswordLength + rand.Intn(delta)
@@ -110,123 +100,58 @@ func GeneratePassword() string {
 	return password.String()
 }
 
-// rotateStream is the minimal streaming surface shared by the credentialz
-// RotateHostParameters and RotateAccountCredentials client streams. Both
-// generated clients already satisfy it, which lets a single helper drive the
-// full end-to-end rotate handshake for either RPC.
-type rotateStream[Req any, Resp any] interface {
-	Send(Req) error
-	Recv() (Resp, error)
-}
-
-// runRotate performs the complete, end-to-end credentialz Rotate handshake and
-// guarantees the device is left in a committed (clean) state for every call:
-//
-//  1. Send the caller's request.
-//  2. Recv the server's acknowledgement.
-//  3. Send Finalize.
-//  4. Drain Recv until io.EOF so the commit is fully applied and the stream is
-//     closed cleanly before returning.
-//
-// Context handling (why this is not simply context.Background()):
-//
-// The rotate stream is derived from t.Context() while it is still live. This is
-// exactly what we want from the test body: if the test is canceled or hits its
-// deadline, the in-flight rotate stream is torn down with it, so the Recv-until-
-// EOF drain below can never outlive the test.
-//
-// However, per the Go testing contract, t.Context() is canceled *just before* a
-// test's t.Cleanup callbacks run. These credentialz helpers are intentionally
-// invoked from BOTH the test body and from t.Cleanup / deferred teardown (that
-// is the whole point of the cleanup-every-run contract). If we used t.Context()
-// unconditionally, every teardown rotation would fail with
-// "rpc error: code = Canceled desc = context canceled" and leave the device
-// dirty. So once t.Context() is already canceled (i.e. we are running from
-// cleanup) we transparently fall back to context.Background() for that call.
-//
-// In both cases we layer a WithTimeout(rotateStreamTimeout) on top, so a stuck
-// stream fails fast in CI instead of hanging until the outer `go test` -timeout.
-func runRotate[Req any, Resp any](
-	t *testing.T,
-	rpcName string,
-	open func(context.Context) (rotateStream[Req, Resp], error),
-	request Req,
-	finalize Req,
-) {
-	t.Helper()
-
-	// Prefer the live test context; fall back to Background only when t.Context()
-	// is already canceled (cleanup/teardown path). Always bounded by a timeout.
-	base := t.Context()
-	if base.Err() != nil {
-		t.Logf("t.Context() already canceled (%v); using background context for credentialz %s (cleanup path).", base.Err(), rpcName)
-		base = context.Background()
-	}
-	ctx, cancel := context.WithTimeout(base, rotateStreamTimeout)
-	defer cancel()
-
-	stream, err := open(ctx)
-	if err != nil {
-		t.Fatalf("Failed fetching credentialz %s client, error: %s", rpcName, err)
-	}
-
-	t.Logf("Sending credentialz %s request: %s", rpcName, PrettyPrint(request))
-	if err := stream.Send(request); err != nil {
-		t.Fatalf("Failed sending credentialz %s request, error: %s", rpcName, err)
-	}
-	if _, err := stream.Recv(); err != nil {
-		t.Fatalf("Failed receiving credentialz %s response, error: %s", rpcName, err)
-	}
-
-	if err := stream.Send(finalize); err != nil {
-		t.Fatalf("Failed sending credentialz %s finalize request, error: %s", rpcName, err)
-	}
-	// Read response to Finalize until EOF so the commit is fully applied.
-	for {
-		_, err := stream.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("Failed during %s finalize Recv, error: %s", rpcName, err)
-		}
-	}
-}
-
 func sendHostParametersRequest(t *testing.T, dut *ondatra.DUTDevice, request *cpb.RotateHostParametersRequest) {
-	t.Helper()
 	credzClient := dut.RawAPIs().GNSI(t).Credentialz()
-	runRotate(
-		t,
-		"rotate host parameters",
-		func(ctx context.Context) (rotateStream[*cpb.RotateHostParametersRequest, *cpb.RotateHostParametersResponse], error) {
-			return credzClient.RotateHostParameters(ctx)
+	credzRotateClient, err := credzClient.RotateHostParameters(context.Background())
+	if err != nil {
+		t.Fatalf("Failed fetching credentialz rotate host parameters client, error: %s", err)
+	}
+	t.Logf("Sending credentialz rotate host request: %s", PrettyPrint(request))
+	err = credzRotateClient.Send(request)
+	if err != nil {
+		t.Fatalf("Failed sending credentialz rotate host parameters request, error: %s", err)
+	}
+	_, err = credzRotateClient.Recv()
+	if err != nil {
+		t.Fatalf("Failed receiving credentialz rotate host parameters response, error: %s", err)
+	}
+	err = credzRotateClient.Send(&cpb.RotateHostParametersRequest{
+		Request: &cpb.RotateHostParametersRequest_Finalize{
+			Finalize: request.GetFinalize(),
 		},
-		request,
-		&cpb.RotateHostParametersRequest{
-			Request: &cpb.RotateHostParametersRequest_Finalize{
-				Finalize: request.GetFinalize(),
-			},
-		},
-	)
+	})
+	if err != nil {
+		t.Fatalf("Failed sending credentialz rotate host parameters finalize request, error: %s", err)
+	}
+	// Brief sleep for finalize to get processed.
+	time.Sleep(time.Second)
 }
 
 func sendAccountCredentialsRequest(t *testing.T, dut *ondatra.DUTDevice, request *cpb.RotateAccountCredentialsRequest) {
-	t.Helper()
 	credzClient := dut.RawAPIs().GNSI(t).Credentialz()
-	runRotate(
-		t,
-		"rotate account credentials",
-		func(ctx context.Context) (rotateStream[*cpb.RotateAccountCredentialsRequest, *cpb.RotateAccountCredentialsResponse], error) {
-			return credzClient.RotateAccountCredentials(ctx)
+	credzRotateClient, err := credzClient.RotateAccountCredentials(context.Background())
+	if err != nil {
+		t.Fatalf("Failed fetching credentialz rotate account credentials client, error: %s", err)
+	}
+	t.Logf("Sending credentialz rotate account request: %s", PrettyPrint(request))
+	err = credzRotateClient.Send(request)
+	if err != nil {
+		t.Fatalf("Failed sending credentialz rotate account credentials request, error: %s", err)
+	}
+	_, err = credzRotateClient.Recv()
+	if err != nil {
+		t.Fatalf("Failed receiving credentialz rotate account credentials response, error: %s", err)
+	}
+	err = credzRotateClient.Send(&cpb.RotateAccountCredentialsRequest{
+		Request: &cpb.RotateAccountCredentialsRequest_Finalize{
+			Finalize: request.GetFinalize(),
 		},
-		request,
-		&cpb.RotateAccountCredentialsRequest{
-			Request: &cpb.RotateAccountCredentialsRequest_Finalize{
-				Finalize: request.GetFinalize(),
-			},
-		},
-	)
+	})
+	if err != nil {
+		t.Fatalf("Failed sending credentialz rotate account credentials finalize request, error: %s", err)
+	}
+	// Brief sleep for finalize to get processed.
+	time.Sleep(time.Second)
 }
 
 // GenerateVersion returns a unique version string for gNSI rotations.
@@ -234,29 +159,19 @@ func GenerateVersion() string {
 	return fmt.Sprintf("v%d", time.Now().UnixNano())
 }
 
-// RotateUserPassword applies or deletes the password for the specified username on the DUT.
-// To add/update a password, provide non-empty password, version, and createdOn.
-// To delete a password, provide empty strings for password and version, and 0 for createdOn.
-//
-// The request is always constructed as a single, well-formed message. The plaintext
-// password value is only attached when a password is supplied, so no combination of
-// arguments can leave the request nil (which previously risked a nil pointer
-// dereference / gRPC panic in sendAccountCredentialsRequest).
+// RotateUserPassword apply password for the specified username on the dut.
 func RotateUserPassword(t *testing.T, dut *ondatra.DUTDevice, username, password, version string, createdOn uint64) {
-	pw := &cpb.PasswordRequest_Password{}
-	if password != "" {
-		pw.Value = &cpb.PasswordRequest_Password_Plaintext{
-			Plaintext: password,
-		}
-	}
-
 	request := &cpb.RotateAccountCredentialsRequest{
 		Request: &cpb.RotateAccountCredentialsRequest_Password{
 			Password: &cpb.PasswordRequest{
 				Accounts: []*cpb.PasswordRequest_Account{
 					{
-						Account:   username,
-						Password:  pw,
+						Account: username,
+						Password: &cpb.PasswordRequest_Password{
+							Value: &cpb.PasswordRequest_Password_Plaintext{
+								Plaintext: password,
+							},
+						},
 						Version:   version,
 						CreatedOn: createdOn,
 					},
@@ -268,35 +183,23 @@ func RotateUserPassword(t *testing.T, dut *ondatra.DUTDevice, username, password
 	sendAccountCredentialsRequest(t, dut, request)
 }
 
-// RotateAuthorizedPrincipal applies or deletes authorized principal for the specified username on the dut.
-// To add/update authorized principal, provide non-empty authorized principal, version, and createdOn.
-// To delete authorized principal, provide empty strings for authorized principal and version, and 0 for createdOn.
-//
-// The request is always constructed as a single, well-formed message. Authorized
-// principals are only attached when a principal is supplied, so no combination of
-// arguments can leave the request nil (which previously risked a nil pointer
-// dereference / gRPC panic in sendAccountCredentialsRequest).
-func RotateAuthorizedPrincipal(t *testing.T, dut *ondatra.DUTDevice, username, userPrincipal, version string, createdOn uint64) {
-	var authPrincipals *cpb.UserPolicy_SshAuthorizedPrincipals
-	if userPrincipal != "" {
-		authPrincipals = &cpb.UserPolicy_SshAuthorizedPrincipals{
-			AuthorizedPrincipals: []*cpb.UserPolicy_SshAuthorizedPrincipal{
-				{
-					AuthorizedUser: userPrincipal,
-				},
-			},
-		}
-	}
-
+// RotateAuthorizedPrincipal apply authorized principal for the specified username on the dut.
+func RotateAuthorizedPrincipal(t *testing.T, dut *ondatra.DUTDevice, username, userPrincipal string) {
 	request := &cpb.RotateAccountCredentialsRequest{
 		Request: &cpb.RotateAccountCredentialsRequest_User{
 			User: &cpb.AuthorizedUsersRequest{
 				Policies: []*cpb.UserPolicy{
 					{
-						Account:              username,
-						AuthorizedPrincipals: authPrincipals,
-						Version:              version,
-						CreatedOn:            createdOn,
+						Account: username,
+						AuthorizedPrincipals: &cpb.UserPolicy_SshAuthorizedPrincipals{
+							AuthorizedPrincipals: []*cpb.UserPolicy_SshAuthorizedPrincipal{
+								{
+									AuthorizedUser: userPrincipal,
+								},
+							},
+						},
+						Version:   GenerateVersion(),
+						CreatedOn: uint64(time.Now().Unix()),
 					},
 				},
 			},
@@ -307,8 +210,6 @@ func RotateAuthorizedPrincipal(t *testing.T, dut *ondatra.DUTDevice, username, u
 }
 
 // RotateAuthorizedKey read user key contents from the specified directory & apply it as authorized key on the dut.
-// To add an authorized key, provide a non-empty dir (and a version/createdOn for telemetry).
-// To delete/clear the authorized key, provide an empty dir (the key list is sent empty).
 func RotateAuthorizedKey(t *testing.T, dut *ondatra.DUTDevice, dir, username, version string, createdOn uint64) {
 	var keyContents []*cpb.AccountCredentials_AuthorizedKey
 
@@ -346,10 +247,8 @@ func RotateAuthorizedKey(t *testing.T, dut *ondatra.DUTDevice, dir, username, ve
 	sendAccountCredentialsRequest(t, dut, request)
 }
 
-// RotateTrustedUserCA applies or deletes CA key contents on the dut.
-// To add the CA, provide a non-empty dir along with a version and createdOn.
-// To delete the CA, provide an empty dir, empty version, and 0 createdOn.
-func RotateTrustedUserCA(t *testing.T, dut *ondatra.DUTDevice, dir, version string, createdOn uint64) {
+// RotateTrustedUserCA read CA key contents from the specified directory & apply it on the dut.
+func RotateTrustedUserCA(t *testing.T, dut *ondatra.DUTDevice, dir string) {
 	var keyContents []*cpb.PublicKey
 
 	if dir != "" {
@@ -372,8 +271,8 @@ func RotateTrustedUserCA(t *testing.T, dut *ondatra.DUTDevice, dir, version stri
 		Request: &cpb.RotateHostParametersRequest_SshCaPublicKey{
 			SshCaPublicKey: &cpb.CaPublicKeyRequest{
 				SshCaPublicKeys: keyContents,
-				Version:         version,
-				CreatedOn:       createdOn,
+				Version:         GenerateVersion(),
+				CreatedOn:       uint64(time.Now().Unix()),
 			},
 		},
 	}
@@ -394,18 +293,7 @@ func RotateAuthenticationTypes(t *testing.T, dut *ondatra.DUTDevice, authTypes [
 	sendHostParametersRequest(t, dut, request)
 }
 
-// RotateAuthenticationArtifacts reads dut key/certificate contents from the specified
-// directories & applies them as host authentication artifacts on the dut.
-//
-// To install artifacts, provide keyDir and/or certDir along with a non-empty version
-// and non-zero createdOn. When both a key and a certificate are provided, they are
-// bundled into a single AuthenticationArtifacts entry.
-//
-// To clear artifacts, pass empty keyDir and certDir. Per the gNSI spec, every
-// ServerKeys rotation must carry a version/created_on (they are persisted and reported
-// via telemetry), so if version is empty / createdOn is 0 they are auto-generated.
-// This keeps the request well-formed and accepted across all vendors (e.g. it avoids
-// vendor rejections such as "Empty version string. Need value for version.").
+// RotateAuthenticationArtifacts read dut key/certificate contents from the specified directory & apply it as host authentication artifacts on the dut.
 func RotateAuthenticationArtifacts(t *testing.T, dut *ondatra.DUTDevice, keyDir, certDir, version string, createdOn uint64) {
 	var artifactContents []*cpb.ServerKeysRequest_AuthenticationArtifacts
 
@@ -413,38 +301,31 @@ func RotateAuthenticationArtifacts(t *testing.T, dut *ondatra.DUTDevice, keyDir,
 	var certData []byte
 	var err error
 	if keyDir != "" {
+		// data, err := os.ReadFile(fmt.Sprintf("%s/%s", keyDir, dut.ID()))
 		keyData, err = os.ReadFile(fmt.Sprintf("%s/%s", keyDir, dut.ID()))
 		if err != nil {
 			t.Fatalf("Failed reading host private key, error: %s", err)
 		}
+		// artifactContents = append(artifactContents, &cpb.ServerKeysRequest_AuthenticationArtifacts{
+		// 	PrivateKey: data,
+		// })
 	}
 
 	if certDir != "" {
+		// data, err := os.ReadFile(fmt.Sprintf("%s/%s-cert.pub", certDir, dut.ID()))
 		certData, err = os.ReadFile(fmt.Sprintf("%s/%s-cert.pub", certDir, dut.ID()))
 		if err != nil {
 			t.Fatalf("Failed reading host signed certificate, error: %s", err)
 		}
+		// artifactContents = append(artifactContents, &cpb.ServerKeysRequest_AuthenticationArtifacts{
+		// 	Certificate: data,
+		// })
 	}
 
-	// Only add an artifact when there is actually a key and/or certificate to send.
-	// This keeps the cleanup call (keyDir == "" && certDir == "") from sending an empty
-	// artifact (auth_artifacts: [{}]), which some vendors reject as malformed.
-	if keyData != nil || certData != nil {
-		artifactContents = append(artifactContents, &cpb.ServerKeysRequest_AuthenticationArtifacts{
-			PrivateKey:  keyData,
-			Certificate: certData,
-		})
-	}
-
-	// The gNSI spec requires version/created_on on every ServerKeys rotation, including
-	// when clearing artifacts. Auto-generate them if the caller did not provide them so
-	// the request is accepted across all vendors.
-	if version == "" {
-		version = GenerateVersion()
-	}
-	if createdOn == 0 {
-		createdOn = uint64(time.Now().Unix())
-	}
+	artifactContents = append(artifactContents, &cpb.ServerKeysRequest_AuthenticationArtifacts{
+		PrivateKey:  keyData,
+		Certificate: certData,
+	})
 
 	request := &cpb.RotateHostParametersRequest{
 		Request: &cpb.RotateHostParametersRequest_ServerKeys{
@@ -528,7 +409,7 @@ func GetDutPublicKey(t *testing.T, dut *ondatra.DUTDevice, targetAlgo string) []
 			t.Fatalf("Failed to find host key for algorithm %s on DUT. Available keys and their types can be inspected via logs.", targetAlgo)
 		}
 	} else {
-		// Form the key bytes from the proto message.
+		// Form the key bytes from the proto message
 		key = response.PublicKeys[0]
 		algo = sshAlgo(t, key)
 		if algo == "" {
@@ -780,6 +661,7 @@ func SSHWithPassword(ctx context.Context, dut *ondatra.DUTDevice, username, pass
 
 // SSHWithCertificate dials ssh with user certificate to be used in credentialz tests.
 func SSHWithCertificate(ctx context.Context, t *testing.T, dut *ondatra.DUTDevice, username, dir string) (binding.SSHClient, error) {
+
 	privateKeyContents, err := os.ReadFile(fmt.Sprintf("%s/%s", dir, userKey))
 	if err != nil {
 		t.Fatalf("Failed reading private key contents, error: %s", err)
@@ -802,7 +684,7 @@ func SSHWithKey(ctx context.Context, t *testing.T, dut *ondatra.DUTDevice, usern
 	return dut.RawAPIs().BindingDUT().DialSSH(ctx, binding.KeyAuth{User: username, Key: privateKeyContents})
 }
 
-// SSHCleanup performs required cleanup on DUT.
+// SSHCleanup performs required cleanup on DUT
 func SSHCleanup(t *testing.T, dut *ondatra.DUTDevice) {
 	switch dut.Vendor() {
 	case ondatra.ARISTA:
@@ -815,10 +697,8 @@ func SSHCleanup(t *testing.T, dut *ondatra.DUTDevice) {
 }
 
 // GetConfiguredHostKey returns the configured host key on the DUT for the given algorithm.
-// fqdn is used for logging/diagnostic context when locating the host key.
 func GetConfiguredHostKey(t *testing.T, dut *ondatra.DUTDevice, algo string, fqdn string) string {
 	t.Helper()
-	t.Logf("Looking up configured host key for algo %q (fqdn: %q)", algo, fqdn)
 	credzClient := dut.RawAPIs().GNSI(t).Credentialz()
 
 	// Polling is required because the host key might not be immediately available after rotation.
@@ -844,7 +724,7 @@ func GetConfiguredHostKey(t *testing.T, dut *ondatra.DUTDevice, algo string, fqd
 		if matchingKey != "" {
 			break
 		}
-		t.Logf("Waiting for %s host key (attempt %d/10) for fqdn %q", algo, i+1, fqdn)
+		t.Logf("Waiting for %s host key (attempt %d/10)", algo, i+1)
 		time.Sleep(5 * time.Second)
 	}
 
@@ -855,7 +735,7 @@ func GetConfiguredHostKey(t *testing.T, dut *ondatra.DUTDevice, algo string, fqd
 		if response != nil {
 			t.Logf("Available public keys: %+v", response.PublicKeys)
 		} else {
-			t.Fatalf("Failed to find host key for algorithm %s (fqdn %q) on DUT. Available keys and their types can be inspected via logs.", algo, fqdn)
+			t.Fatalf("Failed to find host key for algorithm %s on DUT. Available keys and their types can be inspected via logs.", algo)
 		}
 	}
 
@@ -893,7 +773,7 @@ func sshAlgo(t *testing.T, pk *cpb.PublicKey) string {
 	case cpb.KeyType_KEY_TYPE_ED25519:
 		return "ssh-ed25519"
 	case cpb.KeyType_KEY_TYPE_UNSPECIFIED:
-		// Attempt to infer from public key content.
+		// Attempt to infer from public key content
 		keyData := string(pk.PublicKey)
 		parts := strings.Fields(keyData)
 		if len(parts) >= 1 && (strings.HasPrefix(parts[0], "ssh-") || strings.HasPrefix(parts[0], "ecdsa-")) {


### PR DESCRIPTION
Reverts openconfig/featureprofiles#5639

The change was not thoroughly validated. This is breaking the tests for many vendors including Juniper. 
Issue tracker - b/545041733