### PR TITLE
Update traffic validation to use otgutils.ExpectedTrafficLoss

### DIFF
--- a/feature/bgp/gracefulrestart/otg_tests/exrr/exrr_test.go
+++ b/feature/bgp/gracefulrestart/otg_tests/exrr/exrr_test.go
@@ -1035,39 +1035,7 @@ func verifyNoPacketLoss(t *testing.T, ate *ondatra.ATEDevice, flows []string) {
 	defer otgutils.LogFlowMetrics(t, otg, c)
 
 	for _, f := range flows {
-		t.Logf("Verifying flow metrics for flow %s\n", f)
-		gnmi.Watch(t, otg, gnmi.OTG().Flow(f).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-			recvMetric, present := val.Val()
-			if !present {
-				return false
-			}
-			txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-			rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-			if txPackets == 0 {
-				return false
-			}
-			if rxPackets > txPackets {
-				return false
-			}
-			lossPct := (txPackets - rxPackets) * 100.0 / txPackets
-			return int(lossPct) < int(5)
-		}).Await(t)
-
-		recvMetric := gnmi.Get(t, otg, gnmi.OTG().Flow(f).State())
-		txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-		rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-		lostPackets := txPackets - rxPackets
-		if txPackets == 0 {
-			t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", f)
-		}
-		if rxPackets > txPackets {
-			t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPackets, txPackets)
-		}
-		if lossPct := lostPackets * 100 / txPackets; int(lossPct) < int(5) {
-			t.Logf("Traffic received as expected! Got %v loss", lossPct)
-		} else {
-			t.Errorf("Generic Test Assertion Failure: Flow %s: got %f, want < 5.0", f, lossPct)
-		}
+		otgutils.ExpectedTrafficLoss(t, otg, f, 0, 5)
 	}
 }
 
@@ -1077,38 +1045,7 @@ func confirmPacketLoss(t *testing.T, ate *ondatra.ATEDevice, flows []string) {
 	c := otg.FetchConfig(t)
 	defer otgutils.LogFlowMetrics(t, otg, c)
 	for _, f := range flows {
-		t.Logf("Verifying flow metrics for flow %s\n", f)
-		gnmi.Watch(t, otg, gnmi.OTG().Flow(f).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-			recvMetric, present := val.Val()
-			if !present {
-				return false
-			}
-			txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-			rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-			if txPackets == 0 {
-				return false
-			}
-			if rxPackets > txPackets {
-				return false
-			}
-			lossPct := (txPackets - rxPackets) * 100.0 / txPackets
-			return int(lossPct) > int(99)
-		}).Await(t)
-		recvMetric := gnmi.Get(t, otg, gnmi.OTG().Flow(f).State())
-		txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-		rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-		lostPackets := txPackets - rxPackets
-		if txPackets == 0 {
-			t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", f)
-		}
-		if rxPackets > txPackets {
-			t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPackets, txPackets)
-		}
-		if lossPct := lostPackets * 100 / txPackets; int(lossPct) > int(99) {
-			t.Logf("Traffic received as expected! Loss seen as expected: got %v, want 100%% ", lossPct)
-		} else {
-			t.Errorf("Generic Test Assertion Failure: Flow %s: got %f, want 100%% failure", f, lossPct)
-		}
+		otgutils.ExpectedTrafficLoss(t, otg, f, 99, 100)
 	}
 }
 
@@ -1288,51 +1225,10 @@ func validateTrafficFlows(t *testing.T, ate *ondatra.ATEDevice, config gosnappi.
 	otg.StopTraffic(t)
 
 	for _, flow := range config.Flows().Items() {
-		gnmi.Watch(t, otg, gnmi.OTG().Flow(flow.Name()).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-			recvMetric, present := val.Val()
-			if !present {
-				return false
-			}
-			outPkts := float32(recvMetric.GetCounters().GetOutPkts())
-			inPkts := float32(recvMetric.GetCounters().GetInPkts())
-			if outPkts == 0 {
-				return false
-			}
-			if inPkts > outPkts {
-				return false
-			}
-			lossPct := ((outPkts - inPkts) * 100.0) / outPkts
-			if match {
-				return int(lossPct) <= int(0)
-			}
-			return int(lossPct) >= int(100)
-		}).Await(t)
-
-		outPkts := float32(gnmi.Get(t, otg, gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State()))
-		inPkts := float32(gnmi.Get(t, otg, gnmi.OTG().Flow(flow.Name()).Counters().InPkts().State()))
-		lossPct := ((outPkts - inPkts) * 100.0) / outPkts
-
-		t.Logf("Flow %s: OutPkts=%v, InPkts=%v, LossPct=%v", flow.Name(), outPkts, inPkts, lossPct)
-
-		if outPkts == 0 {
-			return fmt.Errorf("IXIA traffic generation failed: TxPkts = 0 for flow %s", flow.Name())
-		}
-		if inPkts > outPkts {
-			return fmt.Errorf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", inPkts, outPkts)
-		}
-
 		if match {
-			// Expecting traffic to pass (0% loss)
-			if got := lossPct; int(got) > int(0) {
-				return fmt.Errorf("Generic Test Assertion Failure: Flow %s has %v%% packet loss, want 0%%", flow.Name(), got)
-			}
-			t.Logf("Traffic validation PASSED: Flow %s has 0%% packet loss", flow.Name())
+			otgutils.ExpectedTrafficLoss(t, otg, flow.Name(), 0, 0)
 		} else {
-			// Expecting traffic to fail (100% loss)
-			if got := lossPct; int(got) != int(100) {
-				return fmt.Errorf("Generic Test Assertion Failure: Flow %s has %v%% packet loss, want 100%%", flow.Name(), got)
-			}
-			t.Logf("Traffic validation PASSED: Flow %s has 100%% packet loss", flow.Name())
+			otgutils.ExpectedTrafficLoss(t, otg, flow.Name(), 100, 100)
 		}
 	}
 	return nil

--- a/feature/bgp/gracefulrestart/otg_tests/exrr/exrr_test.go
+++ b/feature/bgp/gracefulrestart/otg_tests/exrr/exrr_test.go
@@ -1035,7 +1035,15 @@ func verifyNoPacketLoss(t *testing.T, ate *ondatra.ATEDevice, flows []string) {
 	defer otgutils.LogFlowMetrics(t, otg, c)
 
 	for _, f := range flows {
-		otgutils.ExpectedTrafficLoss(t, otg, f, 0, 5)
+		t.Logf("Verifying flow metrics for flow %s\n", f)
+		gnmi.Watch(t, otg, gnmi.OTG().Flow(f).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
+			recvMetric, present := val.Val()
+			if !present || recvMetric.GetCounters() == nil {
+				return false
+			}
+			return true
+		}).Await(t)
+		otgutils.ExpectedTrafficLoss(t, otg, f, 0, 4.99)
 	}
 }
 
@@ -1045,7 +1053,15 @@ func confirmPacketLoss(t *testing.T, ate *ondatra.ATEDevice, flows []string) {
 	c := otg.FetchConfig(t)
 	defer otgutils.LogFlowMetrics(t, otg, c)
 	for _, f := range flows {
-		otgutils.ExpectedTrafficLoss(t, otg, f, 99, 100)
+		t.Logf("Verifying flow metrics for flow %s\n", f)
+		gnmi.Watch(t, otg, gnmi.OTG().Flow(f).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
+			recvMetric, present := val.Val()
+			if !present || recvMetric.GetCounters() == nil {
+				return false
+			}
+			return true
+		}).Await(t)
+		otgutils.ExpectedTrafficLoss(t, otg, f, 100, 100)
 	}
 }
 
@@ -1226,9 +1242,13 @@ func validateTrafficFlows(t *testing.T, ate *ondatra.ATEDevice, config gosnappi.
 
 	for _, flow := range config.Flows().Items() {
 		if match {
-			otgutils.ExpectedTrafficLoss(t, otg, flow.Name(), 0, 0)
+			// Expecting traffic to pass (0% loss)
+			otgutils.ExpectedTrafficLoss(t, otg, flow.Name(), 0, 0.99)
+			t.Logf("Traffic validation PASSED: Flow %s has 0%% packet loss", flow.Name())
 		} else {
+			// Expecting traffic to fail (100% loss)
 			otgutils.ExpectedTrafficLoss(t, otg, flow.Name(), 100, 100)
+			t.Logf("Traffic validation PASSED: Flow %s has 100%% packet loss", flow.Name())
 		}
 	}
 	return nil

--- a/feature/bgp/gracefulrestart/otg_tests/exrr/exrr_test.go
+++ b/feature/bgp/gracefulrestart/otg_tests/exrr/exrr_test.go
@@ -1036,13 +1036,6 @@ func verifyNoPacketLoss(t *testing.T, ate *ondatra.ATEDevice, flows []string) {
 
 	for _, f := range flows {
 		t.Logf("Verifying flow metrics for flow %s\n", f)
-		gnmi.Watch(t, otg, gnmi.OTG().Flow(f).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-			recvMetric, present := val.Val()
-			if !present || recvMetric.GetCounters() == nil {
-				return false
-			}
-			return true
-		}).Await(t)
 		otgutils.ExpectedTrafficLoss(t, otg, f, 0, 4.99)
 	}
 }
@@ -1054,13 +1047,6 @@ func confirmPacketLoss(t *testing.T, ate *ondatra.ATEDevice, flows []string) {
 	defer otgutils.LogFlowMetrics(t, otg, c)
 	for _, f := range flows {
 		t.Logf("Verifying flow metrics for flow %s\n", f)
-		gnmi.Watch(t, otg, gnmi.OTG().Flow(f).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-			recvMetric, present := val.Val()
-			if !present || recvMetric.GetCounters() == nil {
-				return false
-			}
-			return true
-		}).Await(t)
 		otgutils.ExpectedTrafficLoss(t, otg, f, 100, 100)
 	}
 }

--- a/feature/bgp/otg_tests/bgp_always_compare_med/bgp_always_compare_med_test.go
+++ b/feature/bgp/otg_tests/bgp_always_compare_med/bgp_always_compare_med_test.go
@@ -368,55 +368,14 @@ func configureOTG(t *testing.T, otg *otg.OTG) gosnappi.Config {
 	return config
 }
 
-// verifyTraffic confirms that every traffic flow has the expected amount of loss (0% or 100%
-// depending on wantLoss, +- 2%).
 func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, c gosnappi.Config, flowName string, wantLoss bool) {
 	t.Helper()
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, c)
-	t.Logf("Verifying flow metrics for flow %s\n", flowName)
-	gnmi.Watch(t, otg, gnmi.OTG().Flow(flowName).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-		recvMetric, present := val.Val()
-		if !present {
-			return false
-		}
-		txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-		rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-		if txPackets == 0 {
-			return false
-		}
-		if rxPackets > txPackets {
-			return false
-		}
-		lossPct := float32(txPackets-rxPackets) * 100 / float32(txPackets)
-		if wantLoss {
-			return int(lossPct) >= int(100-float32(tolerancePct))
-		}
-		return int(lossPct) <= int(tolerancePct)
-	}).Await(t)
-
-	recvMetric := gnmi.Get(t, otg, gnmi.OTG().Flow(flowName).State())
-	txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-	rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-	if txPackets == 0 {
-		t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", flowName)
-	}
-	if rxPackets > txPackets {
-		t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPackets, txPackets)
-	}
-	lossPct := float32(txPackets-rxPackets) * 100 / float32(txPackets)
 	if wantLoss {
-		if int(lossPct) < int(100-float32(tolerancePct)) {
-			t.Errorf("Generic Test Assertion Failure: Flow %s: got %v, want >= %v", flowName, lossPct, 100-float32(tolerancePct))
-		} else {
-			t.Logf("Traffic Loss Test Passed!")
-		}
+		otgutils.ExpectedTrafficLoss(t, otg, flowName, float64(100-float32(tolerancePct)), 100)
 	} else {
-		if int(lossPct) > int(tolerancePct) {
-			t.Errorf("Generic Test Assertion Failure: Flow %s: got %v, want <= %v", flowName, lossPct, float32(tolerancePct))
-		} else {
-			t.Logf("Traffic Test Passed!")
-		}
+		otgutils.ExpectedTrafficLoss(t, otg, flowName, 0, float64(tolerancePct))
 	}
 }
 

--- a/feature/bgp/otg_tests/bgp_always_compare_med/bgp_always_compare_med_test.go
+++ b/feature/bgp/otg_tests/bgp_always_compare_med/bgp_always_compare_med_test.go
@@ -368,14 +368,17 @@ func configureOTG(t *testing.T, otg *otg.OTG) gosnappi.Config {
 	return config
 }
 
+// verifyTraffic confirms that every traffic flow has the expected amount of loss (0% or 100%
+// depending on wantLoss, +- 2%).
 func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, c gosnappi.Config, flowName string, wantLoss bool) {
 	t.Helper()
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, c)
+	t.Logf("Verifying flow metrics for flow %s\n", flowName)
 	if wantLoss {
 		otgutils.ExpectedTrafficLoss(t, otg, flowName, float64(100-tolerancePct), 100)
 	} else {
-		otgutils.ExpectedTrafficLoss(t, otg, flowName, 0, float64(tolerancePct))
+		otgutils.ExpectedTrafficLoss(t, otg, flowName, 0, float64(tolerancePct)+0.99)
 	}
 }
 

--- a/feature/bgp/otg_tests/bgp_always_compare_med/bgp_always_compare_med_test.go
+++ b/feature/bgp/otg_tests/bgp_always_compare_med/bgp_always_compare_med_test.go
@@ -373,7 +373,7 @@ func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, c gosnappi.Config, flow
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, c)
 	if wantLoss {
-		otgutils.ExpectedTrafficLoss(t, otg, flowName, float64(100-float32(tolerancePct)), 100)
+		otgutils.ExpectedTrafficLoss(t, otg, flowName, float64(100-tolerancePct), 100)
 	} else {
 		otgutils.ExpectedTrafficLoss(t, otg, flowName, 0, float64(tolerancePct))
 	}

--- a/feature/bgp/otg_tests/bgp_scale_test/bgp_scale_test.go
+++ b/feature/bgp/otg_tests/bgp_scale_test/bgp_scale_test.go
@@ -1874,7 +1874,8 @@ func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, conf gosnappi.Config) {
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, conf)
 	for _, flow := range conf.Flows().Items() {
-		otgutils.ExpectedTrafficLoss(t, otg, flow.Name(), 0, float64(tolerancePct))
+		flowName := flow.Name()
+		otgutils.ExpectedTrafficLoss(t, otg, flowName, 0, float64(tolerancePct)+0.99)
 	}
 }
 

--- a/feature/bgp/otg_tests/bgp_scale_test/bgp_scale_test.go
+++ b/feature/bgp/otg_tests/bgp_scale_test/bgp_scale_test.go
@@ -1874,39 +1874,7 @@ func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, conf gosnappi.Config) {
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, conf)
 	for _, flow := range conf.Flows().Items() {
-		flowName := flow.Name()
-		gnmi.Watch(t, otg, gnmi.OTG().Flow(flowName).State(), 45*time.Second, func(v *ygnmi.Value[*otgtelemetry.Flow]) bool {
-			val, present := v.Val()
-			if !present || val.GetCounters() == nil {
-				return false
-			}
-			txPackets := float32(val.GetCounters().GetOutPkts())
-			rxPackets := float32(val.GetCounters().GetInPkts())
-			if txPackets == 0 {
-				return false
-			}
-			if rxPackets > txPackets {
-				return false
-			}
-			lossPct := float32(txPackets-rxPackets) * 100 / float32(txPackets)
-			return int(lossPct) <= int(tolerancePct)
-		}).Await(t)
-
-		recvMetric := gnmi.Get(t, otg, gnmi.OTG().Flow(flowName).State())
-		txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-		rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-		if txPackets == 0 {
-			t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", flowName)
-		}
-		if rxPackets > txPackets {
-			t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPackets, txPackets)
-		}
-		lossPct := float32(txPackets-rxPackets) * 100 / float32(txPackets)
-		if int(lossPct) > int(tolerancePct) {
-			t.Errorf("Generic Test Assertion Failure: Flow %s: got %v, want <= %v", flowName, lossPct, tolerancePct)
-		} else {
-			t.Logf("Traffic Test Passed! for flow %s", flowName)
-		}
+		otgutils.ExpectedTrafficLoss(t, otg, flow.Name(), 0, float64(tolerancePct))
 	}
 }
 

--- a/feature/bgp/policybase/otg_tests/aspath_and_community_test/aspath_and_community_test.go
+++ b/feature/bgp/policybase/otg_tests/aspath_and_community_test/aspath_and_community_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	"github.com/openconfig/ygnmi/ygnmi"
 )
 
 const (

--- a/feature/bgp/policybase/otg_tests/aspath_and_community_test/aspath_and_community_test.go
+++ b/feature/bgp/policybase/otg_tests/aspath_and_community_test/aspath_and_community_test.go
@@ -265,51 +265,10 @@ func configureFlow(t *testing.T, bs *cfgplugins.BGPSession, prefixPair []string,
 func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, c gosnappi.Config, prefixType string, testResults bool, index int) {
 	defer otgutils.LogFlowMetrics(t, ate.OTG(), c)
 	flowName := "flow" + prefixType + strconv.Itoa(index)
-	gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flowName).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-		f, present := val.Val()
-		if !present || f.GetCounters() == nil {
-			return false
-		}
-		framesTx := float32(f.GetCounters().GetOutPkts())
-		framesRx := float32(f.GetCounters().GetInPkts())
-		if framesTx == 0 {
-			return false
-		}
-		if framesRx > framesTx {
-			return false
-		}
-		if testResults {
-			lossPct := float32(framesTx-framesRx) * 100 / float32(framesTx)
-			return int(lossPct) <= int(0)
-		} else {
-			return framesRx == 0
-		}
-	}).Await(t)
-
-	recvMetric := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flowName).State())
-	framesTx := float32(recvMetric.GetCounters().GetOutPkts())
-	framesRx := float32(recvMetric.GetCounters().GetInPkts())
-
-	if framesTx == 0 {
-		t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", flowName)
-	}
-	if framesRx > framesTx {
-		t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", framesRx, framesTx)
-	}
-	lossPct := (framesTx - framesRx) * 100 / framesTx
-
 	if testResults {
-		if int(lossPct) > int(0) {
-			t.Errorf("Generic Test Assertion Failure: Flow %s: got %v, want <= 0", flowName, lossPct)
-		} else {
-			t.Logf("Traffic validation successful for criteria [%t] FramesTx: %f FramesRx: %f", testResults, framesTx, framesRx)
-		}
+		otgutils.ExpectedTrafficLoss(t, ate.OTG(), flowName, 0, 0)
 	} else {
-		if framesRx > 0 {
-			t.Errorf("Generic Test Assertion Failure: Flow %s: got %v framesRx, want 0", flowName, framesRx)
-		} else {
-			t.Logf("Traffic validation successful for criteria [%t] FramesTx: %f FramesRx: %f", testResults, framesTx, framesRx)
-		}
+		otgutils.ExpectedTrafficLoss(t, ate.OTG(), flowName, 100, 100)
 	}
 }
 

--- a/feature/bgp/policybase/otg_tests/aspath_and_community_test/aspath_and_community_test.go
+++ b/feature/bgp/policybase/otg_tests/aspath_and_community_test/aspath_and_community_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
+	"github.com/openconfig/ygnmi/ygnmi"
 )
 
 const (
@@ -264,7 +266,7 @@ func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, c gosnappi.Config, pref
 	defer otgutils.LogFlowMetrics(t, ate.OTG(), c)
 	flowName := "flow" + prefixType + strconv.Itoa(index)
 	if testResults {
-		otgutils.ExpectedTrafficLoss(t, ate.OTG(), flowName, 0, 0)
+		otgutils.ExpectedTrafficLoss(t, ate.OTG(), flowName, 0, 0.99)
 	} else {
 		otgutils.ExpectedTrafficLoss(t, ate.OTG(), flowName, 100, 100)
 	}

--- a/feature/bgp/policybase/otg_tests/aspath_and_community_test/aspath_and_community_test.go
+++ b/feature/bgp/policybase/otg_tests/aspath_and_community_test/aspath_and_community_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
-	"github.com/openconfig/ygnmi/ygnmi"
 )
 
 const (

--- a/feature/bgp/policybase/otg_tests/aspath_and_community_test/aspath_and_community_test.go
+++ b/feature/bgp/policybase/otg_tests/aspath_and_community_test/aspath_and_community_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
 	"github.com/openconfig/ygnmi/ygnmi"
 )
 

--- a/feature/bgp/policybase/otg_tests/aspath_test/aspath_test.go
+++ b/feature/bgp/policybase/otg_tests/aspath_test/aspath_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
+	"github.com/openconfig/ygnmi/ygnmi"
 )
 
 const (
@@ -202,11 +204,10 @@ func incrementIPSlice(ipSlice []string) []string {
 
 func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, c gosnappi.Config, ports int, testResults bool) {
 	defer otgutils.LogFlowMetrics(t, ate.OTG(), c)
-	otg := ate.OTG()
 	if testResults {
-		otgutils.ExpectedTrafficLoss(t, otg, "flow", 0, 5)
+		otgutils.ExpectedTrafficLoss(t, ate.OTG(), "flow", 0, 5.99)
 	} else {
-		otgutils.ExpectedTrafficLoss(t, otg, "flow", 99, 100)
+		otgutils.ExpectedTrafficLoss(t, ate.OTG(), "flow", 99, 100)
 	}
 }
 

--- a/feature/bgp/policybase/otg_tests/aspath_test/aspath_test.go
+++ b/feature/bgp/policybase/otg_tests/aspath_test/aspath_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
-	"github.com/openconfig/ygnmi/ygnmi"
 )
 
 const (

--- a/feature/bgp/policybase/otg_tests/aspath_test/aspath_test.go
+++ b/feature/bgp/policybase/otg_tests/aspath_test/aspath_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
-	"github.com/openconfig/ygnmi/ygnmi"
 )
 
 const (
@@ -204,40 +202,11 @@ func incrementIPSlice(ipSlice []string) []string {
 
 func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, c gosnappi.Config, ports int, testResults bool) {
 	defer otgutils.LogFlowMetrics(t, ate.OTG(), c)
-	// compare the flows transmitted and received instead of the ports counters
-	gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow("flow").State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-		recvMetric, present := val.Val()
-		if !present {
-			return false
-		}
-		txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-		rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-		if txPackets == 0 {
-			return false
-		}
-		if rxPackets > txPackets {
-			return false
-		}
-		lossPct := (txPackets - rxPackets) * 100.0 / txPackets
-		if testResults {
-			return int(lossPct) <= int(5)
-		}
-		return int(lossPct) >= int(99)
-	}).Await(t)
-
-	framesTx := float32(gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow("flow").State()).GetCounters().GetOutPkts())
-	framesRx := float32(gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow("flow").State()).GetCounters().GetInPkts())
-	if framesTx == 0 {
-		t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow flow")
-	}
-	if framesRx > framesTx {
-		t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", framesRx, framesTx)
-	}
-	lossPct := (framesTx - framesRx) * 100.0 / framesTx
-	if (testResults && int(lossPct) <= int(5)) || (!testResults && int(lossPct) >= int(99)) {
-		t.Logf("Traffic validation successful for criteria [%t] FramesTx: %f FramesRx: %f", testResults, framesTx, framesRx)
+	otg := ate.OTG()
+	if testResults {
+		otgutils.ExpectedTrafficLoss(t, otg, "flow", 0, 5)
 	} else {
-		t.Errorf("Generic Test Assertion Failure: Flow flow: got %f loss, want 0%% (testResults=%t)", lossPct, testResults)
+		otgutils.ExpectedTrafficLoss(t, otg, "flow", 99, 100)
 	}
 }
 

--- a/feature/bgp/policybase/otg_tests/comm_match_action_test/bgp_comm_match_action_test.go
+++ b/feature/bgp/policybase/otg_tests/comm_match_action_test/bgp_comm_match_action_test.go
@@ -516,38 +516,7 @@ func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, conf gosnappi.Config) {
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, conf)
 	for _, flow := range conf.Flows().Items() {
-		gnmi.Watch(t, otg, gnmi.OTG().Flow(flow.Name()).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-			f, present := val.Val()
-			if !present || f.GetCounters() == nil {
-				return false
-			}
-			txPackets := f.GetCounters().GetOutPkts()
-			rxPackets := f.GetCounters().GetInPkts()
-			if txPackets == 0 {
-				return false
-			}
-			if rxPackets > txPackets {
-				return false
-			}
-			lossPct := float32(txPackets-rxPackets) * 100 / float32(txPackets)
-			return int(lossPct) <= int(tolerancePct)
-		}).Await(t)
-
-		recvMetric := gnmi.Get(t, otg, gnmi.OTG().Flow(flow.Name()).State())
-		txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-		rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-		if txPackets == 0 {
-			t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", flow.Name())
-		}
-		if rxPackets > txPackets {
-			t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPackets, txPackets)
-		}
-		lossPct := (txPackets - rxPackets) * 100 / txPackets
-		if int(lossPct) > int(tolerancePct) {
-			t.Errorf("Generic Test Assertion Failure: Flow %s: got %v, want <= %d", flow.Name(), lossPct, tolerancePct)
-		} else {
-			t.Logf("Traffic Test Passed! for flow %s", flow.Name())
-		}
+		otgutils.ExpectedTrafficLoss(t, otg, flow.Name(), 0, float64(tolerancePct))
 	}
 }
 

--- a/feature/bgp/policybase/otg_tests/comm_match_action_test/bgp_comm_match_action_test.go
+++ b/feature/bgp/policybase/otg_tests/comm_match_action_test/bgp_comm_match_action_test.go
@@ -516,7 +516,7 @@ func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, conf gosnappi.Config) {
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, conf)
 	for _, flow := range conf.Flows().Items() {
-		otgutils.ExpectedTrafficLoss(t, otg, flow.Name(), 0, float64(tolerancePct))
+		otgutils.ExpectedTrafficLoss(t, otg, flow.Name(), 0, float64(tolerancePct)+0.99)
 	}
 }
 

--- a/feature/bgp/policybase/otg_tests/community_test/community_test.go
+++ b/feature/bgp/policybase/otg_tests/community_test/community_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
+	"github.com/openconfig/ygnmi/ygnmi"
 )
 
 const (
@@ -206,11 +208,10 @@ func configureFlow(t *testing.T, bs *cfgplugins.BGPSession, prefixPair []string,
 
 func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, prefixType string, testResults bool, index int) {
 	flowName := "flow" + prefixType + strconv.Itoa(index)
-	otg := ate.OTG()
 	if testResults {
-		otgutils.ExpectedTrafficLoss(t, otg, flowName, 0, 0)
+		otgutils.ExpectedTrafficLoss(t, ate.OTG(), flowName, 0, 0.99)
 	} else {
-		otgutils.ExpectedTrafficLoss(t, otg, flowName, 100, 100)
+		otgutils.ExpectedTrafficLoss(t, ate.OTG(), flowName, 100, 100)
 	}
 }
 

--- a/feature/bgp/policybase/otg_tests/community_test/community_test.go
+++ b/feature/bgp/policybase/otg_tests/community_test/community_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
-	"github.com/openconfig/ygnmi/ygnmi"
 )
 
 const (
@@ -208,44 +206,11 @@ func configureFlow(t *testing.T, bs *cfgplugins.BGPSession, prefixPair []string,
 
 func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, prefixType string, testResults bool, index int) {
 	flowName := "flow" + prefixType + strconv.Itoa(index)
-	gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flowName).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-		recvMetric, present := val.Val()
-		if !present {
-			return false
-		}
-		txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-		rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-		if txPackets == 0 {
-			return false
-		}
-		if rxPackets > txPackets {
-			return false
-		}
-		lossPct := float32(txPackets-rxPackets) * 100 / float32(txPackets)
-		if testResults {
-			return int(lossPct) <= int(0)
-		} else {
-			return int(lossPct) >= int(100)
-		}
-	}).Await(t)
-
-	recvMetric := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flowName).State())
-	txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-	rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-
-	if txPackets == 0 {
-		t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", flowName)
-	}
-	if rxPackets > txPackets {
-		t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPackets, txPackets)
-	}
-
-	lossPct := float32(txPackets-rxPackets) * 100 / float32(txPackets)
-
-	if (testResults && int(lossPct) <= int(0)) || (!testResults && int(lossPct) >= int(100)) {
-		t.Logf("Traffic validation successful for criteria [%t] FramesTx: %f FramesRx: %f", testResults, txPackets, rxPackets)
+	otg := ate.OTG()
+	if testResults {
+		otgutils.ExpectedTrafficLoss(t, otg, flowName, 0, 0)
 	} else {
-		t.Errorf("Generic Test Assertion Failure: Flow %s: got loss %v%%, want <=0%% (testResults=%t)", flowName, lossPct, testResults)
+		otgutils.ExpectedTrafficLoss(t, otg, flowName, 100, 100)
 	}
 }
 

--- a/feature/bgp/policybase/otg_tests/community_test/community_test.go
+++ b/feature/bgp/policybase/otg_tests/community_test/community_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
-	"github.com/openconfig/ygnmi/ygnmi"
 )
 
 const (

--- a/feature/bgp/policybase/otg_tests/route_installation_test/route_installation_test.go
+++ b/feature/bgp/policybase/otg_tests/route_installation_test/route_installation_test.go
@@ -524,55 +524,10 @@ func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, c gosnappi.Config, want
 	defer otgutils.LogFlowMetrics(t, otg, c)
 	for _, f := range c.Flows().Items() {
 		t.Logf("Verifying flow metrics for flow %s\n", f.Name())
-		gnmi.Watch(t, otg, gnmi.OTG().Flow(f.Name()).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-			recvMetric, ok := val.Val()
-			if !ok {
-				return false
-			}
-			txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-			rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-			if txPackets == 0 {
-				return false
-			}
-			if rxPackets > txPackets {
-				return false
-			}
-			lossPct := (txPackets - rxPackets) * 100 / txPackets
-			if !wantLoss {
-				return int(lossPct) <= int(tolerancePct)
-			}
-			return int(lossPct) >= int(100-tolerancePct)
-		}).Await(t)
-
-		recvMetric := gnmi.Get(t, otg, gnmi.OTG().Flow(f.Name()).State())
-		txPackets := recvMetric.GetCounters().GetOutPkts()
-		rxPackets := recvMetric.GetCounters().GetInPkts()
-
-		if txPackets == 0 {
-			t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", f.Name())
-		}
-		if rxPackets > txPackets {
-			t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPackets, txPackets)
-		}
-
-		lostPackets := txPackets - rxPackets
-		lossPct := float32(lostPackets) * 100 / float32(txPackets)
-
 		if !wantLoss {
-			if lostPackets > tolerance {
-				t.Logf("Packets received not matching packets sent. Sent: %v, Received: %v", txPackets, rxPackets)
-			}
-			if int(lossPct) > int(tolerancePct) {
-				t.Errorf("Generic Test Assertion Failure: Flow %s: got %v, want <= %d", f.Name(), lossPct, tolerancePct)
-			} else {
-				t.Logf("Traffic Test Passed! for flow %s", f.Name())
-			}
+			otgutils.ExpectedTrafficLoss(t, otg, f.Name(), 0, float64(tolerancePct))
 		} else {
-			if int(lossPct) < int(100-tolerancePct) {
-				t.Errorf("Generic Test Assertion Failure: Flow %s: got %v, want >= %d", f.Name(), lossPct, 100-tolerancePct)
-			} else {
-				t.Logf("Traffic Loss Test Passed! for flow %s", f.Name())
-			}
+			otgutils.ExpectedTrafficLoss(t, otg, f.Name(), float64(100-tolerancePct), 100)
 		}
 	}
 }

--- a/feature/bgp/policybase/otg_tests/route_installation_test/route_installation_test.go
+++ b/feature/bgp/policybase/otg_tests/route_installation_test/route_installation_test.go
@@ -525,7 +525,7 @@ func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, c gosnappi.Config, want
 	for _, f := range c.Flows().Items() {
 		t.Logf("Verifying flow metrics for flow %s\n", f.Name())
 		if !wantLoss {
-			otgutils.ExpectedTrafficLoss(t, otg, f.Name(), 0, float64(tolerancePct))
+			otgutils.ExpectedTrafficLoss(t, otg, f.Name(), 0, float64(tolerancePct)+0.99)
 		} else {
 			otgutils.ExpectedTrafficLoss(t, otg, f.Name(), float64(100-tolerancePct), 100)
 		}

--- a/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
+++ b/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
@@ -505,38 +505,7 @@ func (tc *testCase) verifyNoPacketLoss(t *testing.T, ate *ondatra.ATEDevice, con
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, conf)
 	for _, flow := range flowNames {
-		gnmi.Watch(t, otg, gnmi.OTG().Flow(flow).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-			recvMetric, present := val.Val()
-			if !present {
-				return false
-			}
-			txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-			rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-			if txPackets == 0 {
-				return false
-			}
-			if rxPackets > txPackets {
-				return false
-			}
-			lossPct := float32(txPackets-rxPackets) * 100 / float32(txPackets)
-			return int(lossPct) <= int(tolerance)
-		}).Await(t)
-
-		recvMetric := gnmi.Get(t, otg, gnmi.OTG().Flow(flow).State())
-		txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-		rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-		if txPackets == 0 {
-			t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", flow)
-		}
-		if rxPackets > txPackets {
-			t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPackets, txPackets)
-		}
-		lossPct := float32(txPackets-rxPackets) * 100 / float32(txPackets)
-		if int(lossPct) > int(tolerance) {
-			t.Errorf("Generic Test Assertion Failure: Flow %s: got %v, want <= %v", flow, lossPct, tolerance)
-		} else {
-			t.Logf("Traffic Test Passed! Got %v loss", lossPct)
-		}
+		otgutils.ExpectedTrafficLoss(t, otg, flow, 0, float64(tolerance))
 	}
 }
 
@@ -544,38 +513,7 @@ func (tc *testCase) verifyPacketLoss(t *testing.T, ate *ondatra.ATEDevice, conf 
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, conf)
 	for _, flow := range flowNames {
-		gnmi.Watch(t, otg, gnmi.OTG().Flow(flow).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-			recvMetric, present := val.Val()
-			if !present {
-				return false
-			}
-			txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-			rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-			if txPackets == 0 {
-				return false
-			}
-			if rxPackets > txPackets {
-				return false
-			}
-			lossPct := float32(txPackets-rxPackets) * 100 / float32(txPackets)
-			return int(lossPct) >= int(100-tolerance) && int(lossPct) <= 100
-		}).Await(t)
-
-		recvMetric := gnmi.Get(t, otg, gnmi.OTG().Flow(flow).State())
-		txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-		rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-		if txPackets == 0 {
-			t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", flow)
-		}
-		if rxPackets > txPackets {
-			t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPackets, txPackets)
-		}
-		lossPct := float32(txPackets-rxPackets) * 100 / float32(txPackets)
-		if int(lossPct) >= int(100-tolerance) && int(lossPct) <= 100 {
-			t.Logf("Traffic Test Passed! Loss seen as expected: got %v, want 100%% ", lossPct)
-		} else {
-			t.Errorf("Generic Test Assertion Failure: Flow %s is expected to fail: got %v, want 100%% failure", flow, lossPct)
-		}
+		otgutils.ExpectedTrafficLoss(t, otg, flow, float64(100-tolerance), 100)
 	}
 }
 

--- a/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
+++ b/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )
@@ -504,7 +505,7 @@ func (tc *testCase) verifyNoPacketLoss(t *testing.T, ate *ondatra.ATEDevice, con
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, conf)
 	for _, flow := range flowNames {
-		otgutils.ExpectedTrafficLoss(t, otg, flow, 0, float64(tolerance))
+		otgutils.ExpectedTrafficLoss(t, otg, flow, 0, tolerance+0.99)
 	}
 }
 
@@ -512,7 +513,7 @@ func (tc *testCase) verifyPacketLoss(t *testing.T, ate *ondatra.ATEDevice, conf 
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, conf)
 	for _, flow := range flowNames {
-		otgutils.ExpectedTrafficLoss(t, otg, flow, float64(100-tolerance), 100)
+		otgutils.ExpectedTrafficLoss(t, otg, flow, 100-tolerance, 100)
 	}
 }
 

--- a/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
+++ b/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
@@ -504,7 +504,7 @@ func (tc *testCase) verifyNoPacketLoss(t *testing.T, ate *ondatra.ATEDevice, con
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, conf)
 	for _, flow := range flowNames {
-		otgutils.ExpectedTrafficLoss(t, otg, flow, 0, tolerance+0.99)
+		otgutils.ExpectedTrafficLoss(t, otg, flow, 0, float64(tolerance)+0.99)
 	}
 }
 
@@ -512,7 +512,7 @@ func (tc *testCase) verifyPacketLoss(t *testing.T, ate *ondatra.ATEDevice, conf 
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, conf)
 	for _, flow := range flowNames {
-		otgutils.ExpectedTrafficLoss(t, otg, flow, 100-tolerance, 100)
+		otgutils.ExpectedTrafficLoss(t, otg, flow, 100-float64(tolerance), 100)
 	}
 }
 

--- a/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
+++ b/feature/bgp/prefixlimit/otg_tests/bgp_prefix_limit_test/bgp_prefix_limit_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )

--- a/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/static_route_bgp_redistribution_test.go
+++ b/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/static_route_bgp_redistribution_test.go
@@ -437,38 +437,7 @@ func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, conf gosnappi.Config) {
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, conf)
 	for _, flow := range conf.Flows().Items() {
-		gnmi.Watch(t, otg, gnmi.OTG().Flow(flow.Name()).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-			f, present := val.Val()
-			if !present || f.GetCounters() == nil {
-				return false
-			}
-			txPackets := f.GetCounters().GetOutPkts()
-			rxPackets := f.GetCounters().GetInPkts()
-			if txPackets == 0 {
-				return false
-			}
-			if rxPackets > txPackets {
-				return false
-			}
-			lossPct := float32(txPackets-rxPackets) * 100 / float32(txPackets)
-			return int(lossPct) <= int(tolerancePct)
-		}).Await(t)
-
-		recvMetric := gnmi.Get(t, otg, gnmi.OTG().Flow(flow.Name()).State())
-		txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-		rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-		if txPackets == 0 {
-			t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", flow.Name())
-		}
-		if rxPackets > txPackets {
-			t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPackets, txPackets)
-		}
-		lossPct := (txPackets - rxPackets) * 100 / txPackets
-		if int(lossPct) > int(tolerancePct) {
-			t.Errorf("Generic Test Assertion Failure: Flow %s: got %v, want <= %d", flow.Name(), lossPct, tolerancePct)
-		} else {
-			t.Logf("Traffic Test Passed! for flow %s", flow.Name())
-		}
+		otgutils.ExpectedTrafficLoss(t, otg, flow.Name(), 0, float64(tolerancePct))
 	}
 }
 

--- a/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/static_route_bgp_redistribution_test.go
+++ b/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/static_route_bgp_redistribution_test.go
@@ -437,7 +437,7 @@ func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, conf gosnappi.Config) {
 	otg := ate.OTG()
 	defer otgutils.LogFlowMetrics(t, otg, conf)
 	for _, flow := range conf.Flows().Items() {
-		otgutils.ExpectedTrafficLoss(t, otg, flow.Name(), 0, float64(tolerancePct))
+		otgutils.ExpectedTrafficLoss(t, otg, flow.Name(), 0, float64(tolerancePct)+0.99)
 	}
 }
 

--- a/feature/gribi/otg_tests/hierarchical_weight_resolution_pbf_test/hierarchical_weight_resolution_pbf_test.go
+++ b/feature/gribi/otg_tests/hierarchical_weight_resolution_pbf_test/hierarchical_weight_resolution_pbf_test.go
@@ -482,36 +482,7 @@ func testTraffic(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config) map[
 	time.Sleep(1 * time.Minute)
 	ate.OTG().StopTraffic(t)
 
-	gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flowipv4.Name()).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-		recvMetric, ok := val.Val()
-		if !ok || recvMetric.GetCounters() == nil {
-			return false
-		}
-		txPkts := recvMetric.GetCounters().GetOutPkts()
-		rxPkts := recvMetric.GetCounters().GetInPkts()
-		if txPkts == 0 {
-			return false
-		}
-		if rxPkts > txPkts {
-			return false
-		}
-		lossPct := float32(txPkts-rxPkts) * 100 / float32(txPkts)
-		return int(lossPct) <= 0
-	}).Await(t)
-
-	recvMetric := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flowipv4.Name()).State())
-	txPkts := recvMetric.GetCounters().GetOutPkts()
-	rxPkts := recvMetric.GetCounters().GetInPkts()
-	if txPkts == 0 {
-		t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", flowipv4.Name())
-	}
-	if rxPkts > txPkts {
-		t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPkts, txPkts)
-	}
-	lossPct := float32(txPkts-rxPkts) * 100 / float32(txPkts)
-	if int(lossPct) > 0 {
-		t.Errorf("Generic Test Assertion Failure: Flow %s: got %v, want <= 0", flowipv4.Name(), lossPct)
-	}
+	otgutils.ExpectedTrafficLoss(t, ate.OTG(), flowipv4.Name(), 0, 0.99)
 
 	// Compare traffic distribution with the wanted results.
 	results := filterPacketReceived(t, "flow", ate)

--- a/feature/gribi/otg_tests/hierarchical_weight_resolution_pbf_test/hierarchical_weight_resolution_pbf_test.go
+++ b/feature/gribi/otg_tests/hierarchical_weight_resolution_pbf_test/hierarchical_weight_resolution_pbf_test.go
@@ -41,8 +41,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
-	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )
 

--- a/feature/gribi/otg_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/otg_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -40,8 +40,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
-	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )
 

--- a/feature/gribi/otg_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
+++ b/feature/gribi/otg_tests/hierarchical_weight_resolution_test/hierarchical_weight_resolution_test.go
@@ -478,39 +478,7 @@ func testTraffic(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config) map[
 	time.Sleep(1 * time.Minute)
 	ate.OTG().StopTraffic(t)
 
-	gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flowipv4.Name()).State(), 45*time.Second, func(v *ygnmi.Value[*otgtelemetry.Flow]) bool {
-		val, present := v.Val()
-		if !present {
-			return false
-		}
-		tx := val.GetCounters().GetOutPkts()
-		rx := val.GetCounters().GetInPkts()
-		if tx == 0 {
-			return false
-		}
-		if rx > tx {
-			return false
-		}
-		lossPct := float32(tx-rx) * 100 / float32(tx)
-		return int(lossPct) <= 0
-	}).Await(t)
-
-	recvMetric := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flowipv4.Name()).State())
-	txPkts := recvMetric.GetCounters().GetOutPkts()
-	rxPkts := recvMetric.GetCounters().GetInPkts()
-
-	if txPkts == 0 {
-		t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", flowipv4.Name())
-	}
-
-	if rxPkts > txPkts {
-		t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPkts, txPkts)
-	}
-
-	lossPct := float32(txPkts-rxPkts) * 100 / float32(txPkts)
-	if int(lossPct) > 0 {
-		t.Errorf("Generic Test Assertion Failure: Flow %s: got %v, want <= 0", flowipv4.Name(), lossPct)
-	}
+	otgutils.ExpectedTrafficLoss(t, ate.OTG(), flowipv4.Name(), 0, 0.99)
 
 	// Compare traffic distribution with the wanted results.
 	results := filterPacketReceived(t, "flow", ate)

--- a/feature/mpls/sr/otg_tests/isis_node_sid_forward/isis_node_sid_forward_test.go
+++ b/feature/mpls/sr/otg_tests/isis_node_sid_forward/isis_node_sid_forward_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
+	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )
 
@@ -198,7 +200,7 @@ func verifySRCounters(t *testing.T, ts *isissession.TestSession, ate *ondatra.AT
 	d := ts.DUTConf
 	networkInstance := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(ts.DUT))
 
-	otgutils.ExpectedTrafficLoss(t, ate.OTG(), v4FlowName, 0, 0)
+	otgutils.ExpectedTrafficLoss(t, ate.OTG(), v4FlowName, 0, 0.99)
 
 	recvMetricV4 := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(v4FlowName).State())
 	txPkts := recvMetricV4.GetCounters().GetOutPkts()
@@ -223,7 +225,7 @@ func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config) {
 	defer otgutils.LogFlowMetrics(t, ate.OTG(), top)
 	defer otgutils.LogPortMetrics(t, ate.OTG(), top)
 	for _, flowName := range []string{v4FlowName, v6FlowName} {
-		otgutils.ExpectedTrafficLoss(t, ate.OTG(), flowName, 0, 0)
+		otgutils.ExpectedTrafficLoss(t, ate.OTG(), flowName, 0, 0.99)
 	}
 }
 

--- a/feature/mpls/sr/otg_tests/isis_node_sid_forward/isis_node_sid_forward_test.go
+++ b/feature/mpls/sr/otg_tests/isis_node_sid_forward/isis_node_sid_forward_test.go
@@ -200,36 +200,11 @@ func verifySRCounters(t *testing.T, ts *isissession.TestSession, ate *ondatra.AT
 	d := ts.DUTConf
 	networkInstance := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(ts.DUT))
 
-	gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(v4FlowName).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-		recvMetric, ok := val.Val()
-		if !ok || recvMetric.GetCounters() == nil {
-			return false
-		}
-		txPkts := recvMetric.GetCounters().GetOutPkts()
-		rxPkts := recvMetric.GetCounters().GetInPkts()
-		if txPkts == 0 {
-			return false
-		}
-		if rxPkts > txPkts {
-			return false
-		}
-		lossPct := float32(txPkts-rxPkts) * 100 / float32(txPkts)
-		return int(lossPct) <= 0
-	}).Await(t)
+	otgutils.ExpectedTrafficLoss(t, ate.OTG(), v4FlowName, 0, 0)
 
 	recvMetricV4 := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(v4FlowName).State())
 	txPkts := recvMetricV4.GetCounters().GetOutPkts()
 	rxPkts := recvMetricV4.GetCounters().GetInPkts()
-	if txPkts == 0 {
-		t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", v4FlowName)
-	}
-	if rxPkts > txPkts {
-		t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPkts, txPkts)
-	}
-	lossPct := float32(txPkts-rxPkts) * 100 / float32(txPkts)
-	if int(lossPct) > 0 {
-		t.Errorf("Generic Test Assertion Failure: Flow %s: got %v, want <= 0", v4FlowName, lossPct)
-	}
 	v4InPkts := rxPkts
 	v4OutPkts := txPkts
 	// Get SR Counters
@@ -250,38 +225,7 @@ func verifyTraffic(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config) {
 	defer otgutils.LogFlowMetrics(t, ate.OTG(), top)
 	defer otgutils.LogPortMetrics(t, ate.OTG(), top)
 	for _, flowName := range []string{v4FlowName, v6FlowName} {
-		gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flowName).State(), 45*time.Second, func(val *ygnmi.Value[*otgtelemetry.Flow]) bool {
-			recvMetric, ok := val.Val()
-			if !ok || recvMetric.GetCounters() == nil {
-				return false
-			}
-			txPkts := recvMetric.GetCounters().GetOutPkts()
-			rxPkts := recvMetric.GetCounters().GetInPkts()
-			if txPkts == 0 {
-				return false
-			}
-			if rxPkts > txPkts {
-				return false
-			}
-			lossPct := float32(txPkts-rxPkts) * 100 / float32(txPkts)
-			return int(lossPct) <= 0
-		}).Await(t)
-
-		recvMetric := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flowName).State())
-		txPkts := recvMetric.GetCounters().GetOutPkts()
-		rxPkts := recvMetric.GetCounters().GetInPkts()
-		if txPkts == 0 {
-			t.Fatalf("IXIA traffic generation failed: TxPkts = 0 for flow %s", flowName)
-		}
-		if rxPkts > txPkts {
-			t.Fatalf("IXIA traffic validation anomaly: RxPkts (%v) > TxPkts (%v)", rxPkts, txPkts)
-		}
-		lossPct := float32(txPkts-rxPkts) * 100 / float32(txPkts)
-		if int(lossPct) > 0 {
-			t.Errorf("Generic Test Assertion Failure: Flow %s: got %v, want <= 0", flowName, lossPct)
-		} else {
-			t.Logf("Traffic validation successful for [%s] FramesTx: %d FramesRx: %d", flowName, txPkts, rxPkts)
-		}
+		otgutils.ExpectedTrafficLoss(t, ate.OTG(), flowName, 0, 0)
 	}
 }
 

--- a/feature/mpls/sr/otg_tests/isis_node_sid_forward/isis_node_sid_forward_test.go
+++ b/feature/mpls/sr/otg_tests/isis_node_sid_forward/isis_node_sid_forward_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
 	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )

--- a/feature/mpls/sr/otg_tests/isis_node_sid_forward/isis_node_sid_forward_test.go
+++ b/feature/mpls/sr/otg_tests/isis_node_sid_forward/isis_node_sid_forward_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )
 

--- a/feature/mpls/sr/otg_tests/isis_node_sid_forward/isis_node_sid_forward_test.go
+++ b/feature/mpls/sr/otg_tests/isis_node_sid_forward/isis_node_sid_forward_test.go
@@ -27,8 +27,6 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
-	otgtelemetry "github.com/openconfig/ondatra/gnmi/otg"
-	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )
 


### PR DESCRIPTION
1. Refactor all BGP tests to use the new ExpectedTrafficLoss function from otgutils.
2. Wherever `int(lossPct)` were used, the function is updated to `otgutils.ExpectedTrafficLoss(t, otg, flowName, 0, 0.99)` to account for the previously truncated decimal values. 