### PR TITLE
Optimize one_sp_queue_traffic_test by replacing static sleep 

### DIFF
--- a/feature/qos/otg_tests/one_sp_queue_traffic_test/one_sp_queue_traffic_test.go
+++ b/feature/qos/otg_tests/one_sp_queue_traffic_test/one_sp_queue_traffic_test.go
@@ -701,26 +701,21 @@ func TestOneSPQueueTraffic(t *testing.T) {
 			ate.OTG().StartTraffic(t)
 			time.Sleep(30 * time.Second)
 			ate.OTG().StopTraffic(t)
-			time.Sleep(30 * time.Second)
 
 			otgutils.LogFlowMetrics(t, ate.OTG(), top)
 			for trafficID, data := range trafficFlows {
+				expectedLossPct := 100.0 - data.expectedThroughputPct
+				minLossPct := expectedLossPct - tolerance
+				if minLossPct < 0 {
+					minLossPct = 0
+				}
+				maxLossPct := expectedLossPct + tolerance
+				otgutils.ExpectedTrafficLoss(t, ate.OTG(), trafficID, float64(minLossPct), float64(maxLossPct))
 				ateOutPkts[data.queue] += gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().OutPkts().State())
 				ateInPkts[data.queue] += gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().InPkts().State())
 				dutQosPktsAfterTraffic[data.queue] += gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(data.queue).TransmitPkts().State())
 				dutQosDroppedPktsAfterTraffic[data.queue] += gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(data.queue).DroppedPkts().State())
 				t.Logf("ateInPkts: %v, txPkts %v, Queue: %v", ateInPkts[data.queue], dutQosPktsAfterTraffic[data.queue], data.queue)
-
-				ateTxPkts := float32(gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().OutPkts().State()))
-				ateRxPkts := float32(gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().InPkts().State()))
-				if ateTxPkts == 0 {
-					t.Fatalf("TxPkts == 0, want >0.")
-				}
-				lossPct := (ateTxPkts - ateRxPkts) * 100 / ateTxPkts
-				t.Logf("Get flow %q: lossPct: %.2f%% or rxPct: %.2f%%, want: %.2f%%\n\n", data.queue, lossPct, 100.0-lossPct, data.expectedThroughputPct)
-				if got, want := 100.0-lossPct, data.expectedThroughputPct; got < want-tolerance || got > want+tolerance {
-					t.Errorf("Get(throughput for queue %q): got %.2f%%, want within [%.2f%%, %.2f%%]", data.queue, got, want-tolerance, want+tolerance)
-				}
 			}
 
 			// Check QoS egress packet counters are updated correctly.


### PR DESCRIPTION
[Test Optimization] Optimize one_sp_queue_traffic_test by replacing static sleep with telemetry watch

- Removed the redundant 30-second static sleep after stopping traffic.
- Added ExpectedTrafficLoss helper to dynamically watch OTG flow packet counters with gnmi.Watch.
- Updated imports to include otgtelemetry and ondatra otg packages.