### PR TITLE
Change goverall version from v1.8.0 to v1.11.1

### DIFF
--- a/.github/workflows/go-experimental-arm.yml
+++ b/.github/workflows/go-experimental-arm.yml
@@ -71,7 +71,7 @@ jobs:
       - run: go test -v -coverprofile=profile.cov $(go list ./... | grep -v /.*test.*)
       - name: Send coverage
         continue-on-error: true
-        uses: shogo82148/actions-goveralls@7b1bd2871942af030d707d6574e5f684f9891fb2
+        uses: shogo82148/actions-goveralls@8781f5dd05b691c4dd042d5e859c11c73e0104fa # v1.11.1
         with:
           path-to-profile: profile.cov
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,7 +59,7 @@ jobs:
       - run: go test -v -coverprofile=profile.cov $(go list ./... | grep -v /.*test.*)
       - name: Send coverage
         continue-on-error: true
-        uses: shogo82148/actions-goveralls@7b1bd2871942af030d707d6574e5f684f9891fb2
+        uses: shogo82148/actions-goveralls@8781f5dd05b691c4dd042d5e859c11c73e0104fa # v1.11.1
         with:
           path-to-profile: profile.cov
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,7 +59,7 @@ jobs:
       - run: go test -v -coverprofile=profile.cov $(go list ./... | grep -v /.*test.*)
       - name: Send coverage
         continue-on-error: true
-        uses: shogo82148/actions-goveralls@8781f5dd05b691c4dd042d5e859c11c73e0104fa # v1.11.1
+        uses: shogo82148/actions-goveralls@7b1bd2871942af030d707d6574e5f684f9891fb2
         with:
           path-to-profile: profile.cov
 


### PR DESCRIPTION
Changes here are made to bump the goverall version from `v1.8.0` to `v1.11.1`. Bump in this version is required since the older version does not support arm64 based runner. 