### PR TITLE
acctz-2.1: set gRIBI,P4RT aaa role based authorization unsupported deviation to true

### DIFF
--- a/feature/gnsi/acctz/tests/record_subscribe_partial/metadata.textproto
+++ b/feature/gnsi/acctz/tests/record_subscribe_partial/metadata.textproto
@@ -32,6 +32,8 @@ platform_exceptions: {
     vendor: ARISTA
   }
   deviations: {
+    gribi_aaa_role_based_authz_unsupported: true
+    p4rt_aaa_role_based_authz_unsupported: true
     p4rt_capabilities_unsupported: true
   }
 }


### PR DESCRIPTION
set aaa role based authz unsupported deviation for gRIBI, P4RT for ACCTZ-2.1 test as well similar to the ACCTZ-1.1 fix