### PR TITLE
Refactor tests to use otgutils.ExpectedTrafficLoss

### DIFF
--- a/feature/gribi/otg_tests/fib_failed_due_to_hw_res_exhaust_test/fib_failed_due_to_hw_res_exhaust_test.go
+++ b/feature/gribi/otg_tests/fib_failed_due_to_hw_res_exhaust_test/fib_failed_due_to_hw_res_exhaust_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/featureprofiles/internal/gribi"
+	"github.com/openconfig/featureprofiles/internal/otgutils"
 	"github.com/openconfig/gribigo/fluent"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
@@ -366,18 +367,20 @@ func sendTraffic(t *testing.T, args *testArgs) {
 func verifyTraffic(t *testing.T, args *testArgs, flowName string, wantLoss bool) {
 	t.Helper()
 	t.Logf("Verifying flow metrics for the flow %s\n", flowName)
-	recvMetric := gnmi.Get(t, args.otg, gnmi.OTG().Flow(flowName).State())
-	txPackets := recvMetric.GetCounters().GetOutPkts()
-	rxPackets := recvMetric.GetCounters().GetInPkts()
-	lostPackets := txPackets - rxPackets
-	var lossPct uint64
-	trafficPassed := false
-	if txPackets != 0 {
-		lossPct = lostPackets * 100 / txPackets
-	} else {
-		t.Errorf("Traffic stats are not correct %v", recvMetric)
-	}
 	if wantLoss {
+		if _, ok := gnmi.Watch(t, args.otg, gnmi.OTG().Flow(flowName).Counters().OutPkts().State(), 45*time.Second, func(val *ygnmi.Value[uint64]) bool {
+			v, present := val.Val()
+			return present && v > 0
+		}).Await(t); !ok {
+			t.Fatalf("Timeout waiting for TxPackets to populate")
+		}
+		recvMetric := gnmi.Get(t, args.otg, gnmi.OTG().Flow(flowName).State())
+		txPackets := recvMetric.GetCounters().GetOutPkts()
+		rxPackets := recvMetric.GetCounters().GetInPkts()
+		trafficPassed := false
+		if txPackets == 0 {
+			t.Errorf("Traffic stats are not correct %v", recvMetric)
+		}
 		// If no rxPackets are received, the first route is fibFailedRoute, resulting in no packets being generated with tagged metrics.
 		if rxPackets > 0 {
 			etPath := gnmi.OTG().Flow(flowName).TaggedMetricAny()
@@ -398,13 +401,9 @@ func verifyTraffic(t *testing.T, args *testArgs, flowName string, wantLoss bool)
 			t.Logf("Traffic Test Passed!")
 		}
 	} else {
-		if lossPct > tolerancePct {
-			t.Errorf("Traffic Loss Pct for Flow: %s\n got %v, want 0", flowName, lossPct)
-		} else {
-			t.Logf("Traffic Test Passed!")
-		}
+		otgutils.ExpectedTrafficLoss(t, args.otg, flowName, 0, tolerancePct)
+		t.Logf("Traffic Test Passed!")
 	}
-
 }
 
 func verifyBgpTelemetry(t *testing.T, dut *ondatra.DUTDevice) {

--- a/feature/interface/aggregate/otg_tests/aggregate_forwarding_viable_test/aggregate_forwarding_viable_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_forwarding_viable_test/aggregate_forwarding_viable_test.go
@@ -460,17 +460,7 @@ func (tc *testArgs) portWantsNotViable(t *testing.T) []float64 {
 
 // debugATEFlows logs detailed tracking information on traffic flows and find if there is any loss pct in the flow.
 func debugATEFlows(t *testing.T, ate *ondatra.ATEDevice, flow gosnappi.Flow, lp linkPairs) {
-
-	recvMetric := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).State())
-	txPackets := float32(recvMetric.GetCounters().GetOutPkts())
-	rxPackets := float32(recvMetric.GetCounters().GetInPkts())
-	if txPackets == 0 {
-		t.Fatalf("Tx packets should be higher than 0")
-	}
-	lostPackets := txPackets - rxPackets
-	if got := lostPackets * 100 / txPackets; got > 0 {
-		t.Fatalf("LossPct for flow %s: got %f, want 0", flow.Name(), got)
-	}
+	otgutils.ExpectedTrafficLoss(t, ate.OTG(), flow.Name(), 0, 0)
 }
 
 // verifyCounterDiff finds the difference between counter values before and after sending traffic. It also calculates if there is any packet loss.

--- a/feature/policy_forwarding/encapsulation/otg_tests/decap_gre_ipv4/decap_gre_ipv4_test.go
+++ b/feature/policy_forwarding/encapsulation/otg_tests/decap_gre_ipv4/decap_gre_ipv4_test.go
@@ -659,15 +659,7 @@ func validateTrafficLoss(t *testing.T, otgConfig *otg.OTG, config gosnappi.Confi
 	otgutils.LogFlowMetrics(t, otgConfig, config)
 	otgutils.LogPortMetrics(t, otgConfig, config)
 
-	outPkts := float32(gnmi.Get(t, otgConfig, gnmi.OTG().Flow(flowName).Counters().OutPkts().State()))
-	inPkts := float32(gnmi.Get(t, otgConfig, gnmi.OTG().Flow(flowName).Counters().InPkts().State()))
-	t.Logf("outPkts: %v, inPkts: %v", outPkts, inPkts)
-	if outPkts == 0 {
-		t.Fatalf("OutPkts for flow %s is 0, want > 0", flowName)
-	}
-	if got := ((outPkts - inPkts) * 100) / outPkts; got > 0 {
-		t.Fatalf("LossPct for flow %s: got %v, want 0", flowName, got)
-	}
+	otgutils.ExpectedTrafficLoss(t, otgConfig, flowName, 0, 0)
 }
 
 func processCapture(t *testing.T, otg *otg.OTG, port string) string {

--- a/feature/policy_forwarding/otg_tests/mpls_gre_ipv4_decap_scale_test/mpls_gre_ipv4_decap_scale_test.go
+++ b/feature/policy_forwarding/otg_tests/mpls_gre_ipv4_decap_scale_test/mpls_gre_ipv4_decap_scale_test.go
@@ -15,6 +15,7 @@ import (
 	otgconfighelpers "github.com/openconfig/featureprofiles/internal/otg_helpers/otg_config_helpers"
 	otgvalidationhelpers "github.com/openconfig/featureprofiles/internal/otg_helpers/otg_validation_helpers"
 	"github.com/openconfig/featureprofiles/internal/otg_helpers/packetvalidationhelpers"
+	"github.com/openconfig/featureprofiles/internal/otgutils"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
@@ -542,7 +543,6 @@ func TestMPLSOGREDecapScale(t *testing.T) {
 		name                    string
 		outerFlow               *otgconfighelpers.Flow
 		innerFlow               *otgconfighelpers.Flow
-		flowValidator           func(*testing.T, *ondatra.ATEDevice) error
 		ecmpValidator           func(*testing.T, *ondatra.ATEDevice) error
 		validatePayloadPreserve bool
 		validationConfig        *packetvalidationhelpers.PacketValidation
@@ -551,21 +551,18 @@ func TestMPLSOGREDecapScale(t *testing.T) {
 			name:          "IPv4 Traffic Scale",
 			outerFlow:     flowOuterIPv4,
 			innerFlow:     flowInnerIPv4,
-			flowValidator: flowOuterIPv4Validation.ValidateLossOnFlows,
 			ecmpValidator: lagECMPValidation.ValidateECMPonLAG,
 		},
 		{
 			name:          "IPv6 Traffic Scale",
 			outerFlow:     flowOuterIPv6,
 			innerFlow:     flowInnerIPv6,
-			flowValidator: flowOuterIPv6Validation.ValidateLossOnFlows,
 			ecmpValidator: lagECMPValidationV6.ValidateECMPonLAG,
 		},
 		{
 			name:                    "IPv4 Payload Preserve",
 			outerFlow:               flowOuterIPv4,
 			innerFlow:               flowInnerIPv4,
-			flowValidator:           flowOuterIPv4Validation.ValidateLossOnFlows,
 			validatePayloadPreserve: true,
 			validationConfig:        decapValidationIPv4,
 		},
@@ -573,7 +570,6 @@ func TestMPLSOGREDecapScale(t *testing.T) {
 			name:                    "IPv6 Payload Preserve",
 			outerFlow:               flowOuterIPv6,
 			innerFlow:               flowInnerIPv6,
-			flowValidator:           flowOuterIPv6Validation.ValidateLossOnFlows,
 			validatePayloadPreserve: true,
 			validationConfig:        decapValidationIPv6,
 		},
@@ -594,9 +590,7 @@ func TestMPLSOGREDecapScale(t *testing.T) {
 				sendTraffic(t, ate)
 			}
 
-			if err := tc.flowValidator(t, ate); err != nil {
-				t.Errorf("validateLossOnFlows(): got err: %q, want nil", err)
-			}
+			otgutils.ExpectedTrafficLoss(t, ate.OTG(), tc.outerFlow.FlowName, 0, 0.5)
 
 			if tc.ecmpValidator != nil {
 				if err := tc.ecmpValidator(t, ate); err != nil {

--- a/feature/qos/otg_tests/wrr_traffic_test/wrr_traffic_test.go
+++ b/feature/qos/otg_tests/wrr_traffic_test/wrr_traffic_test.go
@@ -889,6 +889,13 @@ func TestWrrTraffic(t *testing.T) {
 
 			otgutils.LogFlowMetrics(t, ate.OTG(), top)
 			for trafficID, data := range trafficFlows {
+				minLossPct := float64(100.0 - (data.expectedThroughputPct + tolerance))
+				if minLossPct < 0 {
+					minLossPct = 0
+				}
+				maxLossPct := float64(100.0 - (data.expectedThroughputPct - tolerance))
+				otgutils.ExpectedTrafficLoss(t, ate.OTG(), trafficID, minLossPct, maxLossPct)
+
 				ateTxPkts := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().OutPkts().State())
 				ateRxPkts := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().InPkts().State())
 				ateOutPkts[data.queue] += ateTxPkts
@@ -898,11 +905,6 @@ func TestWrrTraffic(t *testing.T) {
 				t.Logf("ateInPkts: %v, txPkts %v, Queue: %v", ateInPkts[data.queue], dutQosPktsAfterTraffic[data.queue], data.queue)
 				if ateTxPkts == 0 {
 					t.Fatalf("TxPkts == 0, want >0.")
-				}
-				lossPct := (float32)((float64(ateTxPkts-ateRxPkts) * 100.0) / float64(ateTxPkts))
-				t.Logf("Get flow %q: lossPct: %.2f%% or rxPct: %.2f%%, want: %.2f%%\n\n", data.queue, lossPct, 100.0-lossPct, data.expectedThroughputPct)
-				if got, want := 100.0-lossPct, data.expectedThroughputPct; got < want-tolerance || got > want+tolerance {
-					t.Errorf("Get(throughput for queue %q): got %.2f%%, want within [%.2f%%, %.2f%%]", data.queue, got, want-tolerance, want+tolerance)
 				}
 			}
 


### PR DESCRIPTION
Refactor the below tests to use the new ExpectedTrafficLoss function from otgutils.

- otg_tests/decap_gre_ipv4
- mpls_gre_ipv4_decap_scale_test
- aggregate_forwarding_viable_test
- wrr_traffic_test
- fib_failed_due_to_hw_res_exhaust_test