### PR TITLE
Unset p4rt_capabilities_unsupported deviation for Arista

### DIFF
--- a/feature/gnsi/acctz/tests/record_subscribe_full/metadata.textproto
+++ b/feature/gnsi/acctz/tests/record_subscribe_full/metadata.textproto
@@ -33,6 +33,5 @@ platform_exceptions: {
   deviations: {
     gribi_aaa_role_based_authz_unsupported: true
     p4rt_aaa_role_based_authz_unsupported: true
-    p4rt_capabilities_unsupported: true
   }
 }

--- a/feature/gnsi/acctz/tests/record_subscribe_partial/metadata.textproto
+++ b/feature/gnsi/acctz/tests/record_subscribe_partial/metadata.textproto
@@ -34,6 +34,5 @@ platform_exceptions: {
   deviations: {
     gribi_aaa_role_based_authz_unsupported: true
     p4rt_aaa_role_based_authz_unsupported: true
-    p4rt_capabilities_unsupported: true
   }
 }


### PR DESCRIPTION
Arista does have support for P4RT capabilities rpc request, removing the deviation in ACCTZ tests