### PR TITLE
KNE Nokia SR Linux: enable dutate interfaces in startup config

### DIFF
--- a/topologies/kne/nokia/srlinux/config.cfg
+++ b/topologies/kne/nokia/srlinux/config.cfg
@@ -185,3 +185,30 @@ ufJifhmpItpy3mkUCLEJ33ex2AA6
 }
 network-instance DEFAULT {
 }
+interface ethernet-1/1 {
+    admin-state enable
+}
+interface ethernet-1/2 {
+    admin-state enable
+}
+interface ethernet-1/3 {
+    admin-state enable
+}
+interface ethernet-1/4 {
+    admin-state enable
+}
+interface ethernet-1/5 {
+    admin-state enable
+}
+interface ethernet-1/6 {
+    admin-state enable
+}
+interface ethernet-1/7 {
+    admin-state enable
+}
+interface ethernet-1/8 {
+    admin-state enable
+}
+interface ethernet-1/9 {
+    admin-state enable
+}


### PR DESCRIPTION
## Summary
- Enable `ethernet-1/1` through `ethernet-1/9` in the shared Nokia SR Linux KNE startup config (`topologies/kne/nokia/srlinux/config.cfg`).
- Without these interfaces administratively up, BGP OTG tests on the `dutate` topology fail to establish sessions because the DUT-facing links remain down at boot.

## Tests verified on KNE
- RT-1.1 — Base BGP Session Parameters
- RT-1.12 — BGP always compare MED
- RT-1.51 — BGP multipath ECMP
- RT-1.52 — BGP multipath UCMP with Link Bandwidth Community
- RT-1.55 — BGP session mode (active/passive)
- RT-1.64 — BGP Import/Export Policy

## Test plan
- [x] KNE run on Nokia SR Linux `dutate` topology with updated `config.cfg`
- [ ] CI / reviewer validation on KNE lab
