### PR TITLE
Update fib_failed_due_to_hw_res_exhaust_test.go

### DIFF
--- a/feature/gribi/otg_tests/fib_failed_due_to_hw_res_exhaust_test/fib_failed_due_to_hw_res_exhaust_test.go
+++ b/feature/gribi/otg_tests/fib_failed_due_to_hw_res_exhaust_test/fib_failed_due_to_hw_res_exhaust_test.go
@@ -354,6 +354,9 @@ func sendTraffic(t *testing.T, args *testArgs) {
 	t.Helper()
 	t.Logf("TestBGP:start otg Traffic")
 
+	t.Logf("Waiting for ARP to resolve")
+	otgutils.WaitForARP(t, args.otg, args.otgConfig, "IPv4")
+
 	t.Logf("Starting traffic")
 	args.otg.StartTraffic(t)
 	time.Sleep(15 * time.Second)


### PR DESCRIPTION
Adds a call to otgutils.WaitForARP to ensure IPv4 ARP is resolved before starting traffic in the test. 