### PR TITLE
Fix packet capture validation failures caused by control-plane traffic

### DIFF
--- a/internal/otg_helpers/packetvalidationhelpers/packetvalidationhelpers.go
+++ b/internal/otg_helpers/packetvalidationhelpers/packetvalidationhelpers.go
@@ -310,7 +310,7 @@ func validateIPv4Header(t *testing.T, packetSource *gopacket.PacketSource, packe
 				}
 			}
 			if ip.DstIP.String() != packetVal.IPv4Layer.DstIP {
-				return fmt.Errorf("IP Dst IP is not set properly. Expected: %s, Actual: %s", packetVal.IPv4Layer.DstIP, ip.DstIP)
+				continue
 			}
 			if ip.TTL != packetVal.IPv4Layer.TTL {
 				return fmt.Errorf("IP TTL value is altered to: %d, expected: %d", ip.TTL, packetVal.IPv4Layer.TTL)
@@ -336,7 +336,7 @@ func validateIPv6Header(t *testing.T, packetSource *gopacket.PacketSource, packe
 			ipv6, _ := ipLayer.(*layers.IPv6)
 
 			if ipv6.DstIP.String() != packetVal.IPv6Layer.DstIP {
-				return fmt.Errorf("IPv6 Dst IP is not set properly. Expected: %s, Actual: %s", packetVal.IPv6Layer.DstIP, ipv6.DstIP)
+				continue
 			}
 			if ipv6.HopLimit != packetVal.IPv6Layer.HopLimit {
 				return fmt.Errorf("IPv6 HopLimit value is altered to: %d. Expected: %d", ipv6.HopLimit, packetVal.IPv6Layer.HopLimit)

--- a/internal/otg_helpers/packetvalidationhelpers/packetvalidationhelpers.go
+++ b/internal/otg_helpers/packetvalidationhelpers/packetvalidationhelpers.go
@@ -304,6 +304,9 @@ func validateIPv4Header(t *testing.T, packetSource *gopacket.PacketSource, packe
 	for packet := range packetSource.Packets() {
 		if ipLayer := packet.Layer(layers.LayerTypeIPv4); ipLayer != nil {
 			ip, _ := ipLayer.(*layers.IPv4)
+			if packetVal.IPv4Layer == nil {
+				return fmt.Errorf("IPv4Layer configuration is missing")
+			}
 			if ip.DstIP.String() != packetVal.IPv4Layer.DstIP {
 				continue
 			}
@@ -334,7 +337,9 @@ func validateIPv6Header(t *testing.T, packetSource *gopacket.PacketSource, packe
 		t.Logf("packet: %v", packet)
 		if ipLayer := packet.Layer(layers.LayerTypeIPv6); ipLayer != nil {
 			ipv6, _ := ipLayer.(*layers.IPv6)
-
+			if packetVal.IPv6Layer == nil {
+				return fmt.Errorf("IPv6Layer configuration is missing")
+			}
 			if ipv6.DstIP.String() != packetVal.IPv6Layer.DstIP {
 				continue
 			}

--- a/internal/otg_helpers/packetvalidationhelpers/packetvalidationhelpers.go
+++ b/internal/otg_helpers/packetvalidationhelpers/packetvalidationhelpers.go
@@ -304,13 +304,13 @@ func validateIPv4Header(t *testing.T, packetSource *gopacket.PacketSource, packe
 	for packet := range packetSource.Packets() {
 		if ipLayer := packet.Layer(layers.LayerTypeIPv4); ipLayer != nil {
 			ip, _ := ipLayer.(*layers.IPv4)
+			if ip.DstIP.String() != packetVal.IPv4Layer.DstIP {
+				continue
+			}
 			if !packetVal.IPv4Layer.SkipProtocolCheck {
 				if uint32(ip.Protocol) != packetVal.IPv4Layer.Protocol {
 					return fmt.Errorf("packet is not encapsulated properly. Encapsulated protocol is: %d, expected: %d", ip.Protocol, packetVal.IPv4Layer.Protocol)
 				}
-			}
-			if ip.DstIP.String() != packetVal.IPv4Layer.DstIP {
-				continue
 			}
 			if ip.TTL != packetVal.IPv4Layer.TTL {
 				return fmt.Errorf("IP TTL value is altered to: %d, expected: %d", ip.TTL, packetVal.IPv4Layer.TTL)

--- a/internal/otg_helpers/packetvalidationhelpers/packetvalidationhelpers.go
+++ b/internal/otg_helpers/packetvalidationhelpers/packetvalidationhelpers.go
@@ -304,7 +304,7 @@ func validateIPv4Header(t *testing.T, packetSource *gopacket.PacketSource, packe
 	if packetVal.IPv4Layer == nil {
 		return fmt.Errorf("IPv4Layer configuration is missing")
 	}
-	
+
 	for packet := range packetSource.Packets() {
 		if ipLayer := packet.Layer(layers.LayerTypeIPv4); ipLayer != nil {
 			ip, _ := ipLayer.(*layers.IPv4)
@@ -337,7 +337,7 @@ func validateIPv6Header(t *testing.T, packetSource *gopacket.PacketSource, packe
 	if packetVal.IPv6Layer == nil {
 		return fmt.Errorf("IPv6Layer configuration is missing")
 	}
-	
+
 	for packet := range packetSource.Packets() {
 		t.Logf("packet: %v", packet)
 		if ipLayer := packet.Layer(layers.LayerTypeIPv6); ipLayer != nil {

--- a/internal/otg_helpers/packetvalidationhelpers/packetvalidationhelpers.go
+++ b/internal/otg_helpers/packetvalidationhelpers/packetvalidationhelpers.go
@@ -301,12 +301,13 @@ func validateIPv4Header(t *testing.T, packetSource *gopacket.PacketSource, packe
 	t.Helper()
 	t.Log("Validating IPv4 header")
 
+	if packetVal.IPv4Layer == nil {
+		return fmt.Errorf("IPv4Layer configuration is missing")
+	}
+	
 	for packet := range packetSource.Packets() {
 		if ipLayer := packet.Layer(layers.LayerTypeIPv4); ipLayer != nil {
 			ip, _ := ipLayer.(*layers.IPv4)
-			if packetVal.IPv4Layer == nil {
-				return fmt.Errorf("IPv4Layer configuration is missing")
-			}
 			if ip.DstIP.String() != packetVal.IPv4Layer.DstIP {
 				continue
 			}
@@ -333,13 +334,15 @@ func validateIPv6Header(t *testing.T, packetSource *gopacket.PacketSource, packe
 	t.Helper()
 	t.Log("Validating IPv6 header")
 
+	if packetVal.IPv6Layer == nil {
+		return fmt.Errorf("IPv6Layer configuration is missing")
+	}
+	
 	for packet := range packetSource.Packets() {
 		t.Logf("packet: %v", packet)
 		if ipLayer := packet.Layer(layers.LayerTypeIPv6); ipLayer != nil {
 			ipv6, _ := ipLayer.(*layers.IPv6)
-			if packetVal.IPv6Layer == nil {
-				return fmt.Errorf("IPv6Layer configuration is missing")
-			}
+
 			if ipv6.DstIP.String() != packetVal.IPv6Layer.DstIP {
 				continue
 			}


### PR DESCRIPTION
- The OTG CaptureAndValidatePackets mechanism captures all packets crossing the wire, including background control-plane noise generated by the DUT. 
- The current validateIPv4Header and validateIPv6Header implementations assume the very first packet captured is the data payload. If the DstIP of the first captured packet does not exactly match the test's expected payload, the function immediately returns an error and fails the test.
- Changed the strict return fmt.Errorf(...) failure conditions to continue statements for Destination IP mismatches.
- This enables the validation loop to gracefully skip irrelevant control plane traffic