### PR TITLE
OTG grpc timeout parameter for kne tests

### DIFF
--- a/topologies/binding/new.go
+++ b/topologies/binding/new.go
@@ -38,14 +38,15 @@ import (
 )
 
 var (
-	pluginFile   = flag.String("plugin", "", "vendor binding as a Go plugin")
-	pluginArgs   = flag.String("plugin-args", "", "arguments for the vendor binding")
-	bindingFile  = flag.String("binding", "", "static binding configuration file")
-	kneConfig    = flag.String("kne-config", "", "YAML configuration file")
-	pushConfig   = flag.Bool("push-config", true, "push device reset config supplied to static binding")
-	kneTopo      = flag.String("kne-topo", "", "KNE topology file")
-	kneSkipReset = flag.Bool("kne-skip-reset", false, "skip the initial config reset phase when using KNE")
-	credFlags    = knecreds.DefineFlags()
+	pluginFile       = flag.String("plugin", "", "vendor binding as a Go plugin")
+	pluginArgs       = flag.String("plugin-args", "", "arguments for the vendor binding")
+	bindingFile      = flag.String("binding", "", "static binding configuration file")
+	kneConfig        = flag.String("kne-config", "", "YAML configuration file")
+	pushConfig       = flag.Bool("push-config", true, "push device reset config supplied to static binding")
+	kneTopo          = flag.String("kne-topo", "", "KNE topology file")
+	kneSkipReset     = flag.Bool("kne-skip-reset", false, "skip the initial config reset phase when using KNE")
+	kneOTGReqTimeout = flag.Duration("kne-otg-request-timeout", knebind.DefaultOTGRequestTimeout, "timeout for OTG API requests like SetConfig (e.g. '90s')")
+	credFlags        = knecreds.DefineFlags()
 )
 
 // New creates a new binding that could be either a vendor plugin, a
@@ -94,7 +95,7 @@ func newBind() (binding.Binding, error) {
 			Topology:    *kneTopo,
 			Credentials: cred,
 			SkipReset:   *kneSkipReset,
-		})
+		}, knebind.WithOTGRequestTimeout(*kneOTGReqTimeout))
 	}
 	if *kneConfig != "" {
 		glog.Warning("-kne-config flag is deprecated; use -kne-topo and credentials flags instead")


### PR DESCRIPTION
The default value for grpc timeout is 30 seconds which is too low on certain tests with kne.
This PR is meant to allow the user to specify a new timeout using ```-kne-otg-request-timeout``` argument.

See example below.

```
go test -v feature/bgp/addpath/otg_tests/route_propagation_test/route_propagation_test.go -kne-topo ~/featureprofiles/topologies/kne/cisco/8000e/dutate.textproto -default_creds cisco/cisco123 -timeout 60m -kne-otg-request-timeout 60s
```