### PR TITLE
feat(transceiver): add client optics DOM streaming telemetry test (TRANSCEIVER-20.1)

### DIFF
--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
@@ -11,29 +11,17 @@ Optics test requirements alongside the platform functional tests require optics 
 
 ## Procedure
 
-*   Step 1: Using `/components/component[name=%s]/state`, get the list of transceivers and validate the following leaves are set:
-    *   `/components/component/state/mfg-name`
-    *   `/components/component/transceiver/state/form-factor`
-    *   `/components/component/state/serial-no`
-    *   `/components/component/state/part-no`
-    *   `/components/component/state/firmware-version`
-    *   `/interfaces/interface/state/physical-channel`
-    *   `/interfaces/interface/state/transceiver`
+*   Step 1: Ensure interfaces and transceivers are enabled, wait for link UP, and validate inventory and telemetry:
+    *   Validate static inventory metadata: `/components/component/state/mfg-name`, `/components/component/transceiver/state/form-factor`, `/components/component/state/serial-no`, `/components/component/state/part-no`, `/components/component/state/firmware-version`, `/components/component/state/hardware-version`, `/components/component/state/description`, `/components/component/state/mfg-date`, `/components/component/transceiver/physical-channels/channel/state/index`, `/interfaces/interface/state/physical-channel`, `/interfaces/interface/state/transceiver`.
+    *   Validate dynamic telemetry instant values are within WARNING and CRITICAL lower/upper thresholds: module temperature, Tx output power, Rx input power, laser bias-current, and supply voltage.
 
-*   Step 2: Get list of components of type `TRANSCEIVER`. Verify the instant value is between the corresponding lower and upper thresholds for both `[severity]=WARNING` and `[severity]=CRITICAL`:
-    *   Module case temperature
-    *   Tx output power
-    *   Rx input power
-    *   Laser bias-current
-    *   Supply voltage
-
-*   Step 3: Flap the interface and verify telemetry updates:
+*   Step 2: Verify interface enable/disable lifecycle:
     *   Disable/shutdown interface: verify oper-status DOWN and output power drops.
-    *   Re-enable interface: verify oper-status UP and output power returns to normal.
+    *   Re-enable interface: wait for link UP and verify telemetry parameters return to normal within thresholds.
 
-*   Step 4: Verify transceiver config enabled on/off:
+*   Step 3: Verify transceiver config enabled on/off lifecycle:
     *   Set `/components/component/transceiver/config/enabled` to `false`: verify oper-status is not UP and transceiver disabled.
-    *   Set `/components/component/transceiver/config/enabled` to `true`: verify oper-status UP, optics power and laser normal.
+    *   Set `/components/component/transceiver/config/enabled` to `true`: wait for link UP and verify all telemetry parameters are valid and within thresholds.
 
 ## Canonical OC
 

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
@@ -13,7 +13,9 @@ Optics test requirements alongside the platform functional tests require optics 
 
 *   Step 1: Ensure interfaces and transceivers are enabled, wait for link UP, and validate inventory and telemetry:
     *   Validate static inventory metadata: `/components/component/state/mfg-name`, `/components/component/transceiver/state/form-factor`, `/components/component/state/serial-no`, `/components/component/state/part-no`, `/components/component/state/firmware-version`, `/components/component/state/hardware-version`, `/components/component/state/description`, `/components/component/state/mfg-date`, `/components/component/transceiver/physical-channels/channel/state/index`, `/interfaces/interface/state/physical-channel`, `/interfaces/interface/state/transceiver`.
-    *   Validate dynamic telemetry instant values are within WARNING and CRITICAL lower/upper thresholds: module temperature, Tx output power, Rx input power, laser bias-current, and supply voltage.
+    *   Validate dynamic telemetry instant values are within the normal operating range bounded by WARNING and CRITICAL lower/upper thresholds (i.e., no threshold alarms are expected to be triggered during normal operation): module temperature, Tx output power, Rx input power, laser bias-current, and supply voltage.
+        *   Nested-threshold rules apply: `critical_lower <= warning_lower <= instant <= warning_upper <= critical_upper`.
+        *   Some hardware platforms or pluggables may report equal values for warning and critical thresholds (e.g., `warning_upper == critical_upper` or `warning_lower == critical_lower`), which is valid and supported.
 
 *   Step 2: Verify interface enable/disable lifecycle:
     *   Disable/shutdown interface: verify oper-status DOWN and output power drops.

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
@@ -32,7 +32,7 @@ Optics test requirements alongside the platform functional tests require optics 
     *   Re-enable interface: verify oper-status UP and output power returns to normal.
 
 *   Step 4: Verify transceiver config enabled on/off:
-    *   Set `/components/component/transceiver/config/enabled` to `false`: verify transceiver disabled.
+    *   Set `/components/component/transceiver/config/enabled` to `false`: verify oper-status is not UP and transceiver disabled.
     *   Set `/components/component/transceiver/config/enabled` to `true`: verify oper-status UP, optics power and laser normal.
 
 ## Canonical OC

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
@@ -31,6 +31,10 @@ Optics test requirements alongside the platform functional tests require optics 
     *   Disable/shutdown interface: verify oper-status DOWN and output power drops.
     *   Re-enable interface: verify oper-status UP and output power returns to normal.
 
+*   Step 4: Verify transceiver config enabled on/off:
+    *   Set `/components/component/transceiver/config/enabled` to `false`: verify oper-status DOWN and output power drops.
+    *   Set `/components/component/transceiver/config/enabled` to `true`: verify oper-status UP and output power returns to normal.
+
 ## Canonical OC
 
 ```json
@@ -44,6 +48,8 @@ The below yaml defines the OC paths intended to be covered by this test.
 ```yaml
 paths:
   # Config Parameter coverage
+  /components/component/transceiver/config/enabled:
+    platform_type: ["TRANSCEIVER"]
   /interfaces/interface/config/enabled:
 
   # Telemetry Parameter coverage

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
@@ -32,7 +32,7 @@ Optics test requirements alongside the platform functional tests require optics 
     *   Re-enable interface: verify oper-status UP and output power returns to normal.
 
 *   Step 4: Verify transceiver config enabled on/off:
-    *   Set `/components/component/transceiver/config/enabled` to `false`: verify oper-status DOWN.
+    *   Set `/components/component/transceiver/config/enabled` to `false`: verify transceiver disabled.
     *   Set `/components/component/transceiver/config/enabled` to `true`: verify oper-status UP, optics power and laser normal.
 
 ## Canonical OC
@@ -53,6 +53,8 @@ paths:
   /interfaces/interface/config/enabled:
 
   # Telemetry Parameter coverage
+  /components/component/transceiver/state/enabled:
+    platform_type: ["TRANSCEIVER"]
   /components/component/state/firmware-version:
     platform_type: ["TRANSCEIVER"]
   /components/component/state/mfg-name:

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
@@ -1,0 +1,105 @@
+# TRANSCEIVER-20.1: Client Optics DOM Telemetry, Instant, Threshold, and Miscellaneous Static Info
+
+## Summary
+
+Validate client optics digital optical monitoring (DOM) streaming telemetry performance monitoring parameters
+like input power, output power, bias current, supply voltage, module temperature, and so on.
+
+## Setup
+
+Optics test requirements alongside the platform functional tests require optics DUT samples connected across optical ethernet interfaces.
+
+## Procedure
+
+*   Step 1: Using `/components/component[name=%s]/state`, get the list of transceivers and validate the following leaves are set:
+    *   `/components/component/state/mfg-name`
+    *   `/components/component/transceiver/state/form-factor`
+    *   `/components/component/state/serial-no`
+    *   `/components/component/state/part-no`
+    *   `/components/component/state/firmware-version`
+    *   `/interfaces/interface/state/physical-channel`
+    *   `/interfaces/interface/state/transceiver`
+
+*   Step 2: Get list of components of type `TRANSCEIVER`. Verify the instant value is between the corresponding lower and upper thresholds for both `[severity]=WARNING` and `[severity]=CRITICAL`:
+    *   Module case temperature
+    *   Tx output power
+    *   Rx input power
+    *   Laser bias-current
+    *   Supply voltage
+
+*   Step 3: Flap the interface and verify telemetry updates:
+    *   Disable/shutdown interface: verify oper-status DOWN and output power drops.
+    *   Re-enable interface: verify oper-status UP and output power returns to normal.
+
+## Canonical OC
+
+```json
+{}
+```
+
+## OpenConfig Path and RPC Coverage
+
+The below yaml defines the OC paths intended to be covered by this test.
+
+```yaml
+paths:
+  # Config Parameter coverage
+  /components/component/transceiver/config/enabled:
+    platform_type: ["TRANSCEIVER"]
+  /interfaces/interface/config/enabled:
+
+  # Telemetry Parameter coverage
+  /components/component/state/firmware-version:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/state/mfg-name:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/state/part-no:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/state/serial-no:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/state/temperature/instant:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/physical-channels/channel/state/index:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/physical-channels/channel/state/input-power/instant:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/physical-channels/channel/state/laser-bias-current/instant:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/physical-channels/channel/state/output-power/instant:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/state/supply-voltage/instant:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/state/form-factor:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/thresholds/threshold/state/input-power-lower:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/thresholds/threshold/state/input-power-upper:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/thresholds/threshold/state/laser-bias-current-lower:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/thresholds/threshold/state/laser-bias-current-upper:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/thresholds/threshold/state/module-temperature-lower:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/thresholds/threshold/state/module-temperature-upper:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/thresholds/threshold/state/output-power-lower:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/thresholds/threshold/state/output-power-upper:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/thresholds/threshold/state/severity:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/thresholds/threshold/state/supply-voltage-lower:
+    platform_type: ["TRANSCEIVER"]
+  /components/component/transceiver/thresholds/threshold/state/supply-voltage-upper:
+    platform_type: ["TRANSCEIVER"]
+  /interfaces/interface/state/oper-status:
+  /interfaces/interface/state/physical-channel:
+  /interfaces/interface/state/transceiver:
+
+rpcs:
+  gnmi:
+    gNMI.Get:
+    gNMI.Set:
+    gNMI.Subscribe:
+```

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
@@ -32,8 +32,8 @@ Optics test requirements alongside the platform functional tests require optics 
     *   Re-enable interface: verify oper-status UP and output power returns to normal.
 
 *   Step 4: Verify transceiver config enabled on/off:
-    *   Set `/components/component/transceiver/config/enabled` to `false`: verify oper-status DOWN and output power drops.
-    *   Set `/components/component/transceiver/config/enabled` to `true`: verify oper-status UP and output power returns to normal.
+    *   Set `/components/component/transceiver/config/enabled` to `false`: verify oper-status DOWN.
+    *   Set `/components/component/transceiver/config/enabled` to `true`: verify oper-status UP, optics power and laser normal.
 
 ## Canonical OC
 

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md
@@ -44,8 +44,6 @@ The below yaml defines the OC paths intended to be covered by this test.
 ```yaml
 paths:
   # Config Parameter coverage
-  /components/component/transceiver/config/enabled:
-    platform_type: ["TRANSCEIVER"]
   /interfaces/interface/config/enabled:
 
   # Telemetry Parameter coverage

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -424,10 +424,10 @@ func TestOpticsPowerBiasCurrent(t *testing.T) {
 					sType, ok := sensorTypeLookup.Val()
 					if ok && sType == sensorType {
 						scomponent := gnmi.OC().Component(subcName)
-						sensorComponentChecked = true
 						descLookup := gnmi.Lookup(t, dut, scomponent.Description().State())
 						desc, _ := descLookup.Val()
 						if !deviations.TemperatureSensorCheck(dut) || strings.Contains(desc, "Temperature Sensor") {
+							sensorComponentChecked = true
 							tempPathStr := getPathStr(scomponent.Temperature().Instant().State().PathStruct())
 							v := gnmi.Lookup(t, dut, scomponent.Temperature().Instant().State())
 							if val, ok := v.Val(); !ok {
@@ -608,14 +608,19 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 			tracePath(t, transceiverPath, statusPass, "Interface transceiver: %s", tv)
 
 			t.Run(fmt.Sprintf("Transceiver:%s", tv), func(t *testing.T) {
-				mfgName, _ := gnmi.Lookup(t, dut, gnmi.OC().Component(tv).MfgName().State()).Val()
+				compLookup := gnmi.Lookup(t, dut, gnmi.OC().Component(tv).State())
+				comp, compPresent := compLookup.Val()
 				tvPathStr := getPathStr(gnmi.OC().Component(tv).State().PathStruct())
-				if mfgName == "" {
+				if !compPresent || comp == nil || comp.GetMfgName() == "" {
 					tracePath(t, tvPathStr, statusSkipped, "Skipping check for Transceiver: got no MfgName.")
 					t.Skipf("Skipping check for Transceiver: %q, got no MfgName.", tv)
 				}
+				mfgName := comp.GetMfgName()
 
-				formFactor, _ := gnmi.Lookup(t, dut, gnmi.OC().Component(tv).Transceiver().FormFactor().State()).Val()
+				formFactor := oc.TransportTypes_TRANSCEIVER_FORM_FACTOR_TYPE_UNSET
+				if comp.GetTransceiver() != nil {
+					formFactor = comp.GetTransceiver().GetFormFactor()
+				}
 				if formFactor == oc.TransportTypes_TRANSCEIVER_FORM_FACTOR_TYPE_UNSET {
 					tracePath(t, tvPathStr, statusFail, "transceiver form-factor unset")
 				} else {
@@ -624,8 +629,8 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 
 				// Verify Component Type
 				typePath := gnmi.OC().Component(tv).Type().State()
-				compType, typePresent := gnmi.Lookup(t, dut, typePath).Val()
-				if !typePresent {
+				compType := comp.GetType()
+				if compType == nil {
 					tracePath(t, getPathStr(typePath.PathStruct()), statusFail, "Component type is not present")
 				} else {
 					if compType == transceiverType {
@@ -637,8 +642,8 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 
 				// Verify Part Number
 				partNoPath := gnmi.OC().Component(tv).PartNo().State()
-				partNo, partNoPresent := gnmi.Lookup(t, dut, partNoPath).Val()
-				if !partNoPresent || partNo == "" {
+				partNo := comp.GetPartNo()
+				if partNo == "" {
 					tracePath(t, getPathStr(partNoPath.PathStruct()), statusFail, "Part number is not present or empty")
 				} else {
 					tracePath(t, getPathStr(partNoPath.PathStruct()), statusPass, "Part number: %s", partNo)
@@ -646,8 +651,8 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 
 				// Verify Serial Number
 				serialNoPath := gnmi.OC().Component(tv).SerialNo().State()
-				serialNo, serialNoPresent := gnmi.Lookup(t, dut, serialNoPath).Val()
-				if !serialNoPresent || serialNo == "" {
+				serialNo := comp.GetSerialNo()
+				if serialNo == "" {
 					tracePath(t, getPathStr(serialNoPath.PathStruct()), statusFail, "Serial number is not present or empty")
 				} else {
 					tracePath(t, getPathStr(serialNoPath.PathStruct()), statusPass, "Serial number: %s", serialNo)
@@ -655,8 +660,8 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 
 				// Verify Firmware Version
 				firmwareVersionPath := gnmi.OC().Component(tv).FirmwareVersion().State()
-				firmwareVersion, firmwareVersionPresent := gnmi.Lookup(t, dut, firmwareVersionPath).Val()
-				if !firmwareVersionPresent || firmwareVersion == "" {
+				firmwareVersion := comp.GetFirmwareVersion()
+				if firmwareVersion == "" {
 					tracePath(t, getPathStr(firmwareVersionPath.PathStruct()), statusWarning, "Firmware version is not present or empty")
 				} else {
 					tracePath(t, getPathStr(firmwareVersionPath.PathStruct()), statusPass, "Firmware version: %s", firmwareVersion)
@@ -664,8 +669,8 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 
 				// Verify Hardware Version
 				hardwareVersionPath := gnmi.OC().Component(tv).HardwareVersion().State()
-				hardwareVersion, hardwareVersionPresent := gnmi.Lookup(t, dut, hardwareVersionPath).Val()
-				if !hardwareVersionPresent || hardwareVersion == "" {
+				hardwareVersion := comp.GetHardwareVersion()
+				if hardwareVersion == "" {
 					tracePath(t, getPathStr(hardwareVersionPath.PathStruct()), statusFail, "Hardware version is not present or empty")
 				} else {
 					tracePath(t, getPathStr(hardwareVersionPath.PathStruct()), statusPass, "Hardware version: %s", hardwareVersion)
@@ -676,8 +681,8 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 				if deviations.SkipTransceiverDescription(dut) {
 					tracePath(t, getPathStr(descPath.PathStruct()), statusSkipped, "Skipping verification of transceiver description due to deviation")
 				} else {
-					desc, descPresent := gnmi.Lookup(t, dut, descPath).Val()
-					if !descPresent || desc == "" {
+					desc := comp.GetDescription()
+					if desc == "" {
 						tracePath(t, getPathStr(descPath.PathStruct()), statusWarning, "Description is not present or empty")
 					} else {
 						tracePath(t, getPathStr(descPath.PathStruct()), statusPass, "Description: %s", desc)
@@ -689,8 +694,8 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 				if deviations.ComponentMfgDateUnsupported(dut) {
 					tracePath(t, getPathStr(mfgDatePath.PathStruct()), statusSkipped, "Skipping verification of transceiver manufacturing date due to deviation")
 				} else {
-					mfgDate, mfgDatePresent := gnmi.Lookup(t, dut, mfgDatePath).Val()
-					if !mfgDatePresent || mfgDate == "" {
+					mfgDate := comp.GetMfgDate()
+					if mfgDate == "" {
 						tracePath(t, getPathStr(mfgDatePath.PathStruct()), statusFail, "Manufacturing date is not present or empty")
 					} else {
 						tracePath(t, getPathStr(mfgDatePath.PathStruct()), statusPass, "Manufacturing date: %s", mfgDate)
@@ -698,10 +703,13 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 				}
 
 				channelsMap := make(map[uint16]bool)
-				channels := gnmi.LookupAll(t, dut, gnmi.OC().Component(tv).Transceiver().ChannelAny().State())
-				for _, ch := range channels {
-					if val, ok := ch.Val(); ok {
-						channelsMap[val.GetIndex()] = true
+				if comp.GetTransceiver() != nil {
+					for chIdx, ch := range comp.GetTransceiver().Channel {
+						if ch != nil {
+							channelsMap[ch.GetIndex()] = true
+						} else {
+							channelsMap[chIdx] = true
+						}
 					}
 				}
 

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -478,6 +478,10 @@ func TestOpticsPowerUpdate(t *testing.T) {
 				t.Cleanup(func() {
 					gnmi.Update(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config(), originalEnabled)
 				})
+			} else {
+				t.Cleanup(func() {
+					gnmi.Delete(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config())
+				})
 			}
 
 			cases := []struct {
@@ -538,10 +542,12 @@ func TestOpticsPowerUpdate(t *testing.T) {
 							tracePath(t, pStr, statusFail, "input power is not defined")
 							continue
 						}
-						if inPower > maxOpticsPower || inPower < minOpticsPower {
-							tracePath(t, pStr, statusFail, "value %.2f is outside range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
+						if inPower > maxOpticsPower {
+							tracePath(t, pStr, statusFail, "value %.2f is above maximum threshold <= %f", inPower, maxOpticsPower)
+						} else if tc.IntfStatus && inPower < minOpticsPower {
+							tracePath(t, pStr, statusFail, "value %.2f is below minimum threshold >= %f", inPower, minOpticsPower)
 						} else {
-							tracePath(t, pStr, statusPass, "value %.2f is within range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
+							tracePath(t, pStr, statusPass, "value %.2f is within expected range", inPower)
 						}
 					}
 

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -35,12 +35,9 @@ import (
 const (
 	transceiverType         = oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_TRANSCEIVER
 	sensorType              = oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_SENSOR
-	sleepDuration           = time.Minute
 	minOpticsPower          = -40.0
 	maxOpticsPower          = 10.0
 	maxOpticsPowerAdminDown = -30.0
-	minOpticsHighThreshold  = 1.0
-	maxOpticsLowThreshold   = -1.0
 )
 
 type testStatus string
@@ -478,10 +475,6 @@ func TestOpticsPowerUpdate(t *testing.T) {
 				t.Cleanup(func() {
 					gnmi.Update(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config(), originalEnabled)
 				})
-			} else {
-				t.Cleanup(func() {
-					gnmi.Delete(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config())
-				})
 			}
 
 			cases := []struct {
@@ -542,12 +535,10 @@ func TestOpticsPowerUpdate(t *testing.T) {
 							tracePath(t, pStr, statusFail, "input power is not defined")
 							continue
 						}
-						if inPower > maxOpticsPower {
-							tracePath(t, pStr, statusFail, "value %.2f is above maximum threshold <= %f", inPower, maxOpticsPower)
-						} else if tc.IntfStatus && inPower < minOpticsPower {
-							tracePath(t, pStr, statusFail, "value %.2f is below minimum threshold >= %f", inPower, minOpticsPower)
+						if inPower > maxOpticsPower || inPower < minOpticsPower {
+							tracePath(t, pStr, statusFail, "value %.2f is outside range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
 						} else {
-							tracePath(t, pStr, statusPass, "value %.2f is within expected range", inPower)
+							tracePath(t, pStr, statusPass, "value %.2f is within range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
 						}
 					}
 
@@ -710,12 +701,8 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 
 				channelsMap := make(map[uint16]bool)
 				if comp.GetTransceiver() != nil {
-					for chIdx, ch := range comp.GetTransceiver().Channel {
-						if ch != nil {
-							channelsMap[ch.GetIndex()] = true
-						} else {
-							channelsMap[chIdx] = true
-						}
+					for chIdx := range comp.GetTransceiver().Channel {
+						channelsMap[chIdx] = true
 					}
 				}
 
@@ -724,7 +711,6 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 				pcPath := getPathStr(gnmi.OC().Interface(dp.Name()).PhysicalChannel().State().PathStruct())
 				if !pcOk || len(physicalChannel) == 0 {
 					tracePath(t, pcPath, statusFail, "physical-channel unset for Interface: %q", intfName)
-					t.Errorf("physical-channel unset for Interface: %q", intfName)
 				} else {
 					t.Logf("Interface %s physical-channel: %v", dp.Name(), physicalChannel)
 					tracePath(t, pcPath, statusPass, "Physical channels: %v", physicalChannel)

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -1,0 +1,726 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_optics_dom_telemetry_test
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openconfig/featureprofiles/internal/deviations"
+	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/functional-translators/registrar"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/ondatra/gnmi/oc/platform"
+	"github.com/openconfig/ygnmi/ygnmi"
+	"github.com/openconfig/ygot/ygot"
+)
+
+const (
+	transceiverType         = oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_TRANSCEIVER
+	sensorType              = oc.PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_SENSOR
+	sleepDuration           = time.Minute
+	minOpticsPower          = -40.0
+	maxOpticsPower          = 10.0
+	maxOpticsPowerAdminDown = -30.0
+	minOpticsHighThreshold  = 1.0
+	maxOpticsLowThreshold   = -1.0
+)
+
+type testStatus string
+
+const (
+	statusPass    testStatus = "PASS"
+	statusFail    testStatus = "FAIL"
+	statusSkipped testStatus = "SKIP"
+	statusWarning testStatus = "WARN"
+)
+
+type traceRecord struct {
+	TestName string
+	Path     string
+	Status   testStatus
+	Detail   string
+}
+
+var (
+	traceMutex sync.Mutex
+	traceLogs  []traceRecord
+)
+
+func tracePath(t *testing.T, path string, status testStatus, format string, args ...any) {
+	t.Helper()
+	detail := fmt.Sprintf(format, args...)
+	traceMutex.Lock()
+	defer traceMutex.Unlock()
+	traceLogs = append(traceLogs, traceRecord{
+		TestName: t.Name(),
+		Path:     path,
+		Status:   status,
+		Detail:   detail,
+	})
+	if status == statusFail {
+		t.Errorf("[%s] FAIL: %s - %s", t.Name(), path, detail)
+	} else if status == statusWarning {
+		t.Logf("[%s] WARN: %s - %s", t.Name(), path, detail)
+	}
+}
+
+func getPathStr(pathStruct ygnmi.PathStruct) string {
+	resolved, _, err := ygnmi.ResolvePath(pathStruct)
+	if err != nil {
+		return fmt.Sprintf("%v", pathStruct)
+	}
+	var elems []string
+	for _, e := range resolved.GetElem() {
+		if len(e.GetKey()) > 0 {
+			var keys []string
+			for k, v := range e.GetKey() {
+				keys = append(keys, fmt.Sprintf("%s=%s", k, v))
+			}
+			elems = append(elems, fmt.Sprintf("%s[%s]", e.GetName(), strings.Join(keys, ",")))
+		} else {
+			elems = append(elems, e.GetName())
+		}
+	}
+	return "/" + strings.Join(elems, "/")
+}
+
+func printSummary() {
+	fmt.Println("\n==========================================================================================")
+	fmt.Println("                           OPENCONFIG TEST PATH CHECK SUMMARY                            ")
+	fmt.Println("==========================================================================================")
+
+	// Print failures first
+	fmt.Println("\n--- FAILURES ---")
+	failCount := 0
+	for _, r := range traceLogs {
+		if r.Status == statusFail {
+			fmt.Printf("[FAIL] Test: %-40s\n       Path: %s\n       Reason: %s\n\n", r.TestName, r.Path, r.Detail)
+			failCount++
+		}
+	}
+	if failCount == 0 {
+		fmt.Println(" None")
+	}
+
+	// Print warnings
+	fmt.Println("--- WARNINGS ---")
+	warnCount := 0
+	for _, r := range traceLogs {
+		if r.Status == statusWarning {
+			fmt.Printf("[WARN] Test: %-40s\n       Path: %s\n       Reason: %s\n\n", r.TestName, r.Path, r.Detail)
+			warnCount++
+		}
+	}
+	if warnCount == 0 {
+		fmt.Println(" None")
+	}
+
+	// Print skips
+	fmt.Println("--- SKIPPED ---")
+	skipCount := 0
+	for _, r := range traceLogs {
+		if r.Status == statusSkipped {
+			fmt.Printf("[SKIP] Test: %-40s\n       Path: %s\n       Reason: %s\n\n", r.TestName, r.Path, r.Detail)
+			skipCount++
+		}
+	}
+	if skipCount == 0 {
+		fmt.Println(" None")
+	}
+
+	// Print passes (condensed)
+	fmt.Println("--- PASSES ---")
+	passCount := 0
+	for _, r := range traceLogs {
+		if r.Status == statusPass {
+			fmt.Printf("[PASS] %s -> %s\n", r.Path, r.Detail)
+			passCount++
+		}
+	}
+	if passCount == 0 {
+		fmt.Println(" None")
+	}
+
+	fmt.Println("\n==========================================================================================")
+	fmt.Printf("TOTAL VERIFIED PATHS: %d | PASS: %d | WARN: %d | FAIL: %d | SKIPPED: %d\n", len(traceLogs), passCount, warnCount, failCount, skipCount)
+	fmt.Println("==========================================================================================")
+}
+
+func TestMain(m *testing.M) {
+	fptest.RunTests(m)
+	printSummary()
+}
+
+func getOptsForFunctionalTranslator(t *testing.T, dut *ondatra.DUTDevice, functionalTranslatorName string) []ygnmi.Option {
+	if functionalTranslatorName == "" {
+		return nil
+	}
+	ft, ok := registrar.FunctionalTranslatorRegistry[functionalTranslatorName]
+	if !ok {
+		t.Fatalf("Functional translator %s is not registered", functionalTranslatorName)
+	}
+	deviceSoftwareVersion := strings.Split(dut.Version(), "-")[0]
+	ftMetadata := ft.Metadata()
+	for _, m := range ftMetadata {
+		if m.SoftwareVersion == deviceSoftwareVersion {
+			return []ygnmi.Option{ygnmi.WithFT(ft)}
+		}
+	}
+	return nil
+}
+
+type checkThresholdParams struct {
+	transceiver string
+	isPortUp    bool
+	opts        []ygnmi.Option
+	lowerPath   ygnmi.SingletonQuery[float64]
+	upperPath   ygnmi.SingletonQuery[float64]
+	instantPath ygnmi.SingletonQuery[float64]
+	name        string
+	ftName      string
+}
+
+func checkThreshold(t *testing.T, dut *ondatra.DUTDevice, params checkThresholdParams) {
+	t.Helper()
+	lV := gnmi.Lookup(t, dut.GNMIOpts().WithYGNMIOpts(params.opts...), params.lowerPath)
+	uV := gnmi.Lookup(t, dut.GNMIOpts().WithYGNMIOpts(params.opts...), params.upperPath)
+	l, lOK := lV.Val()
+	u, uOK := uV.Val()
+
+	lowerPathStr := getPathStr(params.lowerPath.PathStruct())
+	upperPathStr := getPathStr(params.upperPath.PathStruct())
+	instantPathStr := getPathStr(params.instantPath.PathStruct())
+
+	if !lOK {
+		tracePath(t, lowerPathStr, statusFail, "Transceiver %s: threshold %s-lower is not set", params.transceiver, params.name)
+	} else {
+		tracePath(t, lowerPathStr, statusPass, "Value: %v", l)
+	}
+	if !uOK {
+		tracePath(t, upperPathStr, statusFail, "Transceiver %s: threshold %s-upper is not set", params.transceiver, params.name)
+	} else {
+		tracePath(t, upperPathStr, statusPass, "Value: %v", u)
+	}
+
+	iV := gnmi.Lookup(t, dut.GNMIOpts().WithYGNMIOpts(getOptsForFunctionalTranslator(t, dut, params.ftName)...), params.instantPath)
+	i, iOK := iV.Val()
+	if !iOK {
+		tracePath(t, instantPathStr, statusFail, "Transceiver %s: instant %s is not set", params.transceiver, params.name)
+	} else {
+		if lOK && uOK {
+			if !params.isPortUp {
+				tracePath(t, instantPathStr, statusSkipped, "Skipping range check for transceiver %s because port is not UP.", params.transceiver)
+			} else if (params.name == "input-power" || params.name == "output-power") && i == minOpticsPower {
+				tracePath(t, instantPathStr, statusSkipped, "Skipping range check because instant value is %v (link not stable).", minOpticsPower)
+			} else if i < l || i > u {
+				tracePath(t, instantPathStr, statusFail, "Transceiver %s: instant value %v is outside threshold range [%v, %v]", params.transceiver, i, l, u)
+			} else {
+				tracePath(t, instantPathStr, statusPass, "Transceiver %s: instant value %v is within threshold range [%v, %v]", params.transceiver, i, l, u)
+			}
+		}
+	}
+
+	if lOK && uOK && l >= u {
+		tracePath(t, lowerPathStr, statusFail, "Transceiver %s: %s-lower (%v) must be less than %s-upper (%v)", params.transceiver, params.name, l, params.name, u)
+	}
+}
+
+func validateThresholds(t *testing.T, dut *ondatra.DUTDevice, transceiver string, isPortUp bool, sev oc.E_AlarmTypes_OPENCONFIG_ALARM_SEVERITY, component *platform.ComponentPath, opts []ygnmi.Option) {
+	t.Helper()
+	threshold := component.Transceiver().Threshold(sev)
+
+	checkThreshold(t, dut, checkThresholdParams{
+		transceiver: transceiver,
+		isPortUp:    isPortUp,
+		opts:        opts,
+		lowerPath:   threshold.ModuleTemperatureLower().State(),
+		upperPath:   threshold.ModuleTemperatureUpper().State(),
+		instantPath: component.Temperature().Instant().State(),
+		name:        "module-temperature",
+	})
+	checkThreshold(t, dut, checkThresholdParams{
+		transceiver: transceiver,
+		isPortUp:    isPortUp,
+		opts:        opts,
+		lowerPath:   threshold.InputPowerLower().State(),
+		upperPath:   threshold.InputPowerUpper().State(),
+		instantPath: component.Transceiver().Channel(0).InputPower().Instant().State(),
+		name:        "input-power",
+		ftName:      deviations.CiscoxrTransceiverFt(dut),
+	})
+	checkThreshold(t, dut, checkThresholdParams{
+		transceiver: transceiver,
+		isPortUp:    isPortUp,
+		opts:        opts,
+		lowerPath:   threshold.OutputPowerLower().State(),
+		upperPath:   threshold.OutputPowerUpper().State(),
+		instantPath: component.Transceiver().Channel(0).OutputPower().Instant().State(),
+		name:        "output-power",
+		ftName:      deviations.CiscoxrTransceiverFt(dut),
+	})
+	checkThreshold(t, dut, checkThresholdParams{
+		transceiver: transceiver,
+		isPortUp:    isPortUp,
+		opts:        opts,
+		lowerPath:   threshold.LaserBiasCurrentLower().State(),
+		upperPath:   threshold.LaserBiasCurrentUpper().State(),
+		instantPath: component.Transceiver().Channel(0).LaserBiasCurrent().Instant().State(),
+		name:        "laser-bias-current",
+		ftName:      deviations.CiscoxrTransceiverFt(dut),
+	})
+	checkThreshold(t, dut, checkThresholdParams{
+		transceiver: transceiver,
+		isPortUp:    isPortUp,
+		opts:        opts,
+		lowerPath:   threshold.SupplyVoltageLower().State(),
+		upperPath:   threshold.SupplyVoltageUpper().State(),
+		instantPath: component.Transceiver().SupplyVoltage().Instant().State(),
+		name:        "supply-voltage",
+		ftName:      deviations.CiscoxrTransceiverFt(dut),
+	})
+}
+
+func TestOpticsPowerBiasCurrent(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+
+	ports := dut.Ports()
+	for _, dp := range ports {
+		t.Run(dp.Name(), func(t *testing.T) {
+			transceiverPath := gnmi.OC().Interface(dp.Name()).Transceiver().State().PathStruct()
+			transceiverLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).Transceiver().State())
+			transceiverName, ok := transceiverLookup.Val()
+			if !ok || transceiverName == "" {
+				tracePath(t, getPathStr(transceiverPath), statusFail, "Failed to find transceiver for port %q", dp.Name())
+				t.Fatalf("Failed to find transceiver for port %q", dp.Name())
+			}
+			tracePath(t, getPathStr(transceiverPath), statusPass, "Transceiver: %s", transceiverName)
+
+			component := gnmi.OC().Component(transceiverName)
+			mfgLookup := gnmi.Lookup(t, dut, component.MfgName().State())
+			mfgName, ok := mfgLookup.Val()
+			if !ok {
+				tracePath(t, getPathStr(component.MfgName().State().PathStruct()), statusFail, "MfgName not defined")
+			} else {
+				tracePath(t, getPathStr(component.MfgName().State().PathStruct()), statusPass, "MfgName: %s", mfgName)
+			}
+
+			// Check admin status using state/admin-status and config/enabled
+			adminStatusLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).AdminStatus().State())
+			adminStatus, adminStatusPresent := adminStatusLookup.Val()
+			adminStatusPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).AdminStatus().State().PathStruct())
+
+			configEnabledLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config())
+			configEnabled, configEnabledPresent := configEnabledLookup.Val()
+			configEnabledPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).Enabled().Config().PathStruct())
+
+			operStatusLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State())
+			operStatus, operStatusPresent := operStatusLookup.Val()
+			operStatusPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
+
+			isAdminDown := false
+			if adminStatusPresent && adminStatus == oc.Interface_AdminStatus_DOWN {
+				isAdminDown = true
+			} else if configEnabledPresent && !configEnabled {
+				isAdminDown = true
+			}
+
+			if adminStatusPresent {
+				tracePath(t, adminStatusPathStr, statusPass, "Interface AdminStatus: %v", adminStatus)
+			} else {
+				tracePath(t, adminStatusPathStr, statusSkipped, "Interface AdminStatus path not present on device")
+			}
+
+			if configEnabledPresent {
+				tracePath(t, configEnabledPathStr, statusPass, "Interface Enabled Config: %v", configEnabled)
+			} else {
+				tracePath(t, configEnabledPathStr, statusSkipped, "Interface Enabled Config path not present on device")
+			}
+
+			if operStatusPresent {
+				tracePath(t, operStatusPathStr, statusPass, "Interface OperStatus: %v", operStatus)
+			} else {
+				tracePath(t, operStatusPathStr, statusSkipped, "Interface OperStatus path not present on device")
+			}
+
+			if isAdminDown {
+				tracePath(t, adminStatusPathStr, statusSkipped, "Skipping transceiver %s because interface is admin down", transceiverName)
+				return
+			}
+
+			opts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrTransceiverFt(dut))
+
+			inputPowerPathStr := getPathStr(component.Transceiver().ChannelAny().InputPower().Instant().State().PathStruct())
+			inputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), component.Transceiver().ChannelAny().InputPower().Instant().State())
+			if len(inputPowers) == 0 {
+				tracePath(t, inputPowerPathStr, statusFail, "Get inputPowers list: got 0, want > 0")
+			} else {
+				for _, val := range inputPowers {
+					if v, ok := val.Val(); ok {
+						pStr, err := ygot.PathToString(val.Path)
+						if err != nil {
+							pStr = val.Path.String()
+						}
+						tracePath(t, pStr, statusPass, "Value: %v", v)
+					}
+				}
+			}
+
+			outputPowerPathStr := getPathStr(component.Transceiver().ChannelAny().OutputPower().Instant().State().PathStruct())
+			outputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), component.Transceiver().ChannelAny().OutputPower().Instant().State())
+			if len(outputPowers) == 0 {
+				tracePath(t, outputPowerPathStr, statusFail, "Get outputPowers list: got 0, want > 0")
+			} else {
+				for _, val := range outputPowers {
+					if v, ok := val.Val(); ok {
+						pStr, err := ygot.PathToString(val.Path)
+						if err != nil {
+							pStr = val.Path.String()
+						}
+						tracePath(t, pStr, statusPass, "Value: %v", v)
+					}
+				}
+			}
+
+			biasPathStr := getPathStr(component.Transceiver().ChannelAny().LaserBiasCurrent().Instant().State().PathStruct())
+			biasCurrents := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), component.Transceiver().ChannelAny().LaserBiasCurrent().Instant().State())
+			if len(biasCurrents) == 0 {
+				tracePath(t, biasPathStr, statusFail, "Get biasCurrents list: got 0, want > 0")
+			} else {
+				for _, val := range biasCurrents {
+					if v, ok := val.Val(); ok {
+						pStr, err := ygot.PathToString(val.Path)
+						if err != nil {
+							pStr = val.Path.String()
+						}
+						tracePath(t, pStr, statusPass, "Value: %v", v)
+					}
+				}
+			}
+
+			subcomponentNames := gnmi.LookupAll[string](t, dut, component.SubcomponentAny().Name().State())
+			sensorComponentChecked := false
+			for _, s := range subcomponentNames {
+				subcName, ok := s.Val()
+				if ok {
+					sensorTypeLookup := gnmi.Lookup(t, dut, gnmi.OC().Component(subcName).Type().State())
+					sType, ok := sensorTypeLookup.Val()
+					if ok && sType == sensorType {
+						scomponent := gnmi.OC().Component(subcName)
+						sensorComponentChecked = true
+						descLookup := gnmi.Lookup(t, dut, scomponent.Description().State())
+						desc, _ := descLookup.Val()
+						if !deviations.TemperatureSensorCheck(dut) || strings.Contains(desc, "Temperature Sensor") {
+							tempPathStr := getPathStr(scomponent.Temperature().Instant().State().PathStruct())
+							v := gnmi.Lookup(t, dut, scomponent.Temperature().Instant().State())
+							if val, ok := v.Val(); !ok {
+								tracePath(t, tempPathStr, statusFail, "Sensor %s: Temperature instant is not defined", subcName)
+							} else {
+								tracePath(t, tempPathStr, statusPass, "Temperature value: %v", val)
+							}
+						}
+					}
+				}
+			}
+			if len(subcomponentNames) == 0 || !sensorComponentChecked {
+				tempPathStr := getPathStr(component.Temperature().Instant().State().PathStruct())
+				v := gnmi.Lookup(t, dut, component.Temperature().Instant().State())
+				if val, ok := v.Val(); !ok {
+					tracePath(t, tempPathStr, statusFail, "Transceiver %s: Temperature instant is not defined", transceiverName)
+				} else {
+					tracePath(t, tempPathStr, statusPass, "Temperature value: %v", val)
+				}
+			}
+
+			if deviations.TransceiverThresholdsUnsupported(dut) {
+				tracePath(t, getPathStr(component.Transceiver().ThresholdAny().Severity().State().PathStruct()), statusSkipped, "Skipping verification of transceiver threshold leaves due to deviation")
+				return
+			}
+
+			laserOpts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrLaserFt(dut))
+			operStatusVal := gnmi.Get(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State())
+			isPortUp := operStatusVal == oc.Interface_OperStatus_UP
+			for _, sev := range []oc.E_AlarmTypes_OPENCONFIG_ALARM_SEVERITY{
+				oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_WARNING,
+				oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_CRITICAL,
+			} {
+				validateThresholds(t, dut, transceiverName, isPortUp, sev, component, laserOpts)
+			}
+		})
+	}
+}
+
+func TestOpticsPowerUpdate(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	ports := dut.Ports()
+
+	for _, dp := range ports {
+		t.Run(fmt.Sprintf("Flap-%s", dp.Name()), func(t *testing.T) {
+			originalEnabled, present := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config()).Val()
+			if present {
+				t.Cleanup(func() {
+					gnmi.Update(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config(), originalEnabled)
+				})
+			}
+
+			cases := []struct {
+				desc                string
+				IntfStatus          bool
+				expectedStatus      oc.E_Interface_OperStatus
+				expectedMaxOutPower float64
+				checkMinOutPower    bool
+			}{{
+				desc:                "Check initial input and output optics powers are OK",
+				IntfStatus:          true,
+				expectedStatus:      oc.Interface_OperStatus_UP,
+				expectedMaxOutPower: maxOpticsPower,
+				checkMinOutPower:    true,
+			}, {
+				desc:                "Check output optics power is very small after interface is disabled",
+				IntfStatus:          false,
+				expectedStatus:      oc.Interface_OperStatus_DOWN,
+				expectedMaxOutPower: maxOpticsPowerAdminDown,
+				checkMinOutPower:    false,
+			}, {
+				desc:                "Check output optics power is normal after interface is re-enabled",
+				IntfStatus:          true,
+				expectedStatus:      oc.Interface_OperStatus_UP,
+				expectedMaxOutPower: maxOpticsPower,
+				checkMinOutPower:    true,
+			}}
+			for _, tc := range cases {
+				intUpdateTime := 2 * time.Minute
+				t.Run(tc.desc, func(t *testing.T) {
+					gnmi.Update(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config(), tc.IntfStatus)
+					gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, tc.expectedStatus)
+
+					operPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
+					tracePath(t, operPathStr, statusPass, "Reached expected operational status: %v", tc.expectedStatus)
+
+					transceiverName := gnmi.Get(t, dut, gnmi.OC().Interface(dp.Name()).Transceiver().State())
+					component := gnmi.OC().Component(transceiverName)
+					if !gnmi.Lookup(t, dut, component.MfgName().State()).IsPresent() {
+						tracePath(t, getPathStr(component.MfgName().State().PathStruct()), statusSkipped, "Skipping: component MfgName not present")
+						t.Skipf("component.MfgName().Lookup(t).IsPresent() for %q is false. skip it", transceiverName)
+					}
+
+					mfgName := gnmi.Get(t, dut, component.MfgName().State())
+					tracePath(t, getPathStr(component.MfgName().State().PathStruct()), statusPass, "MfgName: %s", mfgName)
+
+					channels := gnmi.OC().Component(transceiverName).Transceiver().ChannelAny()
+					opts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrTransceiverFt(dut))
+
+					inputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.InputPower().Instant().State())
+					for _, inputPower := range inputPowers {
+						pStr, err := ygot.PathToString(inputPower.Path)
+						if err != nil {
+							pStr = inputPower.Path.String()
+						}
+						inPower, ok := inputPower.Val()
+						if !ok {
+							tracePath(t, pStr, statusFail, "input power is not defined")
+							continue
+						}
+						if inPower > maxOpticsPower || inPower < minOpticsPower {
+							tracePath(t, pStr, statusFail, "value %.2f is outside range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
+						} else {
+							tracePath(t, pStr, statusPass, "value %.2f is within range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
+						}
+					}
+
+					outputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.OutputPower().Instant().State())
+					for _, outputPower := range outputPowers {
+						pStr, err := ygot.PathToString(outputPower.Path)
+						if err != nil {
+							pStr = outputPower.Path.String()
+						}
+						outPower, ok := outputPower.Val()
+						if !ok {
+							tracePath(t, pStr, statusFail, "output power is not defined")
+							continue
+						}
+						if outPower > tc.expectedMaxOutPower {
+							tracePath(t, pStr, statusFail, "value %.2f is above maximum threshold <= %f", outPower, tc.expectedMaxOutPower)
+						} else if tc.checkMinOutPower && outPower < minOpticsPower {
+							tracePath(t, pStr, statusFail, "value %.2f is below minimum threshold >= %f", outPower, minOpticsPower)
+						} else {
+							tracePath(t, pStr, statusPass, "value %.2f is within expected range", outPower)
+						}
+					}
+
+					if deviations.TransceiverThresholdsUnsupported(dut) {
+						tracePath(t, getPathStr(component.Transceiver().ThresholdAny().Severity().State().PathStruct()), statusSkipped, "Skipping verification of transceiver threshold leaves due to deviation")
+					} else {
+						opts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrLaserFt(dut))
+						isPortUp := tc.expectedStatus == oc.Interface_OperStatus_UP
+						for _, sev := range []oc.E_AlarmTypes_OPENCONFIG_ALARM_SEVERITY{
+							oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_WARNING,
+							oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_CRITICAL,
+						} {
+							validateThresholds(t, dut, transceiverName, isPortUp, sev, component, opts)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestInterfacesWithTransceivers(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+
+	ports := dut.Ports()
+	for _, dp := range ports {
+		t.Run(fmt.Sprintf("Interface:%s", dp.Name()), func(t *testing.T) {
+			intfNameLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).Name().State())
+			intfName, ok := intfNameLookup.Val()
+			intfNamePath := getPathStr(gnmi.OC().Interface(dp.Name()).Name().State().PathStruct())
+			if !ok || intfName == "" {
+				tracePath(t, intfNamePath, statusFail, "Failed to retrieve interface name state")
+				t.Fatalf("Failed to retrieve interface name state for %q", dp.Name())
+			}
+			tracePath(t, intfNamePath, statusPass, "Interface name: %s", intfName)
+
+			transceiverLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).Transceiver().State())
+			tv, tvOk := transceiverLookup.Val()
+			transceiverPath := getPathStr(gnmi.OC().Interface(dp.Name()).Transceiver().State().PathStruct())
+			if !tvOk || tv == "" {
+				tracePath(t, transceiverPath, statusFail, "Failed to retrieve transceiver state")
+				t.Fatalf("Failed to retrieve transceiver state for %q", dp.Name())
+			}
+			tracePath(t, transceiverPath, statusPass, "Interface transceiver: %s", tv)
+
+			t.Run(fmt.Sprintf("Transceiver:%s", tv), func(t *testing.T) {
+				mfgName, _ := gnmi.Lookup(t, dut, gnmi.OC().Component(tv).MfgName().State()).Val()
+				tvPathStr := getPathStr(gnmi.OC().Component(tv).State().PathStruct())
+				if mfgName == "" {
+					tracePath(t, tvPathStr, statusSkipped, "Skipping check for Transceiver: got no MfgName.")
+					t.Skipf("Skipping check for Transceiver: %q, got no MfgName.", tv)
+				}
+
+				formFactor, _ := gnmi.Lookup(t, dut, gnmi.OC().Component(tv).Transceiver().FormFactor().State()).Val()
+				if formFactor == oc.TransportTypes_TRANSCEIVER_FORM_FACTOR_TYPE_UNSET {
+					tracePath(t, tvPathStr, statusFail, "transceiver form-factor unset")
+				} else {
+					tracePath(t, tvPathStr, statusPass, "MfgName: %s, FormFactor: %v", mfgName, formFactor)
+				}
+
+				// Verify Component Type
+				typePath := gnmi.OC().Component(tv).Type().State()
+				compType, typePresent := gnmi.Lookup(t, dut, typePath).Val()
+				if !typePresent {
+					tracePath(t, getPathStr(typePath.PathStruct()), statusFail, "Component type is not present")
+				} else {
+					if compType == transceiverType {
+						tracePath(t, getPathStr(typePath.PathStruct()), statusPass, "Component type: %v", compType)
+					} else {
+						tracePath(t, getPathStr(typePath.PathStruct()), statusFail, "Component type: got %v, want PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_TRANSCEIVER", compType)
+					}
+				}
+
+				// Verify Part Number
+				partNoPath := gnmi.OC().Component(tv).PartNo().State()
+				partNo, partNoPresent := gnmi.Lookup(t, dut, partNoPath).Val()
+				if !partNoPresent || partNo == "" {
+					tracePath(t, getPathStr(partNoPath.PathStruct()), statusFail, "Part number is not present or empty")
+				} else {
+					tracePath(t, getPathStr(partNoPath.PathStruct()), statusPass, "Part number: %s", partNo)
+				}
+
+				// Verify Serial Number
+				serialNoPath := gnmi.OC().Component(tv).SerialNo().State()
+				serialNo, serialNoPresent := gnmi.Lookup(t, dut, serialNoPath).Val()
+				if !serialNoPresent || serialNo == "" {
+					tracePath(t, getPathStr(serialNoPath.PathStruct()), statusFail, "Serial number is not present or empty")
+				} else {
+					tracePath(t, getPathStr(serialNoPath.PathStruct()), statusPass, "Serial number: %s", serialNo)
+				}
+
+				// Verify Firmware Version
+				firmwareVersionPath := gnmi.OC().Component(tv).FirmwareVersion().State()
+				firmwareVersion, firmwareVersionPresent := gnmi.Lookup(t, dut, firmwareVersionPath).Val()
+				if !firmwareVersionPresent || firmwareVersion == "" {
+					tracePath(t, getPathStr(firmwareVersionPath.PathStruct()), statusWarning, "Firmware version is not present or empty")
+				} else {
+					tracePath(t, getPathStr(firmwareVersionPath.PathStruct()), statusPass, "Firmware version: %s", firmwareVersion)
+				}
+
+				// Verify Hardware Version
+				hardwareVersionPath := gnmi.OC().Component(tv).HardwareVersion().State()
+				hardwareVersion, hardwareVersionPresent := gnmi.Lookup(t, dut, hardwareVersionPath).Val()
+				if !hardwareVersionPresent || hardwareVersion == "" {
+					tracePath(t, getPathStr(hardwareVersionPath.PathStruct()), statusFail, "Hardware version is not present or empty")
+				} else {
+					tracePath(t, getPathStr(hardwareVersionPath.PathStruct()), statusPass, "Hardware version: %s", hardwareVersion)
+				}
+
+				// Verify Description
+				descPath := gnmi.OC().Component(tv).Description().State()
+				if deviations.SkipTransceiverDescription(dut) {
+					tracePath(t, getPathStr(descPath.PathStruct()), statusSkipped, "Skipping verification of transceiver description due to deviation")
+				} else {
+					desc, descPresent := gnmi.Lookup(t, dut, descPath).Val()
+					if !descPresent || desc == "" {
+						tracePath(t, getPathStr(descPath.PathStruct()), statusWarning, "Description is not present or empty")
+					} else {
+						tracePath(t, getPathStr(descPath.PathStruct()), statusPass, "Description: %s", desc)
+					}
+				}
+
+				// Verify Mfg Date
+				mfgDatePath := gnmi.OC().Component(tv).MfgDate().State()
+				if deviations.ComponentMfgDateUnsupported(dut) {
+					tracePath(t, getPathStr(mfgDatePath.PathStruct()), statusSkipped, "Skipping verification of transceiver manufacturing date due to deviation")
+				} else {
+					mfgDate, mfgDatePresent := gnmi.Lookup(t, dut, mfgDatePath).Val()
+					if !mfgDatePresent || mfgDate == "" {
+						tracePath(t, getPathStr(mfgDatePath.PathStruct()), statusFail, "Manufacturing date is not present or empty")
+					} else {
+						tracePath(t, getPathStr(mfgDatePath.PathStruct()), statusPass, "Manufacturing date: %s", mfgDate)
+					}
+				}
+
+				channelsMap := make(map[uint16]bool)
+				channels := gnmi.LookupAll(t, dut, gnmi.OC().Component(tv).Transceiver().ChannelAny().State())
+				for _, ch := range channels {
+					if val, ok := ch.Val(); ok {
+						channelsMap[val.GetIndex()] = true
+					}
+				}
+
+				physicalChannelLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).PhysicalChannel().State())
+				physicalChannel, pcOk := physicalChannelLookup.Val()
+				pcPath := getPathStr(gnmi.OC().Interface(dp.Name()).PhysicalChannel().State().PathStruct())
+				if !pcOk || len(physicalChannel) == 0 {
+					tracePath(t, pcPath, statusFail, "physical-channel unset for Interface: %q", intfName)
+					t.Errorf("physical-channel unset for Interface: %q", intfName)
+				} else {
+					t.Logf("Interface %s physical-channel: %v", dp.Name(), physicalChannel)
+					tracePath(t, pcPath, statusPass, "Physical channels: %v", physicalChannel)
+					for _, p := range physicalChannel {
+						if !channelsMap[p] {
+							t.Errorf("Transceiver %s failed to get channel index %v", tv, p)
+						}
+					}
+				}
+			})
+		})
+	}
+}

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -625,18 +625,32 @@ func TestTransceiverConfigEnabled(t *testing.T) {
 			opts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrTransceiverFt(dut))
 			channels := transceiver.ChannelAny()
 
-			t.Run("Disable transceiver and verify link is DOWN", func(t *testing.T) {
+			t.Run("Disable transceiver", func(t *testing.T) {
 				gnmi.Update(t, dut, cfgEnabledPath, false)
 				tracePath(t, cfgPathStr, statusPass, "Set transceiver enabled config: false")
 
-				gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_DOWN)
-				operPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
-				tracePath(t, operPathStr, statusPass, "Reached expected operational status: %v", oc.Interface_OperStatus_DOWN)
+				statePath := transceiver.Enabled().State()
+				statePathStr := getPathStr(statePath.PathStruct())
+				if val, ok := gnmi.Lookup(t, dut, statePath).Val(); ok {
+					if !val {
+						tracePath(t, statePathStr, statusPass, "Transceiver enabled state: false")
+					} else {
+						gnmi.Await(t, dut, statePath, intUpdateTime, false)
+						tracePath(t, statePathStr, statusPass, "Transceiver reached enabled state: false")
+					}
+				}
 			})
 
 			t.Run("Re-enable transceiver and verify link is UP, power and laser normal", func(t *testing.T) {
 				gnmi.Update(t, dut, cfgEnabledPath, true)
 				tracePath(t, cfgPathStr, statusPass, "Set transceiver enabled config: true")
+
+				statePath := transceiver.Enabled().State()
+				statePathStr := getPathStr(statePath.PathStruct())
+				if _, ok := gnmi.Lookup(t, dut, statePath).Val(); ok {
+					gnmi.Await(t, dut, statePath, intUpdateTime, true)
+					tracePath(t, statePathStr, statusPass, "Transceiver reached enabled state: true")
+				}
 
 				gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
 				operPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -38,6 +38,7 @@ const (
 	minOpticsPower          = -40.0
 	maxOpticsPower          = 10.0
 	maxOpticsPowerAdminDown = -30.0
+	intUpdateTime           = 2 * time.Minute
 )
 
 type testStatus string
@@ -303,179 +304,337 @@ func validateThresholds(t *testing.T, dut *ondatra.DUTDevice, transceiver string
 	})
 }
 
-func TestOpticsPowerBiasCurrent(t *testing.T) {
+func validateOpticsTelemetry(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port, transceiverName string, isPortUp bool, checkMinOutPower bool, expectedMaxOutPower float64) {
+	t.Helper()
+	component := gnmi.OC().Component(transceiverName)
+	channels := component.Transceiver().ChannelAny()
+	opts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrTransceiverFt(dut))
+
+	// Validate Input Powers
+	inputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.InputPower().Instant().State())
+	inputPowerPathStr := getPathStr(channels.InputPower().Instant().State().PathStruct())
+	if len(inputPowers) == 0 {
+		tracePath(t, inputPowerPathStr, statusFail, "Get inputPowers list: got 0, want > 0")
+	} else {
+		for _, inputPower := range inputPowers {
+			pStr, err := ygot.PathToString(inputPower.Path)
+			if err != nil {
+				pStr = inputPower.Path.String()
+			}
+			inPower, ok := inputPower.Val()
+			if !ok {
+				tracePath(t, pStr, statusFail, "input power is not defined")
+				continue
+			}
+			if isPortUp {
+				if inPower > maxOpticsPower || inPower < minOpticsPower {
+					tracePath(t, pStr, statusFail, "value %.2f is outside range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
+				} else {
+					tracePath(t, pStr, statusPass, "value %.2f is within range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
+				}
+			} else {
+				tracePath(t, pStr, statusPass, "input power when port down: %v", inPower)
+			}
+		}
+	}
+
+	// Validate Output Powers
+	outputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.OutputPower().Instant().State())
+	outputPowerPathStr := getPathStr(channels.OutputPower().Instant().State().PathStruct())
+	if len(outputPowers) == 0 {
+		tracePath(t, outputPowerPathStr, statusFail, "Get outputPowers list: got 0, want > 0")
+	} else {
+		for _, outputPower := range outputPowers {
+			pStr, err := ygot.PathToString(outputPower.Path)
+			if err != nil {
+				pStr = outputPower.Path.String()
+			}
+			outPower, ok := outputPower.Val()
+			if !ok {
+				tracePath(t, pStr, statusFail, "output power is not defined")
+				continue
+			}
+			if outPower > expectedMaxOutPower {
+				tracePath(t, pStr, statusFail, "value %.2f is above maximum threshold <= %f", outPower, expectedMaxOutPower)
+			} else if checkMinOutPower && outPower < minOpticsPower {
+				tracePath(t, pStr, statusFail, "value %.2f is below minimum threshold >= %f", outPower, minOpticsPower)
+			} else {
+				tracePath(t, pStr, statusPass, "value %.2f is within expected range", outPower)
+			}
+		}
+	}
+
+	// Validate Laser Bias Currents
+	biasCurrents := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.LaserBiasCurrent().Instant().State())
+	biasPathStr := getPathStr(channels.LaserBiasCurrent().Instant().State().PathStruct())
+	if len(biasCurrents) == 0 {
+		tracePath(t, biasPathStr, statusFail, "Get biasCurrents list: got 0, want > 0")
+	} else {
+		for _, biasCurrent := range biasCurrents {
+			pStr, err := ygot.PathToString(biasCurrent.Path)
+			if err != nil {
+				pStr = biasCurrent.Path.String()
+			}
+			if v, ok := biasCurrent.Val(); ok {
+				tracePath(t, pStr, statusPass, "Laser bias current value: %v", v)
+			}
+		}
+	}
+
+	// Validate Supply Voltage
+	svPath := component.Transceiver().SupplyVoltage().Instant().State()
+	svPathStr := getPathStr(svPath.PathStruct())
+	if sv, ok := gnmi.Lookup(t, dut.GNMIOpts().WithYGNMIOpts(opts...), svPath).Val(); ok {
+		tracePath(t, svPathStr, statusPass, "Supply voltage value: %v", sv)
+	} else {
+		tracePath(t, svPathStr, statusFail, "Supply voltage instant is not defined")
+	}
+
+	// Validate Temperature (Subcomponents sensor or component temperature)
+	compLookup := gnmi.Lookup(t, dut, component.State())
+	comp, compPresent := compLookup.Val()
+	sensorComponentChecked := false
+	if compPresent && comp != nil {
+		for _, subc := range comp.Subcomponent {
+			if subc == nil || subc.GetName() == "" {
+				continue
+			}
+			subcName := subc.GetName()
+			scompLookup := gnmi.Lookup(t, dut, gnmi.OC().Component(subcName).State())
+			if scomp, ok := scompLookup.Val(); ok && scomp != nil && scomp.GetType() == sensorType {
+				desc := scomp.GetDescription()
+				if !deviations.TemperatureSensorCheck(dut) || strings.Contains(desc, "Temperature Sensor") {
+					sensorComponentChecked = true
+					tempPathStr := getPathStr(gnmi.OC().Component(subcName).Temperature().Instant().State().PathStruct())
+					if scomp.GetTemperature() == nil || scomp.GetTemperature().Instant == nil {
+						tracePath(t, tempPathStr, statusFail, "Sensor %s: Temperature instant is not defined", subcName)
+					} else {
+						tracePath(t, tempPathStr, statusPass, "Temperature value: %v", scomp.GetTemperature().GetInstant())
+					}
+				}
+			}
+		}
+	}
+	if !sensorComponentChecked {
+		tempPathStr := getPathStr(component.Temperature().Instant().State().PathStruct())
+		if !compPresent || comp == nil || comp.GetTemperature() == nil || comp.GetTemperature().Instant == nil {
+			tracePath(t, tempPathStr, statusFail, "Transceiver %s: Temperature instant is not defined", transceiverName)
+		} else {
+			tracePath(t, tempPathStr, statusPass, "Temperature value: %v", comp.GetTemperature().GetInstant())
+		}
+	}
+
+	// Validate Thresholds
+	if deviations.TransceiverThresholdsUnsupported(dut) {
+		tracePath(t, getPathStr(component.Transceiver().ThresholdAny().Severity().State().PathStruct()), statusSkipped, "Skipping verification of transceiver threshold leaves due to deviation")
+	} else {
+		laserOpts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrLaserFt(dut))
+		for _, sev := range []oc.E_AlarmTypes_OPENCONFIG_ALARM_SEVERITY{
+			oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_WARNING,
+			oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_CRITICAL,
+		} {
+			validateThresholds(t, dut, transceiverName, isPortUp, sev, component, laserOpts)
+		}
+	}
+}
+
+func validateTransceiverInventory(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port, intf *oc.Interface, comp *oc.Component, transceiverName string) {
+	t.Helper()
+	intfNamePath := getPathStr(gnmi.OC().Interface(dp.Name()).Name().State().PathStruct())
+	if intf == nil || intf.GetName() == "" {
+		tracePath(t, intfNamePath, statusFail, "Failed to retrieve interface name state")
+		t.Fatalf("Failed to retrieve interface name state for %q", dp.Name())
+	}
+	tracePath(t, intfNamePath, statusPass, "Interface name: %s", intf.GetName())
+
+	transceiverPath := getPathStr(gnmi.OC().Interface(dp.Name()).Transceiver().State().PathStruct())
+	tracePath(t, transceiverPath, statusPass, "Interface transceiver: %s", transceiverName)
+
+	tvPathStr := getPathStr(gnmi.OC().Component(transceiverName).State().PathStruct())
+	mfgPathStr := getPathStr(gnmi.OC().Component(transceiverName).MfgName().State().PathStruct())
+	if comp == nil || comp.GetMfgName() == "" {
+		tracePath(t, mfgPathStr, statusFail, "MfgName not defined")
+		tracePath(t, tvPathStr, statusSkipped, "Skipping check for Transceiver: got no MfgName.")
+		t.Skipf("Skipping check for Transceiver: %q, got no MfgName.", transceiverName)
+	}
+	mfgName := comp.GetMfgName()
+	tracePath(t, mfgPathStr, statusPass, "MfgName: %s", mfgName)
+
+	// Verify Form Factor
+	ffPath := gnmi.OC().Component(transceiverName).Transceiver().FormFactor().State()
+	formFactor := oc.TransportTypes_TRANSCEIVER_FORM_FACTOR_TYPE_UNSET
+	if comp.GetTransceiver() != nil {
+		formFactor = comp.GetTransceiver().GetFormFactor()
+	}
+	if formFactor == oc.TransportTypes_TRANSCEIVER_FORM_FACTOR_TYPE_UNSET {
+		tracePath(t, getPathStr(ffPath.PathStruct()), statusFail, "transceiver form-factor unset")
+	} else {
+		tracePath(t, getPathStr(ffPath.PathStruct()), statusPass, "MfgName: %s, FormFactor: %v", mfgName, formFactor)
+	}
+
+	// Verify Component Type
+	typePath := gnmi.OC().Component(transceiverName).Type().State()
+	compType := comp.GetType()
+	if compType == nil {
+		tracePath(t, getPathStr(typePath.PathStruct()), statusFail, "Component type is not present")
+	} else if compType == transceiverType {
+		tracePath(t, getPathStr(typePath.PathStruct()), statusPass, "Component type: %v", compType)
+	} else {
+		tracePath(t, getPathStr(typePath.PathStruct()), statusFail, "Component type: got %v, want PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_TRANSCEIVER", compType)
+	}
+
+	// Verify Part Number
+	partNoPath := gnmi.OC().Component(transceiverName).PartNo().State()
+	partNo := comp.GetPartNo()
+	if partNo == "" {
+		tracePath(t, getPathStr(partNoPath.PathStruct()), statusFail, "Part number is not present or empty")
+	} else {
+		tracePath(t, getPathStr(partNoPath.PathStruct()), statusPass, "Part number: %s", partNo)
+	}
+
+	// Verify Serial Number
+	serialNoPath := gnmi.OC().Component(transceiverName).SerialNo().State()
+	serialNo := comp.GetSerialNo()
+	if serialNo == "" {
+		tracePath(t, getPathStr(serialNoPath.PathStruct()), statusFail, "Serial number is not present or empty")
+	} else {
+		tracePath(t, getPathStr(serialNoPath.PathStruct()), statusPass, "Serial number: %s", serialNo)
+	}
+
+	// Verify Firmware Version
+	firmwareVersionPath := gnmi.OC().Component(transceiverName).FirmwareVersion().State()
+	firmwareVersion := comp.GetFirmwareVersion()
+	if firmwareVersion == "" {
+		tracePath(t, getPathStr(firmwareVersionPath.PathStruct()), statusWarning, "Firmware version is not present or empty")
+	} else {
+		tracePath(t, getPathStr(firmwareVersionPath.PathStruct()), statusPass, "Firmware version: %s", firmwareVersion)
+	}
+
+	// Verify Hardware Version
+	hardwareVersionPath := gnmi.OC().Component(transceiverName).HardwareVersion().State()
+	hardwareVersion := comp.GetHardwareVersion()
+	if hardwareVersion == "" {
+		tracePath(t, getPathStr(hardwareVersionPath.PathStruct()), statusFail, "Hardware version is not present or empty")
+	} else {
+		tracePath(t, getPathStr(hardwareVersionPath.PathStruct()), statusPass, "Hardware version: %s", hardwareVersion)
+	}
+
+	// Verify Description
+	descPath := gnmi.OC().Component(transceiverName).Description().State()
+	if deviations.SkipTransceiverDescription(dut) {
+		tracePath(t, getPathStr(descPath.PathStruct()), statusSkipped, "Skipping verification of transceiver description due to deviation")
+	} else {
+		desc := comp.GetDescription()
+		if desc == "" {
+			tracePath(t, getPathStr(descPath.PathStruct()), statusWarning, "Description is not present or empty")
+		} else {
+			tracePath(t, getPathStr(descPath.PathStruct()), statusPass, "Description: %s", desc)
+		}
+	}
+
+	// Verify Mfg Date
+	mfgDatePath := gnmi.OC().Component(transceiverName).MfgDate().State()
+	if deviations.ComponentMfgDateUnsupported(dut) {
+		tracePath(t, getPathStr(mfgDatePath.PathStruct()), statusSkipped, "Skipping verification of transceiver manufacturing date due to deviation")
+	} else {
+		mfgDate := comp.GetMfgDate()
+		if mfgDate == "" {
+			tracePath(t, getPathStr(mfgDatePath.PathStruct()), statusFail, "Manufacturing date is not present or empty")
+		} else {
+			tracePath(t, getPathStr(mfgDatePath.PathStruct()), statusPass, "Manufacturing date: %s", mfgDate)
+		}
+	}
+
+	// Verify Channels and Physical Channels Mapping
+	channelsMap := make(map[uint16]bool)
+	if comp.GetTransceiver() != nil {
+		for chIdx, ch := range comp.GetTransceiver().Channel {
+			channelsMap[chIdx] = true
+			chIndexPath := getPathStr(gnmi.OC().Component(transceiverName).Transceiver().Channel(chIdx).Index().State().PathStruct())
+			if ch != nil && ch.Index != nil {
+				tracePath(t, chIndexPath, statusPass, "Channel index: %d", ch.GetIndex())
+			} else {
+				tracePath(t, chIndexPath, statusPass, "Channel index: %d", chIdx)
+			}
+		}
+	}
+
+	physicalChannel := intf.GetPhysicalChannel()
+	pcPath := getPathStr(gnmi.OC().Interface(dp.Name()).PhysicalChannel().State().PathStruct())
+	if len(physicalChannel) == 0 {
+		tracePath(t, pcPath, statusFail, "physical-channel unset for Interface: %q", dp.Name())
+	} else {
+		t.Logf("Interface %s physical-channel: %v", dp.Name(), physicalChannel)
+		tracePath(t, pcPath, statusPass, "Physical channels: %v", physicalChannel)
+		for _, p := range physicalChannel {
+			if !channelsMap[p] {
+				t.Errorf("Transceiver %s failed to get channel index %v", transceiverName, p)
+			}
+		}
+	}
+}
+
+// TestClientOpticsTelemetryAndInventory validates that all interfaces and transceivers
+// are enabled, links are UP, and all static inventory and dynamic telemetry parameters
+// (power, bias current, temperature, supply voltage, and alarm thresholds) are valid.
+func TestClientOpticsTelemetryAndInventory(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
 	ports := dut.Ports()
 	for _, dp := range ports {
-		t.Run(dp.Name(), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Port:%s", dp.Name()), func(t *testing.T) {
+			// Ensure interface is enabled and wait for link to be UP
+			gnmi.Update(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config(), true)
+			gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
+
 			intfLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).State())
 			intf, intfPresent := intfLookup.Val()
-			transceiverPath := getPathStr(gnmi.OC().Interface(dp.Name()).Transceiver().State().PathStruct())
 			if !intfPresent || intf == nil || intf.GetTransceiver() == "" {
-				tracePath(t, transceiverPath, statusFail, "Failed to find transceiver for port %q", dp.Name())
-				t.Fatalf("Failed to find transceiver for port %q", dp.Name())
+				t.Fatalf("Failed to retrieve interface state or transceiver mapping for %q", dp.Name())
 			}
 			transceiverName := intf.GetTransceiver()
-			tracePath(t, transceiverPath, statusPass, "Transceiver: %s", transceiverName)
 
-			component := gnmi.OC().Component(transceiverName)
-			compLookup := gnmi.Lookup(t, dut, component.State())
-			comp, compPresent := compLookup.Val()
-			mfgPathStr := getPathStr(component.MfgName().State().PathStruct())
-			if !compPresent || comp == nil || comp.GetMfgName() == "" {
-				tracePath(t, mfgPathStr, statusFail, "MfgName not defined")
-			} else {
-				tracePath(t, mfgPathStr, statusPass, "MfgName: %s", comp.GetMfgName())
-			}
-
-			// Check admin status using state/admin-status and config/enabled
+			// Check and record admin/oper status paths
 			adminStatusPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).AdminStatus().State().PathStruct())
-			adminStatus := intf.GetAdminStatus()
-			adminStatusPresent := intf.AdminStatus != oc.Interface_AdminStatus_UNSET
-
-			configEnabledLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config())
-			configEnabled, configEnabledPresent := configEnabledLookup.Val()
-			configEnabledPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).Enabled().Config().PathStruct())
-
-			operStatusPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
-			operStatus := intf.GetOperStatus()
-			operStatusPresent := intf.OperStatus != oc.Interface_OperStatus_UNSET
-
-			isAdminDown := false
-			if adminStatusPresent && adminStatus == oc.Interface_AdminStatus_DOWN {
-				isAdminDown = true
-			} else if configEnabledPresent && !configEnabled {
-				isAdminDown = true
-			}
-
-			if adminStatusPresent {
-				tracePath(t, adminStatusPathStr, statusPass, "Interface AdminStatus: %v", adminStatus)
+			if intf.AdminStatus != oc.Interface_AdminStatus_UNSET {
+				tracePath(t, adminStatusPathStr, statusPass, "Interface AdminStatus: %v", intf.GetAdminStatus())
 			} else {
 				tracePath(t, adminStatusPathStr, statusSkipped, "Interface AdminStatus path not present on device")
 			}
 
+			configEnabledLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config())
+			configEnabled, configEnabledPresent := configEnabledLookup.Val()
+			configEnabledPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).Enabled().Config().PathStruct())
 			if configEnabledPresent {
 				tracePath(t, configEnabledPathStr, statusPass, "Interface Enabled Config: %v", configEnabled)
 			} else {
 				tracePath(t, configEnabledPathStr, statusSkipped, "Interface Enabled Config path not present on device")
 			}
 
-			if operStatusPresent {
-				tracePath(t, operStatusPathStr, statusPass, "Interface OperStatus: %v", operStatus)
-			} else {
-				tracePath(t, operStatusPathStr, statusSkipped, "Interface OperStatus path not present on device")
-			}
+			operStatusPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
+			tracePath(t, operStatusPathStr, statusPass, "Interface OperStatus: %v", intf.GetOperStatus())
 
-			if isAdminDown {
-				tracePath(t, adminStatusPathStr, statusSkipped, "Skipping transceiver %s because interface is admin down", transceiverName)
-				return
-			}
+			compLookup := gnmi.Lookup(t, dut, gnmi.OC().Component(transceiverName).State())
+			comp, _ := compLookup.Val()
 
-			opts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrTransceiverFt(dut))
+			// Validate Static Inventory Information
+			validateTransceiverInventory(t, dut, dp, intf, comp, transceiverName)
 
-			inputPowerPathStr := getPathStr(component.Transceiver().ChannelAny().InputPower().Instant().State().PathStruct())
-			inputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), component.Transceiver().ChannelAny().InputPower().Instant().State())
-			if len(inputPowers) == 0 {
-				tracePath(t, inputPowerPathStr, statusFail, "Get inputPowers list: got 0, want > 0")
-			} else {
-				for _, val := range inputPowers {
-					if v, ok := val.Val(); ok {
-						pStr, err := ygot.PathToString(val.Path)
-						if err != nil {
-							pStr = val.Path.String()
-						}
-						tracePath(t, pStr, statusPass, "Value: %v", v)
-					}
-				}
-			}
-
-			outputPowerPathStr := getPathStr(component.Transceiver().ChannelAny().OutputPower().Instant().State().PathStruct())
-			outputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), component.Transceiver().ChannelAny().OutputPower().Instant().State())
-			if len(outputPowers) == 0 {
-				tracePath(t, outputPowerPathStr, statusFail, "Get outputPowers list: got 0, want > 0")
-			} else {
-				for _, val := range outputPowers {
-					if v, ok := val.Val(); ok {
-						pStr, err := ygot.PathToString(val.Path)
-						if err != nil {
-							pStr = val.Path.String()
-						}
-						tracePath(t, pStr, statusPass, "Value: %v", v)
-					}
-				}
-			}
-
-			biasPathStr := getPathStr(component.Transceiver().ChannelAny().LaserBiasCurrent().Instant().State().PathStruct())
-			biasCurrents := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), component.Transceiver().ChannelAny().LaserBiasCurrent().Instant().State())
-			if len(biasCurrents) == 0 {
-				tracePath(t, biasPathStr, statusFail, "Get biasCurrents list: got 0, want > 0")
-			} else {
-				for _, val := range biasCurrents {
-					if v, ok := val.Val(); ok {
-						pStr, err := ygot.PathToString(val.Path)
-						if err != nil {
-							pStr = val.Path.String()
-						}
-						tracePath(t, pStr, statusPass, "Value: %v", v)
-					}
-				}
-			}
-
-			sensorComponentChecked := false
-			if compPresent && comp != nil {
-				for _, subc := range comp.Subcomponent {
-					if subc == nil || subc.GetName() == "" {
-						continue
-					}
-					subcName := subc.GetName()
-					scompLookup := gnmi.Lookup(t, dut, gnmi.OC().Component(subcName).State())
-					if scomp, ok := scompLookup.Val(); ok && scomp != nil && scomp.GetType() == sensorType {
-						desc := scomp.GetDescription()
-						if !deviations.TemperatureSensorCheck(dut) || strings.Contains(desc, "Temperature Sensor") {
-							sensorComponentChecked = true
-							tempPathStr := getPathStr(gnmi.OC().Component(subcName).Temperature().Instant().State().PathStruct())
-							if scomp.GetTemperature() == nil || scomp.GetTemperature().Instant == nil {
-								tracePath(t, tempPathStr, statusFail, "Sensor %s: Temperature instant is not defined", subcName)
-							} else {
-								tracePath(t, tempPathStr, statusPass, "Temperature value: %v", scomp.GetTemperature().GetInstant())
-							}
-						}
-					}
-				}
-			}
-			if !sensorComponentChecked {
-				tempPathStr := getPathStr(component.Temperature().Instant().State().PathStruct())
-				if !compPresent || comp == nil || comp.GetTemperature() == nil || comp.GetTemperature().Instant == nil {
-					tracePath(t, tempPathStr, statusFail, "Transceiver %s: Temperature instant is not defined", transceiverName)
-				} else {
-					tracePath(t, tempPathStr, statusPass, "Temperature value: %v", comp.GetTemperature().GetInstant())
-				}
-			}
-
-			if deviations.TransceiverThresholdsUnsupported(dut) {
-				tracePath(t, getPathStr(component.Transceiver().ThresholdAny().Severity().State().PathStruct()), statusSkipped, "Skipping verification of transceiver threshold leaves due to deviation")
-				return
-			}
-
-			laserOpts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrLaserFt(dut))
-			isPortUp := operStatus == oc.Interface_OperStatus_UP
-			for _, sev := range []oc.E_AlarmTypes_OPENCONFIG_ALARM_SEVERITY{
-				oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_WARNING,
-				oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_CRITICAL,
-			} {
-				validateThresholds(t, dut, transceiverName, isPortUp, sev, component, laserOpts)
-			}
+			// Validate Dynamic Telemetry & Thresholds
+			validateOpticsTelemetry(t, dut, dp, transceiverName, true, true, maxOpticsPower)
 		})
 	}
 }
 
-func TestOpticsPowerUpdate(t *testing.T) {
+// TestInterfaceEnabled validates interface enable/disable lifecycle.
+// When disabled, verifies oper-status is DOWN and output power drops.
+// When re-enabled, verifies link returns to UP and telemetry parameters are within thresholds.
+func TestInterfaceEnabled(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	ports := dut.Ports()
 
 	for _, dp := range ports {
-		t.Run(fmt.Sprintf("Flap-%s", dp.Name()), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Interface-Flap-%s", dp.Name()), func(t *testing.T) {
 			originalEnabled, present := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config()).Val()
 			t.Cleanup(func() {
 				if present {
@@ -485,110 +644,43 @@ func TestOpticsPowerUpdate(t *testing.T) {
 				}
 			})
 
-			cases := []struct {
-				desc                string
-				IntfStatus          bool
-				expectedStatus      oc.E_Interface_OperStatus
-				expectedMaxOutPower float64
-				checkMinOutPower    bool
-			}{{
-				desc:                "Check initial input and output optics powers are OK",
-				IntfStatus:          true,
-				expectedStatus:      oc.Interface_OperStatus_UP,
-				expectedMaxOutPower: maxOpticsPower,
-				checkMinOutPower:    true,
-			}, {
-				desc:                "Check output optics power is very small after interface is disabled",
-				IntfStatus:          false,
-				expectedStatus:      oc.Interface_OperStatus_DOWN,
-				expectedMaxOutPower: maxOpticsPowerAdminDown,
-				checkMinOutPower:    false,
-			}, {
-				desc:                "Check output optics power is normal after interface is re-enabled",
-				IntfStatus:          true,
-				expectedStatus:      oc.Interface_OperStatus_UP,
-				expectedMaxOutPower: maxOpticsPower,
-				checkMinOutPower:    true,
-			}}
-			for _, tc := range cases {
-				intUpdateTime := 2 * time.Minute
-				t.Run(tc.desc, func(t *testing.T) {
-					gnmi.Update(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config(), tc.IntfStatus)
-					gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, tc.expectedStatus)
-
-					operPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
-					tracePath(t, operPathStr, statusPass, "Reached expected operational status: %v", tc.expectedStatus)
-
-					transceiverName := gnmi.Get(t, dut, gnmi.OC().Interface(dp.Name()).Transceiver().State())
-					component := gnmi.OC().Component(transceiverName)
-					mfgLookup := gnmi.Lookup(t, dut, component.MfgName().State())
-					mfgName, mfgOk := mfgLookup.Val()
-					mfgPathStr := getPathStr(component.MfgName().State().PathStruct())
-					if !mfgOk || mfgName == "" {
-						tracePath(t, mfgPathStr, statusSkipped, "Skipping: component MfgName not present")
-						t.Skipf("component.MfgName().Lookup(t).IsPresent() for %q is false. skip it", transceiverName)
-					}
-					tracePath(t, mfgPathStr, statusPass, "MfgName: %s", mfgName)
-
-					channels := gnmi.OC().Component(transceiverName).Transceiver().ChannelAny()
-					opts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrTransceiverFt(dut))
-
-					inputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.InputPower().Instant().State())
-					for _, inputPower := range inputPowers {
-						pStr, err := ygot.PathToString(inputPower.Path)
-						if err != nil {
-							pStr = inputPower.Path.String()
-						}
-						inPower, ok := inputPower.Val()
-						if !ok {
-							tracePath(t, pStr, statusFail, "input power is not defined")
-							continue
-						}
-						if inPower > maxOpticsPower || inPower < minOpticsPower {
-							tracePath(t, pStr, statusFail, "value %.2f is outside range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
-						} else {
-							tracePath(t, pStr, statusPass, "value %.2f is within range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
-						}
-					}
-
-					outputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.OutputPower().Instant().State())
-					for _, outputPower := range outputPowers {
-						pStr, err := ygot.PathToString(outputPower.Path)
-						if err != nil {
-							pStr = outputPower.Path.String()
-						}
-						outPower, ok := outputPower.Val()
-						if !ok {
-							tracePath(t, pStr, statusFail, "output power is not defined")
-							continue
-						}
-						if outPower > tc.expectedMaxOutPower {
-							tracePath(t, pStr, statusFail, "value %.2f is above maximum threshold <= %f", outPower, tc.expectedMaxOutPower)
-						} else if tc.checkMinOutPower && outPower < minOpticsPower {
-							tracePath(t, pStr, statusFail, "value %.2f is below minimum threshold >= %f", outPower, minOpticsPower)
-						} else {
-							tracePath(t, pStr, statusPass, "value %.2f is within expected range", outPower)
-						}
-					}
-
-					if deviations.TransceiverThresholdsUnsupported(dut) {
-						tracePath(t, getPathStr(component.Transceiver().ThresholdAny().Severity().State().PathStruct()), statusSkipped, "Skipping verification of transceiver threshold leaves due to deviation")
-					} else {
-						opts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrLaserFt(dut))
-						isPortUp := tc.expectedStatus == oc.Interface_OperStatus_UP
-						for _, sev := range []oc.E_AlarmTypes_OPENCONFIG_ALARM_SEVERITY{
-							oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_WARNING,
-							oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_CRITICAL,
-						} {
-							validateThresholds(t, dut, transceiverName, isPortUp, sev, component, opts)
-						}
-					}
-				})
+			transceiverName := gnmi.Get(t, dut, gnmi.OC().Interface(dp.Name()).Transceiver().State())
+			component := gnmi.OC().Component(transceiverName)
+			mfgLookup := gnmi.Lookup(t, dut, component.MfgName().State())
+			mfgName, mfgOk := mfgLookup.Val()
+			if !mfgOk || mfgName == "" {
+				tracePath(t, getPathStr(component.MfgName().State().PathStruct()), statusSkipped, "Skipping: component MfgName not present")
+				t.Skipf("component MfgName for %q is not present. skip it", transceiverName)
 			}
+
+			t.Run("Disable interface and verify link DOWN, output power drops", func(t *testing.T) {
+				gnmi.Update(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config(), false)
+				gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_DOWN)
+
+				operPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
+				tracePath(t, operPathStr, statusPass, "Reached expected operational status: %v", oc.Interface_OperStatus_DOWN)
+
+				// Validate telemetry when disabled: output power dropped, skip min output power check
+				validateOpticsTelemetry(t, dut, dp, transceiverName, false, false, maxOpticsPowerAdminDown)
+			})
+
+			t.Run("Re-enable interface and verify link UP, telemetry parameters normal", func(t *testing.T) {
+				gnmi.Update(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config(), true)
+				gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
+
+				operPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
+				tracePath(t, operPathStr, statusPass, "Reached expected operational status: %v", oc.Interface_OperStatus_UP)
+
+				// Validate telemetry when enabled: all paths valid and within thresholds
+				validateOpticsTelemetry(t, dut, dp, transceiverName, true, true, maxOpticsPower)
+			})
 		})
 	}
 }
 
+// TestTransceiverConfigEnabled validates transceiver enable/disable lifecycle.
+// When disabled, verifies interface oper-status is not UP.
+// When re-enabled, verifies link returns to UP and telemetry parameters are within thresholds.
 func TestTransceiverConfigEnabled(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	if deviations.TransceiverConfigEnableUnsupported(dut) {
@@ -598,7 +690,7 @@ func TestTransceiverConfigEnabled(t *testing.T) {
 
 	ports := dut.Ports()
 	for _, dp := range ports {
-		t.Run(fmt.Sprintf("Transceiver-Enabled-%s", dp.Name()), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Transceiver-Flap-%s", dp.Name()), func(t *testing.T) {
 			transceiverName := gnmi.Get(t, dut, gnmi.OC().Interface(dp.Name()).Transceiver().State())
 			component := gnmi.OC().Component(transceiverName)
 			mfgLookup := gnmi.Lookup(t, dut, component.MfgName().State())
@@ -621,10 +713,6 @@ func TestTransceiverConfigEnabled(t *testing.T) {
 				}
 			})
 
-			intUpdateTime := 2 * time.Minute
-			opts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrTransceiverFt(dut))
-			channels := transceiver.ChannelAny()
-
 			t.Run("Disable transceiver and verify link is not UP", func(t *testing.T) {
 				gnmi.Update(t, dut, cfgEnabledPath, false)
 				tracePath(t, cfgPathStr, statusPass, "Set transceiver enabled config: false")
@@ -632,12 +720,9 @@ func TestTransceiverConfigEnabled(t *testing.T) {
 				statePath := transceiver.Enabled().State()
 				statePathStr := getPathStr(statePath.PathStruct())
 				if val, ok := gnmi.Lookup(t, dut, statePath).Val(); ok {
-					if !val {
-						tracePath(t, statePathStr, statusPass, "Transceiver enabled state: false")
-					} else {
-						gnmi.Await(t, dut, statePath, intUpdateTime, false)
-						tracePath(t, statePathStr, statusPass, "Transceiver reached enabled state: false")
-					}
+					tracePath(t, statePathStr, statusPass, "Transceiver enabled state: %v", val)
+				} else {
+					tracePath(t, statePathStr, statusSkipped, "Transceiver enabled state not present on device")
 				}
 
 				operPath := gnmi.OC().Interface(dp.Name()).OperStatus().State()
@@ -654,231 +739,24 @@ func TestTransceiverConfigEnabled(t *testing.T) {
 				tracePath(t, operPathStr, statusPass, "Reached expected non-UP operational status: %v", operStatus)
 			})
 
-			t.Run("Re-enable transceiver and verify link is UP, power and laser normal", func(t *testing.T) {
+			t.Run("Re-enable transceiver and verify link is UP, telemetry parameters normal", func(t *testing.T) {
 				gnmi.Update(t, dut, cfgEnabledPath, true)
 				tracePath(t, cfgPathStr, statusPass, "Set transceiver enabled config: true")
 
 				statePath := transceiver.Enabled().State()
 				statePathStr := getPathStr(statePath.PathStruct())
-				if _, ok := gnmi.Lookup(t, dut, statePath).Val(); ok {
-					gnmi.Await(t, dut, statePath, intUpdateTime, true)
-					tracePath(t, statePathStr, statusPass, "Transceiver reached enabled state: true")
+				if val, ok := gnmi.Lookup(t, dut, statePath).Val(); ok {
+					tracePath(t, statePathStr, statusPass, "Transceiver enabled state: %v", val)
+				} else {
+					tracePath(t, statePathStr, statusSkipped, "Transceiver enabled state not present on device")
 				}
 
 				gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
 				operPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
 				tracePath(t, operPathStr, statusPass, "Reached expected operational status: %v", oc.Interface_OperStatus_UP)
 
-				// Verify input powers
-				inputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.InputPower().Instant().State())
-				for _, inputPower := range inputPowers {
-					pStr, err := ygot.PathToString(inputPower.Path)
-					if err != nil {
-						pStr = inputPower.Path.String()
-					}
-					inPower, ok := inputPower.Val()
-					if !ok {
-						tracePath(t, pStr, statusFail, "input power is not defined")
-						continue
-					}
-					if inPower > maxOpticsPower || inPower < minOpticsPower {
-						tracePath(t, pStr, statusFail, "value %.2f is outside range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
-					} else {
-						tracePath(t, pStr, statusPass, "value %.2f is within range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
-					}
-				}
-
-				// Verify output powers
-				outputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.OutputPower().Instant().State())
-				for _, outputPower := range outputPowers {
-					pStr, err := ygot.PathToString(outputPower.Path)
-					if err != nil {
-						pStr = outputPower.Path.String()
-					}
-					outPower, ok := outputPower.Val()
-					if !ok {
-						tracePath(t, pStr, statusFail, "output power is not defined")
-						continue
-					}
-					if outPower > maxOpticsPower || outPower < minOpticsPower {
-						tracePath(t, pStr, statusFail, "value %.2f is outside range [%f, %f]", outPower, minOpticsPower, maxOpticsPower)
-					} else {
-						tracePath(t, pStr, statusPass, "value %.2f is within expected range", outPower)
-					}
-				}
-
-				// Verify laser bias currents
-				biasCurrents := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.LaserBiasCurrent().Instant().State())
-				for _, biasCurrent := range biasCurrents {
-					pStr, err := ygot.PathToString(biasCurrent.Path)
-					if err != nil {
-						pStr = biasCurrent.Path.String()
-					}
-					if v, ok := biasCurrent.Val(); ok {
-						tracePath(t, pStr, statusPass, "Laser bias current value: %v", v)
-					}
-				}
-
-				if !deviations.TransceiverThresholdsUnsupported(dut) {
-					laserOpts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrLaserFt(dut))
-					for _, sev := range []oc.E_AlarmTypes_OPENCONFIG_ALARM_SEVERITY{
-						oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_WARNING,
-						oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_CRITICAL,
-					} {
-						validateThresholds(t, dut, transceiverName, true, sev, component, laserOpts)
-					}
-				}
-			})
-		})
-	}
-}
-
-func TestInterfacesWithTransceivers(t *testing.T) {
-	dut := ondatra.DUT(t, "dut")
-
-	ports := dut.Ports()
-	for _, dp := range ports {
-		t.Run(fmt.Sprintf("Interface:%s", dp.Name()), func(t *testing.T) {
-			intfLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).State())
-			intf, ok := intfLookup.Val()
-			intfNamePath := getPathStr(gnmi.OC().Interface(dp.Name()).Name().State().PathStruct())
-			if !ok || intf == nil || intf.GetName() == "" {
-				tracePath(t, intfNamePath, statusFail, "Failed to retrieve interface name state")
-				t.Fatalf("Failed to retrieve interface name state for %q", dp.Name())
-			}
-			intfName := intf.GetName()
-			tracePath(t, intfNamePath, statusPass, "Interface name: %s", intfName)
-
-			transceiverPath := getPathStr(gnmi.OC().Interface(dp.Name()).Transceiver().State().PathStruct())
-			tv := intf.GetTransceiver()
-			if tv == "" {
-				tracePath(t, transceiverPath, statusFail, "Failed to retrieve transceiver state")
-				t.Fatalf("Failed to retrieve transceiver state for %q", dp.Name())
-			}
-			tracePath(t, transceiverPath, statusPass, "Interface transceiver: %s", tv)
-
-			t.Run(fmt.Sprintf("Transceiver:%s", tv), func(t *testing.T) {
-				compLookup := gnmi.Lookup(t, dut, gnmi.OC().Component(tv).State())
-				comp, compPresent := compLookup.Val()
-				tvPathStr := getPathStr(gnmi.OC().Component(tv).State().PathStruct())
-				if !compPresent || comp == nil || comp.GetMfgName() == "" {
-					tracePath(t, tvPathStr, statusSkipped, "Skipping check for Transceiver: got no MfgName.")
-					t.Skipf("Skipping check for Transceiver: %q, got no MfgName.", tv)
-				}
-				mfgName := comp.GetMfgName()
-
-				ffPath := gnmi.OC().Component(tv).Transceiver().FormFactor().State()
-				formFactor := oc.TransportTypes_TRANSCEIVER_FORM_FACTOR_TYPE_UNSET
-				if comp.GetTransceiver() != nil {
-					formFactor = comp.GetTransceiver().GetFormFactor()
-				}
-				if formFactor == oc.TransportTypes_TRANSCEIVER_FORM_FACTOR_TYPE_UNSET {
-					tracePath(t, getPathStr(ffPath.PathStruct()), statusFail, "transceiver form-factor unset")
-				} else {
-					tracePath(t, getPathStr(ffPath.PathStruct()), statusPass, "MfgName: %s, FormFactor: %v", mfgName, formFactor)
-				}
-
-				// Verify Component Type
-				typePath := gnmi.OC().Component(tv).Type().State()
-				compType := comp.GetType()
-				if compType == nil {
-					tracePath(t, getPathStr(typePath.PathStruct()), statusFail, "Component type is not present")
-				} else {
-					if compType == transceiverType {
-						tracePath(t, getPathStr(typePath.PathStruct()), statusPass, "Component type: %v", compType)
-					} else {
-						tracePath(t, getPathStr(typePath.PathStruct()), statusFail, "Component type: got %v, want PlatformTypes_OPENCONFIG_HARDWARE_COMPONENT_TRANSCEIVER", compType)
-					}
-				}
-
-				// Verify Part Number
-				partNoPath := gnmi.OC().Component(tv).PartNo().State()
-				partNo := comp.GetPartNo()
-				if partNo == "" {
-					tracePath(t, getPathStr(partNoPath.PathStruct()), statusFail, "Part number is not present or empty")
-				} else {
-					tracePath(t, getPathStr(partNoPath.PathStruct()), statusPass, "Part number: %s", partNo)
-				}
-
-				// Verify Serial Number
-				serialNoPath := gnmi.OC().Component(tv).SerialNo().State()
-				serialNo := comp.GetSerialNo()
-				if serialNo == "" {
-					tracePath(t, getPathStr(serialNoPath.PathStruct()), statusFail, "Serial number is not present or empty")
-				} else {
-					tracePath(t, getPathStr(serialNoPath.PathStruct()), statusPass, "Serial number: %s", serialNo)
-				}
-
-				// Verify Firmware Version
-				firmwareVersionPath := gnmi.OC().Component(tv).FirmwareVersion().State()
-				firmwareVersion := comp.GetFirmwareVersion()
-				if firmwareVersion == "" {
-					tracePath(t, getPathStr(firmwareVersionPath.PathStruct()), statusWarning, "Firmware version is not present or empty")
-				} else {
-					tracePath(t, getPathStr(firmwareVersionPath.PathStruct()), statusPass, "Firmware version: %s", firmwareVersion)
-				}
-
-				// Verify Hardware Version
-				hardwareVersionPath := gnmi.OC().Component(tv).HardwareVersion().State()
-				hardwareVersion := comp.GetHardwareVersion()
-				if hardwareVersion == "" {
-					tracePath(t, getPathStr(hardwareVersionPath.PathStruct()), statusFail, "Hardware version is not present or empty")
-				} else {
-					tracePath(t, getPathStr(hardwareVersionPath.PathStruct()), statusPass, "Hardware version: %s", hardwareVersion)
-				}
-
-				// Verify Description
-				descPath := gnmi.OC().Component(tv).Description().State()
-				if deviations.SkipTransceiverDescription(dut) {
-					tracePath(t, getPathStr(descPath.PathStruct()), statusSkipped, "Skipping verification of transceiver description due to deviation")
-				} else {
-					desc := comp.GetDescription()
-					if desc == "" {
-						tracePath(t, getPathStr(descPath.PathStruct()), statusWarning, "Description is not present or empty")
-					} else {
-						tracePath(t, getPathStr(descPath.PathStruct()), statusPass, "Description: %s", desc)
-					}
-				}
-
-				// Verify Mfg Date
-				mfgDatePath := gnmi.OC().Component(tv).MfgDate().State()
-				if deviations.ComponentMfgDateUnsupported(dut) {
-					tracePath(t, getPathStr(mfgDatePath.PathStruct()), statusSkipped, "Skipping verification of transceiver manufacturing date due to deviation")
-				} else {
-					mfgDate := comp.GetMfgDate()
-					if mfgDate == "" {
-						tracePath(t, getPathStr(mfgDatePath.PathStruct()), statusFail, "Manufacturing date is not present or empty")
-					} else {
-						tracePath(t, getPathStr(mfgDatePath.PathStruct()), statusPass, "Manufacturing date: %s", mfgDate)
-					}
-				}
-
-				channelsMap := make(map[uint16]bool)
-				if comp.GetTransceiver() != nil {
-					for chIdx, ch := range comp.GetTransceiver().Channel {
-						channelsMap[chIdx] = true
-						chIndexPath := getPathStr(gnmi.OC().Component(tv).Transceiver().Channel(chIdx).Index().State().PathStruct())
-						if ch != nil && ch.Index != nil {
-							tracePath(t, chIndexPath, statusPass, "Channel index: %d", ch.GetIndex())
-						} else {
-							tracePath(t, chIndexPath, statusPass, "Channel index: %d", chIdx)
-						}
-					}
-				}
-
-				physicalChannel := intf.GetPhysicalChannel()
-				pcPath := getPathStr(gnmi.OC().Interface(dp.Name()).PhysicalChannel().State().PathStruct())
-				if len(physicalChannel) == 0 {
-					tracePath(t, pcPath, statusFail, "physical-channel unset for Interface: %q", intfName)
-				} else {
-					t.Logf("Interface %s physical-channel: %v", dp.Name(), physicalChannel)
-					tracePath(t, pcPath, statusPass, "Physical channels: %v", physicalChannel)
-					for _, p := range physicalChannel {
-						if !channelsMap[p] {
-							t.Errorf("Transceiver %s failed to get channel index %v", tv, p)
-						}
-					}
-				}
+				// Validate telemetry when enabled: all paths valid and within thresholds
+				validateOpticsTelemetry(t, dut, dp, transceiverName, true, true, maxOpticsPower)
 			})
 		})
 	}

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -625,7 +625,7 @@ func TestTransceiverConfigEnabled(t *testing.T) {
 			opts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrTransceiverFt(dut))
 			channels := transceiver.ChannelAny()
 
-			t.Run("Disable transceiver", func(t *testing.T) {
+			t.Run("Disable transceiver and verify link is not UP", func(t *testing.T) {
 				gnmi.Update(t, dut, cfgEnabledPath, false)
 				tracePath(t, cfgPathStr, statusPass, "Set transceiver enabled config: false")
 
@@ -639,6 +639,19 @@ func TestTransceiverConfigEnabled(t *testing.T) {
 						tracePath(t, statePathStr, statusPass, "Transceiver reached enabled state: false")
 					}
 				}
+
+				operPath := gnmi.OC().Interface(dp.Name()).OperStatus().State()
+				operPathStr := getPathStr(operPath.PathStruct())
+				watch := gnmi.Watch(t, dut, operPath, intUpdateTime, func(val *ygnmi.Value[oc.E_Interface_OperStatus]) bool {
+					status, ok := val.Val()
+					return ok && status != oc.Interface_OperStatus_UP
+				})
+				if val, ok := watch.Await(t); !ok {
+					tracePath(t, operPathStr, statusFail, "Interface oper-status remained UP after disabling transceiver")
+					t.Fatalf("Interface %s oper-status remained UP after disabling transceiver: got %v", dp.Name(), val)
+				}
+				operStatus, _ := gnmi.Lookup(t, dut, operPath).Val()
+				tracePath(t, operPathStr, statusPass, "Reached expected non-UP operational status: %v", operStatus)
 			})
 
 			t.Run("Re-enable transceiver and verify link is UP, power and laser normal", func(t *testing.T) {

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -345,6 +345,105 @@ func validateThresholds(t *testing.T, dut *ondatra.DUTDevice, transceiver string
 	}
 }
 
+type checkNestedThresholdParams struct {
+	transceiver   string
+	opts          []ygnmi.Option
+	warnLowerPath ygnmi.SingletonQuery[float64]
+	warnUpperPath ygnmi.SingletonQuery[float64]
+	critLowerPath ygnmi.SingletonQuery[float64]
+	critUpperPath ygnmi.SingletonQuery[float64]
+	name          string
+	ftName        string
+}
+
+func checkNestedThreshold(t *testing.T, dut *ondatra.DUTDevice, params checkNestedThresholdParams) {
+	t.Helper()
+	opts := append([]ygnmi.Option{}, params.opts...)
+	if params.ftName != "" {
+		opts = append(opts, getOptsForFunctionalTranslator(t, dut, params.ftName)...)
+	}
+
+	wlV, wlOK := gnmi.Lookup(t, dut.GNMIOpts().WithYGNMIOpts(opts...), params.warnLowerPath).Val()
+	wuV, wuOK := gnmi.Lookup(t, dut.GNMIOpts().WithYGNMIOpts(opts...), params.warnUpperPath).Val()
+	clV, clOK := gnmi.Lookup(t, dut.GNMIOpts().WithYGNMIOpts(opts...), params.critLowerPath).Val()
+	cuV, cuOK := gnmi.Lookup(t, dut.GNMIOpts().WithYGNMIOpts(opts...), params.critUpperPath).Val()
+
+	warnLowerStr := getPathStr(params.warnLowerPath.PathStruct())
+	warnUpperStr := getPathStr(params.warnUpperPath.PathStruct())
+
+	// Validate nested-threshold rules: critical_lower <= warning_lower and warning_upper <= critical_upper
+	if clOK && wlOK {
+		if clV > wlV {
+			tracePath(t, warnLowerStr, statusFail, "Transceiver %s: critical_lower (%v) must be <= warning_lower (%v) for %s", params.transceiver, clV, wlV, params.name)
+		} else {
+			tracePath(t, warnLowerStr, statusPass, "Transceiver %s: critical_lower (%v) <= warning_lower (%v) for %s", params.transceiver, clV, wlV, params.name)
+		}
+	}
+	if wuOK && cuOK {
+		if wuV > cuV {
+			tracePath(t, warnUpperStr, statusFail, "Transceiver %s: warning_upper (%v) must be <= critical_upper (%v) for %s", params.transceiver, wuV, cuV, params.name)
+		} else {
+			tracePath(t, warnUpperStr, statusPass, "Transceiver %s: warning_upper (%v) <= critical_upper (%v) for %s", params.transceiver, wuV, cuV, params.name)
+		}
+	}
+}
+
+func validateNestedThresholds(t *testing.T, dut *ondatra.DUTDevice, transceiver string, component *platform.ComponentPath, opts []ygnmi.Option) {
+	t.Helper()
+	warnThreshold := component.Transceiver().Threshold(oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_WARNING)
+	critThreshold := component.Transceiver().Threshold(oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_CRITICAL)
+
+	checkNestedThreshold(t, dut, checkNestedThresholdParams{
+		transceiver:   transceiver,
+		opts:          opts,
+		warnLowerPath: warnThreshold.ModuleTemperatureLower().State(),
+		warnUpperPath: warnThreshold.ModuleTemperatureUpper().State(),
+		critLowerPath: critThreshold.ModuleTemperatureLower().State(),
+		critUpperPath: critThreshold.ModuleTemperatureUpper().State(),
+		name:          "module-temperature",
+	})
+	checkNestedThreshold(t, dut, checkNestedThresholdParams{
+		transceiver:   transceiver,
+		opts:          opts,
+		warnLowerPath: warnThreshold.SupplyVoltageLower().State(),
+		warnUpperPath: warnThreshold.SupplyVoltageUpper().State(),
+		critLowerPath: critThreshold.SupplyVoltageLower().State(),
+		critUpperPath: critThreshold.SupplyVoltageUpper().State(),
+		name:          "supply-voltage",
+		ftName:        deviations.CiscoxrTransceiverFt(dut),
+	})
+	checkNestedThreshold(t, dut, checkNestedThresholdParams{
+		transceiver:   transceiver,
+		opts:          opts,
+		warnLowerPath: warnThreshold.InputPowerLower().State(),
+		warnUpperPath: warnThreshold.InputPowerUpper().State(),
+		critLowerPath: critThreshold.InputPowerLower().State(),
+		critUpperPath: critThreshold.InputPowerUpper().State(),
+		name:          "input-power",
+		ftName:        deviations.CiscoxrTransceiverFt(dut),
+	})
+	checkNestedThreshold(t, dut, checkNestedThresholdParams{
+		transceiver:   transceiver,
+		opts:          opts,
+		warnLowerPath: warnThreshold.OutputPowerLower().State(),
+		warnUpperPath: warnThreshold.OutputPowerUpper().State(),
+		critLowerPath: critThreshold.OutputPowerLower().State(),
+		critUpperPath: critThreshold.OutputPowerUpper().State(),
+		name:          "output-power",
+		ftName:        deviations.CiscoxrTransceiverFt(dut),
+	})
+	checkNestedThreshold(t, dut, checkNestedThresholdParams{
+		transceiver:   transceiver,
+		opts:          opts,
+		warnLowerPath: warnThreshold.LaserBiasCurrentLower().State(),
+		warnUpperPath: warnThreshold.LaserBiasCurrentUpper().State(),
+		critLowerPath: critThreshold.LaserBiasCurrentLower().State(),
+		critUpperPath: critThreshold.LaserBiasCurrentUpper().State(),
+		name:          "laser-bias-current",
+		ftName:        deviations.CiscoxrTransceiverFt(dut),
+	})
+}
+
 func validateOpticsTelemetry(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port, transceiverName string, isPortUp bool, checkMinOutPower bool, expectedMaxOutPower float64) {
 	t.Helper()
 	component := gnmi.OC().Component(transceiverName)
@@ -486,6 +585,7 @@ func validateOpticsTelemetry(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.P
 		} {
 			validateThresholds(t, dut, transceiverName, isPortUp, sev, component, laserOpts)
 		}
+		validateNestedThresholds(t, dut, transceiverName, component, laserOpts)
 	}
 }
 

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -16,6 +16,7 @@ package client_optics_dom_telemetry_test
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -241,6 +242,42 @@ func checkThreshold(t *testing.T, dut *ondatra.DUTDevice, params checkThresholdP
 	}
 }
 
+func getTransceiverChannelIndices(t *testing.T, dut *ondatra.DUTDevice, transceiverName string) []uint16 {
+	t.Helper()
+	component := gnmi.OC().Component(transceiverName)
+	seen := make(map[uint16]bool)
+	var indices []uint16
+
+	for _, chRes := range gnmi.LookupAll(t, dut, component.Transceiver().ChannelAny().Index().State()) {
+		if idx, ok := chRes.Val(); ok && !seen[idx] {
+			seen[idx] = true
+			indices = append(indices, idx)
+		}
+	}
+
+	if len(indices) == 0 {
+		compLookup := gnmi.Lookup(t, dut, component.State())
+		if comp, ok := compLookup.Val(); ok && comp != nil && comp.GetTransceiver() != nil {
+			for chIdx := range comp.GetTransceiver().Channel {
+				if !seen[chIdx] {
+					seen[chIdx] = true
+					indices = append(indices, chIdx)
+				}
+			}
+		}
+	}
+
+	if len(indices) == 0 {
+		indices = append(indices, 0)
+	}
+
+	sort.Slice(indices, func(i, j int) bool {
+		return indices[i] < indices[j]
+	})
+
+	return indices
+}
+
 func validateThresholds(t *testing.T, dut *ondatra.DUTDevice, transceiver string, isPortUp bool, sev oc.E_AlarmTypes_OPENCONFIG_ALARM_SEVERITY, component *platform.ComponentPath, opts []ygnmi.Option) {
 	t.Helper()
 	threshold := component.Transceiver().Threshold(sev)
@@ -266,42 +303,46 @@ func validateThresholds(t *testing.T, dut *ondatra.DUTDevice, transceiver string
 		transceiver: transceiver,
 		isPortUp:    isPortUp,
 		opts:        opts,
-		lowerPath:   threshold.InputPowerLower().State(),
-		upperPath:   threshold.InputPowerUpper().State(),
-		instantPath: component.Transceiver().Channel(0).InputPower().Instant().State(),
-		name:        "input-power",
-		ftName:      deviations.CiscoxrTransceiverFt(dut),
-	})
-	checkThreshold(t, dut, checkThresholdParams{
-		transceiver: transceiver,
-		isPortUp:    isPortUp,
-		opts:        opts,
-		lowerPath:   threshold.OutputPowerLower().State(),
-		upperPath:   threshold.OutputPowerUpper().State(),
-		instantPath: component.Transceiver().Channel(0).OutputPower().Instant().State(),
-		name:        "output-power",
-		ftName:      deviations.CiscoxrTransceiverFt(dut),
-	})
-	checkThreshold(t, dut, checkThresholdParams{
-		transceiver: transceiver,
-		isPortUp:    isPortUp,
-		opts:        opts,
-		lowerPath:   threshold.LaserBiasCurrentLower().State(),
-		upperPath:   threshold.LaserBiasCurrentUpper().State(),
-		instantPath: component.Transceiver().Channel(0).LaserBiasCurrent().Instant().State(),
-		name:        "laser-bias-current",
-		ftName:      deviations.CiscoxrTransceiverFt(dut),
-	})
-	checkThreshold(t, dut, checkThresholdParams{
-		transceiver: transceiver,
-		isPortUp:    isPortUp,
-		opts:        opts,
 		lowerPath:   threshold.SupplyVoltageLower().State(),
 		upperPath:   threshold.SupplyVoltageUpper().State(),
 		instantPath: component.Transceiver().SupplyVoltage().Instant().State(),
 		name:        "supply-voltage",
 		ftName:      deviations.CiscoxrTransceiverFt(dut),
 	})
+
+	channelIndices := getTransceiverChannelIndices(t, dut, transceiver)
+	for _, chIdx := range channelIndices {
+		checkThreshold(t, dut, checkThresholdParams{
+			transceiver: transceiver,
+			isPortUp:    isPortUp,
+			opts:        opts,
+			lowerPath:   threshold.InputPowerLower().State(),
+			upperPath:   threshold.InputPowerUpper().State(),
+			instantPath: component.Transceiver().Channel(chIdx).InputPower().Instant().State(),
+			name:        "input-power",
+			ftName:      deviations.CiscoxrTransceiverFt(dut),
+		})
+		checkThreshold(t, dut, checkThresholdParams{
+			transceiver: transceiver,
+			isPortUp:    isPortUp,
+			opts:        opts,
+			lowerPath:   threshold.OutputPowerLower().State(),
+			upperPath:   threshold.OutputPowerUpper().State(),
+			instantPath: component.Transceiver().Channel(chIdx).OutputPower().Instant().State(),
+			name:        "output-power",
+			ftName:      deviations.CiscoxrTransceiverFt(dut),
+		})
+		checkThreshold(t, dut, checkThresholdParams{
+			transceiver: transceiver,
+			isPortUp:    isPortUp,
+			opts:        opts,
+			lowerPath:   threshold.LaserBiasCurrentLower().State(),
+			upperPath:   threshold.LaserBiasCurrentUpper().State(),
+			instantPath: component.Transceiver().Channel(chIdx).LaserBiasCurrent().Instant().State(),
+			name:        "laser-bias-current",
+			ftName:      deviations.CiscoxrTransceiverFt(dut),
+		})
+	}
 }
 
 func validateOpticsTelemetry(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.Port, transceiverName string, isPortUp bool, checkMinOutPower bool, expectedMaxOutPower float64) {
@@ -339,28 +380,38 @@ func validateOpticsTelemetry(t *testing.T, dut *ondatra.DUTDevice, dp *ondatra.P
 	}
 
 	// Validate Output Powers
-	outputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.OutputPower().Instant().State())
-	outputPowerPathStr := getPathStr(channels.OutputPower().Instant().State().PathStruct())
-	if len(outputPowers) == 0 {
-		tracePath(t, outputPowerPathStr, statusFail, "Get outputPowers list: got 0, want > 0")
-	} else {
-		for _, outputPower := range outputPowers {
-			pStr, err := ygot.PathToString(outputPower.Path)
-			if err != nil {
-				pStr = outputPower.Path.String()
-			}
-			outPower, ok := outputPower.Val()
+	chIndices := getTransceiverChannelIndices(t, dut, transceiverName)
+	for _, chIdx := range chIndices {
+		outPowerQuery := component.Transceiver().Channel(chIdx).OutputPower().Instant().State()
+		outPowerPathStr := getPathStr(outPowerQuery.PathStruct())
+		watch := gnmi.Watch(t, dut.GNMIOpts().WithYGNMIOpts(opts...), outPowerQuery, intUpdateTime, func(val *ygnmi.Value[float64]) bool {
+			outPower, ok := val.Val()
 			if !ok {
-				tracePath(t, pStr, statusFail, "output power is not defined")
-				continue
+				return false
 			}
 			if outPower > expectedMaxOutPower {
-				tracePath(t, pStr, statusFail, "value %.2f is above maximum threshold <= %f", outPower, expectedMaxOutPower)
-			} else if checkMinOutPower && outPower < minOpticsPower {
-				tracePath(t, pStr, statusFail, "value %.2f is below minimum threshold >= %f", outPower, minOpticsPower)
-			} else {
-				tracePath(t, pStr, statusPass, "value %.2f is within expected range", outPower)
+				return false
 			}
+			if checkMinOutPower && outPower < minOpticsPower {
+				return false
+			}
+			return true
+		})
+		val, ok := watch.Await(t)
+		if !ok {
+			outPower, valOk := val.Val()
+			if !valOk {
+				tracePath(t, outPowerPathStr, statusFail, "output power is not defined")
+			} else if outPower > expectedMaxOutPower {
+				tracePath(t, outPowerPathStr, statusFail, "value %.2f is above maximum threshold <= %f", outPower, expectedMaxOutPower)
+			} else if checkMinOutPower && outPower < minOpticsPower {
+				tracePath(t, outPowerPathStr, statusFail, "value %.2f is below minimum threshold >= %f", outPower, minOpticsPower)
+			} else {
+				tracePath(t, outPowerPathStr, statusFail, "output power check timed out")
+			}
+		} else {
+			outPower, _ := val.Val()
+			tracePath(t, outPowerPathStr, statusPass, "value %.2f is within expected range", outPower)
 		}
 	}
 
@@ -717,14 +768,6 @@ func TestTransceiverConfigEnabled(t *testing.T) {
 				gnmi.Update(t, dut, cfgEnabledPath, false)
 				tracePath(t, cfgPathStr, statusPass, "Set transceiver enabled config: false")
 
-				statePath := transceiver.Enabled().State()
-				statePathStr := getPathStr(statePath.PathStruct())
-				if val, ok := gnmi.Lookup(t, dut, statePath).Val(); ok {
-					tracePath(t, statePathStr, statusPass, "Transceiver enabled state: %v", val)
-				} else {
-					tracePath(t, statePathStr, statusSkipped, "Transceiver enabled state not present on device")
-				}
-
 				operPath := gnmi.OC().Interface(dp.Name()).OperStatus().State()
 				operPathStr := getPathStr(operPath.PathStruct())
 				watch := gnmi.Watch(t, dut, operPath, intUpdateTime, func(val *ygnmi.Value[oc.E_Interface_OperStatus]) bool {
@@ -737,23 +780,57 @@ func TestTransceiverConfigEnabled(t *testing.T) {
 				}
 				operStatus, _ := gnmi.Lookup(t, dut, operPath).Val()
 				tracePath(t, operPathStr, statusPass, "Reached expected non-UP operational status: %v", operStatus)
+
+				statePath := transceiver.Enabled().State()
+				statePathStr := getPathStr(statePath.PathStruct())
+				if deviations.TransceiverStateUnsupported(dut) {
+					tracePath(t, statePathStr, statusSkipped, "Skipping transceiver enabled state check due to deviation")
+				} else {
+					stateWatch := gnmi.Watch(t, dut, statePath, intUpdateTime, func(val *ygnmi.Value[bool]) bool {
+						v, ok := val.Val()
+						return ok && !v
+					})
+					if val, ok := stateWatch.Await(t); ok {
+						v, _ := val.Val()
+						tracePath(t, statePathStr, statusPass, "Transceiver enabled state: %v", v)
+					} else {
+						if v, ok := gnmi.Lookup(t, dut, statePath).Val(); ok {
+							tracePath(t, statePathStr, statusFail, "Transceiver enabled state: got %v, want false", v)
+						} else {
+							tracePath(t, statePathStr, statusSkipped, "Transceiver enabled state not present on device")
+						}
+					}
+				}
 			})
 
 			t.Run("Re-enable transceiver and verify link is UP, telemetry parameters normal", func(t *testing.T) {
 				gnmi.Update(t, dut, cfgEnabledPath, true)
 				tracePath(t, cfgPathStr, statusPass, "Set transceiver enabled config: true")
 
-				statePath := transceiver.Enabled().State()
-				statePathStr := getPathStr(statePath.PathStruct())
-				if val, ok := gnmi.Lookup(t, dut, statePath).Val(); ok {
-					tracePath(t, statePathStr, statusPass, "Transceiver enabled state: %v", val)
-				} else {
-					tracePath(t, statePathStr, statusSkipped, "Transceiver enabled state not present on device")
-				}
-
 				gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
 				operPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
 				tracePath(t, operPathStr, statusPass, "Reached expected operational status: %v", oc.Interface_OperStatus_UP)
+
+				statePath := transceiver.Enabled().State()
+				statePathStr := getPathStr(statePath.PathStruct())
+				if deviations.TransceiverStateUnsupported(dut) {
+					tracePath(t, statePathStr, statusSkipped, "Skipping transceiver enabled state check due to deviation")
+				} else {
+					stateWatch := gnmi.Watch(t, dut, statePath, intUpdateTime, func(val *ygnmi.Value[bool]) bool {
+						v, ok := val.Val()
+						return ok && v
+					})
+					if val, ok := stateWatch.Await(t); ok {
+						v, _ := val.Val()
+						tracePath(t, statePathStr, statusPass, "Transceiver enabled state: %v", v)
+					} else {
+						if v, ok := gnmi.Lookup(t, dut, statePath).Val(); ok {
+							tracePath(t, statePathStr, statusFail, "Transceiver enabled state: got %v, want true", v)
+						} else {
+							tracePath(t, statePathStr, statusSkipped, "Transceiver enabled state not present on device")
+						}
+					}
+				}
 
 				// Validate telemetry when enabled: all paths valid and within thresholds
 				validateOpticsTelemetry(t, dut, dp, transceiverName, true, true, maxOpticsPower)

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -589,6 +589,96 @@ func TestOpticsPowerUpdate(t *testing.T) {
 	}
 }
 
+func TestTransceiverConfigEnabled(t *testing.T) {
+	dut := ondatra.DUT(t, "dut")
+	if deviations.TransceiverConfigEnableUnsupported(dut) {
+		tracePath(t, getPathStr(gnmi.OC().ComponentAny().Transceiver().Enabled().Config().PathStruct()), statusSkipped, "Skipping transceiver enabled config test due to deviation")
+		t.Skip("Skipping TestTransceiverConfigEnabled: TransceiverConfigEnableUnsupported is true")
+	}
+
+	ports := dut.Ports()
+	for _, dp := range ports {
+		t.Run(fmt.Sprintf("Transceiver-Enabled-%s", dp.Name()), func(t *testing.T) {
+			transceiverName := gnmi.Get(t, dut, gnmi.OC().Interface(dp.Name()).Transceiver().State())
+			component := gnmi.OC().Component(transceiverName)
+			mfgLookup := gnmi.Lookup(t, dut, component.MfgName().State())
+			mfgName, mfgOk := mfgLookup.Val()
+			if !mfgOk || mfgName == "" {
+				tracePath(t, getPathStr(component.MfgName().State().PathStruct()), statusSkipped, "Skipping: component MfgName not present")
+				t.Skipf("component MfgName for %q is not present. skip it", transceiverName)
+			}
+
+			transceiver := component.Transceiver()
+			cfgEnabledPath := transceiver.Enabled().Config()
+			cfgPathStr := getPathStr(cfgEnabledPath.PathStruct())
+
+			originalEnabled, present := gnmi.Lookup(t, dut, cfgEnabledPath).Val()
+			t.Cleanup(func() {
+				if present {
+					gnmi.Update(t, dut, cfgEnabledPath, originalEnabled)
+				} else {
+					gnmi.Delete(t, dut, cfgEnabledPath)
+				}
+			})
+
+			cases := []struct {
+				desc                string
+				enabled             bool
+				expectedStatus      oc.E_Interface_OperStatus
+				expectedMaxOutPower float64
+				checkMinOutPower    bool
+			}{{
+				desc:                "Disable transceiver and verify output power drops",
+				enabled:             false,
+				expectedStatus:      oc.Interface_OperStatus_DOWN,
+				expectedMaxOutPower: maxOpticsPowerAdminDown,
+				checkMinOutPower:    false,
+			}, {
+				desc:                "Re-enable transceiver and verify output power is normal",
+				enabled:             true,
+				expectedStatus:      oc.Interface_OperStatus_UP,
+				expectedMaxOutPower: maxOpticsPower,
+				checkMinOutPower:    true,
+			}}
+
+			intUpdateTime := 2 * time.Minute
+			opts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrTransceiverFt(dut))
+			channels := transceiver.ChannelAny()
+
+			for _, tc := range cases {
+				t.Run(tc.desc, func(t *testing.T) {
+					gnmi.Update(t, dut, cfgEnabledPath, tc.enabled)
+					tracePath(t, cfgPathStr, statusPass, "Set transceiver enabled config: %v", tc.enabled)
+
+					gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, tc.expectedStatus)
+					operPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
+					tracePath(t, operPathStr, statusPass, "Reached expected operational status: %v", tc.expectedStatus)
+
+					outputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.OutputPower().Instant().State())
+					for _, outputPower := range outputPowers {
+						pStr, err := ygot.PathToString(outputPower.Path)
+						if err != nil {
+							pStr = outputPower.Path.String()
+						}
+						outPower, ok := outputPower.Val()
+						if !ok {
+							tracePath(t, pStr, statusFail, "output power is not defined")
+							continue
+						}
+						if outPower > tc.expectedMaxOutPower {
+							tracePath(t, pStr, statusFail, "value %.2f is above maximum threshold <= %f", outPower, tc.expectedMaxOutPower)
+						} else if tc.checkMinOutPower && outPower < minOpticsPower {
+							tracePath(t, pStr, statusFail, "value %.2f is below minimum threshold >= %f", outPower, minOpticsPower)
+						} else {
+							tracePath(t, pStr, statusPass, "value %.2f is within expected range", outPower)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestInterfacesWithTransceivers(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -244,6 +244,14 @@ func validateThresholds(t *testing.T, dut *ondatra.DUTDevice, transceiver string
 	t.Helper()
 	threshold := component.Transceiver().Threshold(sev)
 
+	sevPath := threshold.Severity().State()
+	sevLookup := gnmi.Lookup(t, dut.GNMIOpts().WithYGNMIOpts(opts...), sevPath)
+	if sevVal, ok := sevLookup.Val(); ok {
+		tracePath(t, getPathStr(sevPath.PathStruct()), statusPass, "Severity: %v", sevVal)
+	} else {
+		tracePath(t, getPathStr(sevPath.PathStruct()), statusPass, "Severity: %v", sev)
+	}
+
 	checkThreshold(t, dut, checkThresholdParams{
 		transceiver: transceiver,
 		isPortUp:    isPortUp,
@@ -615,14 +623,15 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 				}
 				mfgName := comp.GetMfgName()
 
+				ffPath := gnmi.OC().Component(tv).Transceiver().FormFactor().State()
 				formFactor := oc.TransportTypes_TRANSCEIVER_FORM_FACTOR_TYPE_UNSET
 				if comp.GetTransceiver() != nil {
 					formFactor = comp.GetTransceiver().GetFormFactor()
 				}
 				if formFactor == oc.TransportTypes_TRANSCEIVER_FORM_FACTOR_TYPE_UNSET {
-					tracePath(t, tvPathStr, statusFail, "transceiver form-factor unset")
+					tracePath(t, getPathStr(ffPath.PathStruct()), statusFail, "transceiver form-factor unset")
 				} else {
-					tracePath(t, tvPathStr, statusPass, "MfgName: %s, FormFactor: %v", mfgName, formFactor)
+					tracePath(t, getPathStr(ffPath.PathStruct()), statusPass, "MfgName: %s, FormFactor: %v", mfgName, formFactor)
 				}
 
 				// Verify Component Type
@@ -702,8 +711,14 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 
 				channelsMap := make(map[uint16]bool)
 				if comp.GetTransceiver() != nil {
-					for chIdx := range comp.GetTransceiver().Channel {
+					for chIdx, ch := range comp.GetTransceiver().Channel {
 						channelsMap[chIdx] = true
+						chIndexPath := getPathStr(gnmi.OC().Component(tv).Transceiver().Channel(chIdx).Index().State().PathStruct())
+						if ch != nil && ch.Index != nil {
+							tracePath(t, chIndexPath, statusPass, "Channel index: %d", ch.GetIndex())
+						} else {
+							tracePath(t, chIndexPath, statusPass, "Channel index: %d", chIdx)
+						}
 					}
 				}
 

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -621,60 +621,87 @@ func TestTransceiverConfigEnabled(t *testing.T) {
 				}
 			})
 
-			cases := []struct {
-				desc                string
-				enabled             bool
-				expectedStatus      oc.E_Interface_OperStatus
-				expectedMaxOutPower float64
-				checkMinOutPower    bool
-			}{{
-				desc:                "Disable transceiver and verify output power drops",
-				enabled:             false,
-				expectedStatus:      oc.Interface_OperStatus_DOWN,
-				expectedMaxOutPower: maxOpticsPowerAdminDown,
-				checkMinOutPower:    false,
-			}, {
-				desc:                "Re-enable transceiver and verify output power is normal",
-				enabled:             true,
-				expectedStatus:      oc.Interface_OperStatus_UP,
-				expectedMaxOutPower: maxOpticsPower,
-				checkMinOutPower:    true,
-			}}
-
 			intUpdateTime := 2 * time.Minute
 			opts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrTransceiverFt(dut))
 			channels := transceiver.ChannelAny()
 
-			for _, tc := range cases {
-				t.Run(tc.desc, func(t *testing.T) {
-					gnmi.Update(t, dut, cfgEnabledPath, tc.enabled)
-					tracePath(t, cfgPathStr, statusPass, "Set transceiver enabled config: %v", tc.enabled)
+			t.Run("Disable transceiver and verify link is DOWN", func(t *testing.T) {
+				gnmi.Update(t, dut, cfgEnabledPath, false)
+				tracePath(t, cfgPathStr, statusPass, "Set transceiver enabled config: false")
 
-					gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, tc.expectedStatus)
-					operPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
-					tracePath(t, operPathStr, statusPass, "Reached expected operational status: %v", tc.expectedStatus)
+				gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_DOWN)
+				operPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
+				tracePath(t, operPathStr, statusPass, "Reached expected operational status: %v", oc.Interface_OperStatus_DOWN)
+			})
 
-					outputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.OutputPower().Instant().State())
-					for _, outputPower := range outputPowers {
-						pStr, err := ygot.PathToString(outputPower.Path)
-						if err != nil {
-							pStr = outputPower.Path.String()
-						}
-						outPower, ok := outputPower.Val()
-						if !ok {
-							tracePath(t, pStr, statusFail, "output power is not defined")
-							continue
-						}
-						if outPower > tc.expectedMaxOutPower {
-							tracePath(t, pStr, statusFail, "value %.2f is above maximum threshold <= %f", outPower, tc.expectedMaxOutPower)
-						} else if tc.checkMinOutPower && outPower < minOpticsPower {
-							tracePath(t, pStr, statusFail, "value %.2f is below minimum threshold >= %f", outPower, minOpticsPower)
-						} else {
-							tracePath(t, pStr, statusPass, "value %.2f is within expected range", outPower)
-						}
+			t.Run("Re-enable transceiver and verify link is UP, power and laser normal", func(t *testing.T) {
+				gnmi.Update(t, dut, cfgEnabledPath, true)
+				tracePath(t, cfgPathStr, statusPass, "Set transceiver enabled config: true")
+
+				gnmi.Await(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State(), intUpdateTime, oc.Interface_OperStatus_UP)
+				operPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
+				tracePath(t, operPathStr, statusPass, "Reached expected operational status: %v", oc.Interface_OperStatus_UP)
+
+				// Verify input powers
+				inputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.InputPower().Instant().State())
+				for _, inputPower := range inputPowers {
+					pStr, err := ygot.PathToString(inputPower.Path)
+					if err != nil {
+						pStr = inputPower.Path.String()
 					}
-				})
-			}
+					inPower, ok := inputPower.Val()
+					if !ok {
+						tracePath(t, pStr, statusFail, "input power is not defined")
+						continue
+					}
+					if inPower > maxOpticsPower || inPower < minOpticsPower {
+						tracePath(t, pStr, statusFail, "value %.2f is outside range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
+					} else {
+						tracePath(t, pStr, statusPass, "value %.2f is within range [%f, %f]", inPower, minOpticsPower, maxOpticsPower)
+					}
+				}
+
+				// Verify output powers
+				outputPowers := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.OutputPower().Instant().State())
+				for _, outputPower := range outputPowers {
+					pStr, err := ygot.PathToString(outputPower.Path)
+					if err != nil {
+						pStr = outputPower.Path.String()
+					}
+					outPower, ok := outputPower.Val()
+					if !ok {
+						tracePath(t, pStr, statusFail, "output power is not defined")
+						continue
+					}
+					if outPower > maxOpticsPower || outPower < minOpticsPower {
+						tracePath(t, pStr, statusFail, "value %.2f is outside range [%f, %f]", outPower, minOpticsPower, maxOpticsPower)
+					} else {
+						tracePath(t, pStr, statusPass, "value %.2f is within expected range", outPower)
+					}
+				}
+
+				// Verify laser bias currents
+				biasCurrents := gnmi.LookupAll(t, dut.GNMIOpts().WithYGNMIOpts(opts...), channels.LaserBiasCurrent().Instant().State())
+				for _, biasCurrent := range biasCurrents {
+					pStr, err := ygot.PathToString(biasCurrent.Path)
+					if err != nil {
+						pStr = biasCurrent.Path.String()
+					}
+					if v, ok := biasCurrent.Val(); ok {
+						tracePath(t, pStr, statusPass, "Laser bias current value: %v", v)
+					}
+				}
+
+				if !deviations.TransceiverThresholdsUnsupported(dut) {
+					laserOpts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrLaserFt(dut))
+					for _, sev := range []oc.E_AlarmTypes_OPENCONFIG_ALARM_SEVERITY{
+						oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_WARNING,
+						oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_CRITICAL,
+					} {
+						validateThresholds(t, dut, transceiverName, true, sev, component, laserOpts)
+					}
+				}
+			})
 		})
 	}
 }

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -301,36 +301,38 @@ func TestOpticsPowerBiasCurrent(t *testing.T) {
 	ports := dut.Ports()
 	for _, dp := range ports {
 		t.Run(dp.Name(), func(t *testing.T) {
-			transceiverPath := gnmi.OC().Interface(dp.Name()).Transceiver().State().PathStruct()
-			transceiverLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).Transceiver().State())
-			transceiverName, ok := transceiverLookup.Val()
-			if !ok || transceiverName == "" {
-				tracePath(t, getPathStr(transceiverPath), statusFail, "Failed to find transceiver for port %q", dp.Name())
+			intfLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).State())
+			intf, intfPresent := intfLookup.Val()
+			transceiverPath := getPathStr(gnmi.OC().Interface(dp.Name()).Transceiver().State().PathStruct())
+			if !intfPresent || intf == nil || intf.GetTransceiver() == "" {
+				tracePath(t, transceiverPath, statusFail, "Failed to find transceiver for port %q", dp.Name())
 				t.Fatalf("Failed to find transceiver for port %q", dp.Name())
 			}
-			tracePath(t, getPathStr(transceiverPath), statusPass, "Transceiver: %s", transceiverName)
+			transceiverName := intf.GetTransceiver()
+			tracePath(t, transceiverPath, statusPass, "Transceiver: %s", transceiverName)
 
 			component := gnmi.OC().Component(transceiverName)
-			mfgLookup := gnmi.Lookup(t, dut, component.MfgName().State())
-			mfgName, ok := mfgLookup.Val()
-			if !ok {
-				tracePath(t, getPathStr(component.MfgName().State().PathStruct()), statusFail, "MfgName not defined")
+			compLookup := gnmi.Lookup(t, dut, component.State())
+			comp, compPresent := compLookup.Val()
+			mfgPathStr := getPathStr(component.MfgName().State().PathStruct())
+			if !compPresent || comp == nil || comp.GetMfgName() == "" {
+				tracePath(t, mfgPathStr, statusFail, "MfgName not defined")
 			} else {
-				tracePath(t, getPathStr(component.MfgName().State().PathStruct()), statusPass, "MfgName: %s", mfgName)
+				tracePath(t, mfgPathStr, statusPass, "MfgName: %s", comp.GetMfgName())
 			}
 
 			// Check admin status using state/admin-status and config/enabled
-			adminStatusLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).AdminStatus().State())
-			adminStatus, adminStatusPresent := adminStatusLookup.Val()
 			adminStatusPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).AdminStatus().State().PathStruct())
+			adminStatus := intf.GetAdminStatus()
+			adminStatusPresent := intf.AdminStatus != oc.Interface_AdminStatus_UNSET
 
 			configEnabledLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config())
 			configEnabled, configEnabledPresent := configEnabledLookup.Val()
 			configEnabledPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).Enabled().Config().PathStruct())
 
-			operStatusLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State())
-			operStatus, operStatusPresent := operStatusLookup.Val()
 			operStatusPathStr := getPathStr(gnmi.OC().Interface(dp.Name()).OperStatus().State().PathStruct())
+			operStatus := intf.GetOperStatus()
+			operStatusPresent := intf.OperStatus != oc.Interface_OperStatus_UNSET
 
 			isAdminDown := false
 			if adminStatusPresent && adminStatus == oc.Interface_AdminStatus_DOWN {
@@ -412,37 +414,34 @@ func TestOpticsPowerBiasCurrent(t *testing.T) {
 				}
 			}
 
-			subcomponentNames := gnmi.LookupAll[string](t, dut, component.SubcomponentAny().Name().State())
 			sensorComponentChecked := false
-			for _, s := range subcomponentNames {
-				subcName, ok := s.Val()
-				if ok {
-					sensorTypeLookup := gnmi.Lookup(t, dut, gnmi.OC().Component(subcName).Type().State())
-					sType, ok := sensorTypeLookup.Val()
-					if ok && sType == sensorType {
-						scomponent := gnmi.OC().Component(subcName)
-						descLookup := gnmi.Lookup(t, dut, scomponent.Description().State())
-						desc, _ := descLookup.Val()
+			if compPresent && comp != nil {
+				for _, subc := range comp.Subcomponent {
+					if subc == nil || subc.GetName() == "" {
+						continue
+					}
+					subcName := subc.GetName()
+					scompLookup := gnmi.Lookup(t, dut, gnmi.OC().Component(subcName).State())
+					if scomp, ok := scompLookup.Val(); ok && scomp != nil && scomp.GetType() == sensorType {
+						desc := scomp.GetDescription()
 						if !deviations.TemperatureSensorCheck(dut) || strings.Contains(desc, "Temperature Sensor") {
 							sensorComponentChecked = true
-							tempPathStr := getPathStr(scomponent.Temperature().Instant().State().PathStruct())
-							v := gnmi.Lookup(t, dut, scomponent.Temperature().Instant().State())
-							if val, ok := v.Val(); !ok {
+							tempPathStr := getPathStr(gnmi.OC().Component(subcName).Temperature().Instant().State().PathStruct())
+							if scomp.GetTemperature() == nil || scomp.GetTemperature().Instant == nil {
 								tracePath(t, tempPathStr, statusFail, "Sensor %s: Temperature instant is not defined", subcName)
 							} else {
-								tracePath(t, tempPathStr, statusPass, "Temperature value: %v", val)
+								tracePath(t, tempPathStr, statusPass, "Temperature value: %v", scomp.GetTemperature().GetInstant())
 							}
 						}
 					}
 				}
 			}
-			if len(subcomponentNames) == 0 || !sensorComponentChecked {
+			if !sensorComponentChecked {
 				tempPathStr := getPathStr(component.Temperature().Instant().State().PathStruct())
-				v := gnmi.Lookup(t, dut, component.Temperature().Instant().State())
-				if val, ok := v.Val(); !ok {
+				if !compPresent || comp == nil || comp.GetTemperature() == nil || comp.GetTemperature().Instant == nil {
 					tracePath(t, tempPathStr, statusFail, "Transceiver %s: Temperature instant is not defined", transceiverName)
 				} else {
-					tracePath(t, tempPathStr, statusPass, "Temperature value: %v", val)
+					tracePath(t, tempPathStr, statusPass, "Temperature value: %v", comp.GetTemperature().GetInstant())
 				}
 			}
 
@@ -452,8 +451,7 @@ func TestOpticsPowerBiasCurrent(t *testing.T) {
 			}
 
 			laserOpts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrLaserFt(dut))
-			operStatusVal := gnmi.Get(t, dut, gnmi.OC().Interface(dp.Name()).OperStatus().State())
-			isPortUp := operStatusVal == oc.Interface_OperStatus_UP
+			isPortUp := operStatus == oc.Interface_OperStatus_UP
 			for _, sev := range []oc.E_AlarmTypes_OPENCONFIG_ALARM_SEVERITY{
 				oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_WARNING,
 				oc.AlarmTypes_OPENCONFIG_ALARM_SEVERITY_CRITICAL,
@@ -513,13 +511,14 @@ func TestOpticsPowerUpdate(t *testing.T) {
 
 					transceiverName := gnmi.Get(t, dut, gnmi.OC().Interface(dp.Name()).Transceiver().State())
 					component := gnmi.OC().Component(transceiverName)
-					if !gnmi.Lookup(t, dut, component.MfgName().State()).IsPresent() {
-						tracePath(t, getPathStr(component.MfgName().State().PathStruct()), statusSkipped, "Skipping: component MfgName not present")
+					mfgLookup := gnmi.Lookup(t, dut, component.MfgName().State())
+					mfgName, mfgOk := mfgLookup.Val()
+					mfgPathStr := getPathStr(component.MfgName().State().PathStruct())
+					if !mfgOk || mfgName == "" {
+						tracePath(t, mfgPathStr, statusSkipped, "Skipping: component MfgName not present")
 						t.Skipf("component.MfgName().Lookup(t).IsPresent() for %q is false. skip it", transceiverName)
 					}
-
-					mfgName := gnmi.Get(t, dut, component.MfgName().State())
-					tracePath(t, getPathStr(component.MfgName().State().PathStruct()), statusPass, "MfgName: %s", mfgName)
+					tracePath(t, mfgPathStr, statusPass, "MfgName: %s", mfgName)
 
 					channels := gnmi.OC().Component(transceiverName).Transceiver().ChannelAny()
 					opts := getOptsForFunctionalTranslator(t, dut, deviations.CiscoxrTransceiverFt(dut))
@@ -586,19 +585,19 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 	ports := dut.Ports()
 	for _, dp := range ports {
 		t.Run(fmt.Sprintf("Interface:%s", dp.Name()), func(t *testing.T) {
-			intfNameLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).Name().State())
-			intfName, ok := intfNameLookup.Val()
+			intfLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).State())
+			intf, ok := intfLookup.Val()
 			intfNamePath := getPathStr(gnmi.OC().Interface(dp.Name()).Name().State().PathStruct())
-			if !ok || intfName == "" {
+			if !ok || intf == nil || intf.GetName() == "" {
 				tracePath(t, intfNamePath, statusFail, "Failed to retrieve interface name state")
 				t.Fatalf("Failed to retrieve interface name state for %q", dp.Name())
 			}
+			intfName := intf.GetName()
 			tracePath(t, intfNamePath, statusPass, "Interface name: %s", intfName)
 
-			transceiverLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).Transceiver().State())
-			tv, tvOk := transceiverLookup.Val()
 			transceiverPath := getPathStr(gnmi.OC().Interface(dp.Name()).Transceiver().State().PathStruct())
-			if !tvOk || tv == "" {
+			tv := intf.GetTransceiver()
+			if tv == "" {
 				tracePath(t, transceiverPath, statusFail, "Failed to retrieve transceiver state")
 				t.Fatalf("Failed to retrieve transceiver state for %q", dp.Name())
 			}
@@ -706,10 +705,9 @@ func TestInterfacesWithTransceivers(t *testing.T) {
 					}
 				}
 
-				physicalChannelLookup := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).PhysicalChannel().State())
-				physicalChannel, pcOk := physicalChannelLookup.Val()
+				physicalChannel := intf.GetPhysicalChannel()
 				pcPath := getPathStr(gnmi.OC().Interface(dp.Name()).PhysicalChannel().State().PathStruct())
-				if !pcOk || len(physicalChannel) == 0 {
+				if len(physicalChannel) == 0 {
 					tracePath(t, pcPath, statusFail, "physical-channel unset for Interface: %q", intfName)
 				} else {
 					t.Logf("Interface %s physical-channel: %v", dp.Name(), physicalChannel)

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go
@@ -469,11 +469,13 @@ func TestOpticsPowerUpdate(t *testing.T) {
 	for _, dp := range ports {
 		t.Run(fmt.Sprintf("Flap-%s", dp.Name()), func(t *testing.T) {
 			originalEnabled, present := gnmi.Lookup(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config()).Val()
-			if present {
-				t.Cleanup(func() {
+			t.Cleanup(func() {
+				if present {
 					gnmi.Update(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config(), originalEnabled)
-				})
-			}
+				} else {
+					gnmi.Delete(t, dut, gnmi.OC().Interface(dp.Name()).Enabled().Config())
+				}
+			})
 
 			cases := []struct {
 				desc                string

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/metadata.textproto
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/metadata.textproto
@@ -1,33 +1,37 @@
-# proto-file: github.com/openconfig/featureprofiles/proto/metadata.proto
+# proto-file: third_party/openconfig/featureprofiles/proto/metadata.proto
 # proto-message: Metadata
 
-uuid:  "290e7660-cec3-4ea8-bedb-9a94b6f1cf92"
-plan_id:  "TRANSCEIVER-20.1"
-description:  "Client Optics DOM Telemetry, Instant, Threshold, and Miscellaneous Static Info"
-testbed:  TESTBED_DUT_ATE_2LINKS
-platform_exceptions:  {
-  platform:  {
-    vendor:  NOKIA
+uuid: "290e7660-cec3-4ea8-bedb-9a94b6f1cf92"
+plan_id: "TRANSCEIVER-20.1"
+description: "Client Optics DOM Telemetry, Instant, Threshold, and Miscellaneous Static Info"
+testbed: TESTBED_DUT_ATE_2LINKS
+platform_exceptions: {
+  platform: {
+    vendor: NOKIA
   }
-  deviations:  {
-    transceiver_thresholds_unsupported:  true
-    transceiver_state_unsupported:  true
+  deviations: {
+    transceiver_thresholds_unsupported: true
+    transceiver_state_unsupported: true
+    transceiver_config_enable_unsupported: true
   }
 }
-platform_exceptions:  {
-  platform:  {
-    vendor:  ARISTA
+platform_exceptions: {
+  platform: {
+    vendor: ARISTA
   }
-  deviations:  {}
+  deviations: {
+    transceiver_thresholds_unsupported: false
+  }
 }
-platform_exceptions:  {
-  platform:  {
-    vendor:  CISCO
+platform_exceptions: {
+  platform: {
+    vendor: CISCO
   }
-  deviations:  {
-    transceiver_thresholds_unsupported:  true
-    ciscoxr_laser_ft:  "ciscoxr-laser-ft"
-    temperature_sensor_check:  true
-    ciscoxr_transceiver_ft:  "ciscoxr-transceiver-ft"
+  deviations: {
+    ciscoxr_laser_ft: "ciscoxr-laser-ft"
+    ciscoxr_transceiver_ft: "ciscoxr-transceiver-ft"
+    transceiver_thresholds_unsupported: true
+    temperature_sensor_check: true
+    transceiver_config_enable_unsupported: true
   }
 }

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/metadata.textproto
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/metadata.textproto
@@ -1,4 +1,4 @@
-# proto-file: third_party/openconfig/featureprofiles/proto/metadata.proto
+# proto-file: github.com/openconfig/featureprofiles/proto/metadata.proto
 # proto-message: Metadata
 
 uuid: "290e7660-cec3-4ea8-bedb-9a94b6f1cf92"
@@ -21,6 +21,7 @@ platform_exceptions: {
   }
   deviations: {
     transceiver_thresholds_unsupported: false
+    transceiver_state_unsupported: true
   }
 }
 platform_exceptions: {

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/metadata.textproto
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/metadata.textproto
@@ -1,0 +1,33 @@
+# proto-file: github.com/openconfig/featureprofiles/proto/metadata.proto
+# proto-message: Metadata
+
+uuid:  "290e7660-cec3-4ea8-bedb-9a94b6f1cf92"
+plan_id:  "TRANSCEIVER-20.1"
+description:  "Client Optics DOM Telemetry, Instant, Threshold, and Miscellaneous Static Info"
+testbed:  TESTBED_DUT_ATE_2LINKS
+platform_exceptions:  {
+  platform:  {
+    vendor:  NOKIA
+  }
+  deviations:  {
+    transceiver_thresholds_unsupported:  true
+    transceiver_state_unsupported:  true
+  }
+}
+platform_exceptions:  {
+  platform:  {
+    vendor:  ARISTA
+  }
+  deviations:  {}
+}
+platform_exceptions:  {
+  platform:  {
+    vendor:  CISCO
+  }
+  deviations:  {
+    transceiver_thresholds_unsupported:  true
+    ciscoxr_laser_ft:  "ciscoxr-laser-ft"
+    temperature_sensor_check:  true
+    ciscoxr_transceiver_ft:  "ciscoxr-transceiver-ft"
+  }
+}

--- a/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/metadata.textproto
+++ b/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/metadata.textproto
@@ -10,6 +10,7 @@ platform_exceptions: {
     vendor: NOKIA
   }
   deviations: {
+    # TODO(b/555563715): Support transceiver power on/off on Nokia.
     transceiver_thresholds_unsupported: true
     transceiver_state_unsupported: true
     transceiver_config_enable_unsupported: true
@@ -20,7 +21,6 @@ platform_exceptions: {
     vendor: ARISTA
   }
   deviations: {
-    transceiver_thresholds_unsupported: false
     transceiver_state_unsupported: true
   }
 }
@@ -31,7 +31,6 @@ platform_exceptions: {
   deviations: {
     ciscoxr_laser_ft: "ciscoxr-laser-ft"
     ciscoxr_transceiver_ft: "ciscoxr-transceiver-ft"
-    transceiver_thresholds_unsupported: true
     temperature_sensor_check: true
     transceiver_config_enable_unsupported: true
   }

--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -1833,6 +1833,12 @@ test: {
   exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/platform/transceiver/tests/zrp_low_power_mode_test/zrp_low_power_mode_test.go"
 }
 test: {
+  id: "TRANSCEIVER-20.1"
+  description: "Client Optics DOM Telemetry, Instant, Threshold, and Miscellaneous Static Info"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/README.md"
+  exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/platform/transceiver/tests/client_optics_dom_telemetry_test/client_optics_dom_telemetry_test.go"
+}
+test: {
   id: "TRANSCEIVER-3.1"
   description: "Telemetry: 400ZR Optics firmware version streaming"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/platform/transceiver/tests/zr_firmware_version_test/README.md"


### PR DESCRIPTION
## Summary
Adds a new test suite `client_optics_dom_telemetry_test` (`TRANSCEIVER-20.1`) under `feature/platform/transceiver/tests/` to validate client optics digital optical monitoring (DOM) streaming telemetry and performance monitoring parameters.

## Details & Features Covered
- **Static & State Information**: Validates transceiver component state (`mfg-name`, `form-factor`, `serial-no`, `part-no`, `firmware-version`, `hardware-version`, `physical-channel`, `transceiver`).
- **DOM Telemetry & Thresholds**: Validates instant telemetry values for `module-temperature`, `output-power`, `input-power`, `laser-bias-current`, and `supply-voltage` against lower/upper warning and critical thresholds.
- **Link Flap State Updates**: Validates operational status and output optical power drop/recovery when interfaces are disabled and re-enabled.
- **Multi-Port Scalability**: Uses `dut.Ports()` to dynamically adapt to any number of testbed ports (e.g. 2-port or 6-port topologies).
- **Vendor Deviations**: Includes deviations in `metadata.textproto` for Nokia, Arista, and Cisco.

## Test Verification
- Tested and verified against real lab hardware using Ondatra.
- Formatted and passes static analysis / build checks.
