### PR TITLE
Update multipath_bgp_ecmp_protocol_nexthop_test.go

### DIFF
--- a/feature/bgp/policybase/otg_tests/multipath_bgp_ecmp_protocol_nexthop/multipath_bgp_ecmp_protocol_nexthop_test.go
+++ b/feature/bgp/policybase/otg_tests/multipath_bgp_ecmp_protocol_nexthop/multipath_bgp_ecmp_protocol_nexthop_test.go
@@ -698,7 +698,7 @@ func verifyBGPPrefixesTelemetry(t *testing.T, dut *ondatra.DUTDevice, nbrs []str
 		} else {
 			prefixPath = statePath.Neighbor(nbr).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).Prefixes()
 		}
-		if gotRx, ok := gnmi.Watch(t, dut, prefixPath.ReceivedPrePolicy().State(), 30*time.Second, func(val *ygnmi.Value[uint32]) bool {
+		if gotRx, ok := gnmi.Watch(t, dut, prefixPath.ReceivedPrePolicy().State(), 90*time.Second, func(val *ygnmi.Value[uint32]) bool {
 			gotRx, ok := val.Val()
 			return ok && gotRx == wantRx
 		}).Await(t); !ok {
@@ -766,45 +766,7 @@ func checkPacketLoss(t *testing.T, ate *ondatra.ATEDevice, ipType string) {
 	if ipType == "ipv6" {
 		flowName = "Traffic IPv6"
 	}
-	otg := ate.OTG()
-
-	// 1. Fetch Flow Metrics using the container path (more reliable)
-	flowMetric := gnmi.Get(t, otg, gnmi.OTG().Flow(flowName).State())
-	txPackets := flowMetric.GetCounters().GetOutPkts()
-	rxPackets := flowMetric.GetCounters().GetInPkts()
-
-	// 2. Fallback: If Flow Metrics are 0, use physical Port Metrics
-	if txPackets == 0 {
-		t.Logf("Flow %s counters are 0; falling back to physical Port Metrics...", flowName)
-		txPackets = gnmi.Get(t, otg, gnmi.OTG().Port(ate.Port(t, "port1").ID()).Counters().OutFrames().State())
-
-		// Sum Rx from all active receive ports (port2, port3, port4)
-		rxPackets = 0
-		for _, pID := range []string{"port2", "port3", "port4"} {
-			rxPackets += gnmi.Get(t, otg, gnmi.OTG().Port(ate.Port(t, pID).ID()).Counters().InFrames().State())
-		}
-	}
-
-	if txPackets < 1 {
-		t.Fatalf("No traffic detected: Port1 OutFrames and Flow OutPkts are both 0")
-	}
-	// Handle potential underflow if rxPackets > txPackets (e.g. due to control traffic)
-	var lostPackets uint64
-	if rxPackets < txPackets {
-		lostPackets = txPackets - rxPackets
-	} else {
-		lostPackets = 0
-	}
-
-	// lostPackets = txPackets - rxPackets
-	if txPackets == 0 {
-		t.Fatalf("txPackets == 0, want > 0")
-	}
-	if got := lostPackets * 100 / txPackets; uint64(got) > uint64(lossTolerancePct) {
-		t.Errorf("Packet loss percentage for flow %s: got %v, want %v", flowName, got, lossTolerancePct)
-	} else {
-		t.Logf("Packet loss validation successful for %s: Loss=%d%% (Tx=%d, Rx=%d)", flowName, got, txPackets, rxPackets)
-	}
+	otgutils.ExpectedTrafficLoss(t, ate.OTG(), flowName, 0, float64(lossTolerancePct))
 }
 
 func verifyECMPLoadBalance(t *testing.T, ate *ondatra.ATEDevice, pc int, expectedLinks int) {


### PR DESCRIPTION
1. Increase timeout to 90s for the `verifyBGPPrefixesTelemetry`.
2. Replace traffic validation block with `ExpectedTrafficLoss`