### PR TITLE
Updating IS-IS Drain test to use overload bit

### DIFF
--- a/feature/isis/otg_tests/isis_drain_test/README.md
+++ b/feature/isis/otg_tests/isis_drain_test/README.md
@@ -52,7 +52,7 @@ Verify that traffic can be drained out of DUT trunk interfaces by changing ISIS 
           "protocol": [
             {
               "identifier": "ISIS",
-              "name": "ISIS",
+              "name": "DEFAULT",
               "isis": {
                 "global": {
                   "lsp-bit": {

--- a/feature/isis/otg_tests/isis_drain_test/README.md
+++ b/feature/isis/otg_tests/isis_drain_test/README.md
@@ -2,21 +2,76 @@
 
 ## Summary
 
-Ensure that IS-IS metric change can drain traffic from a DUT trunk interface
+Verify that traffic can be drained out of DUT trunk interfaces by changing ISIS metric and using overload bit.
 
-## Canonical OC
-```json
-{}
-```  
+## Testbed type
+
+* [`atedut_3.testbed`](https://github.com/openconfig/featureprofiles/tree/main/topologies)
 
 ## Procedure
-* Connect three ATE ports to the DUT
-* Port-2 and port-3 each makes a one-member trunk port with the same ISIS metric 10 configured for the trunk interfaces (trunk-2 and trunk-3).  
-* Configure a destination network-a connected to trunk-2 and trunk-3.
-* Verify that IPv4 prefix advertised by ATE is correctly installed into DUTs forwarding table.
-* Send 10K IPv4 traffic flows from ATE port-1 to network-a. Validate that traffic is going via trunk-2 and trunk-3 and there is no traffic loss
-* Change the ISIS metric of trunk-2 to 1000 value. Verify prefix is correctly installed into DUTs forwarding table.Validate that 100% of the traffic is going out of only trunk-3 and there is no traffic loss.
-* Revert back the ISIS metric on trunk-2. Verify prefix is correctly installed into DUTs forwarding table.Validate that the traffic is going via both trunk-2 and trunk-3, and there is no traffic loss.
+
+### Test environment setup
+
+* Configure a 3-port ATE topology connected to the DUT (ATE Port-1, Port-2, and Port-3).
+* Configure DUT with trunk interfaces (e.g., trunk-2 connected to Port-2, and trunk-3 connected to Port-3) and a single interface connected to Port-1.
+* Establish IS-IS adjacencies (IPv4 and IPv6) on all links between the DUT and ATE ports.
+* Configure a DUT Loopback IP and advertise it into IS-IS.
+
+### RT-2.14.1 - IS-IS Metric Drain (Trunk Interfaces)
+
+* Step 1 - Advertise 1,000 IPv4 and 1,000 IPv6 prefixes from the ATE connected to trunk-2 and trunk-3.
+* Step 2 - Send continuous IPv4 and IPv6 traffic flows from ATE Port-1 to the 2,000 advertised prefixes.
+* Step 3 - Wait for IS-IS convergence (up to 30s). Validate that steady-state traffic loss is 0% and traffic is load-balanced or transits via trunk-2 and trunk-3.
+* Step 4 - Change the ISIS metric of trunk-2 to `1000` via gNMI Set on path `/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/afi-safi/af/config/metric`.
+* Step 5 - Validate that 100% of the traffic transits via trunk-3 only. Verify steady-state traffic loss is 0% after a brief convergence window.
+* Step 6 - Revert the ISIS metric on trunk-2 back to its original value. Validate that traffic recovers and is again load-balanced/transiting via both trunk-2 and trunk-3 with 0% steady-state loss.
+
+### RT-2.14.2 - IS-IS Overload Bit Drain
+
+* Step 1 - Continuing from the previous subtest, ensure ATE Port-2 advertises transit networks.
+* Step 2 - Establish an iBGP session from ATE Port-1 to the DUT's loopback interface to simulate control plane traffic.
+* Step 3 - Send transit traffic (ATE Port-1 -> DUT -> ATE Port-2) and local traffic (ATE Port-1 -> DUT Loopback).
+* Step 4 - Set the ISIS Overload bit to `true` via gNMI Set on path `/network-instances/network-instance/protocols/protocol/isis/global/lsp-bit/overload-bit/config/set-bit`.
+* Step 5 - Use gNMI Get to verify the telemetry state `/network-instances/network-instance/protocols/protocol/isis/global/lsp-bit/overload-bit/state/set-bit` reflects the `true` configuration.
+* Step 6 - Wait for convergence. Verify that transit traffic to ATE Port-2 drops to 0 (routed around the DUT) with no false positives.
+* Step 7 - Verify that local traffic (and the iBGP session) to the DUT loopback experiences 0% loss (Control Plane Preservation).
+* Step 8 - Verify that toggling the overload-bit config does not flap or reset the existing IS-IS adjacencies by checking that the state path `/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/adjacencies/adjacency/state/adjacency-state` remains `UP` (Adjacency Stability).
+* Step 9 - Clear the ISIS Overload bit by setting it to `false` via gNMI Set on path `/network-instances/network-instance/protocols/protocol/isis/global/lsp-bit/overload-bit/config/set-bit`.
+* Step 10 - Verify the telemetry state reflects the change to `false`.
+* Step 11 - Verify that transit IPv4 and IPv6 traffic recovers and is once again successfully forwarded through the DUT to ATE Port-2 with 0% steady-state loss.
+
+#### Canonical OC
+
+```json
+{
+  "network-instances": {
+    "network-instance": [
+      {
+        "name": "DEFAULT",
+        "protocols": {
+          "protocol": [
+            {
+              "identifier": "ISIS",
+              "name": "ISIS",
+              "isis": {
+                "global": {
+                  "lsp-bit": {
+                    "overload-bit": {
+                      "config": {
+                        "set-bit": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
 
 ## OpenConfig Path and RPC Coverage
 ```yaml
@@ -42,6 +97,7 @@ paths:
   /network-instances/network-instance/protocols/protocol/isis/global/config/max-ecmp-paths:
   /network-instances/network-instance/protocols/protocol/isis/global/config/net:
   /network-instances/network-instance/protocols/protocol/isis/global/lsp-bit/overload-bit/config/set-bit:
+  /network-instances/network-instance/protocols/protocol/isis/global/lsp-bit/overload-bit/state/set-bit:
   /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/afi-safi/af/config/enabled:
   /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/config/circuit-type:
   /network-instances/network-instance/protocols/protocol/isis/interfaces/interface/config/enabled:
@@ -57,6 +113,6 @@ rpcs:
     gNMI.Subscribe:
 ```
 
-## Minimum DUT Platform Requirement
+## Required DUT platform
 
-vRX
+* vRX


### PR DESCRIPTION
# RT-2.14: IS-IS Drain Test using Overload Bit. See b/540868298 for more info

* **Objective:** Verify that setting the ISIS Overload bit via gNMI causes other routers to avoid the DUT for transit traffic.  
  * **Interfaces Used:** gNMI, ISIS, Traffic Generator  
  * **Topology Note:** Requires a topology where the DUT is a transit device.  
  * **Expected Outcome Summary:**  
    * Initially, traffic transits through the DUT.  
    * Set the ISIS overload bit to true on the DUT via gNMI.  
    * Other routers should route traffic *around* the DUT.  
    * Locally originated or terminated traffic on the DUT should still function.  
    * Clearing the bit restores transit traffic.  
  * **Existing Coverage:**  
    * `RT-2.14.` , implement TODO from the READ ME of this

## 1\. Objective Integration and Template Formatting

* **Action**: Ensure all top-level headers conform exactly to `test-requirements-template.md` (e.g., `## Testbed type`, `## Procedure`, `### Test environment setup`, `## Required DUT platform`).  
* **Action**: Rename "Minimum DUT Platform Requirement" to "Required DUT platform".

## 2\. Sequential Subtests & Readability Improvements

Restructure the `## Procedure` section to create a logical, sequential workflow where subtests build upon one another. Self-explanatory assumptions will be removed, and precise OpenConfig paths will be cited.

### Test environment setup

* Use a 3-port ATE topology to accommodate both metric-based and overload-bit-based draining.  
* Configure DUT with trunk interfaces (e.g., Port-2 and Port-3) and a single interface (Port-1).  
* Establish IS-IS adjacencies (IPv4 and IPv6) on all links.  
* Configure DUT Loopback IP and advertise it into IS-IS.

### Subtest 1: IS-IS Metric Drain (Trunk Interfaces)

* **Scale Enhancement**: Advertise 1000 IPv4 and 1000 IPv6 prefixes from the ATE connected to the trunk interfaces instead of a single prefix.  
* Send continuous traffic from Port-1 to the 1000 advertised prefixes.  
* **OC Path Injection**: Change the ISIS metric using `/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/afi-safi/af/config/metric` to `1000`.  
* **Traffic Validation**: Wait for IS-IS convergence (up to 30s). Validate that steady-state traffic loss is 0% and 100% of traffic transits the alternate trunk interface.  
* Revert the metric and validate load-balancing/recovery.

### Subtest 2: IS-IS Overload Bit Drain

* Continuing from Subtest 1, configure ATE Port-2 to advertise transit networks.  
* **Scale/Topology Enhancement**: Establish an iBGP session from ATE Port-1 to the DUT's loopback interface to simulate control plane traffic.  
* Send transit traffic (Port-1 \-\> DUT \-\> Port-2) and local traffic (Port-1 \-\> DUT Loopback).  
* **OC Path Injection**: Set Overload bit to `true` via `/network-instances/network-instance/protocols/protocol/isis/global/lsp-bit/overload-bit/config/set-bit`.  
* Validate state via `/network-instances/network-instance/protocols/protocol/isis/global/lsp-bit/overload-bit/state/set-bit`.  
* **Traffic Validation**:  
  * Ensure transit traffic drops to 0 on the DUT (routed around) without false positives (allow a brief convergence window before measuring steady-state drop).  
  * Ensure local traffic (and the iBGP session) to the DUT loopback experiences 0% loss, proving the control plane is unaffected.  
* Clear the Overload bit (`false`) and validate transit traffic recovery.

## 3\. High Priority / Mandatory Negative Test Cases

Add a new subtest or explicit validation steps to cover negative testing:

* **Negative Test 1 (Control Plane Preservation)**: Explicitly verify that when the `overload-bit` is `true`, traffic destined directly to the DUT's loopback interface IP (local management/control plane) is strictly **not** dropped. This ensures the router doesn't isolate itself.  
* **Negative Test 2 (Adjacency Stability)**: Verify that toggling the `overload-bit` config does not flap or reset the existing IS-IS adjacencies (state path `/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/adjacencies/adjacency/state/adjacency-state` remains `UP`).