### PR TITLE
Update packetin_test.go

### DIFF
--- a/feature/p4rt/otg_tests/traceroute_packetin_with_vrf_selection_test/packetin_test.go
+++ b/feature/p4rt/otg_tests/traceroute_packetin_with_vrf_selection_test/packetin_test.go
@@ -128,14 +128,14 @@ func testTraffic(t *testing.T, top gosnappi.Config, ate *ondatra.ATEDevice, flow
 		initialOutPkts[flow.Name()] = gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State())
 	}
 	ate.OTG().StartTraffic(t)
-	
+
 	trafficStopped := false
 	defer func() {
 		if !trafficStopped {
 			ate.OTG().StopTraffic(t)
 		}
 	}()
-	
+
 	// AWAIT LOGIC INSTEAD OF SLEEP
 	for _, flow := range flows {
 		_, ok := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State(), time.Minute, func(val *ygnmi.Value[uint64]) bool {
@@ -203,7 +203,7 @@ func testPacketIn(ctx context.Context, t *testing.T, args *testArgs, isIPv4 bool
 		t.Errorf("Stream '%s' expecting Packet qSize(%d) Got (%d)",
 			streamName, qSize, qSizeRead)
 	}
-	
+
 	// Flush any leftover packets from previous tests
 	_, _, _ = args.leader.StreamChannelGetPackets(&streamName, 1000000, 3*time.Second)
 

--- a/feature/p4rt/otg_tests/traceroute_packetin_with_vrf_selection_test/packetin_test.go
+++ b/feature/p4rt/otg_tests/traceroute_packetin_with_vrf_selection_test/packetin_test.go
@@ -128,7 +128,14 @@ func testTraffic(t *testing.T, top gosnappi.Config, ate *ondatra.ATEDevice, flow
 		initialOutPkts[flow.Name()] = gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State())
 	}
 	ate.OTG().StartTraffic(t)
-
+	
+	trafficStopped := false
+	defer func() {
+		if !trafficStopped {
+			ate.OTG().StopTraffic(t)
+		}
+	}()
+	
 	// AWAIT LOGIC INSTEAD OF SLEEP
 	for _, flow := range flows {
 		_, ok := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State(), time.Minute, func(val *ygnmi.Value[uint64]) bool {
@@ -142,7 +149,8 @@ func testTraffic(t *testing.T, top gosnappi.Config, ate *ondatra.ATEDevice, flow
 	}
 
 	ate.OTG().StopTraffic(t)
-	
+	trafficStopped = true
+
 	// Add stabilization: poll counters until they stop incrementing
 	total := 0
 	for _, flow := range flows {

--- a/feature/p4rt/otg_tests/traceroute_packetin_with_vrf_selection_test/packetin_test.go
+++ b/feature/p4rt/otg_tests/traceroute_packetin_with_vrf_selection_test/packetin_test.go
@@ -128,7 +128,6 @@ func testTraffic(t *testing.T, top gosnappi.Config, ate *ondatra.ATEDevice, flow
 		initialOutPkts[flow.Name()] = gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State())
 	}
 	ate.OTG().StartTraffic(t)
-	defer ate.OTG().StopTraffic(t)
 
 	// AWAIT LOGIC INSTEAD OF SLEEP
 	for _, flow := range flows {
@@ -142,10 +141,27 @@ func testTraffic(t *testing.T, top gosnappi.Config, ate *ondatra.ATEDevice, flow
 		}
 	}
 
+	ate.OTG().StopTraffic(t)
+	
+	// Add stabilization: poll counters until they stop incrementing
 	total := 0
 	for _, flow := range flows {
-		current := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State())
-		total += int(current - initialOutPkts[flow.Name()])
+		var lastPkts uint64
+		var stableCount int
+		for {
+			current := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State())
+			if current == lastPkts {
+				stableCount++
+				if stableCount >= 4 { // 4 * 500ms = 2 seconds of stability
+					total += int(current - initialOutPkts[flow.Name()])
+					break
+				}
+			} else {
+				stableCount = 0
+			}
+			lastPkts = current
+			time.Sleep(500 * time.Millisecond)
+		}
 	}
 	return total
 }
@@ -179,6 +195,9 @@ func testPacketIn(ctx context.Context, t *testing.T, args *testArgs, isIPv4 bool
 		t.Errorf("Stream '%s' expecting Packet qSize(%d) Got (%d)",
 			streamName, qSize, qSizeRead)
 	}
+	
+	// Flush any leftover packets from previous tests
+	_, _, _ = args.leader.StreamChannelGetPackets(&streamName, 1000000, 3*time.Second)
 
 	// Send Traceroute traffic from ATE
 	srcEndPoint := ateInterface(t, args.top, "port1")

--- a/feature/p4rt/otg_tests/traceroute_packetin_with_vrf_selection_test/packetin_test.go
+++ b/feature/p4rt/otg_tests/traceroute_packetin_with_vrf_selection_test/packetin_test.go
@@ -110,6 +110,7 @@ func testTraffic(t *testing.T, top gosnappi.Config, ate *ondatra.ATEDevice, flow
 	for _, flow := range flows {
 		flow.TxRx().Port().SetTxName(srcEndPoint.Name()).SetRxName(srcEndPoint.Name())
 		flow.Metrics().SetEnable(true)
+		flow.Duration().FixedPackets().SetPackets(uint32(targetPkts))
 		top.Flows().Append(flow)
 	}
 	ate.OTG().PushConfig(t, top)
@@ -136,7 +137,7 @@ func testTraffic(t *testing.T, top gosnappi.Config, ate *ondatra.ATEDevice, flow
 		}
 	}()
 
-	// AWAIT LOGIC INSTEAD OF SLEEP
+	// Wait for OutPkts to reach the target
 	for _, flow := range flows {
 		_, ok := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State(), time.Minute, func(val *ygnmi.Value[uint64]) bool {
 			pkts, present := val.Val()


### PR DESCRIPTION
This PR stabilizes the otg test traceroute_packetin_with_vrf_selection_test by:
- Flushing out leftover packets from the P4RT Stream Channel prior to starting test traffic to prevent counting stray packets from previous subtests.
- Add a polling loop to guarantee that the OTG generator has fully spun down and flushed all packets before getting the total. 
- Keep Tx packets fixed to 1000 as in other sub-tests to make the code more predictable. 