### PR TITLE
Update two_sp_queue_traffic_test.go

### DIFF
--- a/feature/qos/otg_tests/two_sp_queue_traffic_test/two_sp_queue_traffic_test.go
+++ b/feature/qos/otg_tests/two_sp_queue_traffic_test/two_sp_queue_traffic_test.go
@@ -1116,26 +1116,22 @@ func TestTwoSPQueueTraffic(t *testing.T) {
 			ate.OTG().StartTraffic(t)
 			time.Sleep(30 * time.Second)
 			ate.OTG().StopTraffic(t)
-			time.Sleep(30 * time.Second)
 
 			otgutils.LogFlowMetrics(t, ate.OTG(), top)
 			for trafficID, data := range trafficFlows {
+				expectedLossPct := 100.0 - data.expectedThroughputPct
+				minLossPct := expectedLossPct - tolerance
+				if minLossPct < 0 {
+					minLossPct = 0
+				}
+				maxLossPct := expectedLossPct + tolerance
+				otgutils.ExpectedTrafficLoss(t, ate.OTG(), trafficID, float64(minLossPct), float64(maxLossPct))
+				
 				ateOutPkts[data.queue] += gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().OutPkts().State())
 				ateInPkts[data.queue] += gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().InPkts().State())
 				dutQosPktsAfterTraffic[data.queue] += gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(data.queue).TransmitPkts().State())
 				dutQosDroppedPktsAfterTraffic[data.queue] += gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(data.queue).DroppedPkts().State())
 				t.Logf("ateInPkts: %v, txPkts %v, Queue: %v", ateInPkts[data.queue], dutQosPktsAfterTraffic[data.queue], data.queue)
-
-				ateTxPkts := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().OutPkts().State())
-				ateRxPkts := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().InPkts().State())
-				if ateTxPkts == 0 {
-					t.Fatalf("TxPkts == 0, want >0.")
-				}
-				lossPct := (float32)((float64(ateTxPkts-ateRxPkts) * 100.0) / float64(ateTxPkts))
-				t.Logf("Get flow %q: lossPct: %.2f%% or rxPct: %.2f%%, want: %.2f%%\n\n", data.queue, lossPct, 100.0-lossPct, data.expectedThroughputPct)
-				if got, want := 100.0-lossPct, data.expectedThroughputPct; got < want-tolerance || got > want+tolerance {
-					t.Errorf("Get(throughput for queue %q): got %.2f%%, want within [%.2f%%, %.2f%%]", data.queue, got, want-tolerance, want+tolerance)
-				}
 			}
 
 			// Check QoS egress packet counters are updated correctly.

--- a/feature/qos/otg_tests/two_sp_queue_traffic_test/two_sp_queue_traffic_test.go
+++ b/feature/qos/otg_tests/two_sp_queue_traffic_test/two_sp_queue_traffic_test.go
@@ -781,7 +781,7 @@ func TestTwoSPQueueTraffic(t *testing.T) {
 			trafficRate:           0.7,
 			dscp:                  56,
 			expectedThroughputPct: 100.0,
-			queue:                 queues.BE1,
+			queue:                 queues.NC1,
 			inputIntf:             intf2,
 		},
 		"intf2-be1": {
@@ -1129,8 +1129,8 @@ func TestTwoSPQueueTraffic(t *testing.T) {
 				
 				ateOutPkts[data.queue] += gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().OutPkts().State())
 				ateInPkts[data.queue] += gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().InPkts().State())
-				dutQosPktsAfterTraffic[data.queue] += gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(data.queue).TransmitPkts().State())
-				dutQosDroppedPktsAfterTraffic[data.queue] += gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(data.queue).DroppedPkts().State())
+				dutQosPktsAfterTraffic[data.queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(data.queue).TransmitPkts().State())
+				dutQosDroppedPktsAfterTraffic[data.queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(data.queue).DroppedPkts().State())
 				t.Logf("ateInPkts: %v, txPkts %v, Queue: %v", ateInPkts[data.queue], dutQosPktsAfterTraffic[data.queue], data.queue)
 			}
 

--- a/feature/qos/otg_tests/two_sp_queue_traffic_test/two_sp_queue_traffic_test.go
+++ b/feature/qos/otg_tests/two_sp_queue_traffic_test/two_sp_queue_traffic_test.go
@@ -1126,7 +1126,7 @@ func TestTwoSPQueueTraffic(t *testing.T) {
 				}
 				maxLossPct := expectedLossPct + tolerance
 				otgutils.ExpectedTrafficLoss(t, ate.OTG(), trafficID, float64(minLossPct), float64(maxLossPct))
-				
+
 				ateOutPkts[data.queue] += gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().OutPkts().State())
 				ateInPkts[data.queue] += gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().InPkts().State())
 				dutQosPktsAfterTraffic[data.queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(data.queue).TransmitPkts().State())


### PR DESCRIPTION
Stabilize two_sp_queue_traffic_test 

- Replaced gnmi.Get packet loss check with otgutils.ExpectedTrafficLoss dynamic polling.
- Removed arbitrary time.Sleep(30 * time.Second) post traffic-stop.
- Fixed typo in oversubscribedTrafficFlows6 where intf2-nc1 was mapped to queues.BE1 instead of queues.NC1.
