### PR TITLE
Update protocol_dscp_rules_for_vrf_selection_test.go

### DIFF
--- a/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/openconfig/featureprofiles/internal/attrs"
+	"github.com/openconfig/featureprofiles/internal/cfgplugins"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
 	"github.com/openconfig/featureprofiles/internal/otgutils"
@@ -30,7 +31,6 @@ import (
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
 	"github.com/openconfig/testt"
-	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )
 
@@ -38,6 +38,7 @@ const (
 	trafficDuration = 30 * time.Second
 	ipv4PrefixLen   = 30
 	ipv6PrefixLen   = 126
+	lossTolerance   = 1.0
 )
 
 // testArgs holds the objects needed by a test case.
@@ -486,7 +487,6 @@ func getIPinIPFlow(args *testArgs, src attrs.Attributes, dst attrs.Attributes, f
 
 	flow.Size().SetFixed(1024)
 	flow.Rate().SetPps(100)
-	flow.Duration().FixedPackets().SetPackets(100)
 	flow.Duration().Continuous()
 
 	return flow
@@ -494,7 +494,7 @@ func getIPinIPFlow(args *testArgs, src attrs.Attributes, dst attrs.Attributes, f
 
 // testTrafficFlows verifies traffic for one or more flows.
 func testTrafficFlows(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config, expectPass bool, flows ...gosnappi.Flow) {
-
+	t.Helper()
 	top.Flows().Clear()
 	for _, flow := range flows {
 		top.Flows().Append(flow)
@@ -519,68 +519,10 @@ func testTrafficFlows(t *testing.T, ate *ondatra.ATEDevice, top gosnappi.Config,
 	otgutils.LogFlowMetrics(t, ate.OTG(), otgTop)
 	for _, flow := range flows {
 		t.Run(flow.Name(), func(t *testing.T) {
-			t.Logf("*** Verifying %v traffic on OTG ... ", flow.Name())
-
-			// 1. Wait for flow transmit state to stop
-			if _, ok := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Transmit().State(), 30*time.Second, func(val *ygnmi.Value[bool]) bool {
-				transmitState, present := val.Val()
-				return present && !transmitState
-			}).Await(t); !ok {
-				t.Fatalf("Timeout waiting for flow %s to stop transmitting", flow.Name())
-			}
-
-			var outPkts uint64
-			var inPkts uint64
-
 			if expectPass {
-				// Query OutPkts dynamically inside Watch predicate to allow time for telemetry sync
-				inPktsVal, ok := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().InPkts().State(), 30*time.Second, func(val *ygnmi.Value[uint64]) bool {
-					v, present := val.Val()
-					outPkts = gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State())
-					return present && outPkts > 0 && v == outPkts
-				}).Await(t)
-
-				if ok {
-					inPkts, _ = inPktsVal.Val()
-				} else {
-					inPkts = gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().InPkts().State())
-				}
+				otgutils.ExpectedTrafficLoss(t, ate.OTG(), flow.Name(), 0, lossTolerance)
 			} else {
-				// When expecting failure, watch OutPkts to ensure it registers > 0 before proceeding
-				outPktsVal, ok := gnmi.Watch(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State(), 30*time.Second, func(val *ygnmi.Value[uint64]) bool {
-					v, present := val.Val()
-					return present && v > 0
-				}).Await(t)
-
-				if ok {
-					outPkts, _ = outPktsVal.Val()
-				} else {
-					outPkts = gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().OutPkts().State())
-				}
-				inPkts = gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(flow.Name()).Counters().InPkts().State())
-			}
-
-			// Loss calculation
-			var lossPct float64
-			if outPkts > 0 {
-				lossPct = float64(outPkts-inPkts) * 100.0 / float64(outPkts)
-			} else {
-				// If outPkts is 0, traffic failed to start entirely
-				lossPct = 100.0
-			}
-
-			// Log stats
-			t.Logf("Flow OutPkts : %d", outPkts)
-			t.Logf("Flow InPkts  : %d", inPkts)
-			t.Logf("Flow LossPct : %.2f%%", lossPct)
-
-			// Verification Logic
-			if expectPass && inPkts == outPkts && outPkts > 0 {
-				t.Logf("Traffic for %v flow is passing as expected", flow.Name())
-			} else if !expectPass && inPkts == 0 && outPkts > 0 {
-				t.Logf("Traffic for %v flow is failing as expected", flow.Name())
-			} else {
-				t.Fatalf("Traffic is not working as expected for flow %s. OutPkts: %d, InPkts: %d, LossPct: %.2f%%", flow.Name(), outPkts, inPkts, lossPct)
+				otgutils.ExpectedTrafficLoss(t, ate.OTG(), flow.Name(), 100, 100)
 			}
 		})
 	}
@@ -635,7 +577,21 @@ func TestPBR(t *testing.T) {
 	top := configureATE(t, ate, dut)
 	ate.OTG().PushConfig(t, top)
 	ate.OTG().StartProtocols(t)
-
+	
+	routesToAdvertise := map[string]cfgplugins.RouteInfo{
+		"192.0.2.8/30":  {VRF: "VRF10", IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
+		"192.0.2.12/30": {VRF: "VRF20", IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
+		"192.0.2.16/30": {VRF: "VRF30", IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
+		"192.0.2.36/30": {VRF: "VRF40", IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
+		"192.0.2.40/30": {VRF: "VRF50", IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
+		"192.0.2.44/30": {VRF: "VRF60", IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
+		"192.0.2.0/30":  {VRF: deviations.DefaultNetworkInstance(dut), IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
+		"192.0.2.4/30":  {VRF: deviations.DefaultNetworkInstance(dut), IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
+		"192.0.2.20/30": {VRF: deviations.DefaultNetworkInstance(dut), IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
+		"192.0.2.32/30": {VRF: deviations.DefaultNetworkInstance(dut), IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
+	}
+	cfgplugins.VerifyRoutes(t, dut, routesToAdvertise)
+	
 	// Ingress interface for policies
 	port1 := dut.Port(t, "port1")
 	port3 := dut.Port(t, "port3")

--- a/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -590,6 +590,7 @@ func TestPBR(t *testing.T) {
 		"192.0.2.20/30": {VRF: deviations.DefaultNetworkInstance(dut), IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
 		"192.0.2.32/30": {VRF: deviations.DefaultNetworkInstance(dut), IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
 	}
+	otgutils.WaitForARP(t, ate.OTG(), top, "IPv4")
 	cfgplugins.VerifyRoutes(t, dut, routesToAdvertise)
 	
 	// Ingress interface for policies

--- a/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
+++ b/feature/policy_forwarding/vrf_selection/otg_tests/protocol_dscp_rules_for_vrf_selection_test/protocol_dscp_rules_for_vrf_selection_test.go
@@ -577,7 +577,7 @@ func TestPBR(t *testing.T) {
 	top := configureATE(t, ate, dut)
 	ate.OTG().PushConfig(t, top)
 	ate.OTG().StartProtocols(t)
-	
+
 	routesToAdvertise := map[string]cfgplugins.RouteInfo{
 		"192.0.2.8/30":  {VRF: "VRF10", IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
 		"192.0.2.12/30": {VRF: "VRF20", IPType: cfgplugins.IPv4, DefaultName: deviations.DefaultNetworkInstance(dut)},
@@ -592,7 +592,7 @@ func TestPBR(t *testing.T) {
 	}
 	otgutils.WaitForARP(t, ate.OTG(), top, "IPv4")
 	cfgplugins.VerifyRoutes(t, dut, routesToAdvertise)
-	
+
 	// Ingress interface for policies
 	port1 := dut.Port(t, "port1")
 	port3 := dut.Port(t, "port3")


### PR DESCRIPTION
Stabilize protocol_dscp_rules_for_vrf_selection_test

- Add cfgplugins.VerifyRoutes to ensure all VRF and default routes are resolved and installed in AFT prior to traffic generation.
- Standardize traffic loss assertions using otgutils.ExpectedTrafficLoss with 1.0% loss tolerance.
- Clean up flow duration configuration in getIPinIPFlow.
