### PR TITLE
system: Restore initial DUT hostname and domain name in hostname_test

### DIFF
--- a/feature/system/system_base_test/tests/hostname_test/hostname_test.go
+++ b/feature/system/system_base_test/tests/hostname_test/hostname_test.go
@@ -49,12 +49,19 @@ func TestHostname(t *testing.T) {
 	}
 
 	dut := ondatra.DUT(t, "dut")
+	config := gnmi.OC().System().Hostname()
+	state := gnmi.OC().System().Hostname()
+
+	initialHostname := dut.Name()
+	if val, present := gnmi.LookupConfig(t, dut, config.Config()).Val(); present {
+		initialHostname = val
+	}
+	t.Cleanup(func() {
+		gnmi.Replace(t, dut, config.Config(), initialHostname)
+	})
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			config := gnmi.OC().System().Hostname()
-			state := gnmi.OC().System().Hostname()
-
 			gnmi.Replace(t, dut, config.Config(), testCase.hostname)
 
 			t.Run("Get Hostname Config", func(t *testing.T) {
@@ -103,12 +110,20 @@ func TestDomainName(t *testing.T) {
 	}
 
 	dut := ondatra.DUT(t, "dut")
+	config := gnmi.OC().System().DomainName()
+	state := gnmi.OC().System().DomainName()
+
+	initialDomainName, hasInitialDomainName := gnmi.LookupConfig(t, dut, config.Config()).Val()
+	t.Cleanup(func() {
+		if hasInitialDomainName {
+			gnmi.Replace(t, dut, config.Config(), initialDomainName)
+		} else {
+			gnmi.Delete(t, dut, config.Config())
+		}
+	})
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			config := gnmi.OC().System().DomainName()
-			state := gnmi.OC().System().DomainName()
-
 			gnmi.Replace(t, dut, config.Config(), testCase.domainname)
 
 			t.Run("Get Domainname Config", func(t *testing.T) {

--- a/feature/system/system_base_test/tests/hostname_test/hostname_test.go
+++ b/feature/system/system_base_test/tests/hostname_test/hostname_test.go
@@ -53,7 +53,7 @@ func TestHostname(t *testing.T) {
 	state := gnmi.OC().System().Hostname()
 
 	initialHostname := dut.Name()
-	if val, present := gnmi.LookupConfig(t, dut, config.Config()).Val(); present {
+	if val, present := gnmi.LookupConfig(t, dut, config.Config()).Val(); present && val != "" {
 		initialHostname = val
 	}
 	t.Cleanup(func() {


### PR DESCRIPTION
In TestHostname and TestDomainName, gnmi.Delete was previously called without restoring the DUT's initial hostname or domain name in a cleanup hook. On Arista EOS devices, deleting the hostname reverts the CLI prompt to "localhost#". When subsequent tests in a group reservation execute CLI commands (e.g. "show version" in Ondatra setup), the CLI regex matcher hung waiting for "<dut_name>#", causing a 630s timeout, aborted sessions, and orphaned Caelum config locks on the DUT.

This change captures the initial hostname and domain name (falling back to dut.Name()) and uses t.Cleanup to reliably restore them when the test completes.