### PR TITLE
Fix: go static analysis check issues

### DIFF
--- a/feature/static/otg_tests/next_hop_encap_udp/static_encap_gue_ipv4_test.go
+++ b/feature/static/otg_tests/next_hop_encap_udp/static_encap_gue_ipv4_test.go
@@ -497,7 +497,6 @@ func mustProcessCapture(t *testing.T, otg *otg.OTG, port string) string {
 }
 
 func validatePackets(t *testing.T, filename string, protocolType string, outertos, innertos string, outerttl, innerttl uint8, outerPacket bool) {
-	var packetCount uint32 = 0
 
 	handle, err := pcap.OpenOffline(filename)
 	if err != nil {
@@ -511,7 +510,6 @@ func validatePackets(t *testing.T, filename string, protocolType string, outerto
 		if ipLayer == nil {
 			continue
 		}
-		packetCount += 1
 		ipOuterLayer, ok := ipLayer.(*layers.IPv6)
 		if !ok || ipOuterLayer == nil {
 			t.Errorf("outer IP layer not found %d", ipLayer)

--- a/internal/cfgplugins/policyforwarding.go
+++ b/internal/cfgplugins/policyforwarding.go
@@ -698,7 +698,7 @@ func PolicyForwardingConfigScale(t *testing.T, dut *ondatra.DUTDevice, sb *gnmi.
 		}
 		return nil
 	} else {
-		ruleSeq := uint32(1)
+		//ruleSeq := uint32(1)
 		for i := 1; i <= encapparams.Count; i++ {
 			// https://partnerissuetracker.corp.google.com/issues/417988636
 			//  pols := pf.GetOrCreatePolicy(fmt.Sprintf("tp_cloud_id_3_%d", i))
@@ -708,7 +708,7 @@ func PolicyForwardingConfigScale(t *testing.T, dut *ondatra.DUTDevice, sb *gnmi.
 			// rule.GetOrCreateAction().SetNextHopGroup(groupName)
 			// rule.GetOrCreateAction().SetTtl(1)
 		}
-		ruleSeq++
+		//ruleSeq++
 		gnmi.BatchReplace(sb, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).PolicyForwarding().Config(), pf)
 		return sb
 	}
@@ -801,7 +801,7 @@ func RulesAndActions(params OcPolicyForwardingParams, pf *oc.NetworkInstance_Pol
 	// TODO: sancheetaroy - Set the action to count
 	// rule8.GetOrCreateAction().Count = ygot.Bool(true)
 	// rule8.GetOrCreateAction().NextHopGroup = ygot.String(params.CloudV6NHG)
-	ruleSeq++
+	//ruleSeq++
 }
 
 // DecapPolicyRulesandActionsGre configures the "decap MPLS in GRE" policy and related MPLS global and static LSP settings.


### PR DESCRIPTION
To fix below go static check errors:
Run GOGC=30 staticcheck ./...
Error: feature/static/otg_tests/next_hop_encap_udp/static_encap_gue_ipv4_test.go:514:3: this value of packetCount is never used (SA4006)
Error: internal/cfgplugins/policyforwarding.go:711:3: this value of ruleSeq is never used (SA4006)
Error: internal/cfgplugins/policyforwarding.go:804:2: this value of ruleSeq is never used (SA4006)
Error: Process completed with exit code 1.

Ref:https://github.com/openconfig/featureprofiles/actions/runs/32377936052/job/96453760626