### PR TITLE
Update record_payload_truncation_test.go

### DIFF
--- a/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
+++ b/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
@@ -93,9 +93,14 @@ func TestAccountzRecordPayloadTruncation(t *testing.T) {
 		helpers.GnmiCLIConfig(t, dut, communitySetCLIConfig)
 	}
 
-	startTime := time.Now()
+	// Get the current time from the router via gNMI to avoid clock skew issues.
+	startTime := helpers.GetRouterTime(t, dut)
+	requestTimestamp := &timestamppb.Timestamp{
+		Seconds: startTime.Unix(),
+		Nanos:   0,
+	}
 	request := &acctzpb.RecordRequest{
-		Timestamp: timestamppb.New(startTime),
+		Timestamp: requestTimestamp,
 	}
 
 	acctzClient := dut.RawAPIs().GNSI(t).AcctzStream()
@@ -104,6 +109,7 @@ func TestAccountzRecordPayloadTruncation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to subscribe to acctz records: %v", err)
 	}
+	defer acctzSubClient.CloseSend()
 
 	sendOversizedPayload(t, dut)
 

--- a/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
+++ b/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
@@ -95,10 +95,7 @@ func TestAccountzRecordPayloadTruncation(t *testing.T) {
 
 	// Get the current time from the router via gNMI to avoid clock skew issues.
 	startTime := helpers.GetRouterTime(t, dut)
-	requestTimestamp := &timestamppb.Timestamp{
-		Seconds: startTime.Unix(),
-		Nanos:   0,
-	}
+	requestTimestamp := timestamppb.New(startTime.Truncate(time.Second))
 	request := &acctzpb.RecordRequest{
 		Timestamp: requestTimestamp,
 	}


### PR DESCRIPTION
Fix flaky failures in the test by

- Fetch the DUT's clock time using `helpers.GetRouterTime(t, dut)` via gNMI state query.
- Initialize the RecordRequest timestamp with startTime.Unix() seconds and 0 nanoseconds, preventing any clock skew or future-timestamp rejection from the DUT.
- Added defer acctzSubClient.CloseSend() to properly clean up the stream.