### PR TITLE
RT-5.2/RT-5.4 Updated to clear Lagtype in clearAggregate function

### DIFF
--- a/feature/interface/aggregate/otg_tests/aggregate_forwarding_viable_test/aggregate_forwarding_viable_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_forwarding_viable_test/aggregate_forwarding_viable_test.go
@@ -237,8 +237,12 @@ func (tc *testArgs) setupAggregateAtomically(t *testing.T) {
 
 // clearAggregate delete any previously existing members of aggregate.
 func (tc *testArgs) clearAggregate(t *testing.T) {
+	t.Helper()
+
 	// Clear the aggregate minlink.
 	gnmi.Delete(t, tc.dut, gnmi.OC().Interface(tc.aggID).Aggregation().MinLinks().Config())
+	// Clear the aggregate lag type.
+	gnmi.Delete(t, tc.dut, gnmi.OC().Interface(tc.aggID).Aggregation().LagType().Config())
 
 	// Clear the members of the aggregate.
 	for _, port := range tc.dutPorts[1:] {
@@ -607,6 +611,7 @@ func TestAggregateForwardingViable(t *testing.T) {
 			aggID:    aggID,
 		}
 		t.Run(fmt.Sprintf("LagType=%s", lagType), func(t *testing.T) {
+			args.clearAggregate(t)
 			args.configureATE(t)
 			args.configureDUT(t)
 			args.verifyDUT(t)

--- a/feature/interface/aggregate/otg_tests/aggregate_test/aggregate_test.go
+++ b/feature/interface/aggregate/otg_tests/aggregate_test/aggregate_test.go
@@ -195,8 +195,15 @@ func (tc *testCase) setupAggregateAtomically(t *testing.T) {
 }
 
 func (tc *testCase) clearAggregate(t *testing.T) {
+	t.Helper()
+
+	// Clear the aggregate LACP configuration.
+	gnmi.Delete(t, tc.dut, gnmi.OC().Lacp().Interface(tc.aggID).Config())
+
 	// Clear the aggregate minlink.
 	gnmi.Delete(t, tc.dut, gnmi.OC().Interface(tc.aggID).Aggregation().MinLinks().Config())
+	// Clear the aggregate lag type.
+	gnmi.Delete(t, tc.dut, gnmi.OC().Interface(tc.aggID).Aggregation().LagType().Config())
 
 	// Clear the members of the aggregate.
 	for _, port := range tc.dutPorts[1:] {
@@ -607,6 +614,7 @@ func TestNegotiation(t *testing.T) {
 			aggID:    aggID,
 		}
 		t.Run(fmt.Sprintf("LagType=%s", lagType), func(t *testing.T) {
+			tc.clearAggregate(t)
 			tc.configureDUT(t)
 			t.Run("VerifyDUT", tc.verifyDUT)
 


### PR DESCRIPTION
Changes : 

1. Updated to clear Lagtype in clearAggregate function and,
2. called it to clear up the config for each execution 