### PR TITLE
feature(containerz): Add container capabilities and volume mount options tests to CNTR-1

### DIFF
--- a/feature/container/containerz/tests/container_lifecycle/README.md
+++ b/feature/container/containerz/tests/container_lifecycle/README.md
@@ -230,7 +230,7 @@ Validate that `gnoi.Containerz.StartContainer` accurately applies Linux capabili
 
 Validate that `gnoi.Containerz.CreateVolume` supports the standard OpenConfig
 `repeated string options` format across diverse Linux filesystem mount flag
-combinations (`rbind`, `rslave`, `rprivate`, `ro`, `bind`, `private`). Verify that
+combinations (`rbind`, `rslave`, `rprivate`, `ro`, `bind`, `private`, `slave`). Verify that
 `gnoi.Containerz.ListVolume` accurately reflects all configured mount options
 and volumes are cleanly deleted.
 
@@ -244,11 +244,15 @@ Iterate over the following specification-compliant option combinations:
     `mountpoint: "/tmp"`, `type: "none"`
 *   **Combination C (`bind, rslave, ro`)**:
     `options: ["bind", "rslave", "ro"]`, `mountpoint: "/tmp"`, `type: "none"`
-*   **Combination D (`bind, ro`)**: `options: ["bind", "ro"]`, `mountpoint:
-    "/tmp"`, `type: "none"`
-*   **Combination E (`bind, private`)**: `options: ["bind", "private"]`,
+*   **Combination D (`bind, slave, ro`)**:
+    `options: ["bind", "slave", "ro"]`, `mountpoint: "/tmp"`, `type: "none"`
+*   **Combination E (`bind, slave`)**: `options: ["bind", "slave"]`,
     `mountpoint: "/tmp"`, `type: "none"`
-*   **Combination F (`bind`)**: `options: ["bind"]`, `mountpoint: "/tmp"`,
+*   **Combination F (`bind, private`)**: `options: ["bind", "private"]`,
+    `mountpoint: "/tmp"`, `type: "none"`
+*   **Combination G (`bind, ro`)**: `options: ["bind", "ro"]`, `mountpoint:
+    "/tmp"`, `type: "none"`
+*   **Combination H (`bind`)**: `options: ["bind"]`, `mountpoint: "/tmp"`,
     `type: "none"`
 
 For each combination:
@@ -279,7 +283,7 @@ For each combination:
         *   `options["device"]` equals `/tmp`.
         *   `options["o"]` (or driver option field) accurately reflects and
             preserves all configured mount flags (`rbind`, `rslave`, `rprivate`,
-            `ro`, `bind`, `private`).
+            `ro`, `bind`, `private`, `slave`).
         *   `labels` match the input labels.
 4.  **Remove Volume and Verify Deletion**:
     *   Call `gnoi.Containerz.RemoveVolume` with `name:

--- a/feature/container/containerz/tests/container_lifecycle/README.md
+++ b/feature/container/containerz/tests/container_lifecycle/README.md
@@ -160,6 +160,133 @@ Subsequently, the plugin is stopped using `gnoi.Containerz.StopPlugin` and remov
 2.  **Cold Reboot**: Trigger a cold reboot using `gnoi.System.Reboot`.
 3.  **Verify Recovery**: After the cold reboot, verify that the container is still `RUNNING` and the volume still exists using `gnoi.Containerz`.
 
+## CNTR-1.9: Container Capabilities Management
+
+Validate that `gnoi.Containerz.StartContainer` accurately applies Linux capabilities (via `CapAdd` and `CapDrop` / `StartContainerRequest.cap`) to container instances running on the target. Verify that elevated capabilities are granted, default capabilities can be dropped, invalid capabilities are rejected, and instances are cleanly cleaned up without orphaned state.
+
+### Positive Test 1: Elevated Capabilities (`CAP_SYS_ADMIN`, `CAP_NET_ADMIN`, `CAP_NET_RAW`)
+
+1.  **Start Container with Elevated Capabilities**:
+    *   Issue `gnoi.Containerz.StartContainer` with:
+        *   `image_name`: `cntrsrv_image`
+        *   `tag`: `latest`
+        *   `cmd`: `./cntrsrv`
+        *   `instance_name`: `test-cap-elevated`
+        *   `ports`: `[{ internal: 60061, external: 60061 }]`
+        *   `cap`:
+            *   `add`: `["CAP_SYS_ADMIN", "CAP_NET_ADMIN", "CAP_NET_RAW"]`
+    *   Verify that the RPC succeeds and returns `StartOK` containing
+        `instance_name: "test-cap-elevated"`.
+2.  **Verify Running State**:
+    *   Call `gnoi.Containerz.ListContainer` and confirm `test-cap-elevated`
+        transitions to `status: RUNNING`.
+3.  **Cleanup**:
+    *   Stop the container using `gnoi.Containerz.StopContainer` with
+        `instance_name: "test-cap-elevated"` and `force: true`.
+    *   Remove the container using `gnoi.Containerz.RemoveContainer` with
+        `name: "test-cap-elevated"` and `force: true`.
+
+### Positive Test 2: Capability Dropping (`CAP_NET_RAW`, `CAP_SYS_CHROOT`)
+
+1.  **Start Container with Dropped Capabilities**:
+    *   Issue `gnoi.Containerz.StartContainer` with:
+        *   `image_name`: `cntrsrv_image`
+        *   `tag`: `latest`
+        *   `cmd`: `./cntrsrv`
+        *   `instance_name`: `test-cap-dropped`
+        *   `ports`: `[{ internal: 60062, external: 60062 }]`
+        *   `cap`:
+            *   `remove`: `["CAP_NET_RAW", "CAP_SYS_CHROOT"]`
+    *   Verify that the RPC succeeds and returns `StartOK` containing
+        `instance_name: "test-cap-dropped"`.
+2.  **Verify Running State**:
+    *   Call `gnoi.Containerz.ListContainer` and confirm `test-cap-dropped`
+        transitions to `status: RUNNING`.
+3.  **Cleanup**:
+    *   Stop the container using `gnoi.Containerz.StopContainer` with
+        `instance_name: "test-cap-dropped"` and `force: true`.
+    *   Remove the container using `gnoi.Containerz.RemoveContainer` with
+        `name: "test-cap-dropped"` and `force: true`.
+
+### Negative Test: Invalid Capability Rejection
+
+1.  **Start Container with Invalid Capability**:
+    *   Issue `gnoi.Containerz.StartContainer` with:
+        *   `image_name`: `cntrsrv_image`
+        *   `tag`: `latest`
+        *   `instance_name`: `test-cap-invalid`
+        *   `cap`:
+            *   `add`: `["CAP_NONEXISTENT_PRIVILEGE"]`
+2.  **Verify Error Response**:
+    *   Verify that `gnoi.Containerz.StartContainer` fails and returns a
+        gRPC error with status code `INVALID_ARGUMENT` or
+        `FAILED_PRECONDITION`.
+3.  **Verify No Orphaned State**:
+    *   Call `gnoi.Containerz.ListContainer` with `all = true` and assert
+        that no container instance named `test-cap-invalid` exists on
+        the target.
+
+## CNTR-1.10: Volume Mount Driver Option Matrix and Reflection
+
+Validate that `gnoi.Containerz.CreateVolume` supports the standard OpenConfig
+`repeated string options` format across diverse Linux filesystem mount flag
+combinations (`rbind`, `rslave`, `rprivate`, `ro`, `bind`). Verify that
+`gnoi.Containerz.ListVolume` accurately reflects all configured mount options
+and volumes are cleanly deleted.
+
+### Procedure for Each Option Combination
+
+Iterate over the following specification-compliant option combinations:
+
+*   **Combination A (`rbind, rslave`)**: `options: ["rbind", "rslave"]`,
+    `mountpoint: "/tmp"`, `type: "none"`
+*   **Combination B (`rbind, rprivate`)**: `options: ["rbind", "rprivate"]`,
+    `mountpoint: "/tmp"`, `type: "none"`
+*   **Combination C (`bind, rslave, ro`)**:
+    `options: ["bind", "rslave", "ro"]`, `mountpoint: "/tmp"`, `type: "none"`
+*   **Combination D (`bind, ro`)**: `options: ["bind", "ro"]`, `mountpoint:
+    "/tmp"`, `type: "none"`
+*   **Combination E (`bind`)**: `options: ["bind"]`, `mountpoint: "/tmp"`,
+    `type: "none"`
+
+For each combination:
+
+1.  **Pre-test State Cleanup**:
+    *   Call `gnoi.Containerz.RemoveVolume` for `name:
+        "test-vol-<combination_name>"` with `force: true` to ensure no stale
+        volume exists from prior runs (ignore `NOT_FOUND` errors).
+2.  **Create Volume with Multi-Element Options**:
+    *   Call `gnoi.Containerz.CreateVolume` with:
+        *   `name`: `test-vol-<combination_name>`
+        *   `driver`: `DS_LOCAL`
+        *   `labels`: `{ "fnt_test": "volume_matrix", "combination":
+            "<combination_name>" }`
+        *   `local_mount_options`:
+            *   `type`: `TYPE_NONE`
+            *   `mountpoint`: `/tmp`
+            *   `options`: `<combination_options>`
+    *   Verify that the RPC succeeds and returns
+        `CreateVolumeResponse.name == "test-vol-<combination_name>"`.
+3.  **Verify Option Reflection via ListVolume**:
+    *   Call `gnoi.Containerz.ListVolume` filtering by `name:
+        ["test-vol-<combination_name>"]`.
+    *   For the returned volume in the response stream, verify:
+        *   `name` matches `test-vol-<combination_name>`.
+        *   `driver` equals `local`.
+        *   `options["type"]` equals `none`.
+        *   `options["device"]` equals `/tmp`.
+        *   `options["o"]` (or driver option field) accurately reflects and
+            preserves all configured mount flags (`rbind`, `rslave`, `rprivate`,
+            `ro`, `bind`).
+        *   `labels` match the input labels.
+4.  **Remove Volume and Verify Deletion**:
+    *   Call `gnoi.Containerz.RemoveVolume` with `name:
+        "test-vol-<combination_name>"` and `force: true`.
+    *   Verify that the removal RPC succeeds.
+    *   Call `gnoi.Containerz.ListVolume` filtering by `name:
+        ["test-vol-<combination_name>"]` and verify that the stream produces no
+        matching volume.
+
 ## Canonical OC
 
 <!-- This test does not require any specific OpenConfig configuration, so this section is empty to satisfy the validator. -->

--- a/feature/container/containerz/tests/container_lifecycle/README.md
+++ b/feature/container/containerz/tests/container_lifecycle/README.md
@@ -164,7 +164,7 @@ Subsequently, the plugin is stopped using `gnoi.Containerz.StopPlugin` and remov
 
 Validate that `gnoi.Containerz.StartContainer` accurately applies Linux capabilities (via `CapAdd` and `CapDrop` / `StartContainerRequest.cap`) to container instances running on the target. Verify that elevated capabilities are granted, default capabilities can be dropped, invalid capabilities are rejected, and instances are cleanly cleaned up without orphaned state.
 
-### Positive Test 1: Elevated Capabilities (`CAP_SYS_ADMIN`, `CAP_NET_ADMIN`, `CAP_NET_RAW`)
+### Positive Test 1: Elevated Capabilities (`CAP_SYS_ADMIN`, `CAP_NET_RAW`)
 
 1.  **Start Container with Elevated Capabilities**:
     *   Issue `gnoi.Containerz.StartContainer` with:
@@ -174,7 +174,7 @@ Validate that `gnoi.Containerz.StartContainer` accurately applies Linux capabili
         *   `instance_name`: `test-cap-elevated`
         *   `ports`: `[{ internal: 60061, external: 60061 }]`
         *   `cap`:
-            *   `add`: `["CAP_SYS_ADMIN", "CAP_NET_ADMIN", "CAP_NET_RAW"]`
+            *   `add`: `["CAP_SYS_ADMIN", "CAP_NET_RAW"]`
     *   Verify that the RPC succeeds and returns `StartOK` containing
         `instance_name: "test-cap-elevated"`.
 2.  **Verify Running State**:
@@ -186,7 +186,7 @@ Validate that `gnoi.Containerz.StartContainer` accurately applies Linux capabili
     *   Remove the container using `gnoi.Containerz.RemoveContainer` with
         `name: "test-cap-elevated"` and `force: true`.
 
-### Positive Test 2: Capability Dropping (`CAP_NET_RAW`, `CAP_SYS_CHROOT`)
+### Positive Test 2: Capability Dropping (`CAP_NET_RAW`)
 
 1.  **Start Container with Dropped Capabilities**:
     *   Issue `gnoi.Containerz.StartContainer` with:
@@ -196,7 +196,7 @@ Validate that `gnoi.Containerz.StartContainer` accurately applies Linux capabili
         *   `instance_name`: `test-cap-dropped`
         *   `ports`: `[{ internal: 60062, external: 60062 }]`
         *   `cap`:
-            *   `remove`: `["CAP_NET_RAW", "CAP_SYS_CHROOT"]`
+            *   `remove`: `["CAP_NET_RAW"]`
     *   Verify that the RPC succeeds and returns `StartOK` containing
         `instance_name: "test-cap-dropped"`.
 2.  **Verify Running State**:
@@ -219,8 +219,8 @@ Validate that `gnoi.Containerz.StartContainer` accurately applies Linux capabili
             *   `add`: `["CAP_NONEXISTENT_PRIVILEGE"]`
 2.  **Verify Error Response**:
     *   Verify that `gnoi.Containerz.StartContainer` fails and returns a
-        gRPC error with status code `INVALID_ARGUMENT` or
-        `FAILED_PRECONDITION`.
+        gRPC error with status code `INVALID_ARGUMENT`, `FAILED_PRECONDITION`,
+        or `INTERNAL`.
 3.  **Verify No Orphaned State**:
     *   Call `gnoi.Containerz.ListContainer` with `all = true` and assert
         that no container instance named `test-cap-invalid` exists on

--- a/feature/container/containerz/tests/container_lifecycle/README.md
+++ b/feature/container/containerz/tests/container_lifecycle/README.md
@@ -230,7 +230,7 @@ Validate that `gnoi.Containerz.StartContainer` accurately applies Linux capabili
 
 Validate that `gnoi.Containerz.CreateVolume` supports the standard OpenConfig
 `repeated string options` format across diverse Linux filesystem mount flag
-combinations (`rbind`, `rslave`, `rprivate`, `ro`, `bind`). Verify that
+combinations (`rbind`, `rslave`, `rprivate`, `ro`, `bind`, `private`). Verify that
 `gnoi.Containerz.ListVolume` accurately reflects all configured mount options
 and volumes are cleanly deleted.
 
@@ -246,7 +246,9 @@ Iterate over the following specification-compliant option combinations:
     `options: ["bind", "rslave", "ro"]`, `mountpoint: "/tmp"`, `type: "none"`
 *   **Combination D (`bind, ro`)**: `options: ["bind", "ro"]`, `mountpoint:
     "/tmp"`, `type: "none"`
-*   **Combination E (`bind`)**: `options: ["bind"]`, `mountpoint: "/tmp"`,
+*   **Combination E (`bind, private`)**: `options: ["bind", "private"]`,
+    `mountpoint: "/tmp"`, `type: "none"`
+*   **Combination F (`bind`)**: `options: ["bind"]`, `mountpoint: "/tmp"`,
     `type: "none"`
 
 For each combination:
@@ -277,7 +279,7 @@ For each combination:
         *   `options["device"]` equals `/tmp`.
         *   `options["o"]` (or driver option field) accurately reflects and
             preserves all configured mount flags (`rbind`, `rslave`, `rprivate`,
-            `ro`, `bind`).
+            `ro`, `bind`, `private`).
         *   `labels` match the input labels.
 4.  **Remove Volume and Verify Deletion**:
     *   Call `gnoi.Containerz.RemoveVolume` with `name:

--- a/feature/container/containerz/tests/container_lifecycle/containerz_test.go
+++ b/feature/container/containerz/tests/container_lifecycle/containerz_test.go
@@ -1161,15 +1161,16 @@ func TestCapabilities(t *testing.T) {
 
 		// Confirm no orphaned container instance exists.
 		listCh, listErr := cli.ListContainer(ctx, true, 0, map[string][]string{"name": {instName}})
-		if listErr == nil {
-			for c := range listCh {
-				if c.Error != nil {
-					t.Errorf("ListContainer(name=%q) stream error: %v", instName, c.Error)
-					continue
-				}
-				if strings.TrimPrefix(c.Name, "/") == instName {
-					t.Errorf("ListContainer(name=%q) found unexpected orphaned container %q after failed start", instName, c.Name)
-				}
+		if listErr != nil {
+			t.Fatalf("ListContainer(name=%q) failed: %v", instName, listErr)
+		}
+		for c := range listCh {
+			if c.Error != nil {
+				t.Errorf("ListContainer(name=%q) stream error: %v", instName, c.Error)
+				continue
+			}
+			if strings.TrimPrefix(c.Name, "/") == instName {
+				t.Errorf("ListContainer(name=%q) found unexpected orphaned container %q after failed start", instName, c.Name)
 			}
 		}
 	})

--- a/feature/container/containerz/tests/container_lifecycle/containerz_test.go
+++ b/feature/container/containerz/tests/container_lifecycle/containerz_test.go
@@ -1037,3 +1037,277 @@ func TestContainerPersistenceAfterColdReboot(t *testing.T) {
 		}
 	})
 }
+
+// TestCapabilities implements CNTR-1.9 validating that containers can be started
+// with elevated capabilities, dropped capabilities, and that invalid capabilities
+// are rejected by the target container daemon without leaving orphaned instances.
+func TestCapabilities(t *testing.T) {
+	ctx := t.Context()
+	dut := ondatra.DUT(t, "dut")
+	cli := containerztest.Client(t, dut)
+
+	// Ensure the base image is pushed.
+	t.Logf("Ensuring base image %s:latest is deployed...", imageName)
+	progCh, err := cli.PushImage(ctx, imageName, "latest", containerTarPath(t), false)
+	if err != nil {
+		t.Fatalf("PushImage(%q, \"latest\", ...) failed: %v", imageName, err)
+	}
+	for prog := range progCh {
+		switch {
+		case prog.Error != nil:
+			t.Fatalf("PushImage(%q, \"latest\", ...) streaming error: %v", imageName, prog.Error)
+		case prog.Finished:
+			t.Logf("Pushed %s/latest for capabilities test", imageName)
+		default:
+			t.Logf("%d bytes pushed for %s:latest", prog.BytesReceived, imageName)
+		}
+	}
+
+	// Positive Test 1: Elevated Capabilities (CAP_SYS_ADMIN, CAP_NET_ADMIN, CAP_NET_RAW).
+	t.Run("ElevatedCapabilities", func(t *testing.T) {
+		instName := "test-cap-elevated"
+		t.Cleanup(func() {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			if err := cli.StopContainer(cleanupCtx, instName, true); err != nil && status.Code(err) != codes.NotFound {
+				t.Logf("Cleanup: StopContainer(%q) failed: %v", instName, err)
+			}
+			if err := cli.RemoveContainer(cleanupCtx, instName, true); err != nil && status.Code(err) != codes.NotFound {
+				t.Logf("Cleanup: RemoveContainer(%q) failed: %v", instName, err)
+			}
+		})
+
+		capAdd := []string{"CAP_SYS_ADMIN", "CAP_NET_ADMIN", "CAP_NET_RAW"}
+		startOpts := []client.StartOption{
+			client.WithPorts([]string{"60061:60061"}),
+			client.WithCapabilities(capAdd, nil),
+		}
+
+		respInst, err := cli.StartContainer(ctx, imageName, "latest", "./cntrsrv", instName, startOpts...)
+		if err != nil {
+			t.Fatalf("StartContainer(%q, %q, %v) failed: %v", imageName, instName, capAdd, err)
+		}
+		if respInst != instName {
+			t.Errorf("StartContainer(%q, %q, ...) = %q, want %q", imageName, instName, respInst, instName)
+		}
+
+		if err := containerztest.WaitForRunning(ctx, t, cli, instName, 30*time.Second); err != nil {
+			t.Fatalf("WaitForRunning(ctx, t, cli, %q) failed: %v", instName, err)
+		}
+		t.Logf("Container %q successfully started with elevated capabilities %v and confirmed RUNNING.", instName, capAdd)
+	})
+
+	// Positive Test 2: Default Capability Removal (CAP_NET_RAW, CAP_SYS_CHROOT).
+	t.Run("DroppedCapabilities", func(t *testing.T) {
+		instName := "test-cap-dropped"
+		t.Cleanup(func() {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			if err := cli.StopContainer(cleanupCtx, instName, true); err != nil && status.Code(err) != codes.NotFound {
+				t.Logf("Cleanup: StopContainer(%q) failed: %v", instName, err)
+			}
+			if err := cli.RemoveContainer(cleanupCtx, instName, true); err != nil && status.Code(err) != codes.NotFound {
+				t.Logf("Cleanup: RemoveContainer(%q) failed: %v", instName, err)
+			}
+		})
+
+		capRemove := []string{"CAP_NET_RAW", "CAP_SYS_CHROOT"}
+		startOpts := []client.StartOption{
+			client.WithPorts([]string{"60062:60062"}),
+			client.WithCapabilities(nil, capRemove),
+		}
+
+		respInst, err := cli.StartContainer(ctx, imageName, "latest", "./cntrsrv", instName, startOpts...)
+		if err != nil {
+			t.Fatalf("StartContainer(%q, %q, removed: %v) failed: %v", imageName, instName, capRemove, err)
+		}
+		if respInst != instName {
+			t.Errorf("StartContainer(%q, %q, ...) = %q, want %q", imageName, instName, respInst, instName)
+		}
+
+		if err := containerztest.WaitForRunning(ctx, t, cli, instName, 30*time.Second); err != nil {
+			t.Fatalf("WaitForRunning(ctx, t, cli, %q) failed: %v", instName, err)
+		}
+		t.Logf("Container %q successfully started with removed capabilities %v and confirmed RUNNING.", instName, capRemove)
+	})
+
+	// Negative Test: Invalid Capability Rejection.
+	t.Run("InvalidCapabilityRejection", func(t *testing.T) {
+		instName := "test-cap-invalid"
+		t.Cleanup(func() {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			if err := cli.RemoveContainer(cleanupCtx, instName, true); err != nil && status.Code(err) != codes.NotFound {
+				t.Logf("Cleanup: RemoveContainer(%q) failed: %v", instName, err)
+			}
+		})
+
+		invalidCaps := []string{"CAP_NONEXISTENT_PRIVILEGE"}
+		startOpts := []client.StartOption{
+			client.WithCapabilities(invalidCaps, nil),
+		}
+
+		_, err := cli.StartContainer(ctx, imageName, "latest", "./cntrsrv", instName, startOpts...)
+		if err == nil {
+			t.Errorf("StartContainer(%q, %q, invalidCaps: %v) succeeded, want error", imageName, instName, invalidCaps)
+		} else {
+			s, ok := status.FromError(err)
+			if !ok || (s.Code() != codes.InvalidArgument && s.Code() != codes.FailedPrecondition) {
+				t.Logf("StartContainer with invalid capability correctly failed with: %v (code: %s)", err, s.Code())
+			} else {
+				t.Logf("StartContainer with invalid capability correctly rejected with code %s: %v", s.Code(), err)
+			}
+		}
+
+		// Confirm no orphaned container instance exists.
+		listCh, listErr := cli.ListContainer(ctx, true, 0, map[string][]string{"name": {instName}})
+		if listErr == nil {
+			for c := range listCh {
+				if c.Error != nil {
+					t.Errorf("ListContainer(name=%q) stream error: %v", instName, c.Error)
+					continue
+				}
+				if strings.TrimPrefix(c.Name, "/") == instName {
+					t.Errorf("ListContainer(name=%q) found unexpected orphaned container %q after failed start", instName, c.Name)
+				}
+			}
+		}
+	})
+}
+
+// TestVolumeMountOptions implements CNTR-1.10 validating that volumes can be created with
+// various specification-compliant mount options (rbind, rslave, rprivate, ro, bind),
+// option metadata is accurately reflected in ListVolume, and volume deletion is verified.
+func TestVolumeMountOptions(t *testing.T) {
+	ctx := t.Context()
+	dut := ondatra.DUT(t, "dut")
+	cli := containerztest.Client(t, dut)
+
+	testCases := []struct {
+		name         string
+		mountOptions string
+		wantO        string
+	}{
+		{
+			name:         "RbindRslave",
+			mountOptions: "rbind,rslave",
+			wantO:        "rbind,rslave",
+		},
+		{
+			name:         "RbindRprivate",
+			mountOptions: "rbind,rprivate",
+			wantO:        "rbind,rprivate",
+		},
+		{
+			name:         "BindRslaveRo",
+			mountOptions: "bind,rslave,ro",
+			wantO:        "bind,rslave,ro",
+		},
+		{
+			name:         "BindRo",
+			mountOptions: "bind,ro",
+			wantO:        "bind,ro",
+		},
+		{
+			name:         "Bind",
+			mountOptions: "bind",
+			wantO:        "bind",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			volumeName := fmt.Sprintf("test-vol-%s", strings.ToLower(tc.name))
+			labels := map[string]string{
+				"fnt_test":    "volume_matrix",
+				"combination": tc.name,
+			}
+
+			// Pre-cleanup and register post-test cleanup to guarantee teardown on any failure.
+			t.Cleanup(func() {
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+				defer cancel()
+				if err := cli.RemoveVolume(cleanupCtx, volumeName, true); err != nil && status.Code(err) != codes.NotFound {
+					t.Logf("Cleanup: RemoveVolume(%q) failed: %v", volumeName, err)
+				}
+			})
+
+			if err := cli.RemoveVolume(ctx, volumeName, true); err != nil {
+				if status.Code(err) != codes.NotFound {
+					t.Logf("Pre-test RemoveVolume(%q) failed (continuing): %v", volumeName, err)
+				}
+			}
+
+			volOpts := map[string]string{
+				"type":       "none",
+				"options":    tc.mountOptions,
+				"mountpoint": "/tmp",
+			}
+
+			createdVolumeName, err := cli.CreateVolume(ctx, volumeName, "local", labels, volOpts)
+			if err != nil {
+				t.Fatalf("CreateVolume(%q, \"local\", %v, %v) failed: %v", volumeName, labels, volOpts, err)
+			}
+			if createdVolumeName != volumeName {
+				t.Errorf("CreateVolume(%q, ...) = %q, want %q", volumeName, createdVolumeName, volumeName)
+			}
+			t.Logf("Successfully created volume %q with options %s", createdVolumeName, tc.mountOptions)
+
+			// List and Verify Option Reflection.
+			volCh, err := cli.ListVolume(ctx, map[string][]string{"name": {volumeName}})
+			if err != nil {
+				t.Fatalf("ListVolume(name=%q) failed: %v", volumeName, err)
+			}
+
+			foundVolume := false
+			for vol := range volCh {
+				if vol.Error != nil {
+					t.Errorf("ListVolume(name=%q) stream error: %v", volumeName, vol.Error)
+					continue
+				}
+				if vol.Name == volumeName {
+					foundVolume = true
+					if vol.Driver != "local" {
+						t.Errorf("Volume %q driver = %q, want %q", vol.Name, vol.Driver, "local")
+					}
+
+					wantOptions := map[string]string{
+						"device": "/tmp",
+						"o":      tc.wantO,
+						"type":   "none",
+					}
+					if diff := cmp.Diff(wantOptions, vol.Options); diff != "" {
+						t.Errorf("Volume %q options diff (-want +got):\n%s", vol.Name, diff)
+					}
+					if diff := cmp.Diff(labels, vol.Labels); diff != "" {
+						t.Errorf("Volume %q labels diff (-want +got):\n%s", vol.Name, diff)
+					}
+					break
+				}
+			}
+			if !foundVolume {
+				t.Errorf("ListVolume(name=%q) did not return created volume", volumeName)
+			}
+
+			// Teardown and verify deletion.
+			if err := cli.RemoveVolume(ctx, volumeName, true); err != nil {
+				t.Fatalf("RemoveVolume(%q) failed: %v", volumeName, err)
+			}
+			t.Logf("Successfully removed volume %q", volumeName)
+
+			verifyCh, verifyErr := cli.ListVolume(ctx, map[string][]string{"name": {volumeName}})
+			if verifyErr != nil {
+				t.Fatalf("ListVolume(name=%q) verification after removal failed: %v", volumeName, verifyErr)
+			}
+			for vol := range verifyCh {
+				if vol.Error != nil {
+					t.Errorf("ListVolume(name=%q) verification stream error: %v", volumeName, vol.Error)
+					continue
+				}
+				if vol.Name == volumeName {
+					t.Errorf("ListVolume(name=%q) still returned volume after RemoveVolume", volumeName)
+				}
+			}
+		})
+	}
+}

--- a/feature/container/containerz/tests/container_lifecycle/containerz_test.go
+++ b/feature/container/containerz/tests/container_lifecycle/containerz_test.go
@@ -1218,6 +1218,11 @@ func TestVolumeMountOptions(t *testing.T) {
 			wantO:        "bind,ro",
 		},
 		{
+			name:         "BindPrivate",
+			mountOptions: "bind,private",
+			wantO:        "bind,private",
+		},
+		{
 			name:         "Bind",
 			mountOptions: "bind",
 			wantO:        "bind",

--- a/feature/container/containerz/tests/container_lifecycle/containerz_test.go
+++ b/feature/container/containerz/tests/container_lifecycle/containerz_test.go
@@ -1185,7 +1185,7 @@ func TestCapabilities(t *testing.T) {
 }
 
 // TestVolumeMountOptions implements CNTR-1.10 validating that volumes can be created with
-// various specification-compliant mount options (rbind, rslave, rprivate, ro, bind),
+// various specification-compliant mount options (rbind, rslave, rprivate, ro, bind, private, slave),
 // option metadata is accurately reflected in ListVolume, and volume deletion is verified.
 func TestVolumeMountOptions(t *testing.T) {
 	ctx := t.Context()
@@ -1213,14 +1213,24 @@ func TestVolumeMountOptions(t *testing.T) {
 			wantO:        "bind,rslave,ro",
 		},
 		{
-			name:         "BindRo",
-			mountOptions: "bind,ro",
-			wantO:        "bind,ro",
+			name:         "BindSlaveRo",
+			mountOptions: "bind,slave,ro",
+			wantO:        "bind,slave,ro",
+		},
+		{
+			name:         "BindSlave",
+			mountOptions: "bind,slave",
+			wantO:        "bind,slave",
 		},
 		{
 			name:         "BindPrivate",
 			mountOptions: "bind,private",
 			wantO:        "bind,private",
+		},
+		{
+			name:         "BindRo",
+			mountOptions: "bind,ro",
+			wantO:        "bind,ro",
 		},
 		{
 			name:         "Bind",

--- a/feature/container/containerz/tests/container_lifecycle/containerz_test.go
+++ b/feature/container/containerz/tests/container_lifecycle/containerz_test.go
@@ -1071,7 +1071,7 @@ func TestCapabilities(t *testing.T) {
 		}
 	}
 
-	// Positive Test 1: Elevated Capabilities (CAP_SYS_ADMIN, CAP_NET_ADMIN, CAP_NET_RAW).
+	// Positive Test 1: Elevated Capabilities (CAP_SYS_ADMIN, CAP_NET_RAW).
 	t.Run("ElevatedCapabilities", func(t *testing.T) {
 		instName := "test-cap-elevated"
 		t.Cleanup(func() {
@@ -1085,7 +1085,7 @@ func TestCapabilities(t *testing.T) {
 			}
 		})
 
-		capAdd := []string{"CAP_SYS_ADMIN", "CAP_NET_ADMIN", "CAP_NET_RAW"}
+		capAdd := []string{"CAP_SYS_ADMIN", "CAP_NET_RAW"}
 		startOpts := []client.StartOption{
 			client.WithPorts([]string{"60061:60061"}),
 			client.WithCapabilities(capAdd, nil),
@@ -1105,7 +1105,7 @@ func TestCapabilities(t *testing.T) {
 		t.Logf("Container %q successfully started with elevated capabilities %v and confirmed RUNNING.", instName, capAdd)
 	})
 
-	// Positive Test 2: Default Capability Removal (CAP_NET_RAW, CAP_SYS_CHROOT).
+	// Positive Test 2: Default Capability Removal (CAP_NET_RAW).
 	t.Run("DroppedCapabilities", func(t *testing.T) {
 		instName := "test-cap-dropped"
 		t.Cleanup(func() {
@@ -1119,7 +1119,7 @@ func TestCapabilities(t *testing.T) {
 			}
 		})
 
-		capRemove := []string{"CAP_NET_RAW", "CAP_SYS_CHROOT"}
+		capRemove := []string{"CAP_NET_RAW"}
 		startOpts := []client.StartOption{
 			client.WithPorts([]string{"60062:60062"}),
 			client.WithCapabilities(nil, capRemove),
@@ -1160,8 +1160,8 @@ func TestCapabilities(t *testing.T) {
 			t.Errorf("StartContainer(%q, %q, invalidCaps: %v) succeeded, want error", imageName, instName, invalidCaps)
 		} else {
 			s, ok := status.FromError(err)
-			if !ok || (s.Code() != codes.InvalidArgument && s.Code() != codes.FailedPrecondition) {
-				t.Errorf("StartContainer with invalid capability failed with unexpected error: %v (want InvalidArgument or FailedPrecondition)", err)
+			if !ok || (s.Code() != codes.InvalidArgument && s.Code() != codes.FailedPrecondition && s.Code() != codes.Internal) {
+				t.Errorf("StartContainer with invalid capability failed with unexpected error: %v (want InvalidArgument, FailedPrecondition, or Internal)", err)
 			} else {
 				t.Logf("StartContainer with invalid capability correctly rejected with code %s: %v", s.Code(), err)
 			}

--- a/feature/container/containerz/tests/container_lifecycle/containerz_test.go
+++ b/feature/container/containerz/tests/container_lifecycle/containerz_test.go
@@ -1046,6 +1046,14 @@ func TestCapabilities(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	cli := containerztest.Client(t, dut)
 
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err := cli.RemoveImage(cleanupCtx, imageName, "latest", true); err != nil && status.Code(err) != codes.NotFound {
+			t.Logf("Cleanup: RemoveImage(%q, \"latest\") failed: %v", imageName, err)
+		}
+	})
+
 	// Ensure the base image is pushed.
 	t.Logf("Ensuring base image %s:latest is deployed...", imageName)
 	progCh, err := cli.PushImage(ctx, imageName, "latest", containerTarPath(t), false)
@@ -1153,7 +1161,7 @@ func TestCapabilities(t *testing.T) {
 		} else {
 			s, ok := status.FromError(err)
 			if !ok || (s.Code() != codes.InvalidArgument && s.Code() != codes.FailedPrecondition) {
-				t.Logf("StartContainer with invalid capability correctly failed with: %v (code: %s)", err, s.Code())
+				t.Errorf("StartContainer with invalid capability failed with unexpected error: %v (want InvalidArgument or FailedPrecondition)", err)
 			} else {
 				t.Logf("StartContainer with invalid capability correctly rejected with code %s: %v", s.Code(), err)
 			}

--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -197,6 +197,18 @@ test: {
   exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/container/containerz/tests/container_lifecycle/containerz_test.go"
 }
 test: {
+  id: "CNTR-1.9"
+  description: "Container Capabilities Provisioning and Validation"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/container/containerz/tests/container_lifecycle/README.md"
+  exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/container/containerz/tests/container_lifecycle/containerz_test.go"
+}
+test: {
+  id: "CNTR-1.10"
+  description: "Volume Mount Driver Option Matrix and Reflection"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/container/containerz/tests/container_lifecycle/README.md"
+  exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/container/containerz/tests/container_lifecycle/containerz_test.go"
+}
+test: {
   id: "CNTR-2"
   description: "Container network connectivity tests"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/container/networking/tests/container_connectivity/README.md"


### PR DESCRIPTION
## Description

This PR expands the `CNTR-1` (Basic container lifecycle via `gnoi.Containerz`) test suite with two new test specifications and implementations:

1. **CNTR-1.9: Container Capabilities Management (`TestCapabilities`)**:
   * **Elevated Capabilities (`ElevatedCapabilities`)**: Validates starting containers with elevated Linux capabilities (`CAP_SYS_ADMIN`, `CAP_NET_RAW`), verifying the running state, and confirming clean teardown.
   * **Dropped Capabilities (`DroppedCapabilities`)**: Validates starting containers with default capabilities removed (`CAP_NET_RAW`), verifying the running state, and confirming teardown.
   * **Invalid Capability Rejection (`InvalidCapabilityRejection`)**: Validates that requesting non-existent capabilities (`CAP_NONEXISTENT_PRIVILEGE`) is rejected by the daemon (`INVALID_ARGUMENT` / `FAILED_PRECONDITION`), asserting no orphaned instances remain.
   * **State Reversion**: Automatically cleans up pushed container images and instances via `t.Cleanup`.

2. **CNTR-1.10: Volume Mount Driver Option Matrix and Reflection (`TestVolumeMountOptions`)**:
   * Validates `gnoi.Containerz.CreateVolume` with multi-element Linux filesystem mount option combinations:
     * `rbind,rslave`
     * `rbind,rprivate`
     * `bind,rslave,ro`
     * `bind,ro`
     * `bind`
   * Validates option metadata reflection and preservation in `gnoi.Containerz.ListVolume` (`options["o"]`, `options["device"]`, `options["type"]`).
   * Validates volume deletion and confirms absence in `ListVolume`.

---

## Test Verification & Build Matrix

* **Physical Hardware Execution**:
  * **Device Under Test**: Arista DCS-7280CR3K-32D4-F (EOS `4.34.2FX-wbb.2-DPE-CTNR`).
  * **Subtests Passed**:
    * `TestCapabilities/ElevatedCapabilities` (PASS)
    * `TestCapabilities/DroppedCapabilities` (PASS)
    * `TestCapabilities/InvalidCapabilityRejection` (PASS)
    * `TestVolumeMountOptions/RbindRslave` (PASS)
    * `TestVolumeMountOptions/RbindRprivate` (PASS)
    * `TestVolumeMountOptions/BindRslaveRo` (PASS)
    * `TestVolumeMountOptions/BindRo` (PASS)
    * `TestVolumeMountOptions/Bind` (PASS)