### PR TITLE
Allow fptest pysical re-run of failed or passed run

### DIFF
--- a/tools/ci-trigger/pr.go
+++ b/tools/ci-trigger/pr.go
@@ -165,7 +165,7 @@ func (p *pullRequest) createBuild(ctx context.Context, buildClient *cloudbuild.S
 					continue
 				}
 				for _, t := range physicalDevice.Tests {
-					if t.Status != "pending authorization" && t.Status != "failure" && t.Status != "failed" && t.Status != "success" && t.Status != "passed" {
+					if t.Status == "setup" || t.Status == "pending execution" || t.Status == "environment setup" || t.Status == "running" {
 						continue physicalDeviceLoop
 					}
 				}

--- a/tools/ci-trigger/pr.go
+++ b/tools/ci-trigger/pr.go
@@ -165,7 +165,7 @@ func (p *pullRequest) createBuild(ctx context.Context, buildClient *cloudbuild.S
 					continue
 				}
 				for _, t := range physicalDevice.Tests {
-					if t.Status != "pending authorization" {
+					if t.Status != "pending authorization" && t.Status != "failure" && t.Status != "failed" && t.Status != "success" && t.Status != "passed" {
 						continue physicalDeviceLoop
 					}
 				}


### PR DESCRIPTION
Allow re-triggering physical device CI tests on failed or passed statuses.
Currently, ci-trigger only dispatches physical test jobs if the test's badge
status is in the "pending authorization" state. When a physical test fails due
to transient lab or switch hardware/network issues, engineers are blocked from
re-running tests via PR comments and are forced to push dummy commits to reset
the status.
This change allows physical tests in completed states ("failure", "failed",
"success", "passed") to be re-triggered via issue comments without modifying
the PR. Active running states ("setup", "running", etc.) continue to be skipped
to prevent duplicate parallel jobs.
Note: This behavior is enabled for the current evaluation period to streamline
hardware testbed validation and triage. We will revisit and establish permanent
gating/re-run policies once the evaluation phase is complete.