### PR TITLE
Update vrf_policy_driven_te_test.go

### DIFF
--- a/feature/gribi/otg_tests/vrf_policy_driven_te/vrf_policy_driven_te_test.go
+++ b/feature/gribi/otg_tests/vrf_policy_driven_te/vrf_policy_driven_te_test.go
@@ -1705,17 +1705,35 @@ func validateTrafficTTL(t *testing.T, captureFile *os.File, expectedInHdrIP stri
 		if ipLayer == nil {
 			continue
 		}
-		ipPacket, _ := ipLayer.(*layers.IPv4)
-		if ipPacket.DstIP.String() != expectedInHdrIP {
+		ipPacket, ok := ipLayer.(*layers.IPv4)
+		if !ok || ipPacket == nil {
 			continue
-		}
-		packetCheckCount++
-		if ipPacket.TTL != (correspondingTTL - 1) {
-			t.Errorf("Decap TTL doesnt match; got:%d, want:%d", ipPacket.TTL, (correspondingTTL - 1))
 		}
 		innerPacket := gopacket.NewPacket(ipPacket.Payload, ipPacket.NextLayerType(), gopacket.Default)
 		ipInnerLayer := innerPacket.Layer(layers.LayerTypeIPv4)
 		ipv6InnerLayer := innerPacket.Layer(layers.LayerTypeIPv6)
+
+		var dstIP string
+		if ipInnerLayer != nil {
+			if ipInner, ok := ipInnerLayer.(*layers.IPv4); ok && ipInner != nil {
+				dstIP = ipInner.DstIP.String()
+			}
+		} else if ipv6InnerLayer != nil {
+			if ipv6Inner, ok := ipv6InnerLayer.(*layers.IPv6); ok && ipv6Inner != nil {
+				dstIP = ipv6Inner.DstIP.String()
+			}
+		} else {
+			dstIP = ipPacket.DstIP.String()
+		}
+
+		if dstIP != expectedInHdrIP {
+			continue
+		}
+
+		packetCheckCount++
+		if ipPacket.TTL != (correspondingTTL - 1) {
+			t.Errorf("Decap TTL doesnt match; got:%d, want:%d", ipPacket.TTL, (correspondingTTL - 1))
+		}
 		if ipInnerLayer != nil {
 			t.Errorf("validateTrafficTTL: packets are not decapped, inner IP header is not removed")
 		}

--- a/feature/gribi/otg_tests/vrf_policy_driven_te/vrf_policy_driven_te_test.go
+++ b/feature/gribi/otg_tests/vrf_policy_driven_te/vrf_policy_driven_te_test.go
@@ -1672,7 +1672,7 @@ func captureAndValidatePackets(t *testing.T, args *testArgs, packetVal *packetVa
 	}
 	f.Close()
 	if packetVal.validateTTL {
-		validateTrafficTTL(t, f)
+		validateTrafficTTL(t, f, packetVal.inHdrIP)
 	}
 	if packetVal.validateDecap {
 		validateTrafficDecap(t, f, packetVal.inHdrIP, packetVal.inHdrIPv6, packetVal.inHdrDscp, packetVal.inHdrEcn)
@@ -1688,7 +1688,7 @@ func captureAndValidatePackets(t *testing.T, args *testArgs, packetVal *packetVa
 	time.Sleep(30 * time.Second)
 }
 
-func validateTrafficTTL(t *testing.T, captureFile *os.File) {
+func validateTrafficTTL(t *testing.T, captureFile *os.File, expectedInHdrIP string) {
 	t.Helper()
 	pcapFileHandle, err := pcap.OpenOffline(captureFile.Name())
 	if err != nil {
@@ -1698,22 +1698,32 @@ func validateTrafficTTL(t *testing.T, captureFile *os.File) {
 	var packetCheckCount uint32 = 0
 	packetSource := gopacket.NewPacketSource(pcapFileHandle, pcapFileHandle.LinkType())
 	for packet := range packetSource.Packets() {
+		if packet.Layer(layers.LayerTypeUDP) == nil {
+			continue
+		}
 		ipLayer := packet.Layer(layers.LayerTypeIPv4)
-		if ipLayer != nil && packetCheckCount <= 3 {
-			packetCheckCount++
-			ipPacket, _ := ipLayer.(*layers.IPv4)
-			if ipPacket.TTL != (correspondingTTL - 1) {
-				t.Errorf("Decap TTL doesnt match; got:%d, want:%d", ipPacket.TTL, (correspondingTTL - 1))
-			}
-			innerPacket := gopacket.NewPacket(ipPacket.Payload, ipPacket.NextLayerType(), gopacket.Default)
-			ipInnerLayer := innerPacket.Layer(layers.LayerTypeIPv4)
-			ipv6InnerLayer := innerPacket.Layer(layers.LayerTypeIPv6)
-			if ipInnerLayer != nil {
-				t.Errorf("validateTrafficTTL: packets are not decapped, inner IP header is not removed")
-			}
-			if ipv6InnerLayer != nil {
-				t.Errorf("validateTrafficTTL: packets are not decapped, inner IPv6 header is not removed")
-			}
+		if ipLayer == nil {
+			continue
+		}
+		ipPacket, _ := ipLayer.(*layers.IPv4)
+		if ipPacket.DstIP.String() != expectedInHdrIP {
+			continue
+		}
+		packetCheckCount++
+		if ipPacket.TTL != (correspondingTTL - 1) {
+			t.Errorf("Decap TTL doesnt match; got:%d, want:%d", ipPacket.TTL, (correspondingTTL - 1))
+		}
+		innerPacket := gopacket.NewPacket(ipPacket.Payload, ipPacket.NextLayerType(), gopacket.Default)
+		ipInnerLayer := innerPacket.Layer(layers.LayerTypeIPv4)
+		ipv6InnerLayer := innerPacket.Layer(layers.LayerTypeIPv6)
+		if ipInnerLayer != nil {
+			t.Errorf("validateTrafficTTL: packets are not decapped, inner IP header is not removed")
+		}
+		if ipv6InnerLayer != nil {
+			t.Errorf("validateTrafficTTL: packets are not decapped, inner IPv6 header is not removed")
+		}
+		if packetCheckCount >= 5 {
+			break
 		}
 	}
 	if packetCheckCount == 0 {


### PR DESCRIPTION
Fix flakiness in vrf_policy_driven_te_test TTL validation

Filter captured packets in validateTrafficTTL by UDP layer and expected destination IP (determining effective destination IP from innermost packet layer) to prevent background control-plane traffic from causing false-positive
decap TTL mismatches while preserving decap failure diagnostics.