### PR TITLE
Update telemetry_basic_check_test.go

### DIFF
--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/metadata.textproto
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/metadata.textproto
@@ -50,7 +50,7 @@ platform_exceptions: {
 platform_exceptions: {
   platform: {
     vendor: ARISTA
-    hardware_model_regex: "DCS-7280CR3K-32D4"
+    hardware_model_regex: "DCS-7280.*"
   }
   deviations: {
     interface_enabled: true

--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -1013,8 +1013,8 @@ func TestIntfCounterUpdate(t *testing.T) {
 	otg.PushConfig(t, config)
 	otg.StartProtocols(t)
 
-	gnmi.Await(t, dut, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), 2*time.Minute, oc.Interface_OperStatus_UP)
-	gnmi.Await(t, dut, gnmi.OC().Interface(dp2.Name()).OperStatus().State(), 2*time.Minute, oc.Interface_OperStatus_UP)
+	gnmi.Await(t, dut, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), 2*time.Minute, operStatusUp)
+	gnmi.Await(t, dut, gnmi.OC().Interface(dp2.Name()).OperStatus().State(), 2*time.Minute, operStatusUp)
 
 	otgutils.WaitForARP(t, ate.OTG(), config, "IPv4")
 

--- a/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
+++ b/feature/gnmi/otg_tests/telemetry_basic_check_test/telemetry_basic_check_test.go
@@ -1012,6 +1012,10 @@ func TestIntfCounterUpdate(t *testing.T) {
 	v4.Dst().SetValue(ip4_2.Address())
 	otg.PushConfig(t, config)
 	otg.StartProtocols(t)
+
+	gnmi.Await(t, dut, gnmi.OC().Interface(dp1.Name()).OperStatus().State(), 2*time.Minute, oc.Interface_OperStatus_UP)
+	gnmi.Await(t, dut, gnmi.OC().Interface(dp2.Name()).OperStatus().State(), 2*time.Minute, oc.Interface_OperStatus_UP)
+
 	otgutils.WaitForARP(t, ate.OTG(), config, "IPv4")
 
 	t.Log("Running traffic on DUT interfaces: ", dp1, dp2)


### PR DESCRIPTION
- Add gnmi.Await before waiting for arp as otherwise the code can flakily timeout waiting for arp entries. 
- Update the metadata.textproto to include all Arista FFF platforms.