### PR TITLE
Update record_payload_truncation_test.go

### DIFF
--- a/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
+++ b/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
@@ -100,6 +100,9 @@ func TestAccountzRecordPayloadTruncation(t *testing.T) {
 		Timestamp: requestTimestamp,
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
 	acctzClient := dut.RawAPIs().GNSI(t).AcctzStream()
 	t.Logf("Sending acctz record subscribe request: %s", acctz.PrettyPrint(request))
 	acctzSubClient, err := acctzClient.RecordSubscribe(ctx, request, grpc.MaxCallRecvMsgSize(45000000))
@@ -114,11 +117,9 @@ func TestAccountzRecordPayloadTruncation(t *testing.T) {
 	go func() {
 		for {
 			resp, err := acctzSubClient.Recv()
+			res := recordRequestResult{record: resp, err: err}
 			select {
-			case recordChan <- recordRequestResult{
-				record: resp,
-				err:    err,
-			}:
+			case recordChan <- res:
 			case <-ctx.Done():
 				return
 			}

--- a/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
+++ b/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
@@ -102,7 +102,7 @@ func TestAccountzRecordPayloadTruncation(t *testing.T) {
 
 	acctzClient := dut.RawAPIs().GNSI(t).AcctzStream()
 	t.Logf("Sending acctz record subscribe request: %s", acctz.PrettyPrint(request))
-	acctzSubClient, err := acctzClient.RecordSubscribe(context.Background(), request, grpc.MaxCallRecvMsgSize(45000000))
+	acctzSubClient, err := acctzClient.RecordSubscribe(ctx, request, grpc.MaxCallRecvMsgSize(45000000))
 	if err != nil {
 		t.Fatalf("Failed to subscribe to acctz records: %v", err)
 	}
@@ -114,9 +114,13 @@ func TestAccountzRecordPayloadTruncation(t *testing.T) {
 	go func() {
 		for {
 			resp, err := acctzSubClient.Recv()
-			recordChan <- recordRequestResult{
+			select {
+			case recordChan <- recordRequestResult{
 				record: resp,
 				err:    err,
+			}:
+			case <-ctx.Done():
+				return
 			}
 			if err != nil {
 				return
@@ -128,10 +132,10 @@ func TestAccountzRecordPayloadTruncation(t *testing.T) {
 		var resp recordRequestResult
 		select {
 		case resp = <-recordChan:
-		case <-time.After(60 * time.Second):
+		case <-ctx.Done():
 			t.Fatal("Done receiving records and did not find our record...")
 		}
-		
+
 		if resp.err != nil {
 			t.Fatalf("Failed receiving record response, error: %s", resp.err)
 		}

--- a/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
+++ b/feature/gnsi/acctz/tests/record_payload_truncation/record_payload_truncation_test.go
@@ -110,29 +110,28 @@ func TestAccountzRecordPayloadTruncation(t *testing.T) {
 
 	sendOversizedPayload(t, dut)
 
-	for {
-		r := make(chan recordRequestResult)
-		go func(r chan recordRequestResult) {
+	recordChan := make(chan recordRequestResult)
+	go func() {
+		for {
 			resp, err := acctzSubClient.Recv()
-			r <- recordRequestResult{
+			recordChan <- recordRequestResult{
 				record: resp,
 				err:    err,
 			}
-		}(r)
-		var done bool
-		var resp recordRequestResult
-
-		select {
-		case rr := <-r:
-			resp = rr
-		case <-time.After(60 * time.Second):
-			done = true
+			if err != nil {
+				return
+			}
 		}
+	}()
 
-		if done {
+	for {
+		var resp recordRequestResult
+		select {
+		case resp = <-recordChan:
+		case <-time.After(60 * time.Second):
 			t.Fatal("Done receiving records and did not find our record...")
 		}
-
+		
 		if resp.err != nil {
 			t.Fatalf("Failed receiving record response, error: %s", resp.err)
 		}


### PR DESCRIPTION
Fix flaky gNSI acctz record payload truncation test

- Read stream records sequentially from a single dedicated reader goroutine to avoid concurrent Recv() calls on the same gRPC stream.