### PR TITLE
Acctz-3.1: fix shell command authn status

### DIFF
--- a/internal/security/acctz/acctz.go
+++ b/internal/security/acctz/acctz.go
@@ -1710,7 +1710,7 @@ func SendShellCommand(t *testing.T, dut *ondatra.DUTDevice, staticBinding bool) 
 			IpProto: ipProto,
 			Authn: &acctzpb.AuthnDetail{
 				Type:   acctzpb.AuthnDetail_AUTHN_TYPE_UNSPECIFIED,
-				Status: acctzpb.AuthnDetail_AUTHN_STATUS_UNSPECIFIED,
+				Status: acctzpb.AuthnDetail_AUTHN_STATUS_SUCCESS,
 			},
 			User: &acctzpb.UserDetail{
 				Identity: shellUsername,


### PR DESCRIPTION
Fix authn status for shell commands to expect SUCCESS similar to other command service types (eg. cli commands) used in the test

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."