### PR TITLE
Update packet_link_qualification_test.go

### DIFF
--- a/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/packet_link_qualification_test.go
+++ b/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/packet_link_qualification_test.go
@@ -238,6 +238,9 @@ func TestListDelete(t *testing.T) {
 					t.Fatalf("Failed to handle gnoi LinkQualification().Delete(): %v", err)
 				}
 			}
+			if deviations.LinkQualWaitAfterDeleteRequired(dut1) {
+				time.Sleep(10 * time.Second)
+			}
 		} else {
 			t.Logf("The LinkQualification request was not found on client %d", i+1)
 			continue
@@ -252,9 +255,6 @@ func TestListDelete(t *testing.T) {
 		if got, want := len(listResp.GetResults()), 0; got != want {
 			t.Errorf("len(listResp.GetResults()): got %v, want %v", got, want)
 		}
-	}
-	if deviations.LinkQualWaitAfterDeleteRequired(dut1) {
-		time.Sleep(10 * time.Second)
 	}
 }
 

--- a/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/packet_link_qualification_test.go
+++ b/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/packet_link_qualification_test.go
@@ -238,9 +238,10 @@ func TestListDelete(t *testing.T) {
 					t.Fatalf("Failed to handle gnoi LinkQualification().Delete(): %v", err)
 				}
 			}
-			if deviations.LinkQualWaitAfterDeleteRequired(dut1) {
-				time.Sleep(10 * time.Second)
-			}
+dut := duts[i]
+if deviations.LinkQualWaitAfterDeleteRequired(dut) {
+	time.Sleep(10 * time.Second)
+}
 		} else {
 			t.Logf("The LinkQualification request was not found on client %d", i+1)
 			continue

--- a/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/packet_link_qualification_test.go
+++ b/feature/gnoi/packet_link_qualification/tests/packet_link_qualification_test/packet_link_qualification_test.go
@@ -238,10 +238,9 @@ func TestListDelete(t *testing.T) {
 					t.Fatalf("Failed to handle gnoi LinkQualification().Delete(): %v", err)
 				}
 			}
-dut := duts[i]
-if deviations.LinkQualWaitAfterDeleteRequired(dut) {
-	time.Sleep(10 * time.Second)
-}
+			if deviations.LinkQualWaitAfterDeleteRequired(dut1) {
+				time.Sleep(10 * time.Second)
+			}
 		} else {
 			t.Logf("The LinkQualification request was not found on client %d", i+1)
 			continue


### PR DESCRIPTION
Moved the conditional wait (deviations.LinkQualWaitAfterDeleteRequired) inside the client iteration loop, right after the list of Delete commands are issued and before the verification List command is called.