### PR TITLE
Update record_history_truncation_test.go

### DIFF
--- a/feature/gnsi/acctz/tests/record_history_truncation/record_history_truncation_test.go
+++ b/feature/gnsi/acctz/tests/record_history_truncation/record_history_truncation_test.go
@@ -36,7 +36,7 @@ func TestAccountzRecordHistoryTruncation(t *testing.T) {
 
 	// Run a CLI command to populate the accounting history buffer per test procedure.
 	dut.CLI().Run(t, "show version")
-	
+
 	bootTime := gnmi.Get(t, dut, gnmi.OC().System().BootTime().State())
 
 	// Try to get records from 1 day prior to device's boot time.

--- a/feature/gnsi/acctz/tests/record_history_truncation/record_history_truncation_test.go
+++ b/feature/gnsi/acctz/tests/record_history_truncation/record_history_truncation_test.go
@@ -34,6 +34,9 @@ func TestMain(m *testing.M) {
 func TestAccountzRecordHistoryTruncation(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 
+	// Run a CLI command to populate the accounting history buffer per test procedure.
+	dut.CLI().Run(t, "show version")
+	
 	bootTime := gnmi.Get(t, dut, gnmi.OC().System().BootTime().State())
 
 	// Try to get records from 1 day prior to device's boot time.


### PR DESCRIPTION
To make the test reliable across clean DUTs and fully compliant with ACCTZ-4.1, a CLI command should be added (or executed via an authenticated CLI call that guarantees an accounting record exists in the buffer).