### PR TITLE
Update gnmi_set_test.go

### DIFF
--- a/feature/gnmi/tests/gnmi_set_test/gnmi_set_test.go
+++ b/feature/gnmi/tests/gnmi_set_test/gnmi_set_test.go
@@ -169,9 +169,7 @@ func TestDeleteInterface(t *testing.T) {
 		if deviations.InterfaceEnabled(dut) {
 			intf2.Enabled = ygot.Bool(true)
 		}
-		
-		config.GetOrCreateInterface(p1.Name()).Description = ygot.String(want1)
-		config.GetOrCreateInterface(p2.Name()).Description = ygot.String(want2)
+
 		op.push(t, dut, config, scope)
 
 		t.Run("VerifyBeforeDelete", func(t *testing.T) {

--- a/feature/gnmi/tests/gnmi_set_test/gnmi_set_test.go
+++ b/feature/gnmi/tests/gnmi_set_test/gnmi_set_test.go
@@ -155,6 +155,21 @@ func TestDeleteInterface(t *testing.T) {
 	forEachPushOp(t, dut, func(t *testing.T, op pushOp, config *oc.Root) {
 		t.Log("Initialize")
 
+		config.DeleteInterface(p1.Name())
+		config.DeleteInterface(p2.Name())
+		intf1 := config.GetOrCreateInterface(p1.Name())
+		intf1.Description = ygot.String(want1)
+		intf1.Type = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
+		if deviations.InterfaceEnabled(dut) {
+			intf1.Enabled = ygot.Bool(true)
+		}
+		intf2 := config.GetOrCreateInterface(p2.Name())
+		intf2.Description = ygot.String(want2)
+		intf2.Type = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
+		if deviations.InterfaceEnabled(dut) {
+			intf2.Enabled = ygot.Bool(true)
+		}
+		
 		config.GetOrCreateInterface(p1.Name()).Description = ygot.String(want1)
 		config.GetOrCreateInterface(p2.Name()).Description = ygot.String(want2)
 		op.push(t, dut, config, scope)


### PR DESCRIPTION
Fix `TestDeleteInterface` to enforce strict resetting of the interface during initialization, clearing out hidden state inherited from baselineConfig. This ensures the subsequent deletion targets a pristine OpenConfig model instead of a polluted baseline, preventing devices from triggering restrictive CLI fallback commands (like enable -> default interface) that otherwise cause the test to crash.