### PR TITLE
gNOI-6.1: Factory Reset ==> Increased the timeout value  from 40min to 60min

### DIFF
--- a/feature/gnoi/factory_reset/tests/factory_reset_test/factory_reset_test.go
+++ b/feature/gnoi/factory_reset/tests/factory_reset_test/factory_reset_test.go
@@ -43,7 +43,7 @@ var (
 	}
 )
 
-const maxRebootTime = 40 // 40 mins wait time for the factory reset and sztp to kick in
+const maxRebootTime = 60 // 60 mins wait time for the factory reset and sztp to kick in
 func TestMain(m *testing.M) {
 	fptest.RunTests(m)
 }


### PR DESCRIPTION
**Changes Made**

1. Updated maxRebootTime in feature/gnoi/factory_reset/tests/factory_reset_test/factory_reset_test.go from its previous value to 60 minutes.

**Reason**
Added extra 20 min as bootstrap process first check on Mgmt port then it proceed for WAN interfaces sequentially. For WAN connectivity we need to add additional time for the bootstrap process to complete on WAN port. 