### PR TITLE
Add covered subinterface state paths to system_generic_health_check README.md

### DIFF
--- a/feature/system/health/tests/system_generic_health_check/README.md
+++ b/feature/system/health/tests/system_generic_health_check/README.md
@@ -80,6 +80,9 @@ paths:
     /interfaces/interface/subinterfaces/subinterface/state/counters/in-unknown-protos:
     /interfaces/interface/subinterfaces/subinterface/state/counters/out-discards:
     /interfaces/interface/subinterfaces/subinterface/state/counters/out-errors:
+    /interfaces/interface/subinterfaces/subinterface/state/counters/out-octets:
+    /interfaces/interface/subinterfaces/subinterface/state/admin-status:
+    /interfaces/interface/subinterfaces/subinterface/state/description:
     /interfaces/interface/ethernet/state/counters/in-mac-pause-frames:
     /interfaces/interface/ethernet/state/counters/out-mac-pause-frames:
     /interfaces/interface/ethernet/state/counters/in-crc-errors:


### PR DESCRIPTION
Update the OpenConfig Path Coverage section in `system_generic_health_check/README.md` to document subinterface state paths that are already verified in `TestInterfacesubIntfs` (`system_generic_health_check_test.go`).

OpenConfig paths covered:
- `/interfaces/interface/subinterfaces/subinterface/state/counters/out-octets`
- `/interfaces/interface/subinterfaces/subinterface/state/admin-status`
- `/interfaces/interface/subinterfaces/subinterface/state/description`