### PR TITLE
Add /interfaces/interface/state/mtu to pmtu_handing README.md

### DIFF
--- a/feature/mtu/otg_tests/pmtu_handing/README.md
+++ b/feature/mtu/otg_tests/pmtu_handing/README.md
@@ -76,6 +76,7 @@ paths:
     # tunnel interfaces
     /interfaces/interface/config/mtu:
     # telemetry
+    /interfaces/interface/state/mtu:
     /components/component/integrated-circuit/pipeline-counters/drop/state/packet-processing-aggregate:
       platform_type: [ "INTEGRATED_CIRCUIT" ]
     /components/component/integrated-circuit/pipeline-counters/drop/lookup-block/state/fragment-total-drops:


### PR DESCRIPTION
Update the OpenConfig Path Coverage section in `feature/mtu/otg_tests/pmtu_handing/README.md` to document the interface MTU state path verified in `verifyDUTPort` (`pmtu_handing_test.go`).

OpenConfig paths covered:
- `/interfaces/interface/state/mtu`