### PR TITLE
Add prefix-length state path to gnmi_set_test README.md

### DIFF
--- a/feature/gnmi/tests/gnmi_set_test/README.md
+++ b/feature/gnmi/tests/gnmi_set_test/README.md
@@ -203,6 +203,7 @@ This test checks that the static protocol name is usable.
 paths:
   /interfaces/interface/name:
   /interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/ip:
+  /interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/state/prefix-length:
   /network-instances/network-instance/name:
 rpcs:
   gnmi:

--- a/feature/gnmi/tests/gnmi_set_test/README.md
+++ b/feature/gnmi/tests/gnmi_set_test/README.md
@@ -197,6 +197,77 @@ This test checks that the static protocol name is usable.
 
 *   gNMI.Set
 
+## Canonical OC
+
+```json
+{
+  "interfaces": {
+    "interface": [
+      {
+        "config": {
+          "description": "dut:port1",
+          "name": "port1"
+        },
+        "name": "port1",
+        "subinterfaces": {
+          "subinterface": [
+            {
+              "config": {
+                "index": 0
+              },
+              "index": 0,
+              "ipv4": {
+                "addresses": {
+                  "address": [
+                    {
+                      "config": {
+                        "ip": "192.0.2.1",
+                        "prefix-length": 30
+                      },
+                      "ip": "192.0.2.1"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "config": {
+          "description": "dut:port2",
+          "name": "port2"
+        },
+        "name": "port2",
+        "subinterfaces": {
+          "subinterface": [
+            {
+              "config": {
+                "index": 0
+              },
+              "index": 0,
+              "ipv4": {
+                "addresses": {
+                  "address": [
+                    {
+                      "config": {
+                        "ip": "192.0.2.5",
+                        "prefix-length": 30
+                      },
+                      "ip": "192.0.2.5"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
 ## OpenConfig Path and RPC Coverage
 
 ```yaml


### PR DESCRIPTION
Update the OpenConfig Path Coverage section in `feature/gnmi/tests/gnmi_set_test/README.md` to document the IPv4 subinterface prefix-length state path verified in `verifyInterface` (`gnmi_set_test.go`).

OpenConfig paths covered:
- `/interfaces/interface/subinterfaces/subinterface/ipv4/addresses/address/state/prefix-length`