### PR TITLE
TRANSCEIVER-10.1/TRANSCEIVER-10.2/TRANSCEIVER-6.1/TRANSCEIVER-6.2/TRANSCEIVER-11.2 : optical-transport : Update terminal-device model for logical channel assignments

### DIFF
--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -775,7 +775,6 @@ func ConfigETHChannel(t *testing.T, dut *ondatra.DUTDevice, interfaceName, trans
 	if !deviations.EthChannelIngressParametersUnsupported(dut) {
 		ingress = &oc.TerminalDevice_Channel_Ingress{
 			Interface:   ygot.String(interfaceName),
-			Transceiver: ygot.String(transceiverName),
 		}
 	}
 	var assignment = map[uint32]*oc.TerminalDevice_Channel_Assignment{

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -564,7 +564,7 @@ func updateETHChannelConfig(batch *gnmi.SetBatch, dut *ondatra.DUTDevice, p *ond
 	var ingress *oc.TerminalDevice_Channel_Ingress
 	if !deviations.EthChannelIngressParametersUnsupported(dut) {
 		ingress = &oc.TerminalDevice_Channel_Ingress{
-			Interface:   ygot.String(p.Name()),
+			Interface: ygot.String(p.Name()),
 			//Transceiver: ygot.String(params.TransceiverNames[p.Name()]),
 		}
 	}
@@ -774,7 +774,7 @@ func ConfigETHChannel(t *testing.T, dut *ondatra.DUTDevice, interfaceName, trans
 	var ingress = &oc.TerminalDevice_Channel_Ingress{}
 	if !deviations.EthChannelIngressParametersUnsupported(dut) {
 		ingress = &oc.TerminalDevice_Channel_Ingress{
-			Interface:   ygot.String(interfaceName),
+			Interface: ygot.String(interfaceName),
 			//Transceiver: ygot.String(transceiverName),
 		}
 	}

--- a/internal/cfgplugins/interface.go
+++ b/internal/cfgplugins/interface.go
@@ -565,7 +565,7 @@ func updateETHChannelConfig(batch *gnmi.SetBatch, dut *ondatra.DUTDevice, p *ond
 	if !deviations.EthChannelIngressParametersUnsupported(dut) {
 		ingress = &oc.TerminalDevice_Channel_Ingress{
 			Interface:   ygot.String(p.Name()),
-			Transceiver: ygot.String(params.TransceiverNames[p.Name()]),
+			//Transceiver: ygot.String(params.TransceiverNames[p.Name()]),
 		}
 	}
 	assignment := map[uint32]*oc.TerminalDevice_Channel_Assignment{
@@ -775,6 +775,7 @@ func ConfigETHChannel(t *testing.T, dut *ondatra.DUTDevice, interfaceName, trans
 	if !deviations.EthChannelIngressParametersUnsupported(dut) {
 		ingress = &oc.TerminalDevice_Channel_Ingress{
 			Interface:   ygot.String(interfaceName),
+			//Transceiver: ygot.String(transceiverName),
 		}
 	}
 	var assignment = map[uint32]*oc.TerminalDevice_Channel_Assignment{


### PR DESCRIPTION
- Changes to  Update terminal-device model for logical channel assignments 

https://github.com/openconfig/public/blob/6039bd7b294ad45161da3a258e7f6b4e48b0495c/release/models/optical-transport/openconfig-terminal-device.yang#L1250

snippet as below 
<start>
    leaf interface {
      type oc-if:base-interface-ref;
      description
        "Reference to the interface carrying the input signal
        for the logical channel. The ingress will specify an interface
        in the case of a transceiver being utilized directly in a
        router and bypassing a dedicated terminal device. **When
        specified, the other leaves in the ingress config must be
        empty.";
    }
  }
</end>