### PR TITLE
Add /components/component/cpu/utilization/state/avg to system_generic_health_check README.md

### DIFF
--- a/feature/system/health/tests/system_generic_health_check/README.md
+++ b/feature/system/health/tests/system_generic_health_check/README.md
@@ -52,6 +52,8 @@ rpcs:
 paths:
   ## Config Parameter coverage
 
+    /components/component/cpu/utilization/state/avg:
+       platform_type: ["CPU"]
     /components/component/state/memory/available:
        platform_type: ["CHASSIS", "CONTROLLER_CARD", "CPU"]
     /components/component/state/memory/utilized:


### PR DESCRIPTION
OpenConfig paths covered:
- /components/component/cpu/utilization/state/avg