### PR TITLE
Update bursty_traffic_test.go and ecn_enabled_traffic_test.go‎

### DIFF
--- a/feature/qos/ecn/otg_tests/ecn_enabled_traffic_test/ecn_enabled_traffic_test.go
+++ b/feature/qos/ecn/otg_tests/ecn_enabled_traffic_test/ecn_enabled_traffic_test.go
@@ -349,7 +349,7 @@ func TestECNEnabledTraffic(t *testing.T) {
 					continue
 				}
 				// Watch for ATE rx packets to be available in QoS TransmitPkts
-val, ok := gnmi.Watch(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queue(queue).TransmitPkts().State(), timeout, func(v *ygnmi.Value[uint64]) bool {
+				val, ok := gnmi.Watch(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queue(queue).TransmitPkts().State(), timeout, func(v *ygnmi.Value[uint64]) bool {
 					pkts, present := v.Val()
 					return present && pkts >= dutQosPktsBeforeTraffic[queue]+ateInPkts[queue]
 				}).Await(t)
@@ -357,7 +357,7 @@ val, ok := gnmi.Watch(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queu
 					pkts, _ := val.Val()
 					dutQosPktsAfterTraffic[queue] = pkts
 				} else {
-t.Logf("Warning: TransmitPkts count for queue %q on interface %q did not reach expected value within timeout", queue, p3.Name())
+					t.Logf("Warning: TransmitPkts count for queue %q on interface %q did not reach expected value within timeout", queue, p3.Name())
 					dutQosPktsAfterTraffic[queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queue(queue).TransmitPkts().State())
 				}
 				dutQosDroppedPktsAfterTraffic[queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queue(queue).DroppedPkts().State())

--- a/feature/qos/ecn/otg_tests/ecn_enabled_traffic_test/ecn_enabled_traffic_test.go
+++ b/feature/qos/ecn/otg_tests/ecn_enabled_traffic_test/ecn_enabled_traffic_test.go
@@ -319,19 +319,52 @@ func TestECNEnabledTraffic(t *testing.T) {
 			t.Logf("Running traffic 2 on DUT interfaces: %s => %s ", p2.Name(), p3.Name())
 			t.Logf("Sending traffic flows: \n%v\n\n", tfs)
 			ate.OTG().StartTraffic(t)
-			time.Sleep(30 * time.Second)
+			time.Sleep(15 * time.Second)
 			ate.OTG().StopTraffic(t)
-			time.Sleep(30 * time.Second)
 
 			otgutils.LogFlowMetrics(t, ate.OTG(), top)
+
+			for _, data := range tfs {
+				name := fn + "-" + data.inputIntf.Name
+				expectedLoss := float64(100.0 - data.expectedThroughputPct)
+				minLoss := expectedLoss - float64(tolerance)
+				if minLoss < 0 {
+					minLoss = 0
+				}
+				maxLoss := expectedLoss + float64(tolerance)
+				otgutils.ExpectedTrafficLoss(t, ate.OTG(), name, minLoss, maxLoss)
+			}
+
 			for _, data := range tfs {
 				name := fn + "-" + data.inputIntf.Name
 				flowData := gnmi.Get[*otgtelemetry.Flow](t, ate.OTG(), gnmi.OTG().Flow(name).State())
 
 				ateOutPkts[data.queue] += flowData.GetCounters().GetOutPkts()
-				ateInPkts[data.queue] += flowData.GetCounters().GetOutPkts()
-				dutQosPktsAfterTraffic[data.queue] += gnmi.Get(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queue(data.queue).TransmitPkts().State())
-				dutQosDroppedPktsAfterTraffic[data.queue] += gnmi.Get(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queue(data.queue).DroppedPkts().State())
+				ateInPkts[data.queue] += flowData.GetCounters().GetInPkts()
+			}
+
+			for queue := range ateInPkts {
+				if ateOutPkts[queue] == 0 {
+					continue
+				}
+				// Watch for ATE rx packets to be available in QoS TransmitPkts
+				val, ok := gnmi.Watch(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queue(queue).TransmitPkts().State(), time.Minute, func(v *ygnmi.Value[uint64]) bool {
+					pkts, present := v.Val()
+					return present && pkts >= dutQosPktsBeforeTraffic[queue]+ateInPkts[queue]
+				}).Await(t)
+				if ok {
+					pkts, _ := val.Val()
+					dutQosPktsAfterTraffic[queue] = pkts
+				} else {
+					t.Logf("Warning: TransmitPkts count for queue %q on interface %q did not reach expected value within timeout", p3.Name(), queue)
+					dutQosPktsAfterTraffic[queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queue(queue).TransmitPkts().State())
+				}
+				dutQosDroppedPktsAfterTraffic[queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queue(queue).DroppedPkts().State())
+			}
+
+			for _, data := range tfs {
+				name := fn + "-" + data.inputIntf.Name
+				flowData := gnmi.Get[*otgtelemetry.Flow](t, ate.OTG(), gnmi.OTG().Flow(name).State())
 				t.Logf("ateInPkts: %v, txPkts %v, Queue: %v", ateInPkts[data.queue], dutQosPktsAfterTraffic[data.queue], data.queue)
 
 				ateTxPkts := float32(flowData.GetCounters().GetOutPkts())

--- a/feature/qos/ecn/otg_tests/ecn_enabled_traffic_test/ecn_enabled_traffic_test.go
+++ b/feature/qos/ecn/otg_tests/ecn_enabled_traffic_test/ecn_enabled_traffic_test.go
@@ -349,7 +349,7 @@ func TestECNEnabledTraffic(t *testing.T) {
 					continue
 				}
 				// Watch for ATE rx packets to be available in QoS TransmitPkts
-				val, ok := gnmi.Watch(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queue(queue).TransmitPkts().State(), time.Minute, func(v *ygnmi.Value[uint64]) bool {
+val, ok := gnmi.Watch(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queue(queue).TransmitPkts().State(), timeout, func(v *ygnmi.Value[uint64]) bool {
 					pkts, present := v.Val()
 					return present && pkts >= dutQosPktsBeforeTraffic[queue]+ateInPkts[queue]
 				}).Await(t)

--- a/feature/qos/ecn/otg_tests/ecn_enabled_traffic_test/ecn_enabled_traffic_test.go
+++ b/feature/qos/ecn/otg_tests/ecn_enabled_traffic_test/ecn_enabled_traffic_test.go
@@ -318,6 +318,7 @@ func TestECNEnabledTraffic(t *testing.T) {
 			t.Logf("Running traffic 1 on DUT interfaces: %s => %s ", p1.Name(), p3.Name())
 			t.Logf("Running traffic 2 on DUT interfaces: %s => %s ", p2.Name(), p3.Name())
 			t.Logf("Sending traffic flows: \n%v\n\n", tfs)
+			otgutils.WaitForARP(t, ate.OTG(), top, "IPv4")
 			ate.OTG().StartTraffic(t)
 			time.Sleep(15 * time.Second)
 			ate.OTG().StopTraffic(t)

--- a/feature/qos/ecn/otg_tests/ecn_enabled_traffic_test/ecn_enabled_traffic_test.go
+++ b/feature/qos/ecn/otg_tests/ecn_enabled_traffic_test/ecn_enabled_traffic_test.go
@@ -357,7 +357,7 @@ func TestECNEnabledTraffic(t *testing.T) {
 					pkts, _ := val.Val()
 					dutQosPktsAfterTraffic[queue] = pkts
 				} else {
-					t.Logf("Warning: TransmitPkts count for queue %q on interface %q did not reach expected value within timeout", p3.Name(), queue)
+t.Logf("Warning: TransmitPkts count for queue %q on interface %q did not reach expected value within timeout", queue, p3.Name())
 					dutQosPktsAfterTraffic[queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queue(queue).TransmitPkts().State())
 				}
 				dutQosDroppedPktsAfterTraffic[queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(p3.Name()).Output().Queue(queue).DroppedPkts().State())

--- a/feature/qos/otg_tests/bursty_traffic_test/bursty_traffic_test.go
+++ b/feature/qos/otg_tests/bursty_traffic_test/bursty_traffic_test.go
@@ -422,6 +422,7 @@ func TestBurstyTraffic(t *testing.T) {
 			t.Logf("Running traffic 1 on DUT interfaces: %s => %s ", dp1.Name(), dp3.Name())
 			t.Logf("Running traffic 2 on DUT interfaces: %s => %s ", dp2.Name(), dp3.Name())
 			t.Logf("Sending traffic flows: \n%v\n\n", trafficFlows)
+			otgutils.WaitForARP(t, ate.OTG(), top, "IPv4")
 			ate.OTG().StartTraffic(t)
 			time.Sleep(30 * time.Second)
 			ate.OTG().StopTraffic(t)

--- a/feature/qos/otg_tests/bursty_traffic_test/bursty_traffic_test.go
+++ b/feature/qos/otg_tests/bursty_traffic_test/bursty_traffic_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openconfig/featureprofiles/internal/attrs"
 	"github.com/openconfig/featureprofiles/internal/deviations"
 	"github.com/openconfig/featureprofiles/internal/fptest"
+	"github.com/openconfig/featureprofiles/internal/otgutils"
 	"github.com/openconfig/featureprofiles/internal/qoscfg"
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
@@ -421,33 +422,37 @@ func TestBurstyTraffic(t *testing.T) {
 			t.Logf("Running traffic 1 on DUT interfaces: %s => %s ", dp1.Name(), dp3.Name())
 			t.Logf("Running traffic 2 on DUT interfaces: %s => %s ", dp2.Name(), dp3.Name())
 			t.Logf("Sending traffic flows: \n%v\n\n", trafficFlows)
-			time.Sleep(30 * time.Second)
 			ate.OTG().StartTraffic(t)
 			time.Sleep(30 * time.Second)
 			ate.OTG().StopTraffic(t)
-			time.Sleep(60 * time.Second)
 
+			uniqueQueues := make(map[string]bool)
 			for trafficID, data := range trafficFlows {
+				uniqueQueues[data.queue] = true
+				loss := float64(100.0 - data.expectedThroughputPct)
+				otgutils.ExpectedTrafficLoss(t, ate.OTG(), trafficID, loss, loss)
+
 				flowMetrics := gnmi.Get(t, ate.OTG(), gnmi.OTG().Flow(trafficID).Counters().State())
 				ateTxPkts := flowMetrics.GetOutPkts()
 				ateRxPkts := flowMetrics.GetInPkts()
 				counters["ateOutPkts"][data.queue] += ateTxPkts
 				counters["ateInPkts"][data.queue] += ateRxPkts
+			}
 
-				counters["dutQosPktsAfterTraffic"][data.queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(data.queue).TransmitPkts().State())
-				counters["dutQosOctetsAfterTraffic"][data.queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(data.queue).TransmitOctets().State())
-				counters["dutQosDroppedPktsAfterTraffic"][data.queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(data.queue).DroppedPkts().State())
-				counters["dutQosDroppedOctetsAfterTraffic"][data.queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(data.queue).DroppedOctets().State())
+			for queue := range uniqueQueues {
+				_, ok := gnmi.Watch(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(queue).TransmitPkts().State(), timeout, func(val *ygnmi.Value[uint64]) bool {
+					count, present := val.Val()
+					return present && count >= counters["dutQosPktsBeforeTraffic"][queue]+counters["ateInPkts"][queue]
+				}).Await(t)
+				if !ok {
+					t.Errorf("TransmitPkts count for queue %q on interface %q failed to reach expected value", queue, dp3.Name())
+				}
+				counters["dutQosPktsAfterTraffic"][queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(queue).TransmitPkts().State())
+				counters["dutQosOctetsAfterTraffic"][queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(queue).TransmitOctets().State())
+				counters["dutQosDroppedPktsAfterTraffic"][queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(queue).DroppedPkts().State())
+				counters["dutQosDroppedOctetsAfterTraffic"][queue] = gnmi.Get(t, dut, gnmi.OC().Qos().Interface(dp3.Name()).Output().Queue(queue).DroppedOctets().State())
 
-				t.Logf("ateInPkts: %v, txPkts %v, Queue: %v", counters["ateInPkts"][data.queue], counters["dutQosPktsAfterTraffic"][data.queue], data.queue)
-				if ateTxPkts == 0 {
-					t.Fatalf("TxPkts == 0, want >0.")
-				}
-				lossPct := (float32)((float64(ateTxPkts-ateRxPkts) * 100.0) / float64(ateTxPkts))
-				t.Logf("Get flow %q: lossPct: %.2f%% or rxPct: %.2f%%, want: %.2f%%\n\n", data.queue, lossPct, 100.0-lossPct, data.expectedThroughputPct)
-				if got, want := 100.0-lossPct, data.expectedThroughputPct; got != want {
-					t.Errorf("Get(throughput for queue %q): got %.2f%%, want %.2f%%", data.queue, got, want)
-				}
+				t.Logf("ateInPkts: %v, txPkts: %v, Queue: %v", counters["ateInPkts"][queue], counters["dutQosPktsAfterTraffic"][queue], queue)
 			}
 
 			// Check QoS egress packet counters are updated correctly.


### PR DESCRIPTION
Stabilize ecn_enabled_traffic_test and bursty_traffic_test using robust wait polling

- Replaced time.Sleep with robust polling (ExpectedTrafficLoss)
- Implemented gnmi.Watch for DUT QoS telemetry to settle
- Fixed double-counting of egress absolute metrics logic
- Fixed RX telemetry using GetOutPkts instead of GetInPkts
- Added otgutils dependency and logic to bursty_traffic_test.go to match
