### PR TITLE
Add covered pipeline drop counter state paths to system_generic_health_check README.md

### DIFF
--- a/feature/system/health/tests/system_generic_health_check/README.md
+++ b/feature/system/health/tests/system_generic_health_check/README.md
@@ -54,6 +54,16 @@ paths:
 
     /components/component/cpu/utilization/state/avg:
        platform_type: ["CPU"]
+    /components/component/integrated-circuit/pipeline-counters/drop/fabric-block/state/lost-packets:
+       platform_type: ["INTEGRATED_CIRCUIT"]
+    /components/component/integrated-circuit/pipeline-counters/drop/lookup-block/state/acl-drops:
+       platform_type: ["INTEGRATED_CIRCUIT"]
+    /components/component/integrated-circuit/pipeline-counters/drop/lookup-block/state/incorrect-software-state:
+       platform_type: ["INTEGRATED_CIRCUIT"]
+    /components/component/integrated-circuit/pipeline-counters/drop/lookup-block/state/invalid-packet:
+       platform_type: ["INTEGRATED_CIRCUIT"]
+    /components/component/integrated-circuit/pipeline-counters/drop/lookup-block/state/no-nexthop:
+       platform_type: ["INTEGRATED_CIRCUIT"]
     /components/component/state/memory/available:
        platform_type: ["CHASSIS", "CONTROLLER_CARD", "CPU"]
     /components/component/state/memory/utilized:


### PR DESCRIPTION
OpenConfig paths covered:
- /components/component/integrated-circuit/pipeline-counters/drop/fabric-block/state/lost-packets
- /components/component/integrated-circuit/pipeline-counters/drop/lookup-block/state/acl-drops
- /components/component/integrated-circuit/pipeline-counters/drop/lookup-block/state/incorrect-software-state
- /components/component/integrated-circuit/pipeline-counters/drop/lookup-block/state/invalid-packet
- /components/component/integrated-circuit/pipeline-counters/drop/lookup-block/state/no-nexthop