### PR TITLE
changing the timeout of the binding files

### DIFF
--- a/topologies/otgdut_2.binding
+++ b/topologies/otgdut_2.binding
@@ -52,13 +52,13 @@ ates {
   otg {
     target: "ixia-c-hostname:40051" # Change this to the Ixia-c-grpc server endpoint.
     insecure: true
-    timeout: 30
+    timeout: 540
   }
 
   gnmi {
     target: "ixia-c-hostname:50051"  # Change this to the Ixia-c-gnmi server endpoint.
     skip_verify: true
-    timeout: 30
+    timeout: 540
   }
 
   # Before this binding can be used with a topology, add ports mapping

--- a/topologies/otgdut_4.binding
+++ b/topologies/otgdut_4.binding
@@ -60,13 +60,13 @@ ates {
   otg {
     target: "ixia-c-hostname:40051" # Change this to the Ixia-c-grpc server endpoint.
     insecure: true
-    timeout: 30
+    timeout: 540
   }
 
   gnmi {
     target: "ixia-c-hostname:50051"  # Change this to the Ixia-c-gnmi server endpoint.
     skip_verify: true
-    timeout: 30    
+    timeout: 540   
   }
 
   # Before this binding can be used with a topology, add ports mapping


### PR DESCRIPTION
The OTG and gNMI timeout values specified in the sample binding files are currently too low to accommodate real-world deployment and test scenarios. We recommend increasing the maximum timeout to 9 minutes (540 seconds).

The existing 30-second timeout may not be sufficient under normal operating conditions and can result in misleading timeout failures, obscure error messages, and false alarms. A longer timeout will improve reliability and reduce the likelihood of reporting transient delays as test failures.
