### PR TITLE
Fix Arista BGP neighbor received-prefix limit path

### DIFF
--- a/internal/cfgplugins/bgp.go
+++ b/internal/cfgplugins/bgp.go
@@ -671,7 +671,7 @@ func VerifyPortsUp(t *testing.T, dev *ondatra.Device) {
 
 // DeviationAristaBGPNeighborMaxPrefixes updates the max-prefixes of a specific BGP neighbor.
 // This is an Arista specific augmented model which sets the following path:
-// /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/prefix-limit/config/max-prefixes
+// /network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/prefix-limit-received/config/max-prefixes
 // Set max-prefixes to 0 will mean no limit will be set.
 // Tracking the removal of this deviation in b/438620249
 func DeviationAristaBGPNeighborMaxPrefixes(t *testing.T, dut *ondatra.DUTDevice, neighborIP string, maxPrefixes uint32) {
@@ -686,7 +686,7 @@ func DeviationAristaBGPNeighborMaxPrefixes(t *testing.T, dut *ondatra.DUTDevice,
 					{Name: "bgp"},
 					{Name: "neighbors"},
 					{Name: "neighbor", Key: map[string]string{"neighbor-address": neighborIP}},
-					{Name: "prefix-limit"},
+					{Name: "prefix-limit-received"},
 					{Name: "config"},
 					{Name: "max-prefixes"},
 				},


### PR DESCRIPTION
Update `DeviationAristaBGPNeighborMaxPrefixes` to configure:
`.../neighbor/prefix-limit-received/config/max-prefixes`
instead of:
`.../neighbor/prefix-limit/config/max-prefixes`

An OpenConfig mapping change now distinguishes these paths:
- `prefix-limit-received` maps to `neighbor <peer> maximum-routes <limit>`
- `prefix-limit` maps to `neighbor <peer> maximum-accepted-routes <limit>`

The Arista-specific deviation introduced by [PR #4455](https://github.com/openconfig/featureprofiles/pull/4455) sets the received-route limit to `0`. It must therefore use `prefix-limit-received`.

Error Log:

```
failed to create /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=BGP]/bgp/neighbors/neighbor[neighbor-address=192.0.2.2]/prefix-limit/config/max-prefixes: path invalid: failed to create node "prefix-limit" in node "neighbor"
```

Test Status:

```
--- PASS: TestTrafficBGPPrefixLimit (591.42s)
    --- PASS: TestTrafficBGPPrefixLimit/UnderLimit (210.44s)
        --- PASS: TestTrafficBGPPrefixLimit/UnderLimit/verifyPortsUp (0.01s)
        --- PASS: TestTrafficBGPPrefixLimit/UnderLimit/verifyBGPTelemetry (102.70s)
            --- PASS: TestTrafficBGPPrefixLimit/UnderLimit/verifyBGPTelemetry/verifyPrefixLimitTelemetry (0.00s)
            --- PASS: TestTrafficBGPPrefixLimit/UnderLimit/verifyBGPTelemetry/verifyPrefixLimitTelemetry#01 (0.00s)
        --- PASS: TestTrafficBGPPrefixLimit/UnderLimit/verifyNoPacketLoss (17.55s)
    --- PASS: TestTrafficBGPPrefixLimit/AtLimit (132.44s)
        --- PASS: TestTrafficBGPPrefixLimit/AtLimit/verifyPortsUp (0.01s)
        --- PASS: TestTrafficBGPPrefixLimit/AtLimit/verifyBGPTelemetry (30.12s)
            --- PASS: TestTrafficBGPPrefixLimit/AtLimit/verifyBGPTelemetry/verifyPrefixLimitTelemetry (0.00s)
            --- PASS: TestTrafficBGPPrefixLimit/AtLimit/verifyBGPTelemetry/verifyPrefixLimitTelemetry#01 (0.00s)
        --- PASS: TestTrafficBGPPrefixLimit/AtLimit/verifyNoPacketLoss (15.65s)
    --- PASS: TestTrafficBGPPrefixLimit/OverLimit (73.00s)
        --- PASS: TestTrafficBGPPrefixLimit/OverLimit/verifyPortsUp (0.01s)
        --- PASS: TestTrafficBGPPrefixLimit/OverLimit/verifyBGPTelemetry (30.19s)
            --- PASS: TestTrafficBGPPrefixLimit/OverLimit/verifyBGPTelemetry/verifyPrefixLimitTelemetry (0.00s)
            --- PASS: TestTrafficBGPPrefixLimit/OverLimit/verifyBGPTelemetry/verifyPrefixLimitTelemetry#01 (0.00s)
        --- PASS: TestTrafficBGPPrefixLimit/OverLimit/verifyPacketLoss (16.04s)
    --- PASS: TestTrafficBGPPrefixLimit/ReestablishedAtLimit (135.01s)
        --- PASS: TestTrafficBGPPrefixLimit/ReestablishedAtLimit/verifyPortsUp (0.01s)
        --- PASS: TestTrafficBGPPrefixLimit/ReestablishedAtLimit/verifyBGPTelemetry (32.19s)
            --- PASS: TestTrafficBGPPrefixLimit/ReestablishedAtLimit/verifyBGPTelemetry/verifyPrefixLimitTelemetry (0.00s)
            --- PASS: TestTrafficBGPPrefixLimit/ReestablishedAtLimit/verifyBGPTelemetry/verifyPrefixLimitTelemetry#01 (0.00s)
        --- PASS: TestTrafficBGPPrefixLimit/ReestablishedAtLimit/verifyNoPacketLoss (16.17s)
PASS
```