### PR TITLE
Add sFlow Egress Sampling test README

### DIFF
--- a/feature/sflow/otg_tests/sflow_egress_test/README.md
+++ b/feature/sflow/otg_tests/sflow_egress_test/README.md
@@ -35,15 +35,35 @@ While standard sFlow sampling captures packets at the ingress pipeline, egress s
 2. Configure ATE Port 1 and Port 2 with matching IP addresses and verify bidirectional reachability (ARP / NDP resolution).
 3. Ensure no prior sFlow configuration exists on the DUT.
 
+---
+
 ### SFLOW-2.1: Configure Interface-Level Egress Sampling via OpenConfig
 
-#### 1. Generate DUT Configuration
-
-Configure global sFlow and enable egress sampling on DUT Port 2 with a sampling rate of 1:1,000,000 (or the minimum rate supported by the platform):
+#### Canonical OC
 
 ```json
 {
-  "openconfig-sampling:sampling": {
+  "interfaces": {
+    "interface": [
+      {
+        "name": "port2",
+        "config": {
+          "name": "port2"
+        }
+      }
+    ]
+  },
+  "network-instances": {
+    "network-instance": [
+      {
+        "name": "DEFAULT",
+        "config": {
+          "name": "DEFAULT"
+        }
+      }
+    ]
+  },
+  "sampling": {
     "sflow": {
       "config": {
         "enabled": true,
@@ -80,42 +100,43 @@ Configure global sFlow and enable egress sampling on DUT Port 2 with a sampling 
 }
 ```
 
-#### 2. Push Configuration
-* Push the configuration to the DUT using `gNMI.Set` (Update/Replace).
-
-#### 3. Telemetry Validation
-* Query telemetry using `gNMI.Get` or `gNMI.Subscribe` and verify:
+* Step 2 - Push configuration to DUT using `gNMI.Set` (Update/Replace).
+* Step 3 - Verify Telemetry using `gNMI.Get` or `gNMI.Subscribe`:
   * `/sampling/sflow/state/enabled` is `true`.
   * `/sampling/sflow/collectors/collector[address=192.0.2.2][port=6343]/state/address` matches `192.0.2.2`.
   * `/sampling/sflow/interfaces/interface[name=port2]/state/enabled` is `true`.
   * `/sampling/sflow/interfaces/interface[name=port2]/state/egress-sampling-rate` matches `1000000` (or the configured rate).
 
+---
 
 ### SFLOW-2.2: Verify Egress sFlow Packet Generation on Traffic Flow
 
-#### 1. Traffic Generation
-* Configure ATE Port 1 to transmit IPv4 and IPv6 traffic towards destinations reachable via DUT Port 2.
-* Set traffic rate high enough to generate statistically meaningful samples based on the configured sampling rate (e.g. 100,000 pps for 1,000,000 sampling rate over 60–120 seconds).
-* Start sFlow packet capture on ATE Port 2 listening on UDP port 6343.
+* Step 1 - Traffic Generation:
+  * Configure ATE Port 1 to transmit IPv4 and IPv6 traffic towards destinations reachable via DUT Port 2.
+  * Set traffic rate high enough to generate statistically meaningful samples based on the configured sampling rate (e.g. 100,000 pps for 1,000,000 sampling rate over 60–120 seconds).
+  * Start sFlow packet capture on ATE Port 2 listening on UDP port 6343.
 
-#### 2. Verification
-* Verify that sFlow datagrams (UDP port 6343) arrive at ATE Port 2 from source IP `192.0.2.1`.
-* Parse captured sFlow datagrams and verify:
-  * sFlow version is 5.
-  * Agent address matches the configured source IP address (`192.0.2.1`).
-  * Flow sample records are present.
-  * In the flow record, the **output interface** (`output_interface` / `egress interface index`) matches the SNMP ifIndex of DUT Port 2.
-  * The number of captured samples conforms to the expected sampling rate within statistical tolerance (e.g. ±20%).
+* Step 2 - Telemetry and Packet Verification:
+  * Verify that sFlow datagrams (UDP port 6343) arrive at ATE Port 2 from source IP `192.0.2.1`.
+  * Parse captured sFlow datagrams and verify:
+    * sFlow version is 5.
+    * Agent address matches the configured source IP address (`192.0.2.1`).
+    * Flow sample records are present.
+    * In the flow record, the **output interface** (`output_interface` / `egress interface index`) matches the SNMP ifIndex of DUT Port 2.
+    * The number of captured samples conforms to the expected sampling rate within statistical tolerance (e.g. ±20%).
+
+---
 
 ### SFLOW-2.3: Disable Egress Sampling and Verify Teardown
 
-#### 1. Disable Configuration
-* Remove `egress-sampling-rate` from DUT Port 2, or set `/sampling/sflow/interfaces/interface[name=port2]/config/enabled` to `false`.
+* Step 1 - Disable Configuration:
+  * Remove `egress-sampling-rate` from DUT Port 2, or set `/sampling/sflow/interfaces/interface[name=port2]/config/enabled` to `false`.
 
-#### 2. Telemetry and Traffic Verification
-* Verify telemetry reflects the disabled state.
-* Transmit traffic from ATE Port 1 to ATE Port 2 and confirm no further sFlow sample datagrams are generated or exported by the DUT.
+* Step 2 - Telemetry and Traffic Verification:
+  * Verify telemetry reflects the disabled state.
+  * Transmit traffic from ATE Port 1 to ATE Port 2 and confirm no further sFlow sample datagrams are generated or exported by the DUT.
 
+---
 
 ## OpenConfig Path and RPC Coverage
 
@@ -146,8 +167,6 @@ paths:
 rpcs:
   gnmi:
     gNMI.Set:
-      union_replace: true
     gNMI.Subscribe:
-      on_change: true
 ```
 

--- a/feature/sflow/otg_tests/sflow_egress_test/metadata.textproto
+++ b/feature/sflow/otg_tests/sflow_egress_test/metadata.textproto
@@ -1,0 +1,7 @@
+# proto-file: proto/metadata.proto
+# proto-message: Metadata
+
+uuid: "f6e729a8-348b-4a57-b08e-1736b4859a11"
+plan_id: "SFLOW-2"
+description: "sFlow Egress Sampling Configuration and Verification"
+testbed: TESTBED_DUT_ATE_2LINKS

--- a/feature/sflow/otg_tests/sflow_egress_test/sflow_egress_test_README.md
+++ b/feature/sflow/otg_tests/sflow_egress_test/sflow_egress_test_README.md
@@ -1,0 +1,153 @@
+# SFLOW-2: sFlow Egress Sampling Configuration and Verification
+
+## Summary
+
+This test verifies OpenConfig configuration and telemetry for interface-level **egress sFlow sampling**, as well as the receipt and structure of egress-sampled flow records on an external sFlow collector.
+
+While standard sFlow sampling captures packets at the ingress pipeline, egress sFlow enables sampling of packets as they egress the device (after header modifications, routing, and encapsulation). This test verifies that:
+1. Interface-level `egress-sampling-rate` can be configured via OpenConfig gNMI.
+2. The operational state for `egress-sampling-rate` and interface `enabled` reflect correctly in telemetry.
+3. Transmitted traffic through the configured egress interface generates valid sFlow datagrams sent to the collector.
+4. Captured flow samples correctly identify the sampled egress interface.
+
+## Testbed Type
+
+* [`featureprofiles/topologies/atedut_2.testbed`](https://github.com/openconfig/featureprofiles/blob/main/topologies/atedut_2.testbed)
+
+```text
++------------+                 +------------+
+|            |  Port 1 (Ing)   |            |
+|            |-----------------|            |
+|    ATE     |                 |    DUT     |
+|            |  Port 2 (Egr)   |            |
+|            |-----------------|            |
++------------+                 +------------+
+```
+
+* **DUT Port 1**: Connected to ATE Port 1 (Ingress traffic source).
+* **DUT Port 2**: Connected to ATE Port 2 (Egress traffic destination & sFlow collector receiver).
+
+## Procedure
+
+### Test Environment Setup
+
+1. Configure IP addressing on DUT Port 1 and Port 2 with IPv4 (`/30`) and IPv6 (`/126`) subnets.
+2. Configure ATE Port 1 and Port 2 with matching IP addresses and verify bidirectional reachability (ARP / NDP resolution).
+3. Ensure no prior sFlow configuration exists on the DUT.
+
+### SFLOW-2.1: Configure Interface-Level Egress Sampling via OpenConfig
+
+#### 1. Generate DUT Configuration
+
+Configure global sFlow and enable egress sampling on DUT Port 2 with a sampling rate of 1:1,000,000 (or the minimum rate supported by the platform):
+
+```json
+{
+  "openconfig-sampling:sampling": {
+    "sflow": {
+      "config": {
+        "enabled": true,
+        "sample-size": 256
+      },
+      "collectors": {
+        "collector": [
+          {
+            "address": "192.0.2.2",
+            "port": 6343,
+            "config": {
+              "address": "192.0.2.2",
+              "port": 6343,
+              "source-address": "192.0.2.1",
+              "network-instance": "DEFAULT"
+            }
+          }
+        ]
+      },
+      "interfaces": {
+        "interface": [
+          {
+            "name": "port2",
+            "config": {
+              "name": "port2",
+              "enabled": true,
+              "egress-sampling-rate": 1000000
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+#### 2. Push Configuration
+* Push the configuration to the DUT using `gNMI.Set` (Update/Replace).
+
+#### 3. Telemetry Validation
+* Query telemetry using `gNMI.Get` or `gNMI.Subscribe` and verify:
+  * `/sampling/sflow/state/enabled` is `true`.
+  * `/sampling/sflow/collectors/collector[address=192.0.2.2][port=6343]/state/address` matches `192.0.2.2`.
+  * `/sampling/sflow/interfaces/interface[name=port2]/state/enabled` is `true`.
+  * `/sampling/sflow/interfaces/interface[name=port2]/state/egress-sampling-rate` matches `1000000` (or the configured rate).
+
+
+### SFLOW-2.2: Verify Egress sFlow Packet Generation on Traffic Flow
+
+#### 1. Traffic Generation
+* Configure ATE Port 1 to transmit IPv4 and IPv6 traffic towards destinations reachable via DUT Port 2.
+* Set traffic rate high enough to generate statistically meaningful samples based on the configured sampling rate (e.g. 100,000 pps for 1,000,000 sampling rate over 60–120 seconds).
+* Start sFlow packet capture on ATE Port 2 listening on UDP port 6343.
+
+#### 2. Verification
+* Verify that sFlow datagrams (UDP port 6343) arrive at ATE Port 2 from source IP `192.0.2.1`.
+* Parse captured sFlow datagrams and verify:
+  * sFlow version is 5.
+  * Agent address matches the configured source IP address (`192.0.2.1`).
+  * Flow sample records are present.
+  * In the flow record, the **output interface** (`output_interface` / `egress interface index`) matches the SNMP ifIndex of DUT Port 2.
+  * The number of captured samples conforms to the expected sampling rate within statistical tolerance (e.g. ±20%).
+
+### SFLOW-2.3: Disable Egress Sampling and Verify Teardown
+
+#### 1. Disable Configuration
+* Remove `egress-sampling-rate` from DUT Port 2, or set `/sampling/sflow/interfaces/interface[name=port2]/config/enabled` to `false`.
+
+#### 2. Telemetry and Traffic Verification
+* Verify telemetry reflects the disabled state.
+* Transmit traffic from ATE Port 1 to ATE Port 2 and confirm no further sFlow sample datagrams are generated or exported by the DUT.
+
+
+## OpenConfig Path and RPC Coverage
+
+```yaml
+paths:
+  ## Config Parameter Coverage
+  /sampling/sflow/config/enabled:
+  /sampling/sflow/config/sample-size:
+  /sampling/sflow/collectors/collector/config/address:
+  /sampling/sflow/collectors/collector/config/port:
+  /sampling/sflow/collectors/collector/config/source-address:
+  /sampling/sflow/collectors/collector/config/network-instance:
+  /sampling/sflow/interfaces/interface/config/name:
+  /sampling/sflow/interfaces/interface/config/enabled:
+  /sampling/sflow/interfaces/interface/config/egress-sampling-rate:
+
+  ## Telemetry Parameter Coverage
+  /sampling/sflow/state/enabled:
+  /sampling/sflow/state/sample-size:
+  /sampling/sflow/collectors/collector/state/address:
+  /sampling/sflow/collectors/collector/state/port:
+  /sampling/sflow/collectors/collector/state/source-address:
+  /sampling/sflow/collectors/collector/state/network-instance:
+  /sampling/sflow/interfaces/interface/state/name:
+  /sampling/sflow/interfaces/interface/state/enabled:
+  /sampling/sflow/interfaces/interface/state/egress-sampling-rate:
+
+rpcs:
+  gnmi:
+    gNMI.Set:
+      union_replace: true
+    gNMI.Subscribe:
+      on_change: true
+```
+

--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -1397,6 +1397,11 @@ test: {
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/sflow/otg_tests/sflow_base_test/README.md"
   exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/sflow/otg_tests/sflow_base_test/sflow_base_test.go"
 }
+tests {
+  id: "SFLOW-2"
+  description: "sFlow Egress Sampling Configuration and Verification"
+  readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/sflow/otg_tests/sflow_egress_test/README.md"
+}
 test: {
   id: "SR-1.1"
   description: "Transit forwarding to Node-SID via ISIS"

--- a/testregistry.textproto
+++ b/testregistry.textproto
@@ -1397,7 +1397,7 @@ test: {
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/sflow/otg_tests/sflow_base_test/README.md"
   exec: "https://github.com/openconfig/featureprofiles/blob/main/feature/sflow/otg_tests/sflow_base_test/sflow_base_test.go"
 }
-tests {
+test: {
   id: "SFLOW-2"
   description: "sFlow Egress Sampling Configuration and Verification"
   readme: "https://github.com/openconfig/featureprofiles/blob/main/feature/sflow/otg_tests/sflow_egress_test/README.md"


### PR DESCRIPTION
This PR adds the test requirements (README.md) for **SFLOW-2: sFlow Egress Sampling Configuration and Verification**.

While standard sFlow sampling captures packets at the ingress pipeline, egress sFlow enables sampling of packets as they egress the device (post-encapsulation and routing header modifications). This test qualifies OpenConfig configuration, operational state telemetry, and flow sample verification for interface-level egress sampling on supported platforms.


## Key Coverage
* **Test ID:** `SFLOW-2`
* **Testbed:** `topologies/atedut_2.testbed`
* **OpenConfig Paths Covered:**
  * `/sampling/sflow/interfaces/interface/config/egress-sampling-rate`
  * `/sampling/sflow/interfaces/interface/state/egress-sampling-rate`
  * `/sampling/sflow/interfaces/interface/state/enabled`
  * Global sFlow collector and enablement paths (`/sampling/sflow/config/enabled`, etc.)
* **Test Scenarios:**
  * `SFLOW-2.1`: Configure interface-level egress sampling rate via gNMI Replace and verify telemetry state.
  * `SFLOW-2.2`: Transmit data traffic through the DUT and verify that captured sFlow datagrams report the correct egress output interface (`ifIndex`) and adhere to the configured sampling rate.
  * `SFLOW-2.3`: Disable egress sampling and verify clean teardown.
