### PR TITLE
gRIBI: fix TE-2.1, TE-3.5, TE-11.2, TE-11.21 for KNE

### DIFF
--- a/feature/gribi/otg_tests/backup_nhg_multiple_nh_pbf_test/backup_nhg_multiple_nh_pbf_test.go
+++ b/feature/gribi/otg_tests/backup_nhg_multiple_nh_pbf_test/backup_nhg_multiple_nh_pbf_test.go
@@ -47,8 +47,8 @@ const (
 	routeCount       = 1
 	vrf1             = "TE_VRF_111"
 	vrf2             = "vrfB"
-	fps              = 1000000 // traffic frames per second
-	switchovertime   = 250.0   // switchovertime during interface shut in milliseconds
+	fps              = 10000 // traffic frames per second
+	switchovertime   = 250.0 // switchovertime during interface shut in milliseconds
 	ethernetCsmacd   = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
 	decapFlowSrc     = "198.51.100.111"
 	dscpEncapA1      = 10

--- a/feature/gribi/otg_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
+++ b/feature/gribi/otg_tests/backup_nhg_multiple_nh_test/backup_nhg_multiple_nh_test.go
@@ -45,8 +45,8 @@ const (
 	routeCount       = 1
 	vrf1             = "vrfA"
 	vrf2             = "vrfB"
-	fps              = 1000000 // traffic frames per second
-	switchovertime   = 250.0   // switchovertime during interface shut in milliseconds
+	fps              = 10000 // traffic frames per second
+	switchovertime   = 250.0 // switchovertime during interface shut in milliseconds
 	ethernetCsmacd   = oc.IETFInterfaces_InterfaceType_ethernetCsmacd
 )
 

--- a/feature/gribi/otg_tests/ipv4_entry_test/ipv4_entry_test.go
+++ b/feature/gribi/otg_tests/ipv4_entry_test/ipv4_entry_test.go
@@ -541,6 +541,7 @@ func createTrafficFlows(t *testing.T, ate *ondatra.ATEDevice, good, bad []string
 	if len(good) == 0 && len(bad) == 0 {
 		otg.PushConfig(t, ateTop)
 		otg.StartProtocols(t)
+		otgutils.WaitForARP(t, otg, ateTop, "IPv4")
 		return newGoodFlows, newBadFlows
 	}
 	ateTop.Flows().Clear().Items()
@@ -574,6 +575,7 @@ func createTrafficFlows(t *testing.T, ate *ondatra.ATEDevice, good, bad []string
 	}
 	otg.PushConfig(t, ateTop)
 	otg.StartProtocols(t)
+	otgutils.WaitForARP(t, otg, ateTop, "IPv4")
 	return newGoodFlows, newBadFlows
 }
 

--- a/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
+++ b/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
@@ -453,7 +453,7 @@ func testModifyIPv4AddDelAdd(t *testing.T, args *testArgs) {
 
 	t.Run("Telemetry", func(t *testing.T) {
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-		if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+		if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), awaitDuration, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
 			ipv4Entry, present := val.Val()
 			return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 		}).Await(t); !ok {

--- a/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
+++ b/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
@@ -370,7 +370,7 @@ func testModifyNHGIPv4(t *testing.T, args *testArgs) {
 				}
 			}
 			ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-			if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+			if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), awaitDuration, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
 				ipv4Entry, present := val.Val()
 				return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
 			}).Await(t); !ok {

--- a/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
+++ b/feature/gribi/otg_tests/ordering_ack_test/ordering_ack_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openconfig/ondatra"
 	"github.com/openconfig/ondatra/gnmi"
 	"github.com/openconfig/ondatra/gnmi/oc"
+	"github.com/openconfig/ygnmi/ygnmi"
 	"github.com/openconfig/ygot/ygot"
 )
 
@@ -369,8 +370,11 @@ func testModifyNHGIPv4(t *testing.T, args *testArgs) {
 				}
 			}
 			ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-			if got, want := gnmi.Get(t, args.dut, ipv4Path.State()).GetPrefix(), ateDstNetCIDR; got != want {
-				t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
+			if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+				ipv4Entry, present := val.Val()
+				return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
+			}).Await(t); !ok {
+				t.Errorf("ipv4-entry/state/prefix got %v, want %s", got, ateDstNetCIDR)
 			}
 		}
 	})
@@ -449,8 +453,11 @@ func testModifyIPv4AddDelAdd(t *testing.T, args *testArgs) {
 
 	t.Run("Telemetry", func(t *testing.T) {
 		ipv4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(args.dut)).Afts().Ipv4Entry(ateDstNetCIDR)
-		if got, want := gnmi.Get(t, args.dut, ipv4Path.State()).GetPrefix(), ateDstNetCIDR; got != want {
-			t.Errorf("ipv4-entry/state/prefix got %s, want %s", got, want)
+		if got, ok := gnmi.Watch(t, args.dut, ipv4Path.State(), time.Minute, func(val *ygnmi.Value[*oc.NetworkInstance_Afts_Ipv4Entry]) bool {
+			ipv4Entry, present := val.Val()
+			return present && ipv4Entry.GetPrefix() == ateDstNetCIDR
+		}).Await(t); !ok {
+			t.Errorf("ipv4-entry/state/prefix got %v, want %s", got, ateDstNetCIDR)
 		}
 	})
 


### PR DESCRIPTION
- TE-11.2, TE-11.21: reduce traffic rate to 10k pps for SRL containers.
- TE-2.1: add WaitForARP after StartProtocols in createTrafficFlows.
- TE-3.5: use gnmi.Watch/Await for AFT ipv4-entry telemetry checks.

"This code is a Contribution to the OpenConfig Feature Profiles project ("Work") made under the Google Software Grant and Corporate Contributor License Agreement ("CLA") and governed by the Apache License 2.0. No other rights or licenses in or to any of Nokia's intellectual property are granted for any other purpose. This code is provided on an "as is" basis without any warranties of any kind."