### PR TITLE
BGP OC uprev test changes in RT-1.2, RT-1.27, RT-1.29, RT-1.30, RT-1.32, RT-7.8, RT-7.10, RT-7.11, and gNMI-1.3

### DIFF
--- a/feature/bgp/policybase/otg_tests/actions_med_localpref_prepend_flow_control/actions_MED_LocPref_prepend_flow_control_test.go
+++ b/feature/bgp/policybase/otg_tests/actions_med_localpref_prepend_flow_control/actions_MED_LocPref_prepend_flow_control_test.go
@@ -285,6 +285,20 @@ func configureBGPDefaultImportExportPolicy(t *testing.T, dut *ondatra.DUTDevice,
 	batchConfig.Set(t, dut)
 }
 
+func batchReplaceBGPImportExportPolicy(t *testing.T, dut *ondatra.DUTDevice, batchConfig *gnmi.SetBatch, policyPath *netinstbgp.NetworkInstance_Protocol_Bgp_Neighbor_AfiSafi_ApplyPolicyPath, importPolicy, exportPolicy []string) {
+	applyPolicy, present := gnmi.Lookup(t, dut, policyPath.Config()).Val()
+	if !present {
+		applyPolicy = &oc.NetworkInstance_Protocol_Bgp_Neighbor_AfiSafi_ApplyPolicy{}
+	}
+	applyPolicy.ImportPolicy = importPolicy
+	applyPolicy.ExportPolicy = exportPolicy
+	if len(importPolicy) == 0 && len(exportPolicy) == 0 && applyPolicy.DefaultImportPolicy == 0 && applyPolicy.DefaultExportPolicy == 0 {
+		gnmi.BatchDelete(batchConfig, policyPath.Config())
+		return
+	}
+	gnmi.BatchReplace(batchConfig, policyPath.Config(), applyPolicy)
+}
+
 // configureBGPImportExportPolicy configures import/export policies
 func configureBGPImportExportPolicy(t *testing.T, dut *ondatra.DUTDevice, ipv4, ipv6, policyDef string) {
 	t.Helper()
@@ -292,10 +306,8 @@ func configureBGPImportExportPolicy(t *testing.T, dut *ondatra.DUTDevice, ipv4, 
 	batchConfig := &gnmi.SetBatch{}
 	nbrPolPathv4 := bgpPath.Neighbor(ipv4).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
 	nbrPolPathv6 := bgpPath.Neighbor(ipv6).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).ApplyPolicy()
-	gnmi.BatchReplace(batchConfig, nbrPolPathv4.ImportPolicy().Config(), []string{policyDef})
-	gnmi.BatchReplace(batchConfig, nbrPolPathv4.ExportPolicy().Config(), []string{policyDef})
-	gnmi.BatchReplace(batchConfig, nbrPolPathv6.ImportPolicy().Config(), []string{policyDef})
-	gnmi.BatchReplace(batchConfig, nbrPolPathv6.ExportPolicy().Config(), []string{policyDef})
+	batchReplaceBGPImportExportPolicy(t, dut, batchConfig, nbrPolPathv4, []string{policyDef}, []string{policyDef})
+	batchReplaceBGPImportExportPolicy(t, dut, batchConfig, nbrPolPathv6, []string{policyDef}, []string{policyDef})
 	batchConfig.Set(t, dut)
 
 	// Sleep for 10 second to ensure that OTG has recived the update packet
@@ -311,15 +323,10 @@ func deleteBGPImportExportPolicy(t *testing.T, dut *ondatra.DUTDevice, ipv4, ipv
 	nbrPolPathv6 := bgpPath.Neighbor(ipv6).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).ApplyPolicy()
 	nbrPolPathv4_2 := bgpPath.Neighbor(ipv4_2).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
 	nbrPolPathv6_2 := bgpPath.Neighbor(ipv6_2).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).ApplyPolicy()
-	gnmi.BatchDelete(batchConfig, nbrPolPathv4_2.ImportPolicy().Config())
-	gnmi.BatchDelete(batchConfig, nbrPolPathv4_2.ExportPolicy().Config())
-	gnmi.BatchDelete(batchConfig, nbrPolPathv6_2.ImportPolicy().Config())
-	gnmi.BatchDelete(batchConfig, nbrPolPathv6_2.ExportPolicy().Config())
-
-	gnmi.BatchDelete(batchConfig, nbrPolPathv4.ImportPolicy().Config())
-	gnmi.BatchDelete(batchConfig, nbrPolPathv4.ExportPolicy().Config())
-	gnmi.BatchDelete(batchConfig, nbrPolPathv6.ImportPolicy().Config())
-	gnmi.BatchDelete(batchConfig, nbrPolPathv6.ExportPolicy().Config())
+	batchReplaceBGPImportExportPolicy(t, dut, batchConfig, nbrPolPathv4_2, nil, nil)
+	batchReplaceBGPImportExportPolicy(t, dut, batchConfig, nbrPolPathv6_2, nil, nil)
+	batchReplaceBGPImportExportPolicy(t, dut, batchConfig, nbrPolPathv4, nil, nil)
+	batchReplaceBGPImportExportPolicy(t, dut, batchConfig, nbrPolPathv6, nil, nil)
 	batchConfig.Set(t, dut)
 }
 

--- a/feature/bgp/policybase/otg_tests/actions_med_localpref_prepend_flow_control/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/actions_med_localpref_prepend_flow_control/metadata.textproto
@@ -16,7 +16,6 @@ platform_exceptions: {
     default_route_policy_unsupported: true
     skip_checking_attribute_index: true
     skip_setting_statement_for_policy: true
-    bgp_set_med_action_unsupported: true
   }
 }
 platform_exceptions: {
@@ -46,4 +45,3 @@ platform_exceptions: {
     default_network_instance: "default"
   }
 }
-

--- a/feature/bgp/policybase/otg_tests/chained_policies_test/chained_policies_test.go
+++ b/feature/bgp/policybase/otg_tests/chained_policies_test/chained_policies_test.go
@@ -259,7 +259,10 @@ func configureImportRoutingPolicy(t *testing.T, dut *ondatra.DUTDevice, operatio
 	stmt1.GetOrCreateConditions().GetOrCreateMatchPrefixSet().SetMatchSetOptions(oc.RoutingPolicy_MatchSetOptionsRestrictedType_ANY)
 	stmt1.GetOrCreateConditions().GetOrCreateMatchPrefixSet().SetPrefixSet(v4PrefixSet)
 
-	pdef2 := rp.GetOrCreatePolicyDefinition(v4LPPolicy)
+	pdef2 := pdef1
+	if !deviations.FlattenPolicyWithMultipleStatements(dut) {
+		pdef2 = rp.GetOrCreatePolicyDefinition(v4LPPolicy)
+	}
 	stmt2, err := pdef2.AppendNewStatement(v4LPStatement)
 	if err != nil {
 		t.Fatalf("AppendNewStatement(%s) failed: %v", v4LPStatement, err)
@@ -281,17 +284,26 @@ func configureImportRoutingPolicy(t *testing.T, dut *ondatra.DUTDevice, operatio
 	if !deviations.DefaultImportExportPolicyUnsupported(dut) {
 		policy.SetDefaultImportPolicy(oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE)
 	}
-	policy.SetImportPolicy([]string{v4PrefixPolicy, v4LPPolicy})
-	if deviations.SkipSettingStatementForPolicy(dut) {
-		gnmi.Update(t, dut, path.Config(), policy)
+	if deviations.FlattenPolicyWithMultipleStatements(dut) {
+		policy.SetImportPolicy([]string{v4PrefixPolicy})
 	} else {
-		if operation == "set" {
+		policy.SetImportPolicy([]string{v4PrefixPolicy, v4LPPolicy})
+	}
+	if operation == "set" {
+		if deviations.DefaultImportExportPolicyUnsupported(dut) {
+			policy.SetExportPolicy([]string{"PERMIT-ALL"})
+		}
+		gnmi.BatchReplace(batch, path.Config(), policy)
+	} else if operation == "delete" {
+		if deviations.DefaultImportExportPolicyUnsupported(dut) {
+			policy.SetImportPolicy([]string{"PERMIT-ALL"})
+			policy.SetExportPolicy([]string{"PERMIT-ALL"})
 			gnmi.BatchReplace(batch, path.Config(), policy)
-		} else if operation == "delete" {
+		} else {
 			gnmi.BatchDelete(batch, path.Config())
 		}
-		batch.Set(t, dut)
 	}
+	batch.Set(t, dut)
 	// Sleep for 5 second to ensure that OTG has received the update packet
 	time.Sleep(time.Second * 5)
 }
@@ -411,18 +423,25 @@ func configureExportRoutingPolicy(t *testing.T, dut *ondatra.DUTDevice, operatio
 	} else {
 		policy.SetExportPolicy([]string{v4ASPPolicy, v4MedPolicy})
 	}
-	if deviations.SkipSettingStatementForPolicy(dut) {
-		gnmi.Update(t, dut, path.Config(), policy)
-	} else {
-		if operation == "set" {
+	if operation == "set" {
+		if deviations.DefaultImportExportPolicyUnsupported(dut) {
+			policy.SetImportPolicy([]string{"PERMIT-ALL"})
+			gnmi.BatchReplace(batch, path.Config(), policy)
+		} else {
 			gnmi.BatchReplace(batch, path.Config(), policy)
 			gnmi.BatchReplace(batch, importPolPath.Config(), eBGPPeerPolicy)
-		} else if operation == "delete" {
+		}
+	} else if operation == "delete" {
+		if deviations.DefaultImportExportPolicyUnsupported(dut) {
+			policy.SetImportPolicy([]string{"PERMIT-ALL"})
+			policy.SetExportPolicy([]string{"PERMIT-ALL"})
+			gnmi.BatchReplace(batch, path.Config(), policy)
+		} else {
 			gnmi.BatchDelete(batch, path.Config())
 			gnmi.BatchDelete(batch, importPolPath.Config())
 		}
-		batch.Set(t, dut)
 	}
+	batch.Set(t, dut)
 	time.Sleep(time.Second * 60)
 }
 
@@ -486,7 +505,10 @@ func configureImportRoutingPolicyV6(t *testing.T, dut *ondatra.DUTDevice, operat
 	stmt1.GetOrCreateConditions().GetOrCreateMatchPrefixSet().SetMatchSetOptions(oc.RoutingPolicy_MatchSetOptionsRestrictedType_ANY)
 	stmt1.GetOrCreateConditions().GetOrCreateMatchPrefixSet().SetPrefixSet(v6PrefixSet)
 
-	pdef2 := rp.GetOrCreatePolicyDefinition(v6LPPolicy)
+	pdef2 := pdef1
+	if !deviations.FlattenPolicyWithMultipleStatements(dut) {
+		pdef2 = rp.GetOrCreatePolicyDefinition(v6LPPolicy)
+	}
 	stmt2, err := pdef2.AppendNewStatement(v6LPStatement)
 	if err != nil {
 		t.Fatalf("AppendNewStatement(%s) failed: %v", v6LPStatement, err)
@@ -510,17 +532,26 @@ func configureImportRoutingPolicyV6(t *testing.T, dut *ondatra.DUTDevice, operat
 		policy.SetDefaultImportPolicy(oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE)
 	}
 
-	policy.SetImportPolicy([]string{v6PrefixPolicy, v6LPPolicy})
-	if deviations.SkipSettingStatementForPolicy(dut) {
-		gnmi.Update(t, dut, path.Config(), policy)
+	if deviations.FlattenPolicyWithMultipleStatements(dut) {
+		policy.SetImportPolicy([]string{v6PrefixPolicy})
 	} else {
-		if operation == "set" {
+		policy.SetImportPolicy([]string{v6PrefixPolicy, v6LPPolicy})
+	}
+	if operation == "set" {
+		if deviations.DefaultImportExportPolicyUnsupported(dut) {
+			policy.SetExportPolicy([]string{"PERMIT-ALL"})
+		}
+		gnmi.BatchReplace(batch, path.Config(), policy)
+	} else if operation == "delete" {
+		if deviations.DefaultImportExportPolicyUnsupported(dut) {
+			policy.SetImportPolicy([]string{"PERMIT-ALL"})
+			policy.SetExportPolicy([]string{"PERMIT-ALL"})
 			gnmi.BatchReplace(batch, path.Config(), policy)
-		} else if operation == "delete" {
+		} else {
 			gnmi.BatchDelete(batch, path.Config())
 		}
-		batch.Set(t, dut)
 	}
+	batch.Set(t, dut)
 	time.Sleep(time.Second * 60)
 }
 
@@ -637,18 +668,25 @@ func configureExportRoutingPolicyV6(t *testing.T, dut *ondatra.DUTDevice, operat
 	} else {
 		policy.SetExportPolicy([]string{v6ASPPolicy, v6MedPolicy})
 	}
-	if deviations.SkipSettingStatementForPolicy(dut) {
-		gnmi.Update(t, dut, path.Config(), policy)
-	} else {
-		if operation == "set" {
+	if operation == "set" {
+		if deviations.DefaultImportExportPolicyUnsupported(dut) {
+			policy.SetImportPolicy([]string{"PERMIT-ALL"})
+			gnmi.BatchReplace(batch, path.Config(), policy)
+		} else {
 			gnmi.BatchReplace(batch, path.Config(), policy)
 			gnmi.BatchReplace(batch, importPolPath.Config(), eBGPPeerPolicy)
-		} else if operation == "delete" {
+		}
+	} else if operation == "delete" {
+		if deviations.DefaultImportExportPolicyUnsupported(dut) {
+			policy.SetImportPolicy([]string{"PERMIT-ALL"})
+			policy.SetExportPolicy([]string{"PERMIT-ALL"})
+			gnmi.BatchReplace(batch, path.Config(), policy)
+		} else {
 			gnmi.BatchDelete(batch, path.Config())
 			gnmi.BatchDelete(batch, importPolPath.Config())
 		}
-		batch.Set(t, dut)
 	}
+	batch.Set(t, dut)
 	time.Sleep(time.Second * 60)
 }
 

--- a/feature/bgp/policybase/otg_tests/chained_policies_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/chained_policies_test/metadata.textproto
@@ -35,7 +35,6 @@ platform_exceptions: {
     skip_setting_statement_for_policy: true
     skip_checking_attribute_index: true
     flatten_policy_with_multiple_statements: true
-    bgp_set_med_action_unsupported: true
   }
 }
 platform_exceptions: {

--- a/feature/bgp/policybase/otg_tests/comm_match_action_test/bgp_comm_match_action_test.go
+++ b/feature/bgp/policybase/otg_tests/comm_match_action_test/bgp_comm_match_action_test.go
@@ -223,13 +223,12 @@ func bgpCreateNbr(localAs, peerAs uint32, dut *ondatra.DUTDevice) *oc.NetworkIns
 
 		if deviations.SkipBgpSendCommunityType(dut) {
 			pg.SetSendCommunity(oc.E_Bgp_CommunityType(oc.Bgp_CommunityType_STANDARD))
+		} else if deviations.SkipBgpPeerGroupSendCommunityType(dut) {
+			as4.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
+			as6.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
 		} else {
-			if deviations.SkipBgpPeerGroupSendCommunityType(dut) {
-				as4.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
-				as6.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
-			} else {
-				pg.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
-			}
+			as4.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
+			as6.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
 		}
 
 		bgpNbr := bgp.GetOrCreateNeighbor(nbr.nbrAddr)
@@ -364,13 +363,19 @@ func configureRoutingPolicy(t *testing.T, dut *ondatra.DUTDevice, policyName str
 
 	bgpPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	if nbr != nil {
-		gnmi.BatchReplace(batchConfig, bgpPath.Neighbor(nbr.nbrAddr).AfiSafi(nbr.afiSafi).ApplyPolicy().ImportPolicy().Config(), []string{policyName})
+		applyPolicy := &oc.NetworkInstance_Protocol_Bgp_Neighbor_AfiSafi_ApplyPolicy{}
+		applyPolicy.SetImportPolicy([]string{policyName})
+		gnmi.BatchReplace(batchConfig, bgpPath.Neighbor(nbr.nbrAddr).AfiSafi(nbr.afiSafi).ApplyPolicy().Config(), applyPolicy)
 	}
 	if pgName != "" {
-		gnmi.BatchReplace(batchConfig, bgpPath.PeerGroup(pgName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ImportPolicy().Config(), []string{policyName})
-		gnmi.BatchReplace(batchConfig, bgpPath.PeerGroup(pgName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).ApplyPolicy().ImportPolicy().Config(), []string{policyName})
-		gnmi.BatchDelete(batchConfig, bgpPath.Neighbor(ebgp1NbrV4.nbrAddr).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ImportPolicy().Config())
-		gnmi.BatchDelete(batchConfig, bgpPath.Neighbor(ebgp1NbrV6.nbrAddr).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).ApplyPolicy().ImportPolicy().Config())
+		applyPolicyV4 := &oc.NetworkInstance_Protocol_Bgp_PeerGroup_AfiSafi_ApplyPolicy{}
+		applyPolicyV4.SetImportPolicy([]string{policyName})
+		applyPolicyV6 := &oc.NetworkInstance_Protocol_Bgp_PeerGroup_AfiSafi_ApplyPolicy{}
+		applyPolicyV6.SetImportPolicy([]string{policyName})
+		gnmi.BatchReplace(batchConfig, bgpPath.PeerGroup(pgName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().Config(), applyPolicyV4)
+		gnmi.BatchReplace(batchConfig, bgpPath.PeerGroup(pgName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).ApplyPolicy().Config(), applyPolicyV6)
+		gnmi.BatchDelete(batchConfig, bgpPath.Neighbor(ebgp1NbrV4.nbrAddr).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().Config())
+		gnmi.BatchDelete(batchConfig, bgpPath.Neighbor(ebgp1NbrV6.nbrAddr).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).ApplyPolicy().Config())
 	}
 
 	batchConfig.Set(t, dut)

--- a/feature/bgp/policybase/otg_tests/comm_match_action_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/comm_match_action_test/metadata.textproto
@@ -42,7 +42,6 @@ platform_exceptions:  {
   deviations:  {
     bgp_community_set_refs_unsupported: true
     bgp_conditions_match_community_set_unsupported:  true
-    skip_bgp_send_community_type: true
     skip_setting_statement_for_policy: true
   }
 }

--- a/feature/bgp/policybase/otg_tests/import_export_multi_test/import_export_multi_test.go
+++ b/feature/bgp/policybase/otg_tests/import_export_multi_test/import_export_multi_test.go
@@ -131,12 +131,8 @@ func deleteBGPPolicy(t *testing.T, dut *ondatra.DUTDevice, nbrList []*bgpNbrList
 	bgpPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
 	for _, nbr := range nbrList {
 		nbrAfiSafiPath := bgpPath.Neighbor(nbr.nbrAddr).AfiSafi(nbr.afiSafi)
-		peerAfiSafiPath := bgpPath.PeerGroup(cfgplugins.BGPPeerGroup1).AfiSafi(nbr.afiSafi)
 		b := &gnmi.SetBatch{}
-		gnmi.BatchDelete(b, nbrAfiSafiPath.ApplyPolicy().ImportPolicy().Config())
-		gnmi.BatchDelete(b, nbrAfiSafiPath.ApplyPolicy().ExportPolicy().Config())
-		gnmi.BatchDelete(b, peerAfiSafiPath.ApplyPolicy().ImportPolicy().Config())
-		gnmi.BatchDelete(b, peerAfiSafiPath.ApplyPolicy().ExportPolicy().Config())
+		gnmi.BatchDelete(b, nbrAfiSafiPath.ApplyPolicy().Config())
 		b.Set(t, dut)
 	}
 }
@@ -523,12 +519,6 @@ func configureImportExportMultifacetMatchActionsBGPPolicy(t *testing.T, dut *ond
 	}
 	gnmi.Replace(t, dut, pathV6.Config(), policyV6)
 
-	if !deviations.SkipBgpSendCommunityType(dut) {
-		n6 := root.GetOrCreateNetworkInstance(dni).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).GetOrCreateBgp().GetOrCreateNeighbor(ipv6)
-		n6.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_BOTH})
-		gnmi.Update(t, dut, gnmi.OC().NetworkInstance(dni).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).Bgp().Neighbor(ipv6).Config(), n6)
-	}
-
 	pathV4 := gnmi.OC().NetworkInstance(dni).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).Bgp().Neighbor(ipv4).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
 	policyV4 := root.GetOrCreateNetworkInstance(dni).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).GetOrCreateBgp().GetOrCreateNeighbor(ipv4).GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).GetOrCreateApplyPolicy()
 	policyV4.SetImportPolicy([]string{parentPolicy})
@@ -539,12 +529,6 @@ func configureImportExportMultifacetMatchActionsBGPPolicy(t *testing.T, dut *ond
 	}
 	gnmi.Replace(t, dut, pathV4.Config(), policyV4)
 
-	if !deviations.SkipBgpSendCommunityType(dut) {
-		n4 := root.GetOrCreateNetworkInstance(dni).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).GetOrCreateBgp().GetOrCreateNeighbor(ipv4)
-		n4.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_BOTH})
-		gnmi.Update(t, dut, gnmi.OC().NetworkInstance(dni).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).Bgp().Neighbor(ipv4).Config(), n4)
-	}
-
 	pathV61 := gnmi.OC().NetworkInstance(dni).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).Bgp().Neighbor(ipv61).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).ApplyPolicy()
 	policyV61 := root.GetOrCreateNetworkInstance(dni).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).GetOrCreateBgp().GetOrCreateNeighbor(ipv61).GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).GetOrCreateApplyPolicy()
 	policyV61.SetExportPolicy([]string{parentPolicy})
@@ -552,7 +536,10 @@ func configureImportExportMultifacetMatchActionsBGPPolicy(t *testing.T, dut *ond
 		policyV6.SetDefaultImportPolicy(oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE)
 		policyV6.SetDefaultExportPolicy(oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE)
 	}
-	gnmi.Update(t, dut, pathV61.Config(), policyV61)
+	gnmi.Replace(t, dut, pathV61.Config(), policyV61)
+	if !deviations.SkipBgpSendCommunityType(dut) {
+		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(dni).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).Bgp().Neighbor(ipv61).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).SendCommunityType().Config(), []oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD, oc.Bgp_CommunityType_EXTENDED})
+	}
 
 	pathV41 := gnmi.OC().NetworkInstance(dni).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).Bgp().Neighbor(ipv41).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
 	policyV41 := root.GetOrCreateNetworkInstance(dni).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).GetOrCreateBgp().GetOrCreateNeighbor(ipv41).GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).GetOrCreateApplyPolicy()
@@ -561,7 +548,10 @@ func configureImportExportMultifacetMatchActionsBGPPolicy(t *testing.T, dut *ond
 		policyV4.SetDefaultImportPolicy(oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE)
 		policyV4.SetDefaultExportPolicy(oc.RoutingPolicy_DefaultPolicyType_REJECT_ROUTE)
 	}
-	gnmi.Update(t, dut, pathV41.Config(), policyV41)
+	gnmi.Replace(t, dut, pathV41.Config(), policyV41)
+	if !deviations.SkipBgpSendCommunityType(dut) {
+		gnmi.Replace(t, dut, gnmi.OC().NetworkInstance(dni).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).Bgp().Neighbor(ipv41).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).SendCommunityType().Config(), []oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD, oc.Bgp_CommunityType_EXTENDED})
+	}
 }
 
 func configureOTG(t *testing.T, bs *cfgplugins.BGPSession, prefixesV4 [][]string, prefixesV6 [][]string, communityMembers [][][]int) {
@@ -753,6 +743,21 @@ func verifyTrafficV4AndV6(t *testing.T, bs *cfgplugins.BGPSession, testResults [
 	// Log flow and port metrics
 	otgutils.LogFlowMetrics(t, bs.ATE.OTG(), bs.ATETop)
 	otgutils.LogPortMetrics(t, bs.ATE.OTG(), bs.ATETop)
+}
+
+func awaitBGPReady(t *testing.T, bs *cfgplugins.BGPSession, ipv4, ipv6, ipv41, ipv61 string) {
+	t.Helper()
+	bgpPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(bs.DUT)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).Bgp()
+	for _, nbr := range []string{ipv4, ipv6, ipv41, ipv61} {
+		gnmi.Await(t, bs.DUT, bgpPath.Neighbor(nbr).SessionState().State(), 2*time.Minute, oc.Bgp_Neighbor_SessionState_ESTABLISHED)
+	}
+
+	for _, device := range bs.ATETop.Devices().Items() {
+		bgp4Peer := device.Bgp().Ipv4Interfaces().Items()[0].Peers().Items()[0]
+		bgp6Peer := device.Bgp().Ipv6Interfaces().Items()[0].Peers().Items()[0]
+		gnmi.Await(t, bs.ATE.OTG(), gnmi.OTG().BgpPeer(bgp4Peer.Name()).SessionState().State(), 2*time.Minute, otgtelemetry.BgpPeer_SessionState_ESTABLISHED)
+		gnmi.Await(t, bs.ATE.OTG(), gnmi.OTG().BgpPeer(bgp6Peer.Name()).SessionState().State(), 2*time.Minute, otgtelemetry.BgpPeer_SessionState_ESTABLISHED)
+	}
 }
 
 func validateLocalPreferenceV4(t *testing.T, dut *ondatra.DUTDevice, prefix string, metricValue uint32) {
@@ -966,32 +971,24 @@ func TestImportExportMultifacetMatchActionsBGPPolicy(t *testing.T) {
 	bs := cfgplugins.NewBGPSession(t, cfgplugins.PortCount2, nil)
 	bs.WithEBGP(t, []oc.E_BgpTypes_AFI_SAFI_TYPE{oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST, oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST}, []string{
 		"port1", "port2"}, true, false)
-
 	if deviations.BgpRibStreamingConfigRequired(dut) {
 		cfgplugins.DeviationBgpRibStreamingConfigRequired(t, dut)
 	}
 
 	configureOTG(t, bs, prefixesV4, prefixesV6, communityMembers)
+	configureFlowV4(t, bs)
+	configureFlowV6(t, bs)
 	bs.PushAndStart(t)
-
-	t.Log("Verify DUT BGP sessions up")
-	cfgplugins.VerifyDUTBGPEstablished(t, bs.DUT)
-	t.Log("Verify OTG BGP sessions up")
-	cfgplugins.VerifyOTGBGPEstablished(t, bs.ATE)
 
 	ipv4 := bs.ATETop.Devices().Items()[1].Ethernets().Items()[0].Ipv4Addresses().Items()[0].Address()
 	ipv6 := bs.ATETop.Devices().Items()[1].Ethernets().Items()[0].Ipv6Addresses().Items()[0].Address()
 
 	ipv41 := bs.ATETop.Devices().Items()[0].Ethernets().Items()[0].Ipv4Addresses().Items()[0].Address()
 	ipv61 := bs.ATETop.Devices().Items()[0].Ethernets().Items()[0].Ipv6Addresses().Items()[0].Address()
+	awaitBGPReady(t, bs, ipv4, ipv6, ipv41, ipv61)
 
 	t.Logf("Verify Import Export Accept all bgp policy")
 	configureImportExportAcceptAllBGPPolicy(t, bs.DUT, ipv4, ipv6)
-
-	configureFlowV4(t, bs)
-	configureFlowV6(t, bs)
-
-	bs.PushAndStartATE(t)
 
 	testResults := [6]bool{true, true, true, true, true, true}
 	verifyTrafficV4AndV6(t, bs, testResults)
@@ -1008,10 +1005,8 @@ func TestImportExportMultifacetMatchActionsBGPPolicy(t *testing.T) {
 		},
 	})
 
-	configureImportExportMultifacetMatchActionsBGPPolicy(t, bs.DUT, ipv4, ipv6, ipv41, ipv61)
-	time.Sleep(time.Second * 120)
-
 	testResults1 := [6]bool{false, true, false, false, true, true}
+	configureImportExportMultifacetMatchActionsBGPPolicy(t, bs.DUT, ipv4, ipv6, ipv41, ipv61)
 	verifyTrafficV4AndV6(t, bs, testResults1)
 
 	testMedResults := [6]bool{false, true, false, false, true, true}

--- a/feature/bgp/policybase/otg_tests/import_export_multi_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/import_export_multi_test/metadata.textproto
@@ -33,8 +33,6 @@ platform_exceptions: {
     skip_setting_statement_for_policy: true
     default_route_policy_unsupported: true
     skip_checking_attribute_index: true
-    skip_bgp_send_community_type: true
-    bgp_set_med_action_unsupported: true
   }
 }
 platform_exceptions: {

--- a/feature/bgp/policybase/otg_tests/nested_policies/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/nested_policies/metadata.textproto
@@ -26,7 +26,6 @@ platform_exceptions: {
   deviations: {
     skip_setting_statement_for_policy: true
     skip_checking_attribute_index: true
-    bgp_set_med_action_unsupported: true
   }
 }
 platform_exceptions: {

--- a/feature/bgp/policybase/otg_tests/nested_policies/nested_policies_test.go
+++ b/feature/bgp/policybase/otg_tests/nested_policies/nested_policies_test.go
@@ -304,11 +304,7 @@ func configureImportRoutingPolicy(t *testing.T, dut *ondatra.DUTDevice) {
 		gnmi.BatchDelete(batch, path.Config())
 		policy := root.GetOrCreateNetworkInstance(dni).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).GetOrCreateBgp().GetOrCreateNeighbor(atePort1.IPv4).GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).GetOrCreateApplyPolicy()
 		policy.SetImportPolicy([]string{v4LPPolicy})
-		if !deviations.RoutingPolicyChainingUnsupported(dut) {
-			gnmi.BatchUpdate(batch, path.Config(), policy)
-		} else {
-			gnmi.BatchReplace(batch, path.Config(), policy)
-		}
+		gnmi.BatchReplace(batch, path.Config(), policy)
 	}
 	batch.Set(t, dut)
 	// Sleep for 5 second to ensure that OTG has received the update packet
@@ -415,11 +411,7 @@ func configureExportRoutingPolicy(t *testing.T, dut *ondatra.DUTDevice) {
 		gnmi.BatchDelete(batch, path.Config())
 		policy := root.GetOrCreateNetworkInstance(dni).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).GetOrCreateBgp().GetOrCreateNeighbor(atePort1.IPv4).GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).GetOrCreateApplyPolicy()
 		policy.SetExportPolicy([]string{v4ASPPolicy})
-		if !deviations.RoutingPolicyChainingUnsupported(dut) {
-			gnmi.BatchUpdate(batch, path.Config(), policy)
-		} else {
-			gnmi.BatchReplace(batch, path.Config(), policy)
-		}
+		gnmi.BatchReplace(batch, path.Config(), policy)
 	}
 	batch.Set(t, dut)
 	time.Sleep(time.Second * 60)
@@ -526,11 +518,7 @@ func configureImportRoutingPolicyV6(t *testing.T, dut *ondatra.DUTDevice) {
 		gnmi.BatchDelete(batch, path.Config())
 		policy := root.GetOrCreateNetworkInstance(dni).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).GetOrCreateBgp().GetOrCreateNeighbor(atePort1.IPv6).GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).GetOrCreateApplyPolicy()
 		policy.SetImportPolicy([]string{v6LPPolicy})
-		if !deviations.RoutingPolicyChainingUnsupported(dut) {
-			gnmi.BatchUpdate(batch, path.Config(), policy)
-		} else {
-			gnmi.BatchReplace(batch, path.Config(), policy)
-		}
+		gnmi.BatchReplace(batch, path.Config(), policy)
 	}
 	batch.Set(t, dut)
 	// Sleep for 5 second to ensure that OTG has received the update packet
@@ -640,11 +628,7 @@ func configureExportRoutingPolicyV6(t *testing.T, dut *ondatra.DUTDevice) {
 		gnmi.BatchDelete(batch, path.Config())
 		policy := root.GetOrCreateNetworkInstance(dni).GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, bgpName).GetOrCreateBgp().GetOrCreateNeighbor(atePort1.IPv6).GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).GetOrCreateApplyPolicy()
 		policy.SetExportPolicy([]string{v6ASPPolicy})
-		if !deviations.RoutingPolicyChainingUnsupported(dut) {
-			gnmi.BatchUpdate(batch, path.Config(), policy)
-		} else {
-			gnmi.BatchReplace(batch, path.Config(), policy)
-		}
+		gnmi.BatchReplace(batch, path.Config(), policy)
 	}
 	batch.Set(t, dut)
 	time.Sleep(time.Second * 60)

--- a/feature/bgp/policybase/otg_tests/route_installation_test/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/route_installation_test/metadata.textproto
@@ -12,7 +12,6 @@ platform_exceptions: {
   deviations: {
     ipv4_missing_enabled: true
     prepolicy_received_routes: true
-    bgp_set_med_action_unsupported: true
   }
 }
 platform_exceptions: {

--- a/feature/bgp/policybase/otg_tests/route_installation_test/route_installation_test.go
+++ b/feature/bgp/policybase/otg_tests/route_installation_test/route_installation_test.go
@@ -514,6 +514,8 @@ func configureATE(t *testing.T, otg *otg.OTG) gosnappi.Config {
 	t.Logf("Pushing config to ATE and starting protocols...")
 	otg.PushConfig(t, config)
 	otg.StartProtocols(t)
+	otgutils.WaitForARP(t, otg, config, "IPv4")
+	otgutils.WaitForARP(t, otg, config, "IPv6")
 	return config
 }
 

--- a/feature/bgp/policybase/otg_tests/statement_insertion_removal/metadata.textproto
+++ b/feature/bgp/policybase/otg_tests/statement_insertion_removal/metadata.textproto
@@ -26,12 +26,4 @@ platform_exceptions:  {
     default_network_instance:  "default"
   }
 }
-platform_exceptions:  {
-  platform:  {
-    vendor:  CISCO
-  }
-  deviations:  {
-    bgp_community_type_slice_input_unsupported: true
-  }
-}
 tags:  TAGS_DATACENTER_EDGE

--- a/feature/bgp/policybase/otg_tests/statement_insertion_removal/statement_insertion_removal_test.go
+++ b/feature/bgp/policybase/otg_tests/statement_insertion_removal/statement_insertion_removal_test.go
@@ -224,14 +224,13 @@ func bgpCreateNbr(localAs, peerAs uint32, dut *ondatra.DUTDevice) *oc.NetworkIns
 		pg.PeerAs = ygot.Uint32(nbr.as)
 		pg.PeerGroupName = ygot.String(nbr.peerGrp)
 
+		as4 := pg.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
+		as4.Enabled = ygot.Bool(true)
 		if deviations.BgpCommunityTypeSliceInputUnsupported(dut) {
 			pg.SetSendCommunity(oc.Bgp_CommunityType_STANDARD)
 		} else if !deviations.SkipBgpSendCommunityType(dut) {
-			pg.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
+			as4.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
 		}
-
-		as4 := pg.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST)
-		as4.Enabled = ygot.Bool(true)
 
 		bgpNbr := bgp.GetOrCreateNeighbor(nbr.nbrAddr)
 		bgpNbr.PeerGroup = ygot.String(nbr.peerGrp)

--- a/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/metadata.textproto
+++ b/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/metadata.textproto
@@ -41,15 +41,12 @@ platform_exceptions:  {
   }
   deviations:  {
     set_metric_as_preference: true
-    skip_bgp_send_community_type: true
     bgp_community_set_refs_unsupported: true
     tc_default_import_policy_unsupported: true
     tc_metric_propagation_unsupported: true
     tc_attribute_propagation_unsupported: true
     tc_subscription_unsupported: true
     default_bgp_instance_name: "default"
-    bgp_set_med_action_unsupported: true
-    skip_bgp_peer_group_send_community_type: true 
   }
 }
 platform_exceptions:  {

--- a/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/static_route_bgp_redistribution_test.go
+++ b/feature/bgp/static_route_bgp_redistribution/otg_tests/static_route_bgp_redistribution_test/static_route_bgp_redistribution_test.go
@@ -248,11 +248,6 @@ func configureDUTBGP(t *testing.T, dut *ondatra.DUTDevice) {
 	bgpGlobalIPv6AF := bgpGlobal.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST)
 	bgpGlobalIPv6AF.SetEnabled(true)
 
-	if !deviations.SkipBgpSendCommunityType(dut) {
-		bgpGlobalIPv6AF.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
-		bgpGlobalIPv4AF.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
-	}
-
 	bgpPeerGroup := bgp.GetOrCreatePeerGroup(peerGroupName)
 	bgpPeerGroup.SetPeerAs(dutAsn)
 
@@ -260,6 +255,11 @@ func configureDUTBGP(t *testing.T, dut *ondatra.DUTDevice) {
 		if !deviations.SkipBgpPeerGroupSendCommunityType(dut) {
 			bgpPeerGroup.SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
 		}
+	} else {
+		bgpPeerGroup.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).
+			SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
+		bgpPeerGroup.GetOrCreateAfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV6_UNICAST).
+			SetSendCommunityType([]oc.E_Bgp_CommunityType{oc.Bgp_CommunityType_STANDARD})
 	}
 
 	// dutPort1 -> atePort1 peer (ebgp session)
@@ -612,6 +612,23 @@ func configureTableConnection(t *testing.T, dut *ondatra.DUTDevice, isV4, mPropa
 			}
 		}
 	}
+}
+
+func clearTableConnectionImportPolicy(t *testing.T, dut *ondatra.DUTDevice, addressFamily oc.E_Types_ADDRESS_FAMILY) {
+	t.Helper()
+
+	tableConnPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).TableConnection(
+		oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC,
+		oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP,
+		addressFamily,
+	)
+	if deviations.EnableTableConnections(dut) {
+		gnmi.Delete(t, dut, tableConnPath.ImportPolicy().Config())
+		return
+	}
+	tableConn := gnmi.Get[*oc.NetworkInstance_TableConnection](t, dut, tableConnPath.Config())
+	tableConn.ImportPolicy = nil
+	gnmi.Replace(t, dut, tableConnPath.Config(), tableConn)
 }
 
 // Validate configurations for table-connections and routing-policy
@@ -1015,13 +1032,11 @@ func redistributeStaticRoutePolicyWithCommunitySet(t *testing.T, dut *ondatra.DU
 	communitySetPolicyDefinition := communitySet.GetOrCreateDefinedSets().GetOrCreateBgpDefinedSets().GetOrCreateCommunitySet(communitySetName)
 	communitySetPolicyDefinition.SetCommunityMember([]oc.RoutingPolicy_DefinedSets_BgpDefinedSets_CommunitySet_CommunityMember_Union{oc.UnionString("64512:100")})
 
-	// Delete the references import policy under table connection before replacing the policy.
+	// Detach the referenced import policy under table connection before replacing the policy.
 	if isV4 {
-		tableConnV4Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, oc.Types_ADDRESS_FAMILY_IPV4)
-		gnmi.Delete(t, dut, tableConnV4Path.ImportPolicy().Config())
+		clearTableConnectionImportPolicy(t, dut, oc.Types_ADDRESS_FAMILY_IPV4)
 	} else {
-		tableConnV6Path := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).TableConnection(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_STATIC, oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, oc.Types_ADDRESS_FAMILY_IPV6)
-		gnmi.Delete(t, dut, tableConnV6Path.ImportPolicy().Config())
+		clearTableConnectionImportPolicy(t, dut, oc.Types_ADDRESS_FAMILY_IPV6)
 	}
 
 	gnmi.Replace(t, dut, policyPath.Config(), redistributePolicyDefinition)
@@ -1225,9 +1240,18 @@ func validatePrefixASN(t *testing.T, ate *ondatra.ATEDevice, isV4 bool, bgpPeerN
 	if isV4 {
 		prefixPath := gnmi.OTG().BgpPeer(bgpPeerName).UnicastIpv4PrefixAny()
 		prefix, ok := gnmi.WatchAll(t, ate.OTG(), prefixPath.State(), 20*time.Second, func(val *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv4Prefix]) bool {
-			prefix, _ := val.Val()
+			if val == nil {
+				return false
+			}
+			prefix, present := val.Val()
+			if !present || prefix == nil || len(prefix.AsPath) == 0 {
+				return false
+			}
 			if prefix.GetAddress() == subnet {
 				foundPrefix = true
+				if len(prefix.AsPath[len(prefix.AsPath)-1].GetAsNumbers()) == 0 {
+					return false
+				}
 				gotASPath := prefix.AsPath[len(prefix.AsPath)-1].GetAsNumbers()
 				t.Logf("Prefix %v learned with ASN : %v", prefix.GetAddress(), gotASPath)
 				return reflect.DeepEqual(gotASPath, wantASPath)
@@ -1235,15 +1259,30 @@ func validatePrefixASN(t *testing.T, ate *ondatra.ATEDevice, isV4 bool, bgpPeerN
 			return false
 		}).Await(t)
 		if !ok {
-			pfx, _ := prefix.Val()
-			t.Fatalf("Prefix not updated with required as-path. Got %v, want %v", pfx.AsPath[len(pfx.AsPath)-1].GetAsNumbers(), wantASPath)
+			if prefix == nil {
+				t.Fatalf("Prefix %v absent from OTG peer %v; cannot validate AS path %v", subnet, bgpPeerName, wantASPath)
+			}
+			pfx, present := prefix.Val()
+			if !present || pfx == nil || len(pfx.AsPath) == 0 || len(pfx.AsPath[len(pfx.AsPath)-1].GetAsNumbers()) == 0 {
+				t.Fatalf("Prefix %v received from OTG peer %v without usable AS-path telemetry; want %v", subnet, bgpPeerName, wantASPath)
+			}
+			t.Fatalf("Prefix %v received from OTG peer %v, but AS-path mismatch: got %v, want %v", subnet, bgpPeerName, pfx.AsPath[len(pfx.AsPath)-1].GetAsNumbers(), wantASPath)
 		}
 	} else {
 		prefixPath := gnmi.OTG().BgpPeer(bgpPeerName).UnicastIpv6PrefixAny()
 		prefix, ok := gnmi.WatchAll(t, ate.OTG(), prefixPath.State(), 20*time.Second, func(val *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv6Prefix]) bool {
-			prefix, _ := val.Val()
+			if val == nil {
+				return false
+			}
+			prefix, present := val.Val()
+			if !present || prefix == nil || len(prefix.AsPath) == 0 {
+				return false
+			}
 			if prefix.GetAddress() == subnet {
 				foundPrefix = true
+				if len(prefix.AsPath[len(prefix.AsPath)-1].GetAsNumbers()) == 0 {
+					return false
+				}
 				gotASPath := prefix.AsPath[len(prefix.AsPath)-1].GetAsNumbers()
 				t.Logf("Prefix %v learned with ASN : %v", prefix.GetAddress(), gotASPath)
 				return reflect.DeepEqual(gotASPath, wantASPath)
@@ -1251,8 +1290,14 @@ func validatePrefixASN(t *testing.T, ate *ondatra.ATEDevice, isV4 bool, bgpPeerN
 			return false
 		}).Await(t)
 		if !ok {
-			pfx, _ := prefix.Val()
-			t.Fatalf("Prefix not updated with required as-path. Got %v, want %v", pfx.AsPath[len(pfx.AsPath)-1].GetAsNumbers(), wantASPath)
+			if prefix == nil {
+				t.Fatalf("Prefix %v absent from OTG peer %v; cannot validate AS path %v", subnet, bgpPeerName, wantASPath)
+			}
+			pfx, present := prefix.Val()
+			if !present || pfx == nil || len(pfx.AsPath) == 0 || len(pfx.AsPath[len(pfx.AsPath)-1].GetAsNumbers()) == 0 {
+				t.Fatalf("Prefix %v received from OTG peer %v without usable AS-path telemetry; want %v", subnet, bgpPeerName, wantASPath)
+			}
+			t.Fatalf("Prefix %v received from OTG peer %v, but AS-path mismatch: got %v, want %v", subnet, bgpPeerName, pfx.AsPath[len(pfx.AsPath)-1].GetAsNumbers(), wantASPath)
 		}
 	}
 	if !foundPrefix {
@@ -1267,7 +1312,13 @@ func validatePrefixLocalPreference(t *testing.T, ate *ondatra.ATEDevice, isV4 bo
 	if isV4 {
 		prefixPath := gnmi.OTG().BgpPeer(bgpPeerName).UnicastIpv4PrefixAny()
 		prefix, ok := gnmi.WatchAll(t, ate.OTG(), prefixPath.State(), 10*time.Second, func(val *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv4Prefix]) bool {
-			prefix, _ := val.Val()
+			if val == nil {
+				return false
+			}
+			prefix, present := val.Val()
+			if !present || prefix == nil {
+				return false
+			}
 			if prefix.GetAddress() == subnet {
 				foundPrefix = true
 				gotLocalPreference := prefix.GetLocalPreference()
@@ -1306,59 +1357,82 @@ func validatePrefixLocalPreference(t *testing.T, ate *ondatra.ATEDevice, isV4 bo
 func validatePrefixCommunitySet(t *testing.T, ate *ondatra.ATEDevice, isV4 bool, bgpPeerName, subnet, wantCommunitySet string) {
 
 	foundPrefix := false
+	var gotCommunitySets []string
 	if isV4 {
 		prefixPath := gnmi.OTG().BgpPeer(bgpPeerName).UnicastIpv4PrefixAny()
-		prefix, ok := gnmi.WatchAll(t, ate.OTG(), prefixPath.State(), 10*time.Second, func(val *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv4Prefix]) bool {
-			prefix, _ := val.Val()
+		prefix, ok := gnmi.WatchAll(t, ate.OTG(), prefixPath.State(), 30*time.Second, func(val *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv4Prefix]) bool {
+			if val == nil {
+				return false
+			}
+			prefix, present := val.Val()
+			if !present || prefix == nil {
+				return false
+			}
 			if prefix.GetAddress() == subnet {
 				foundPrefix = true
-				var gotCommunitySet string
+				gotCommunitySets = nil
 				for _, community := range prefix.Community {
 					gotCommunityNumber := community.GetCustomAsNumber()
 					gotCommunityValue := community.GetCustomAsValue()
-					gotCommunitySet = fmt.Sprint(gotCommunityNumber) + ":" + fmt.Sprint(gotCommunityValue)
+					gotCommunitySet := fmt.Sprint(gotCommunityNumber) + ":" + fmt.Sprint(gotCommunityValue)
+					gotCommunitySets = append(gotCommunitySets, gotCommunitySet)
+					if gotCommunitySet == wantCommunitySet {
+						return true
+					}
 				}
-				t.Logf("Prefix %v learned with CommunitySet : %v", prefix.GetAddress(), gotCommunitySet)
-				return gotCommunitySet == wantCommunitySet
 			}
 			return false
 		}).Await(t)
 		if !ok {
-			pfx, _ := prefix.Val()
-			var gotCS string
-			for _, community := range pfx.Community {
-				gotCN := community.GetCustomAsNumber()
-				gotCV := community.GetCustomAsValue()
-				gotCS = fmt.Sprint(gotCN) + ":" + fmt.Sprint(gotCV)
+			if prefix == nil || !foundPrefix {
+				t.Fatalf("Prefix %v absent from OTG peer %v; cannot validate community-set %v", subnet, bgpPeerName, wantCommunitySet)
 			}
-			t.Fatalf("Prefix not updated with the community-set. Got %v, want %v", gotCS, wantCommunitySet)
+			pfx, present := prefix.Val()
+			if !present || pfx == nil {
+				t.Fatalf("Prefix %v received from OTG peer %v without usable telemetry; cannot validate community-set %v", subnet, bgpPeerName, wantCommunitySet)
+			}
+			if len(gotCommunitySets) == 0 {
+				t.Fatalf("Prefix %v received from OTG peer %v without community telemetry; cannot validate community-set %v", subnet, bgpPeerName, wantCommunitySet)
+			}
+			t.Fatalf("Prefix %v received from OTG peer %v, but community-set mismatch: got %v, want %v", subnet, bgpPeerName, gotCommunitySets, wantCommunitySet)
 		}
 	} else {
 		prefixPath := gnmi.OTG().BgpPeer(bgpPeerName).UnicastIpv6PrefixAny()
-		prefix, ok := gnmi.WatchAll(t, ate.OTG(), prefixPath.State(), 10*time.Second, func(val *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv6Prefix]) bool {
-			prefix, _ := val.Val()
+		prefix, ok := gnmi.WatchAll(t, ate.OTG(), prefixPath.State(), 30*time.Second, func(val *ygnmi.Value[*otgtelemetry.BgpPeer_UnicastIpv6Prefix]) bool {
+			if val == nil {
+				return false
+			}
+			prefix, present := val.Val()
+			if !present || prefix == nil {
+				return false
+			}
 			if prefix.GetAddress() == subnet {
 				foundPrefix = true
-				var gotCommunitySet string
+				gotCommunitySets = nil
 				for _, community := range prefix.Community {
 					gotCommunityNumber := community.GetCustomAsNumber()
 					gotCommunityValue := community.GetCustomAsValue()
-					gotCommunitySet = fmt.Sprint(gotCommunityNumber) + ":" + fmt.Sprint(gotCommunityValue)
+					gotCommunitySet := fmt.Sprint(gotCommunityNumber) + ":" + fmt.Sprint(gotCommunityValue)
+					gotCommunitySets = append(gotCommunitySets, gotCommunitySet)
+					if gotCommunitySet == wantCommunitySet {
+						return true
+					}
 				}
-				t.Logf("Prefix %v learned with CommunitySet : %v", prefix.GetAddress(), gotCommunitySet)
-				return gotCommunitySet == wantCommunitySet
 			}
 			return false
 		}).Await(t)
 		if !ok {
-			pfx, _ := prefix.Val()
-			var gotCS string
-			for _, community := range pfx.Community {
-				gotCN := community.GetCustomAsNumber()
-				gotCV := community.GetCustomAsValue()
-				gotCS = fmt.Sprint(gotCN) + ":" + fmt.Sprint(gotCV)
+			if prefix == nil || !foundPrefix {
+				t.Fatalf("Prefix %v absent from OTG peer %v; cannot validate community-set %v", subnet, bgpPeerName, wantCommunitySet)
 			}
-			t.Fatalf("Prefix not updated with the community-set. Got %v, want %v", gotCS, wantCommunitySet)
+			pfx, present := prefix.Val()
+			if !present || pfx == nil {
+				t.Fatalf("Prefix %v received from OTG peer %v without usable telemetry; cannot validate community-set %v", subnet, bgpPeerName, wantCommunitySet)
+			}
+			if len(gotCommunitySets) == 0 {
+				t.Fatalf("Prefix %v received from OTG peer %v without community telemetry; cannot validate community-set %v", subnet, bgpPeerName, wantCommunitySet)
+			}
+			t.Fatalf("Prefix %v received from OTG peer %v, but community-set mismatch: got %v, want %v", subnet, bgpPeerName, gotCommunitySets, wantCommunitySet)
 		}
 	}
 

--- a/feature/gnmi/otg_tests/drained_configuration_convergence_time/drained_configuration_convergence_time_bgp_test.go
+++ b/feature/gnmi/otg_tests/drained_configuration_convergence_time/drained_configuration_convergence_time_bgp_test.go
@@ -120,21 +120,6 @@ func setASPath(t *testing.T, dut *ondatra.DUTDevice, d *oc.Root) {
 	aspend.Asn = ygot.Uint32(setup.DUTAs)
 	aspend.RepeatN = ygot.Uint8(asPathRepeatValue)
 	gnmi.Replace(t, dut, gnmi.OC().RoutingPolicy().Config(), rp)
-
-	netInstance := d.GetOrCreateNetworkInstance(deviations.DefaultNetworkInstance(dut))
-	bgp := netInstance.GetOrCreateProtocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").GetOrCreateBgp()
-	pg := bgp.GetOrCreatePeerGroup(setup.PeerGrpName)
-	rpl := pg.GetOrCreateApplyPolicy()
-
-	if deviations.SameAfiSafiAndPeergroupPoliciesUnsupported(dut) {
-		// Apply the peer-group specific policy.
-		rpl.SetImportPolicy([]string{setALLOWPeerGroupPolicy})
-	} else {
-		// Original behavior.
-		rpl.SetImportPolicy([]string{setALLOWPolicy})
-	}
-
-	gnmi.Update(t, dut, gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).Config(), pg)
 }
 
 // setPolicyPeerGroup to set BGP Import policy.
@@ -200,22 +185,44 @@ prefixLoop:
 	}
 }
 
+func replacePeerGroupExportPolicy(t *testing.T, dut *ondatra.DUTDevice, policy string) {
+	bgpPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
+		Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	if deviations.RoutePolicyUnderAFIUnsupported(dut) {
+		policyPath := bgpPath.PeerGroup(setup.PeerGrpName).ApplyPolicy()
+		applyPolicy := gnmi.Get(t, dut, policyPath.Config())
+		applyPolicy.SetExportPolicy([]string{policy})
+		gnmi.Replace(t, dut, policyPath.Config(), applyPolicy)
+		return
+	}
+	policyPath := bgpPath.PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
+	applyPolicy := gnmi.Get(t, dut, policyPath.Config())
+	applyPolicy.SetExportPolicy([]string{policy})
+	gnmi.Replace(t, dut, policyPath.Config(), applyPolicy)
+}
+
+func deletePeerGroupApplyPolicy(t *testing.T, dut *ondatra.DUTDevice) {
+	bgpPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
+		Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp()
+	peerGroupPath := bgpPath.PeerGroup(setup.PeerGrpName)
+	if deviations.RoutePolicyUnderAFIUnsupported(dut) {
+		gnmi.Delete(t, dut, peerGroupPath.ApplyPolicy().Config())
+		if deviations.SameAfiSafiAndPeergroupPoliciesUnsupported(dut) {
+			gnmi.Delete(t, dut, peerGroupPath.AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().Config())
+		}
+		return
+	}
+	gnmi.Delete(t, dut, peerGroupPath.AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().Config())
+	if deviations.SameAfiSafiAndPeergroupPoliciesUnsupported(dut) {
+		gnmi.Delete(t, dut, peerGroupPath.ApplyPolicy().Config())
+	}
+}
+
 // verifyBGPAsPath is to Validate AS Path attribute using bgp rib telemetry on ATE.
 func verifyBGPAsPath(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
 	// Start the timer.
 	start := time.Now()
-	if deviations.RoutePolicyUnderAFIUnsupported(dut) {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
-			Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
-			PeerGroup(setup.PeerGrpName).ApplyPolicy().ExportPolicy()
-
-		gnmi.Replace(t, dut, dutPolicyConfPath.Config(), []string{setASpathPrependPolicy})
-	} else {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
-			Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
-			PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ExportPolicy()
-		gnmi.Replace(t, dut, dutPolicyConfPath.Config(), []string{setASpathPrependPolicy})
-	}
+	replacePeerGroupExportPolicy(t, dut, setASpathPrependPolicy)
 	t.Run("BGP-AS-PATH Verification", func(t *testing.T) {
 		for _, ap := range ate.Ports() {
 			if ap.ID() == "port1" {
@@ -248,17 +255,7 @@ func verifyBGPAsPath(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevic
 func verifyBGPSetMED(t *testing.T, dut *ondatra.DUTDevice, ate *ondatra.ATEDevice) {
 	// Start the timer.
 	start := time.Now()
-	if deviations.RoutePolicyUnderAFIUnsupported(dut) {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
-			Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
-			PeerGroup(setup.PeerGrpName).ApplyPolicy().ExportPolicy()
-		gnmi.Replace(t, dut, dutPolicyConfPath.Config(), []string{setMEDPolicy})
-	} else {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).
-			Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().
-			PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy().ExportPolicy()
-		gnmi.Replace(t, dut, dutPolicyConfPath.Config(), []string{setMEDPolicy})
-	}
+	replacePeerGroupExportPolicy(t, dut, setMEDPolicy)
 	t.Run("BGP-MED-Verification", func(t *testing.T) {
 		for _, ap := range ate.Ports() {
 			if ap.ID() == "port1" {
@@ -310,15 +307,7 @@ func TestBGPBenchmarking(t *testing.T) {
 	dut := ondatra.DUT(t, "dut")
 	ate := ondatra.ATE(t, "ate")
 	// Cleanup existing policy details.
-	if deviations.RoutePolicyUnderAFIUnsupported(dut) {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).ApplyPolicy()
-		gnmi.Delete(t, dut, dutPolicyConfPath.ExportPolicy().Config())
-		gnmi.Delete(t, dut, dutPolicyConfPath.ImportPolicy().Config())
-	} else {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
-		gnmi.Delete(t, dut, dutPolicyConfPath.ExportPolicy().Config())
-		gnmi.Delete(t, dut, dutPolicyConfPath.ImportPolicy().Config())
-	}
+	deletePeerGroupApplyPolicy(t, dut)
 	gnmi.Delete(t, dut, gnmi.OC().RoutingPolicy().Config())
 
 	if deviations.SameAfiSafiAndPeergroupPoliciesUnsupported(dut) {
@@ -345,15 +334,7 @@ func TestBGPBenchmarking(t *testing.T) {
 	verifyBGPSetMED(t, dut, ate)
 
 	// Cleanup existing policy details.
-	if deviations.RoutePolicyUnderAFIUnsupported(dut) {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).ApplyPolicy()
-		gnmi.Delete(t, dut, dutPolicyConfPath.ExportPolicy().Config())
-		gnmi.Delete(t, dut, dutPolicyConfPath.ImportPolicy().Config())
-	} else {
-		dutPolicyConfPath := gnmi.OC().NetworkInstance(deviations.DefaultNetworkInstance(dut)).Protocol(oc.PolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "BGP").Bgp().PeerGroup(setup.PeerGrpName).AfiSafi(oc.BgpTypes_AFI_SAFI_TYPE_IPV4_UNICAST).ApplyPolicy()
-		gnmi.Delete(t, dut, dutPolicyConfPath.ExportPolicy().Config())
-		gnmi.Delete(t, dut, dutPolicyConfPath.ImportPolicy().Config())
-	}
+	deletePeerGroupApplyPolicy(t, dut)
 	gnmi.Delete(t, dut, gnmi.OC().RoutingPolicy().Config())
 
 	if deviations.SameAfiSafiAndPeergroupPoliciesUnsupported(dut) {

--- a/feature/gnmi/otg_tests/drained_configuration_convergence_time/metadata.textproto
+++ b/feature/gnmi/otg_tests/drained_configuration_convergence_time/metadata.textproto
@@ -45,6 +45,6 @@ platform_exceptions: {
     vendor: CISCO
   }
   deviations: {
-    bgp_set_med_action_unsupported: true
+    set_isis_auth_with_interface_authentication_container: true
   }
 }

--- a/internal/gnmi/setup/setup.go
+++ b/internal/gnmi/setup/setup.go
@@ -240,11 +240,19 @@ func BuildBenchmarkingConfig(t *testing.T) *oc.Root {
 
 		isisIntfLevel := isisIntf.GetOrCreateLevel(2)
 		isisIntfLevel.Enabled = ygot.Bool(true)
-		isisIntfLevelAuth := isisIntfLevel.GetOrCreateHelloAuthentication()
-		isisIntfLevelAuth.Enabled = ygot.Bool(true)
-		isisIntfLevelAuth.AuthPassword = ygot.String(authPassword)
-		isisIntfLevelAuth.AuthMode = oc.IsisTypes_AUTH_MODE_MD5
-		isisIntfLevelAuth.AuthType = oc.KeychainTypes_AUTH_TYPE_SIMPLE_KEY
+		if deviations.SetISISAuthWithInterfaceAuthenticationContainer(dut) {
+			isisIntfAuth := isisIntf.GetOrCreateAuthentication()
+			isisIntfAuth.Enabled = ygot.Bool(true)
+			isisIntfAuth.AuthPassword = ygot.String(authPassword)
+			isisIntfAuth.AuthMode = oc.IsisTypes_AUTH_MODE_MD5
+			isisIntfAuth.AuthType = oc.KeychainTypes_AUTH_TYPE_SIMPLE_KEY
+		} else {
+			isisIntfLevelAuth := isisIntfLevel.GetOrCreateHelloAuthentication()
+			isisIntfLevelAuth.Enabled = ygot.Bool(true)
+			isisIntfLevelAuth.AuthPassword = ygot.String(authPassword)
+			isisIntfLevelAuth.AuthMode = oc.IsisTypes_AUTH_MODE_MD5
+			isisIntfLevelAuth.AuthType = oc.KeychainTypes_AUTH_TYPE_SIMPLE_KEY
+		}
 
 		isisIntfLevelTimers := isisIntfLevel.GetOrCreateTimers()
 		isisIntfLevelTimers.HelloInterval = ygot.Uint32(1)


### PR DESCRIPTION
## Summary

This PR updates nine FNTs for the current BGP OpenConfig model.

The changes update `send-community` paths, import/export policy replacement, and MED actions. The PR also includes test-specific reliability changes.

## OpenConfig path changes

### Peer-group `send-community` configuration

Previous root leaves:

`/network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/config/send-community`

`/network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/config/send-community-type`

Current AFI-SAFI leaf:

`/network-instances/network-instance/protocols/protocol/bgp/peer-groups/peer-group/afi-safis/afi-safi/config/send-community-type`

### Neighbor `send-community` configuration

Previous root leaf:

`/network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/config/send-community-type`

Current AFI-SAFI leaf:

`/network-instances/network-instance/protocols/protocol/bgp/neighbors/neighbor/afi-safis/afi-safi/config/send-community-type`

### Import/export policy root replacement

Previous operation:

- Replace or delete only `.../apply-policy/config/import-policy` or `.../apply-policy/config/export-policy`.

Current operation:

- Read the containing `.../apply-policy/config` root.
- Change `import-policy` or `export-policy` in the returned configuration.
- Replace the complete `.../apply-policy/config` root.

### MED actions

The tests continue to set the MED value at:

`/routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-med`

The tests now set the related operation at:

`/routing-policy/policy-definitions/policy-definition/statements/statement/actions/bgp-actions/config/set-med-action`

The tests use `SET` for assignment. RT-1.32 also uses `ADD` for its additive MED case.

### IS-IS authentication in gNMI-1.3

Previous level path:

`/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/levels/level/hello-authentication/config`

Current interface path for the applicable platform exception:

`/network-instances/network-instance/protocols/protocol/isis/interfaces/interface/authentication/config`

This compatibility change is not related to the BGP OpenConfig uprev.

## Removed deviation assignments

The PR removes these suite metadata assignments:

- `bgp_set_med_action_unsupported`: gNMI-1.3, RT-1.2, RT-1.27, RT-1.29, RT-1.30, RT-1.32, and RT-7.11.
- `skip_bgp_send_community_type`: RT-1.27, RT-7.8, and RT-7.11.
- `skip_bgp_peer_group_send_community_type`: RT-1.27.
- `bgp_community_type_slice_input_unsupported`: RT-7.10.

## Affected FNTs

### RT-1.2

- Pairs `set-med` with `set-med-action: SET` and waits for IPv4/IPv6 neighbor resolution before BGP peer checks.

### RT-1.27

- Moves `send-community-type: STANDARD` from the global AFI-SAFI to the peer-group IPv4/IPv6 AFI-SAFIs, pairs `set-med` with `set-med-action: SET`, and replaces the complete table-connection root when clearing `import-policy`.
- Makes OTG route-attribute checks tolerant of delayed or absent telemetry and extends the send-community validation watch to 30 seconds.

### RT-1.29

- Replaces complete neighbor AFI-SAFI import/export policy roots, preserves required siblings, and pairs `set-med` with `set-med-action: SET`.
- Retains the existing flattened-policy and skipped-statement vendor paths at their required scopes.

### RT-1.30

- Replaces complete IPv4/IPv6 neighbor AFI-SAFI import/export policy roots and pairs `set-med` with `set-med-action: SET`.

### RT-1.32

- Replaces complete neighbor AFI-SAFI import/export policy roots while preserving default-policy values; removes an empty root during cleanup.
- Uses `set-med-action: SET` for MED assignment and `ADD` for MED increments.

### RT-7.8

- Configures peer-group AFI-SAFI `send-community-type: STANDARD` and replaces complete neighbor or peer-group AFI-SAFI import/export policy roots.

### RT-7.10

- Moves `send-community-type: STANDARD` from the peer-group root to the IPv4 peer-group AFI-SAFI.

### RT-7.11

- Replaces complete neighbor AFI-SAFI import/export policy roots, configures AFI-SAFI `send-community-type: STANDARD` and `EXTENDED`, and pairs `set-med` with `set-med-action: SET`.
- Builds flows before one OTG protocol start, waits for the exact BGP peers, and removes the redundant restart and fixed delay.

### gNMI-1.3

- Replaces complete peer-group import/export policy roots, removes a redundant `import-policy` write, and pairs `set-med` with `set-med-action: SET`.
- Uses interface-level IS-IS authentication for `set_isis_auth_with_interface_authentication_container`; this is a compatibility fix from a different OC uprev, but gnmi-1.3 is affected by both. 